### PR TITLE
[21183] `const` qualify all data related inputs in DataWriter APIs

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -683,6 +683,7 @@ jobs:
           show_skipped: 'False'
 
   fastdds_alternative_builds:
+    needs: fastdds_build
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
@@ -690,11 +691,11 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
-      - name: Sync eProsima/Fast-DDS repository
-        uses: eProsima/eProsima-CI/external/checkout@v0
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          path: src/fastdds
-          ref: ${{ inputs.fastdds-branch }}
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -719,7 +720,7 @@ jobs:
       - name: Install Python dependencies
         uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: vcstool xmlschema
+          packages: vcstool xmlschema msparser
           upgrade: false
 
       - name: Setup CCache
@@ -728,15 +729,41 @@ jobs:
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch Fast DDS dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
+      - name: Sync osrf/osrf_testing_tools_cpp repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
         with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
-          destination_workspace: src
-          skip_existing: 'true'
+          repository: osrf/osrf_testing_tools_cpp
+          path: src/osrf_testing_tools_cpp
+          ref: 1.4.0
+
+      - name: OSRF testing tools build
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ''
+          colcon_build_args: ${{ inputs.colcon-args }} --packages-select osrf_testing_tools_cpp
+          cmake_args: '-DBUILD_TESTING=OFF'
+          cmake_args_default: ''
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Profilling tests build
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
+          colcon_build_args: ${{ inputs.colcon-args }}
+          cmake_args: '-DPROFILING_TESTS=ON ${{ inputs.cmake-args }}'
+          cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ${{ github.workspace }}/install
+
+      - name: Clean workspace - Profiling tests
+        run: |
+          cd ${{ github.workspace }}
+          rm -rf build install log src/osrf_testing_tools_cpp
 
       - name: No security colcon build
-        continue-on-error: true
+        continue-on-error: false
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -747,14 +774,11 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No security
-        if: ${{ always() }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: No statistics colcon build
-        continue-on-error: true
-        if: ${{ always() }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -765,15 +789,12 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No statistics
-        if: ${{ always() }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       # No .metas file, so FASTDDS_ENFORCE_LOG_INFO is set OFF by default. Missed important args are manually included
       - name: No enforcing log info colcon build
-        continue-on-error: true
-        if: ${{ always() }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ''
@@ -784,14 +805,11 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No enforce log info
-        if: ${{ always() }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: No shared libs colcon build
-        continue-on-error: true
-        if: ${{ always() }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -710,7 +710,7 @@ jobs:
       - name: Install apt dependencies
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
-          packages: libasio-dev libtinyxml2-dev libssl-dev
+          packages: libasio-dev libtinyxml2-dev libssl-dev valgrind
           update: false
           upgrade: false
 
@@ -750,7 +750,7 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
+          colcon_build_args: ${{ inputs.colcon-args }} --packages-up-to fastdds
           cmake_args: '-DPROFILING_TESTS=ON ${{ inputs.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}

--- a/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
+++ b/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
@@ -57,11 +57,11 @@ ConfigurationPubSubType::~ConfigurationPubSubType()
 }
 
 bool ConfigurationPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Configuration* p_type = static_cast<Configuration*>(data);
+    const Configuration* p_type = static_cast<const Configuration*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool ConfigurationPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ConfigurationPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> ConfigurationPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Configuration*>(data), current_alignment)) +
+                               *static_cast<const Configuration*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void ConfigurationPubSubType::deleteData(
 }
 
 bool ConfigurationPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool ConfigurationPubSubType::getKey(
         return false;
     }
 
-    Configuration* p_type = static_cast<Configuration*>(data);
+    const Configuration* p_type = static_cast<const Configuration*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/configuration/ConfigurationPubSubTypes.h
+++ b/examples/cpp/configuration/ConfigurationPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~ConfigurationPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/content_filter/HelloWorldPubSubTypes.h
+++ b/examples/cpp/content_filter/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.h
+++ b/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.cxx
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.cxx
@@ -57,11 +57,11 @@ FlowControlExamplePubSubType::~FlowControlExamplePubSubType()
 }
 
 bool FlowControlExamplePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FlowControlExample* p_type = static_cast<FlowControlExample*>(data);
+    const FlowControlExample* p_type = static_cast<const FlowControlExample*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool FlowControlExamplePubSubType::deserialize(
 }
 
 std::function<uint32_t()> FlowControlExamplePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> FlowControlExamplePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FlowControlExample*>(data), current_alignment)) +
+                               *static_cast<const FlowControlExample*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void FlowControlExamplePubSubType::deleteData(
 }
 
 bool FlowControlExamplePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool FlowControlExamplePubSubType::getKey(
         return false;
     }
 
-    FlowControlExample* p_type = static_cast<FlowControlExample*>(data);
+    const FlowControlExample* p_type = static_cast<const FlowControlExample*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.h
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~FlowControlExamplePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/Keys/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/Keys/samplePubSubTypes.cxx
@@ -57,11 +57,11 @@ samplePubSubType::~samplePubSubType()
 }
 
 bool samplePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sample* p_type = static_cast<sample*>(data);
+    const sample* p_type = static_cast<const sample*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool samplePubSubType::deserialize(
 }
 
 std::function<uint32_t()> samplePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> samplePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sample*>(data), current_alignment)) +
+                               *static_cast<const sample*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void samplePubSubType::deleteData(
 }
 
 bool samplePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool samplePubSubType::getKey(
         return false;
     }
 
-    sample* p_type = static_cast<sample*>(data);
+    const sample* p_type = static_cast<const sample*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/Keys/samplePubSubTypes.h
+++ b/examples/cpp/dds/Keys/samplePubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~samplePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.cxx
+++ b/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.cxx
@@ -57,11 +57,11 @@ RequestTypePubSubType::~RequestTypePubSubType()
 }
 
 bool RequestTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    RequestType* p_type = static_cast<RequestType*>(data);
+    const RequestType* p_type = static_cast<const RequestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool RequestTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> RequestTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> RequestTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<RequestType*>(data), current_alignment)) +
+                               *static_cast<const RequestType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void RequestTypePubSubType::deleteData(
 }
 
 bool RequestTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool RequestTypePubSubType::getKey(
         return false;
     }
 
-    RequestType* p_type = static_cast<RequestType*>(data);
+    const RequestType* p_type = static_cast<const RequestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ ReplyTypePubSubType::~ReplyTypePubSubType()
 }
 
 bool ReplyTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ReplyType* p_type = static_cast<ReplyType*>(data);
+    const ReplyType* p_type = static_cast<const ReplyType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool ReplyTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ReplyTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> ReplyTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ReplyType*>(data), current_alignment)) +
+                               *static_cast<const ReplyType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void ReplyTypePubSubType::deleteData(
 }
 
 bool ReplyTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool ReplyTypePubSubType::getKey(
         return false;
     }
 
-    ReplyType* p_type = static_cast<ReplyType*>(data);
+    const ReplyType* p_type = static_cast<const ReplyType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.h
+++ b/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~RequestTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -144,14 +144,14 @@ public:
     eProsima_user_DllExport ~ReplyTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -160,17 +160,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ LoanableHelloWorldPubSubType::~LoanableHelloWorldPubSubType()
 }
 
 bool LoanableHelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LoanableHelloWorld* p_type = static_cast<LoanableHelloWorld*>(data);
+    const LoanableHelloWorld* p_type = static_cast<const LoanableHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool LoanableHelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LoanableHelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> LoanableHelloWorldPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LoanableHelloWorld*>(data), current_alignment)) +
+                               *static_cast<const LoanableHelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void LoanableHelloWorldPubSubType::deleteData(
 }
 
 bool LoanableHelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool LoanableHelloWorldPubSubType::getKey(
         return false;
     }
 
-    LoanableHelloWorld* p_type = static_cast<LoanableHelloWorld*>(data);
+    const LoanableHelloWorld* p_type = static_cast<const LoanableHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.h
@@ -86,14 +86,14 @@ public:
     eProsima_user_DllExport ~LoanableHelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -102,17 +102,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ LoanableHelloWorldPubSubType::~LoanableHelloWorldPubSubType()
 }
 
 bool LoanableHelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LoanableHelloWorld* p_type = static_cast<LoanableHelloWorld*>(data);
+    const LoanableHelloWorld* p_type = static_cast<const LoanableHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool LoanableHelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LoanableHelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> LoanableHelloWorldPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LoanableHelloWorld*>(data), current_alignment)) +
+                               *static_cast<const LoanableHelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void LoanableHelloWorldPubSubType::deleteData(
 }
 
 bool LoanableHelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool LoanableHelloWorldPubSubType::getKey(
         return false;
     }
 
-    LoanableHelloWorld* p_type = static_cast<LoanableHelloWorld*>(data);
+    const LoanableHelloWorld* p_type = static_cast<const LoanableHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.h
+++ b/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.h
@@ -86,14 +86,14 @@ public:
     eProsima_user_DllExport ~LoanableHelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -102,17 +102,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/examples/cpp/hello_world/HelloWorldPubSubTypes.h
+++ b/examples/cpp/hello_world/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -131,7 +131,7 @@ public:
      * @return True if correct, false otherwise
      */
     FASTDDS_EXPORTED_API bool write(
-            void* data);
+            const void* const data);
 
     /**
      * Write data with params to the topic.
@@ -141,7 +141,7 @@ public:
      * @return True if correct, false otherwise
      */
     FASTDDS_EXPORTED_API bool write(
-            void* data,
+            const void* const data,
             fastdds::rtps::WriteParams& params);
 
     /**
@@ -156,7 +156,7 @@ public:
      * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t write(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle);
 
     /**
@@ -176,7 +176,7 @@ public:
      * @return Any of the standard return codes.
      */
     FASTDDS_EXPORTED_API ReturnCode_t write_w_timestamp(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle,
             const fastdds::Time_t& timestamp);
 
@@ -190,7 +190,7 @@ public:
      * In case of error, HANDLE_NIL will be returned.
      */
     FASTDDS_EXPORTED_API InstanceHandle_t register_instance(
-            void* instance);
+            const void* const instance);
 
     /**
      * @brief This operation performs the same function as register_instance and can be used instead of
@@ -211,7 +211,7 @@ public:
      * @return Handle containing the instance's key.
      */
     FASTDDS_EXPORTED_API InstanceHandle_t register_instance_w_timestamp(
-            void* instance,
+            const void* const instance,
             const fastdds::Time_t& timestamp);
 
     /*!
@@ -226,7 +226,7 @@ public:
      * If the operation finishes successfully, RETCODE_OK is returned.
      */
     FASTDDS_EXPORTED_API ReturnCode_t unregister_instance(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle);
 
     /**
@@ -249,7 +249,7 @@ public:
      * @return Handle containing the instance's key.
      */
     FASTDDS_EXPORTED_API ReturnCode_t unregister_instance_w_timestamp(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::Time_t& timestamp);
 
@@ -283,7 +283,7 @@ public:
      * @return handle of the given instance
      */
     FASTDDS_EXPORTED_API InstanceHandle_t lookup_instance(
-            const void* instance) const;
+            const void* const instance) const;
 
     /**
      * Returns the DataWriter's GUID
@@ -418,7 +418,7 @@ public:
      * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t dispose(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle);
 
     /**
@@ -442,7 +442,7 @@ public:
      * @return FASTDDS_EXPORTED_API
      */
     FASTDDS_EXPORTED_API ReturnCode_t dispose_w_timestamp(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::Time_t& timestamp);
     /**
@@ -580,7 +580,7 @@ public:
      * @return RETCODE_TIMEOUT otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t wait_for_acknowledgments(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::Duration_t& max_wait);
 

--- a/include/fastdds/dds/topic/TopicDataType.hpp
+++ b/include/fastdds/dds/topic/TopicDataType.hpp
@@ -82,7 +82,7 @@ public:
     // TODO(jlbueno) Remove when Fast DDS-Gen is updated
     // FASTDDS_TODO_BEFORE(3, 0, "Remove this overload")
     FASTDDS_EXPORTED_API virtual bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload) = 0;
 
     /**
@@ -96,7 +96,7 @@ public:
      * @return True if correct.
      */
     FASTDDS_EXPORTED_API virtual bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload,
             DataRepresentationId_t data_representation);
 
@@ -119,7 +119,7 @@ public:
      */
     // FASTDDS_TODO_BEFORE(3, 0, "Remove this overload")
     FASTDDS_EXPORTED_API virtual std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) = 0;
+            const void* const data) = 0;
 
     /*!
      * @brief Returns a function which can be used to calculate the serialized size of the provided data.
@@ -129,7 +129,7 @@ public:
      * @return Functor which calculates the serialized size of the data.
      */
     FASTDDS_EXPORTED_API virtual std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation);
 
     /**
@@ -155,7 +155,7 @@ public:
      * @return True if correct.
      */
     FASTDDS_EXPORTED_API virtual bool getKey(
-            void* data,
+            const void* const data,
             fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) = 0;
 

--- a/include/fastdds/dds/topic/TypeSupport.hpp
+++ b/include/fastdds/dds/topic/TypeSupport.hpp
@@ -140,7 +140,7 @@ public:
      */
 
     FASTDDS_EXPORTED_API virtual bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload)
     {
         return serialize(data, payload, DEFAULT_DATA_REPRESENTATION);
@@ -155,7 +155,7 @@ public:
      * @return true if it is serialized correctly, false if not
      */
     FASTDDS_EXPORTED_API virtual bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload,
             DataRepresentationId_t data_representation);
 
@@ -177,7 +177,7 @@ public:
      * @return Functor which calculates the serialized size of the data.
      */
     FASTDDS_EXPORTED_API virtual std::function<uint32_t()> get_serialized_size_provider(
-            void* data)
+            const void* const data)
     {
         return get_serialized_size_provider(data, DEFAULT_DATA_REPRESENTATION);
     }
@@ -190,7 +190,7 @@ public:
      * @return Functor which calculates the serialized size of the data.
      */
     FASTDDS_EXPORTED_API virtual std::function<uint32_t()> get_serialized_size_provider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return get()->getSerializedSizeProvider(data, data_representation);

--- a/include/fastdds/dds/xtypes/dynamic_types/DynamicPubSubType.hpp
+++ b/include/fastdds/dds/xtypes/dynamic_types/DynamicPubSubType.hpp
@@ -90,7 +90,7 @@ public:
      * @return bool specifying success
      */
     FASTDDS_EXPORTED_API bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -101,10 +101,10 @@ public:
      */
     // FASTDDS_TODO_BEFORE(3, 0, "Remove this overload")
     FASTDDS_EXPORTED_API std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override;
+            const void* const data) override;
 
     FASTDDS_EXPORTED_API std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation) override;
 
     /*
@@ -114,7 +114,7 @@ public:
      * @return bool specifying success
      */
     FASTDDS_EXPORTED_API bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, fastdds::dds::DEFAULT_DATA_REPRESENTATION);
@@ -127,7 +127,7 @@ public:
      * @return bool specifying success
      */
     FASTDDS_EXPORTED_API bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             fastdds::dds::DataRepresentationId_t data_representation) override;
 

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.h
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.h
@@ -177,14 +177,14 @@ public:
     eProsima_user_DllExport ~StringSTypeDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -193,17 +193,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -323,14 +323,14 @@ public:
     eProsima_user_DllExport ~StringLTypeDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -339,17 +339,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -436,14 +436,14 @@ public:
     eProsima_user_DllExport ~PlainCollectionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -452,17 +452,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -527,14 +527,14 @@ public:
     eProsima_user_DllExport ~PlainSequenceSElemDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -543,17 +543,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -618,14 +618,14 @@ public:
     eProsima_user_DllExport ~PlainSequenceLElemDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -634,17 +634,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -709,14 +709,14 @@ public:
     eProsima_user_DllExport ~PlainArraySElemDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -725,17 +725,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -800,14 +800,14 @@ public:
     eProsima_user_DllExport ~PlainArrayLElemDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -816,17 +816,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -891,14 +891,14 @@ public:
     eProsima_user_DllExport ~PlainMapSTypeDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -907,17 +907,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -982,14 +982,14 @@ public:
     eProsima_user_DllExport ~PlainMapLTypeDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -998,17 +998,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1073,14 +1073,14 @@ public:
     eProsima_user_DllExport ~StronglyConnectedComponentIdPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1089,17 +1089,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1164,14 +1164,14 @@ public:
     eProsima_user_DllExport ~ExtendedTypeDefnPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1180,17 +1180,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1260,14 +1260,14 @@ public:
     eProsima_user_DllExport ~ExtendedAnnotationParameterValuePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1276,17 +1276,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1352,14 +1352,14 @@ public:
     eProsima_user_DllExport ~AppliedAnnotationParameterPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1368,17 +1368,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1444,14 +1444,14 @@ public:
     eProsima_user_DllExport ~AppliedAnnotationPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1460,17 +1460,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1536,14 +1536,14 @@ public:
     eProsima_user_DllExport ~AppliedVerbatimAnnotationPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1552,17 +1552,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1627,14 +1627,14 @@ public:
     eProsima_user_DllExport ~AppliedBuiltinMemberAnnotationsPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1643,17 +1643,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1718,14 +1718,14 @@ public:
     eProsima_user_DllExport ~CommonStructMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1734,17 +1734,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1809,14 +1809,14 @@ public:
     eProsima_user_DllExport ~CompleteMemberDetailPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1825,17 +1825,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1933,14 +1933,14 @@ public:
     eProsima_user_DllExport ~MinimalMemberDetailPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1949,17 +1949,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2046,14 +2046,14 @@ public:
     eProsima_user_DllExport ~CompleteStructMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2062,17 +2062,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2138,14 +2138,14 @@ public:
     eProsima_user_DllExport ~MinimalStructMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2154,17 +2154,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2230,14 +2230,14 @@ public:
     eProsima_user_DllExport ~AppliedBuiltinTypeAnnotationsPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2246,17 +2246,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2321,14 +2321,14 @@ public:
     eProsima_user_DllExport ~MinimalTypeDetailPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2337,17 +2337,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2430,14 +2430,14 @@ public:
     eProsima_user_DllExport ~CompleteTypeDetailPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2446,17 +2446,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2521,14 +2521,14 @@ public:
     eProsima_user_DllExport ~CompleteStructHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2537,17 +2537,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2612,14 +2612,14 @@ public:
     eProsima_user_DllExport ~MinimalStructHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2628,17 +2628,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2703,14 +2703,14 @@ public:
     eProsima_user_DllExport ~CompleteStructTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2719,17 +2719,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2794,14 +2794,14 @@ public:
     eProsima_user_DllExport ~MinimalStructTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2810,17 +2810,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2886,14 +2886,14 @@ public:
     eProsima_user_DllExport ~CommonUnionMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2902,17 +2902,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2977,14 +2977,14 @@ public:
     eProsima_user_DllExport ~CompleteUnionMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2993,17 +2993,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3069,14 +3069,14 @@ public:
     eProsima_user_DllExport ~MinimalUnionMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3085,17 +3085,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3161,14 +3161,14 @@ public:
     eProsima_user_DllExport ~CommonDiscriminatorMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3177,17 +3177,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3252,14 +3252,14 @@ public:
     eProsima_user_DllExport ~CompleteDiscriminatorMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3268,17 +3268,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3343,14 +3343,14 @@ public:
     eProsima_user_DllExport ~MinimalDiscriminatorMemberPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3359,17 +3359,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3434,14 +3434,14 @@ public:
     eProsima_user_DllExport ~CompleteUnionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3450,17 +3450,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3525,14 +3525,14 @@ public:
     eProsima_user_DllExport ~MinimalUnionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3541,17 +3541,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3616,14 +3616,14 @@ public:
     eProsima_user_DllExport ~CompleteUnionTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3632,17 +3632,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3707,14 +3707,14 @@ public:
     eProsima_user_DllExport ~MinimalUnionTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3723,17 +3723,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3798,14 +3798,14 @@ public:
     eProsima_user_DllExport ~CommonAnnotationParameterPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3814,17 +3814,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3889,14 +3889,14 @@ public:
     eProsima_user_DllExport ~CompleteAnnotationParameterPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3905,17 +3905,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3981,14 +3981,14 @@ public:
     eProsima_user_DllExport ~MinimalAnnotationParameterPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3997,17 +3997,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4073,14 +4073,14 @@ public:
     eProsima_user_DllExport ~CompleteAnnotationHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4089,17 +4089,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4164,14 +4164,14 @@ public:
     eProsima_user_DllExport ~MinimalAnnotationHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4180,17 +4180,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4255,14 +4255,14 @@ public:
     eProsima_user_DllExport ~CompleteAnnotationTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4271,17 +4271,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4346,14 +4346,14 @@ public:
     eProsima_user_DllExport ~MinimalAnnotationTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4362,17 +4362,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4437,14 +4437,14 @@ public:
     eProsima_user_DllExport ~CommonAliasBodyPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4453,17 +4453,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4528,14 +4528,14 @@ public:
     eProsima_user_DllExport ~CompleteAliasBodyPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4544,17 +4544,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4619,14 +4619,14 @@ public:
     eProsima_user_DllExport ~MinimalAliasBodyPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4635,17 +4635,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4710,14 +4710,14 @@ public:
     eProsima_user_DllExport ~CompleteAliasHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4726,17 +4726,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4801,14 +4801,14 @@ public:
     eProsima_user_DllExport ~MinimalAliasHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4817,17 +4817,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4892,14 +4892,14 @@ public:
     eProsima_user_DllExport ~CompleteAliasTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4908,17 +4908,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4983,14 +4983,14 @@ public:
     eProsima_user_DllExport ~MinimalAliasTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4999,17 +4999,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5074,14 +5074,14 @@ public:
     eProsima_user_DllExport ~CompleteElementDetailPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5090,17 +5090,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5165,14 +5165,14 @@ public:
     eProsima_user_DllExport ~CommonCollectionElementPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5181,17 +5181,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5256,14 +5256,14 @@ public:
     eProsima_user_DllExport ~CompleteCollectionElementPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5272,17 +5272,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5347,14 +5347,14 @@ public:
     eProsima_user_DllExport ~MinimalCollectionElementPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5363,17 +5363,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5471,14 +5471,14 @@ public:
     eProsima_user_DllExport ~CommonCollectionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5487,17 +5487,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5584,14 +5584,14 @@ public:
     eProsima_user_DllExport ~CompleteCollectionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5600,17 +5600,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5675,14 +5675,14 @@ public:
     eProsima_user_DllExport ~MinimalCollectionHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5691,17 +5691,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5766,14 +5766,14 @@ public:
     eProsima_user_DllExport ~CompleteSequenceTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5782,17 +5782,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5857,14 +5857,14 @@ public:
     eProsima_user_DllExport ~MinimalSequenceTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5873,17 +5873,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5948,14 +5948,14 @@ public:
     eProsima_user_DllExport ~CommonArrayHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5964,17 +5964,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6039,14 +6039,14 @@ public:
     eProsima_user_DllExport ~CompleteArrayHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6055,17 +6055,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6130,14 +6130,14 @@ public:
     eProsima_user_DllExport ~MinimalArrayHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6146,17 +6146,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6221,14 +6221,14 @@ public:
     eProsima_user_DllExport ~CompleteArrayTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6237,17 +6237,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6312,14 +6312,14 @@ public:
     eProsima_user_DllExport ~MinimalArrayTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6328,17 +6328,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6403,14 +6403,14 @@ public:
     eProsima_user_DllExport ~CompleteMapTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6419,17 +6419,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6494,14 +6494,14 @@ public:
     eProsima_user_DllExport ~MinimalMapTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6510,17 +6510,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6586,14 +6586,14 @@ public:
     eProsima_user_DllExport ~CommonEnumeratedLiteralPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6602,17 +6602,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6677,14 +6677,14 @@ public:
     eProsima_user_DllExport ~CompleteEnumeratedLiteralPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6693,17 +6693,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6769,14 +6769,14 @@ public:
     eProsima_user_DllExport ~MinimalEnumeratedLiteralPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6785,17 +6785,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6894,14 +6894,14 @@ public:
     eProsima_user_DllExport ~CommonEnumeratedHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6910,17 +6910,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7007,14 +7007,14 @@ public:
     eProsima_user_DllExport ~CompleteEnumeratedHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7023,17 +7023,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7098,14 +7098,14 @@ public:
     eProsima_user_DllExport ~MinimalEnumeratedHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7114,17 +7114,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7189,14 +7189,14 @@ public:
     eProsima_user_DllExport ~CompleteEnumeratedTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7205,17 +7205,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7280,14 +7280,14 @@ public:
     eProsima_user_DllExport ~MinimalEnumeratedTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7296,17 +7296,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7371,14 +7371,14 @@ public:
     eProsima_user_DllExport ~CommonBitflagPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7387,17 +7387,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7462,14 +7462,14 @@ public:
     eProsima_user_DllExport ~CompleteBitflagPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7478,17 +7478,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7554,14 +7554,14 @@ public:
     eProsima_user_DllExport ~MinimalBitflagPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7570,17 +7570,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7679,14 +7679,14 @@ public:
     eProsima_user_DllExport ~CommonBitmaskHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7695,17 +7695,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7794,14 +7794,14 @@ public:
     eProsima_user_DllExport ~CompleteBitmaskTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7810,17 +7810,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7885,14 +7885,14 @@ public:
     eProsima_user_DllExport ~MinimalBitmaskTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7901,17 +7901,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7976,14 +7976,14 @@ public:
     eProsima_user_DllExport ~CommonBitfieldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7992,17 +7992,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8067,14 +8067,14 @@ public:
     eProsima_user_DllExport ~CompleteBitfieldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8083,17 +8083,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8159,14 +8159,14 @@ public:
     eProsima_user_DllExport ~MinimalBitfieldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8175,17 +8175,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8251,14 +8251,14 @@ public:
     eProsima_user_DllExport ~CompleteBitsetHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8267,17 +8267,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8342,14 +8342,14 @@ public:
     eProsima_user_DllExport ~MinimalBitsetHeaderPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8358,17 +8358,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8433,14 +8433,14 @@ public:
     eProsima_user_DllExport ~CompleteBitsetTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8449,17 +8449,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8524,14 +8524,14 @@ public:
     eProsima_user_DllExport ~MinimalBitsetTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8540,17 +8540,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8615,14 +8615,14 @@ public:
     eProsima_user_DllExport ~CompleteExtendedTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8631,17 +8631,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8707,14 +8707,14 @@ public:
     eProsima_user_DllExport ~MinimalExtendedTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8723,17 +8723,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8802,14 +8802,14 @@ public:
     eProsima_user_DllExport ~TypeIdentifierTypeObjectPairPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8818,17 +8818,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8894,14 +8894,14 @@ public:
     eProsima_user_DllExport ~TypeIdentifierPairPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8910,17 +8910,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8986,14 +8986,14 @@ public:
     eProsima_user_DllExport ~TypeIdentfierWithSizePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9002,17 +9002,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9078,14 +9078,14 @@ public:
     eProsima_user_DllExport ~TypeIdentifierWithDependenciesPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9094,17 +9094,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9170,14 +9170,14 @@ public:
     eProsima_user_DllExport ~TypeInformationPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9186,17 +9186,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
@@ -63,11 +63,11 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypes_InPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_getTypes_In* p_type = static_cast<TypeLookup_getTypes_In*>(data);
+        const TypeLookup_getTypes_In* p_type = static_cast<const TypeLookup_getTypes_In*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -139,7 +139,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_getTypes_InPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -156,7 +156,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_getTypes_In*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_getTypes_In*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -179,7 +179,7 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypes_InPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -188,7 +188,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_getTypes_In* p_type = static_cast<TypeLookup_getTypes_In*>(data);
+        const TypeLookup_getTypes_In* p_type = static_cast<const TypeLookup_getTypes_In*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -257,11 +257,11 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypes_OutPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_getTypes_Out* p_type = static_cast<TypeLookup_getTypes_Out*>(data);
+        const TypeLookup_getTypes_Out* p_type = static_cast<const TypeLookup_getTypes_Out*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -333,7 +333,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_getTypes_OutPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -350,7 +350,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_getTypes_Out*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_getTypes_Out*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -373,7 +373,7 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypes_OutPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -382,7 +382,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_getTypes_Out* p_type = static_cast<TypeLookup_getTypes_Out*>(data);
+        const TypeLookup_getTypes_Out* p_type = static_cast<const TypeLookup_getTypes_Out*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -452,11 +452,11 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypeDependencies_InPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_getTypeDependencies_In* p_type = static_cast<TypeLookup_getTypeDependencies_In*>(data);
+        const TypeLookup_getTypeDependencies_In* p_type = static_cast<const TypeLookup_getTypeDependencies_In*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -528,7 +528,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_getTypeDependencies_InPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -545,7 +545,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_getTypeDependencies_In*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_getTypeDependencies_In*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -568,7 +568,7 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypeDependencies_InPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -577,7 +577,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_getTypeDependencies_In* p_type = static_cast<TypeLookup_getTypeDependencies_In*>(data);
+        const TypeLookup_getTypeDependencies_In* p_type = static_cast<const TypeLookup_getTypeDependencies_In*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -646,11 +646,11 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypeDependencies_OutPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_getTypeDependencies_Out* p_type = static_cast<TypeLookup_getTypeDependencies_Out*>(data);
+        const TypeLookup_getTypeDependencies_Out* p_type = static_cast<const TypeLookup_getTypeDependencies_Out*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -722,7 +722,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_getTypeDependencies_OutPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -739,7 +739,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_getTypeDependencies_Out*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_getTypeDependencies_Out*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -762,7 +762,7 @@ namespace builtin {
     }
 
     bool TypeLookup_getTypeDependencies_OutPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -771,7 +771,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_getTypeDependencies_Out* p_type = static_cast<TypeLookup_getTypeDependencies_Out*>(data);
+        const TypeLookup_getTypeDependencies_Out* p_type = static_cast<const TypeLookup_getTypeDependencies_Out*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -842,11 +842,11 @@ namespace builtin {
     }
 
     bool TypeLookup_RequestPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_Request* p_type = static_cast<TypeLookup_Request*>(data);
+        const TypeLookup_Request* p_type = static_cast<const TypeLookup_Request*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -918,7 +918,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_RequestPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -935,7 +935,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_Request*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_Request*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -958,7 +958,7 @@ namespace builtin {
     }
 
     bool TypeLookup_RequestPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -967,7 +967,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_Request* p_type = static_cast<TypeLookup_Request*>(data);
+        const TypeLookup_Request* p_type = static_cast<const TypeLookup_Request*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1037,11 +1037,11 @@ namespace builtin {
     }
 
     bool TypeLookup_ReplyPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        TypeLookup_Reply* p_type = static_cast<TypeLookup_Reply*>(data);
+        const TypeLookup_Reply* p_type = static_cast<const TypeLookup_Reply*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1113,7 +1113,7 @@ namespace builtin {
     }
 
     std::function<uint32_t()> TypeLookup_ReplyPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -1130,7 +1130,7 @@ namespace builtin {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<TypeLookup_Reply*>(data), current_alignment)) +
+                                   *static_cast<const TypeLookup_Reply*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1153,7 +1153,7 @@ namespace builtin {
     }
 
     bool TypeLookup_ReplyPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -1162,7 +1162,7 @@ namespace builtin {
             return false;
         }
 
-        TypeLookup_Reply* p_type = static_cast<TypeLookup_Reply*>(data);
+        const TypeLookup_Reply* p_type = static_cast<const TypeLookup_Reply*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.h
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.h
@@ -65,14 +65,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_getTypes_InPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -81,17 +81,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -156,14 +156,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_getTypes_OutPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -172,17 +172,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -248,14 +248,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_getTypeDependencies_InPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -264,17 +264,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -339,14 +339,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_getTypeDependencies_OutPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -355,17 +355,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -432,14 +432,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_RequestPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -448,17 +448,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -524,14 +524,14 @@ namespace builtin
         eProsima_user_DllExport ~TypeLookup_ReplyPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -540,17 +540,17 @@ namespace builtin
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
@@ -62,11 +62,11 @@ EntityId_tPubSubType::~EntityId_tPubSubType()
 }
 
 bool EntityId_tPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    EntityId_t* p_type = static_cast<EntityId_t*>(data);
+    const EntityId_t* p_type = static_cast<const EntityId_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -138,7 +138,7 @@ bool EntityId_tPubSubType::deserialize(
 }
 
 std::function<uint32_t()> EntityId_tPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -155,7 +155,7 @@ std::function<uint32_t()> EntityId_tPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<EntityId_t*>(data), current_alignment)) +
+                               *static_cast<const EntityId_t*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -178,7 +178,7 @@ void EntityId_tPubSubType::deleteData(
 }
 
 bool EntityId_tPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -187,7 +187,7 @@ bool EntityId_tPubSubType::getKey(
         return false;
     }
 
-    EntityId_t* p_type = static_cast<EntityId_t*>(data);
+    const EntityId_t* p_type = static_cast<const EntityId_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -256,11 +256,11 @@ GUID_tPubSubType::~GUID_tPubSubType()
 }
 
 bool GUID_tPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    GUID_t* p_type = static_cast<GUID_t*>(data);
+    const GUID_t* p_type = static_cast<const GUID_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -332,7 +332,7 @@ bool GUID_tPubSubType::deserialize(
 }
 
 std::function<uint32_t()> GUID_tPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -349,7 +349,7 @@ std::function<uint32_t()> GUID_tPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<GUID_t*>(data), current_alignment)) +
+                               *static_cast<const GUID_t*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -372,7 +372,7 @@ void GUID_tPubSubType::deleteData(
 }
 
 bool GUID_tPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -381,7 +381,7 @@ bool GUID_tPubSubType::getKey(
         return false;
     }
 
-    GUID_t* p_type = static_cast<GUID_t*>(data);
+    const GUID_t* p_type = static_cast<const GUID_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -450,11 +450,11 @@ SequenceNumber_tPubSubType::~SequenceNumber_tPubSubType()
 }
 
 bool SequenceNumber_tPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceNumber_t* p_type = static_cast<SequenceNumber_t*>(data);
+    const SequenceNumber_t* p_type = static_cast<const SequenceNumber_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -526,7 +526,7 @@ bool SequenceNumber_tPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceNumber_tPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -543,7 +543,7 @@ std::function<uint32_t()> SequenceNumber_tPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceNumber_t*>(data), current_alignment)) +
+                               *static_cast<const SequenceNumber_t*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -566,7 +566,7 @@ void SequenceNumber_tPubSubType::deleteData(
 }
 
 bool SequenceNumber_tPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -575,7 +575,7 @@ bool SequenceNumber_tPubSubType::getKey(
         return false;
     }
 
-    SequenceNumber_t* p_type = static_cast<SequenceNumber_t*>(data);
+    const SequenceNumber_t* p_type = static_cast<const SequenceNumber_t*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -644,11 +644,11 @@ SampleIdentityPubSubType::~SampleIdentityPubSubType()
 }
 
 bool SampleIdentityPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SampleIdentity* p_type = static_cast<SampleIdentity*>(data);
+    const SampleIdentity* p_type = static_cast<const SampleIdentity*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -720,7 +720,7 @@ bool SampleIdentityPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SampleIdentityPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -737,7 +737,7 @@ std::function<uint32_t()> SampleIdentityPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SampleIdentity*>(data), current_alignment)) +
+                               *static_cast<const SampleIdentity*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -760,7 +760,7 @@ void SampleIdentityPubSubType::deleteData(
 }
 
 bool SampleIdentityPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -769,7 +769,7 @@ bool SampleIdentityPubSubType::getKey(
         return false;
     }
 
-    SampleIdentity* p_type = static_cast<SampleIdentity*>(data);
+    const SampleIdentity* p_type = static_cast<const SampleIdentity*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -839,11 +839,11 @@ namespace rpc {
     }
 
     bool RequestHeaderPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        RequestHeader* p_type = static_cast<RequestHeader*>(data);
+        const RequestHeader* p_type = static_cast<const RequestHeader*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -915,7 +915,7 @@ namespace rpc {
     }
 
     std::function<uint32_t()> RequestHeaderPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -932,7 +932,7 @@ namespace rpc {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<RequestHeader*>(data), current_alignment)) +
+                                   *static_cast<const RequestHeader*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -955,7 +955,7 @@ namespace rpc {
     }
 
     bool RequestHeaderPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -964,7 +964,7 @@ namespace rpc {
             return false;
         }
 
-        RequestHeader* p_type = static_cast<RequestHeader*>(data);
+        const RequestHeader* p_type = static_cast<const RequestHeader*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1033,11 +1033,11 @@ namespace rpc {
     }
 
     bool ReplyHeaderPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        ReplyHeader* p_type = static_cast<ReplyHeader*>(data);
+        const ReplyHeader* p_type = static_cast<const ReplyHeader*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1109,7 +1109,7 @@ namespace rpc {
     }
 
     std::function<uint32_t()> ReplyHeaderPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -1126,7 +1126,7 @@ namespace rpc {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<ReplyHeader*>(data), current_alignment)) +
+                                   *static_cast<const ReplyHeader*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1149,7 +1149,7 @@ namespace rpc {
     }
 
     bool ReplyHeaderPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -1158,7 +1158,7 @@ namespace rpc {
             return false;
         }
 
-        ReplyHeader* p_type = static_cast<ReplyHeader*>(data);
+        const ReplyHeader* p_type = static_cast<const ReplyHeader*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.h
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.h
@@ -61,14 +61,14 @@ public:
     eProsima_user_DllExport ~EntityId_tPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -77,17 +77,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -152,14 +152,14 @@ public:
     eProsima_user_DllExport ~GUID_tPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -168,17 +168,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -243,14 +243,14 @@ public:
     eProsima_user_DllExport ~SequenceNumber_tPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -259,17 +259,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -334,14 +334,14 @@ public:
     eProsima_user_DllExport ~SampleIdentityPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -350,17 +350,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -432,14 +432,14 @@ namespace rpc
         eProsima_user_DllExport ~RequestHeaderPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -448,17 +448,17 @@ namespace rpc
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -523,14 +523,14 @@ namespace rpc
         eProsima_user_DllExport ~ReplyHeaderPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -539,17 +539,17 @@ namespace rpc
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1455,6 +1455,16 @@ ReturnCode_t DomainParticipantImpl::register_type(
         return RETCODE_BAD_PARAMETER;
     }
 
+    /*
+     * The type object registration sets the TypeIdentifiers in the type support's underlying TopicDataType.
+     * This means that that we need need to trigger the registration of the type object representation
+     * (idempotent operation) before finding the type in the registry.
+     * Otherwise, registering two TypeSupport instances with the same underlying TopicDataType will fail upon
+     * the second registration, as the TypeIdentifiers of the retrieved type from the registry would not be equal
+     * to those of the incoming type support.
+     */
+    type.get()->register_type_object_representation();
+
     TypeSupport t = find_type(type_name);
 
     if (!t.empty())
@@ -1471,8 +1481,6 @@ ReturnCode_t DomainParticipantImpl::register_type(
     EPROSIMA_LOG_INFO(PARTICIPANT, "Type " << type_name << " registered.");
     std::lock_guard<std::mutex> lock(mtx_types_);
     types_.insert(std::make_pair(type_name, type));
-
-    type.get()->register_type_object_representation();
 
     return RETCODE_OK;
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1457,7 +1457,7 @@ ReturnCode_t DomainParticipantImpl::register_type(
 
     /*
      * The type object registration sets the TypeIdentifiers in the type support's underlying TopicDataType.
-     * This means that that we need need to trigger the registration of the type object representation
+     * This means that we need need to trigger the registration of the type object representation
      * (idempotent operation) before finding the type in the registry.
      * Otherwise, registering two TypeSupport instances with the same underlying TopicDataType will fail upon
      * the second registration, as the TypeIdentifiers of the retrieved type from the registry would not be equal

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -79,27 +79,27 @@ ReturnCode_t DataWriter::discard_loan(
 }
 
 bool DataWriter::write(
-        void* data)
+        const void* const data)
 {
     return impl_->write(data);
 }
 
 bool DataWriter::write(
-        void* data,
+        const void* const data,
         fastdds::rtps::WriteParams& params)
 {
     return impl_->write(data, params);
 }
 
 ReturnCode_t DataWriter::write(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle)
 {
     return impl_->write(data, handle);
 }
 
 ReturnCode_t DataWriter::write_w_timestamp(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle,
         const fastdds::Time_t& timestamp)
 {
@@ -107,27 +107,27 @@ ReturnCode_t DataWriter::write_w_timestamp(
 }
 
 InstanceHandle_t DataWriter::register_instance(
-        void* instance)
+        const void* const instance)
 {
     return impl_->register_instance(instance);
 }
 
 InstanceHandle_t DataWriter::register_instance_w_timestamp(
-        void* instance,
+        const void* const instance,
         const fastdds::Time_t& timestamp)
 {
     return impl_->register_instance_w_timestamp(instance, timestamp);
 }
 
 ReturnCode_t DataWriter::unregister_instance(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(instance, handle);
 }
 
 ReturnCode_t DataWriter::unregister_instance_w_timestamp(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         const fastdds::Time_t& timestamp)
 {
@@ -142,7 +142,7 @@ ReturnCode_t DataWriter::get_key_value(
 }
 
 InstanceHandle_t DataWriter::lookup_instance(
-        const void* instance) const
+        const void* const instance) const
 {
     static_cast<void> (instance);
     EPROSIMA_LOG_WARNING(DATA_WRITER, "lookup_instance method not implemented");
@@ -150,14 +150,14 @@ InstanceHandle_t DataWriter::lookup_instance(
 }
 
 ReturnCode_t DataWriter::dispose(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle)
 {
     return impl_->unregister_instance(data, handle, true);
 }
 
 ReturnCode_t DataWriter::dispose_w_timestamp(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         const fastdds::Time_t& timestamp)
 {
@@ -301,7 +301,7 @@ ReturnCode_t DataWriter::get_sending_locators(
 }
 
 ReturnCode_t DataWriter::wait_for_acknowledgments(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         const fastdds::Duration_t& max_wait)
 {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -94,7 +94,7 @@ public:
     }
 
     bool add_loan(
-            void* data,
+            const void* const data,
             SerializedPayload_t& payload)
     {
         static_cast<void>(data);
@@ -103,10 +103,10 @@ public:
     }
 
     bool check_and_remove_loan(
-            void* data,
+            const void* const data,
             SerializedPayload_t& payload)
     {
-        octet* payload_data = static_cast<octet*>(data) - SerializedPayload_t::representation_header_size;
+        const octet* payload_data = static_cast<const octet*>(data) - SerializedPayload_t::representation_header_size;
         for (auto it = loans_.begin(); it != loans_.end(); ++it)
         {
             if (it->data == payload_data)
@@ -604,7 +604,7 @@ ReturnCode_t DataWriterImpl::discard_loan(
 }
 
 bool DataWriterImpl::write(
-        void* data)
+        const void* const data)
 {
     if (writer_ == nullptr)
     {
@@ -616,7 +616,7 @@ bool DataWriterImpl::write(
 }
 
 bool DataWriterImpl::write(
-        void* data,
+        const void* const data,
         fastdds::rtps::WriteParams& params)
 {
     if (writer_ == nullptr)
@@ -629,7 +629,7 @@ bool DataWriterImpl::write(
 }
 
 ReturnCode_t DataWriterImpl::check_write_preconditions(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle,
         InstanceHandle_t& instance_handle)
 {
@@ -658,7 +658,7 @@ ReturnCode_t DataWriterImpl::check_write_preconditions(
 }
 
 ReturnCode_t DataWriterImpl::write(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle)
 {
     InstanceHandle_t instance_handle;
@@ -674,7 +674,7 @@ ReturnCode_t DataWriterImpl::write(
 }
 
 ReturnCode_t DataWriterImpl::write_w_timestamp(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle,
         const fastdds::Time_t& timestamp)
 {
@@ -702,7 +702,7 @@ ReturnCode_t DataWriterImpl::write_w_timestamp(
 }
 
 ReturnCode_t DataWriterImpl::check_instance_preconditions(
-        void* data,
+        const void* const data,
         const InstanceHandle_t& handle,
         InstanceHandle_t& instance_handle)
 {
@@ -748,7 +748,7 @@ ReturnCode_t DataWriterImpl::check_instance_preconditions(
 }
 
 InstanceHandle_t DataWriterImpl::register_instance(
-        void* key)
+        const void* const key)
 {
     /// Preconditions
     InstanceHandle_t instance_handle;
@@ -762,7 +762,7 @@ InstanceHandle_t DataWriterImpl::register_instance(
 }
 
 InstanceHandle_t DataWriterImpl::register_instance_w_timestamp(
-        void* key,
+        const void* const key,
         const fastdds::Time_t& timestamp)
 {
     /// Preconditions
@@ -779,7 +779,7 @@ InstanceHandle_t DataWriterImpl::register_instance_w_timestamp(
 }
 
 InstanceHandle_t DataWriterImpl::do_register_instance(
-        void* key,
+        const void* const key,
         const InstanceHandle_t instance_handle,
         WriteParams& wparams)
 {
@@ -825,7 +825,7 @@ InstanceHandle_t DataWriterImpl::do_register_instance(
 }
 
 ReturnCode_t DataWriterImpl::unregister_instance(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         bool dispose)
 {
@@ -849,7 +849,7 @@ ReturnCode_t DataWriterImpl::unregister_instance(
 }
 
 ReturnCode_t DataWriterImpl::unregister_instance_w_timestamp(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         const fastdds::Time_t& timestamp,
         bool dispose)
@@ -929,7 +929,7 @@ ReturnCode_t DataWriterImpl::get_key_value(
 
 ReturnCode_t DataWriterImpl::create_new_change(
         ChangeKind_t changeKind,
-        void* data)
+        const void* const data)
 {
     WriteParams wparams;
     return create_new_change_with_params(changeKind, data, wparams);
@@ -937,7 +937,7 @@ ReturnCode_t DataWriterImpl::create_new_change(
 
 ReturnCode_t DataWriterImpl::check_new_change_preconditions(
         ChangeKind_t change_kind,
-        void* data)
+        const void* const data)
 {
     // Preconditions
     if (data == nullptr)
@@ -962,7 +962,7 @@ ReturnCode_t DataWriterImpl::check_new_change_preconditions(
 
 ReturnCode_t DataWriterImpl::perform_create_new_change(
         ChangeKind_t change_kind,
-        void* data,
+        const void* const data,
         WriteParams& wparams,
         const InstanceHandle_t& handle)
 {
@@ -1066,7 +1066,7 @@ ReturnCode_t DataWriterImpl::perform_create_new_change(
 
 ReturnCode_t DataWriterImpl::create_new_change_with_params(
         ChangeKind_t changeKind,
-        void* data,
+        const void* const data,
         WriteParams& wparams)
 {
     ReturnCode_t ret_code = check_new_change_preconditions(changeKind, data);
@@ -1090,7 +1090,7 @@ ReturnCode_t DataWriterImpl::create_new_change_with_params(
 
 ReturnCode_t DataWriterImpl::create_new_change_with_params(
         ChangeKind_t changeKind,
-        void* data,
+        const void* const data,
         WriteParams& wparams,
         const InstanceHandle_t& handle)
 {
@@ -1389,7 +1389,7 @@ ReturnCode_t DataWriterImpl::wait_for_acknowledgments(
 }
 
 ReturnCode_t DataWriterImpl::wait_for_acknowledgments(
-        void* instance,
+        const void* const instance,
         const InstanceHandle_t& handle,
         const Duration_t& max_wait)
 {
@@ -2097,14 +2097,14 @@ bool DataWriterImpl::release_payload_pool()
 }
 
 bool DataWriterImpl::add_loan(
-        void* data,
+        const void* const data,
         SerializedPayload_t& payload)
 {
     return loans_ && loans_->add_loan(data, payload);
 }
 
 bool DataWriterImpl::check_and_remove_loan(
-        void* data,
+        const void* const data,
         SerializedPayload_t& payload)
 {
     return loans_ && loans_->check_and_remove_loan(data, payload);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -165,7 +165,7 @@ public:
      * @return true if data is correctly delivered to the lower layers, false otherwise.
      */
     bool write(
-            void* data);
+            const void* const data);
 
     /**
      * Write data with params to the topic.
@@ -176,7 +176,7 @@ public:
      * @return true if data is correctly delivered to the lower layers, false otherwise.
      */
     bool write(
-            void* data,
+            const void* const data,
             fastdds::rtps::WriteParams& params);
 
     /**
@@ -189,7 +189,7 @@ public:
      * @return any of the standard return codes.
      */
     ReturnCode_t write(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle);
 
     /**
@@ -203,7 +203,7 @@ public:
      * @return any of the standard return codes.
      */
     ReturnCode_t write_w_timestamp(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle,
             const fastdds::Time_t& timestamp);
 
@@ -218,7 +218,7 @@ public:
      * In case of error, HANDLE_NIL will be returned.
      */
     InstanceHandle_t register_instance(
-            void* instance);
+            const void* const instance);
 
     /**
      * @brief Implementation of the DDS `register_instance_w_timestamp` operation.
@@ -232,7 +232,7 @@ public:
      * In case of error, HANDLE_NIL will be returned.
      */
     InstanceHandle_t register_instance_w_timestamp(
-            void* instance,
+            const void* const instance,
             const fastdds::Time_t& timestamp);
 
     /**
@@ -251,7 +251,7 @@ public:
      * If the operation finishes successfully, RETCODE_OK is returned.
      */
     ReturnCode_t unregister_instance(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             bool dispose = false);
 
@@ -272,7 +272,7 @@ public:
      * If the operation finishes successfully, RETCODE_OK is returned.
      */
     ReturnCode_t unregister_instance_w_timestamp(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::Time_t& timestamp,
             bool dispose = false);
@@ -298,7 +298,7 @@ public:
             const fastdds::Duration_t& max_wait);
 
     ReturnCode_t wait_for_acknowledgments(
-            void* instance,
+            const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::Duration_t& max_wait);
 
@@ -501,17 +501,17 @@ protected:
     DataRepresentationId_t data_representation_ {DEFAULT_DATA_REPRESENTATION};
 
     ReturnCode_t check_write_preconditions(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle,
             InstanceHandle_t& instance_handle);
 
     ReturnCode_t check_instance_preconditions(
-            void* data,
+            const void* const data,
             const InstanceHandle_t& handle,
             InstanceHandle_t& instance_handle);
 
     InstanceHandle_t do_register_instance(
-            void* key,
+            const void* const key,
             const InstanceHandle_t instance_handle,
             fastdds::rtps::WriteParams& wparams);
 
@@ -523,7 +523,7 @@ protected:
      */
     ReturnCode_t create_new_change(
             fastdds::rtps::ChangeKind_t kind,
-            void* data);
+            const void* const data);
 
     /**
      *
@@ -534,7 +534,7 @@ protected:
      */
     ReturnCode_t create_new_change_with_params(
             fastdds::rtps::ChangeKind_t kind,
-            void* data,
+            const void* const data,
             fastdds::rtps::WriteParams& wparams);
 
     /**
@@ -547,7 +547,7 @@ protected:
      */
     ReturnCode_t create_new_change_with_params(
             fastdds::rtps::ChangeKind_t kind,
-            void* data,
+            const void* const data,
             fastdds::rtps::WriteParams& wparams,
             const InstanceHandle_t& handle);
 
@@ -577,11 +577,11 @@ protected:
 
     ReturnCode_t check_new_change_preconditions(
             fastdds::rtps::ChangeKind_t change_kind,
-            void* data);
+            const void* const data);
 
     ReturnCode_t perform_create_new_change(
             fastdds::rtps::ChangeKind_t change_kind,
-            void* data,
+            const void* const data,
             fastdds::rtps::WriteParams& wparams,
             const InstanceHandle_t& handle);
 
@@ -682,11 +682,11 @@ protected:
     }
 
     bool add_loan(
-            void* data,
+            const void* const data,
             SerializedPayload_t& payload);
 
     bool check_and_remove_loan(
-            void* data,
+            const void* const data,
             SerializedPayload_t& payload);
 
     /**

--- a/src/cpp/fastdds/topic/TopicDataType.cpp
+++ b/src/cpp/fastdds/topic/TopicDataType.cpp
@@ -43,7 +43,7 @@ TopicDataType::~TopicDataType()
 }
 
 bool TopicDataType::serialize(
-        void* data,
+        const void* const data,
         fastdds::rtps::SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
@@ -53,7 +53,7 @@ bool TopicDataType::serialize(
 }
 
 std::function<uint32_t()> TopicDataType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     static_cast<void>(data);

--- a/src/cpp/fastdds/topic/TypeSupport.cpp
+++ b/src/cpp/fastdds/topic/TypeSupport.cpp
@@ -44,7 +44,7 @@ ReturnCode_t TypeSupport::register_type(
 }
 
 bool TypeSupport::serialize(
-        void* data,
+        const void* const data,
         fastdds::rtps::SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {

--- a/src/cpp/fastdds/xtypes/dynamic_types/DynamicPubSubType.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/DynamicPubSubType.cpp
@@ -103,7 +103,7 @@ traits<DynamicType>::ref_type DynamicPubSubType::get_dynamic_type() const noexce
 }
 
 bool DynamicPubSubType::getKey(
-        void* data,
+        const void* const data,
         eprosima::fastdds::rtps::InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -111,7 +111,7 @@ bool DynamicPubSubType::getKey(
     {
         return false;
     }
-    traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<traits<DynamicDataImpl>::ref_type*>(data);
+    const traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<const traits<DynamicDataImpl>::ref_type*>(data);
     eprosima::fastcdr::CdrSizeCalculator calculator(eprosima::fastcdr::CdrVersion::XCDRv2);
     size_t current_alignment {0};
     size_t keyBufferSize =
@@ -149,16 +149,16 @@ bool DynamicPubSubType::getKey(
 }
 
 std::function<uint32_t()> DynamicPubSubType::getSerializedSizeProvider(
-        void* data)
+        const void* const data)
 {
     return getSerializedSizeProvider(data, DEFAULT_DATA_REPRESENTATION);
 }
 
 std::function<uint32_t()> DynamicPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
-    traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<traits<DynamicDataImpl>::ref_type*>(data);
+    const traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<const traits<DynamicDataImpl>::ref_type*>(data);
 
     return [data_ptr, data_representation]() -> uint32_t
            {
@@ -180,11 +180,11 @@ std::function<uint32_t()> DynamicPubSubType::getSerializedSizeProvider(
 }
 
 bool DynamicPubSubType::serialize(
-        void* data,
+        const void* const data,
         eprosima::fastdds::rtps::SerializedPayload_t* payload,
         fastdds::dds::DataRepresentationId_t data_representation)
 {
-    traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<traits<DynamicDataImpl>::ref_type*>(data);
+    const traits<DynamicDataImpl>::ref_type* data_ptr = static_cast<const traits<DynamicDataImpl>::ref_type*>(data);
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
 

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
@@ -65,11 +65,11 @@ StringSTypeDefnPubSubType::~StringSTypeDefnPubSubType()
 }
 
 bool StringSTypeDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StringSTypeDefn* p_type = static_cast<StringSTypeDefn*>(data);
+    const StringSTypeDefn* p_type = static_cast<const StringSTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -141,7 +141,7 @@ bool StringSTypeDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StringSTypeDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -158,7 +158,7 @@ std::function<uint32_t()> StringSTypeDefnPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StringSTypeDefn*>(data), current_alignment)) +
+                               *static_cast<const StringSTypeDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -181,7 +181,7 @@ void StringSTypeDefnPubSubType::deleteData(
 }
 
 bool StringSTypeDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -190,7 +190,7 @@ bool StringSTypeDefnPubSubType::getKey(
         return false;
     }
 
-    StringSTypeDefn* p_type = static_cast<StringSTypeDefn*>(data);
+    const StringSTypeDefn* p_type = static_cast<const StringSTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -259,11 +259,11 @@ StringLTypeDefnPubSubType::~StringLTypeDefnPubSubType()
 }
 
 bool StringLTypeDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StringLTypeDefn* p_type = static_cast<StringLTypeDefn*>(data);
+    const StringLTypeDefn* p_type = static_cast<const StringLTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -335,7 +335,7 @@ bool StringLTypeDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StringLTypeDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -352,7 +352,7 @@ std::function<uint32_t()> StringLTypeDefnPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StringLTypeDefn*>(data), current_alignment)) +
+                               *static_cast<const StringLTypeDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -375,7 +375,7 @@ void StringLTypeDefnPubSubType::deleteData(
 }
 
 bool StringLTypeDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -384,7 +384,7 @@ bool StringLTypeDefnPubSubType::getKey(
         return false;
     }
 
-    StringLTypeDefn* p_type = static_cast<StringLTypeDefn*>(data);
+    const StringLTypeDefn* p_type = static_cast<const StringLTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -453,11 +453,11 @@ PlainCollectionHeaderPubSubType::~PlainCollectionHeaderPubSubType()
 }
 
 bool PlainCollectionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainCollectionHeader* p_type = static_cast<PlainCollectionHeader*>(data);
+    const PlainCollectionHeader* p_type = static_cast<const PlainCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -529,7 +529,7 @@ bool PlainCollectionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainCollectionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -546,7 +546,7 @@ std::function<uint32_t()> PlainCollectionHeaderPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainCollectionHeader*>(data), current_alignment)) +
+                               *static_cast<const PlainCollectionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -569,7 +569,7 @@ void PlainCollectionHeaderPubSubType::deleteData(
 }
 
 bool PlainCollectionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -578,7 +578,7 @@ bool PlainCollectionHeaderPubSubType::getKey(
         return false;
     }
 
-    PlainCollectionHeader* p_type = static_cast<PlainCollectionHeader*>(data);
+    const PlainCollectionHeader* p_type = static_cast<const PlainCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -647,11 +647,11 @@ PlainSequenceSElemDefnPubSubType::~PlainSequenceSElemDefnPubSubType()
 }
 
 bool PlainSequenceSElemDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainSequenceSElemDefn* p_type = static_cast<PlainSequenceSElemDefn*>(data);
+    const PlainSequenceSElemDefn* p_type = static_cast<const PlainSequenceSElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -723,7 +723,7 @@ bool PlainSequenceSElemDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainSequenceSElemDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -740,7 +740,7 @@ std::function<uint32_t()> PlainSequenceSElemDefnPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainSequenceSElemDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainSequenceSElemDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -763,7 +763,7 @@ void PlainSequenceSElemDefnPubSubType::deleteData(
 }
 
 bool PlainSequenceSElemDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -772,7 +772,7 @@ bool PlainSequenceSElemDefnPubSubType::getKey(
         return false;
     }
 
-    PlainSequenceSElemDefn* p_type = static_cast<PlainSequenceSElemDefn*>(data);
+    const PlainSequenceSElemDefn* p_type = static_cast<const PlainSequenceSElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -841,11 +841,11 @@ PlainSequenceLElemDefnPubSubType::~PlainSequenceLElemDefnPubSubType()
 }
 
 bool PlainSequenceLElemDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainSequenceLElemDefn* p_type = static_cast<PlainSequenceLElemDefn*>(data);
+    const PlainSequenceLElemDefn* p_type = static_cast<const PlainSequenceLElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -917,7 +917,7 @@ bool PlainSequenceLElemDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainSequenceLElemDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -934,7 +934,7 @@ std::function<uint32_t()> PlainSequenceLElemDefnPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainSequenceLElemDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainSequenceLElemDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -957,7 +957,7 @@ void PlainSequenceLElemDefnPubSubType::deleteData(
 }
 
 bool PlainSequenceLElemDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -966,7 +966,7 @@ bool PlainSequenceLElemDefnPubSubType::getKey(
         return false;
     }
 
-    PlainSequenceLElemDefn* p_type = static_cast<PlainSequenceLElemDefn*>(data);
+    const PlainSequenceLElemDefn* p_type = static_cast<const PlainSequenceLElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1035,11 +1035,11 @@ PlainArraySElemDefnPubSubType::~PlainArraySElemDefnPubSubType()
 }
 
 bool PlainArraySElemDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainArraySElemDefn* p_type = static_cast<PlainArraySElemDefn*>(data);
+    const PlainArraySElemDefn* p_type = static_cast<const PlainArraySElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1111,7 +1111,7 @@ bool PlainArraySElemDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainArraySElemDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1128,7 +1128,7 @@ std::function<uint32_t()> PlainArraySElemDefnPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainArraySElemDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainArraySElemDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1151,7 +1151,7 @@ void PlainArraySElemDefnPubSubType::deleteData(
 }
 
 bool PlainArraySElemDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1160,7 +1160,7 @@ bool PlainArraySElemDefnPubSubType::getKey(
         return false;
     }
 
-    PlainArraySElemDefn* p_type = static_cast<PlainArraySElemDefn*>(data);
+    const PlainArraySElemDefn* p_type = static_cast<const PlainArraySElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1229,11 +1229,11 @@ PlainArrayLElemDefnPubSubType::~PlainArrayLElemDefnPubSubType()
 }
 
 bool PlainArrayLElemDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainArrayLElemDefn* p_type = static_cast<PlainArrayLElemDefn*>(data);
+    const PlainArrayLElemDefn* p_type = static_cast<const PlainArrayLElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1305,7 +1305,7 @@ bool PlainArrayLElemDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainArrayLElemDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1322,7 +1322,7 @@ std::function<uint32_t()> PlainArrayLElemDefnPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainArrayLElemDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainArrayLElemDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1345,7 +1345,7 @@ void PlainArrayLElemDefnPubSubType::deleteData(
 }
 
 bool PlainArrayLElemDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1354,7 +1354,7 @@ bool PlainArrayLElemDefnPubSubType::getKey(
         return false;
     }
 
-    PlainArrayLElemDefn* p_type = static_cast<PlainArrayLElemDefn*>(data);
+    const PlainArrayLElemDefn* p_type = static_cast<const PlainArrayLElemDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1423,11 +1423,11 @@ PlainMapSTypeDefnPubSubType::~PlainMapSTypeDefnPubSubType()
 }
 
 bool PlainMapSTypeDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainMapSTypeDefn* p_type = static_cast<PlainMapSTypeDefn*>(data);
+    const PlainMapSTypeDefn* p_type = static_cast<const PlainMapSTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1499,7 +1499,7 @@ bool PlainMapSTypeDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainMapSTypeDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1516,7 +1516,7 @@ std::function<uint32_t()> PlainMapSTypeDefnPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainMapSTypeDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainMapSTypeDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1539,7 +1539,7 @@ void PlainMapSTypeDefnPubSubType::deleteData(
 }
 
 bool PlainMapSTypeDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1548,7 +1548,7 @@ bool PlainMapSTypeDefnPubSubType::getKey(
         return false;
     }
 
-    PlainMapSTypeDefn* p_type = static_cast<PlainMapSTypeDefn*>(data);
+    const PlainMapSTypeDefn* p_type = static_cast<const PlainMapSTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1617,11 +1617,11 @@ PlainMapLTypeDefnPubSubType::~PlainMapLTypeDefnPubSubType()
 }
 
 bool PlainMapLTypeDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    PlainMapLTypeDefn* p_type = static_cast<PlainMapLTypeDefn*>(data);
+    const PlainMapLTypeDefn* p_type = static_cast<const PlainMapLTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1693,7 +1693,7 @@ bool PlainMapLTypeDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> PlainMapLTypeDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1710,7 +1710,7 @@ std::function<uint32_t()> PlainMapLTypeDefnPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<PlainMapLTypeDefn*>(data), current_alignment)) +
+                               *static_cast<const PlainMapLTypeDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1733,7 +1733,7 @@ void PlainMapLTypeDefnPubSubType::deleteData(
 }
 
 bool PlainMapLTypeDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1742,7 +1742,7 @@ bool PlainMapLTypeDefnPubSubType::getKey(
         return false;
     }
 
-    PlainMapLTypeDefn* p_type = static_cast<PlainMapLTypeDefn*>(data);
+    const PlainMapLTypeDefn* p_type = static_cast<const PlainMapLTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1811,11 +1811,11 @@ StronglyConnectedComponentIdPubSubType::~StronglyConnectedComponentIdPubSubType(
 }
 
 bool StronglyConnectedComponentIdPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StronglyConnectedComponentId* p_type = static_cast<StronglyConnectedComponentId*>(data);
+    const StronglyConnectedComponentId* p_type = static_cast<const StronglyConnectedComponentId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1887,7 +1887,7 @@ bool StronglyConnectedComponentIdPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StronglyConnectedComponentIdPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1904,7 +1904,7 @@ std::function<uint32_t()> StronglyConnectedComponentIdPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StronglyConnectedComponentId*>(data), current_alignment)) +
+                               *static_cast<const StronglyConnectedComponentId*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1927,7 +1927,7 @@ void StronglyConnectedComponentIdPubSubType::deleteData(
 }
 
 bool StronglyConnectedComponentIdPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1936,7 +1936,7 @@ bool StronglyConnectedComponentIdPubSubType::getKey(
         return false;
     }
 
-    StronglyConnectedComponentId* p_type = static_cast<StronglyConnectedComponentId*>(data);
+    const StronglyConnectedComponentId* p_type = static_cast<const StronglyConnectedComponentId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2005,11 +2005,11 @@ ExtendedTypeDefnPubSubType::~ExtendedTypeDefnPubSubType()
 }
 
 bool ExtendedTypeDefnPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ExtendedTypeDefn* p_type = static_cast<ExtendedTypeDefn*>(data);
+    const ExtendedTypeDefn* p_type = static_cast<const ExtendedTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2081,7 +2081,7 @@ bool ExtendedTypeDefnPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ExtendedTypeDefnPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2098,7 +2098,7 @@ std::function<uint32_t()> ExtendedTypeDefnPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ExtendedTypeDefn*>(data), current_alignment)) +
+                               *static_cast<const ExtendedTypeDefn*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2121,7 +2121,7 @@ void ExtendedTypeDefnPubSubType::deleteData(
 }
 
 bool ExtendedTypeDefnPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2130,7 +2130,7 @@ bool ExtendedTypeDefnPubSubType::getKey(
         return false;
     }
 
-    ExtendedTypeDefn* p_type = static_cast<ExtendedTypeDefn*>(data);
+    const ExtendedTypeDefn* p_type = static_cast<const ExtendedTypeDefn*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2204,11 +2204,11 @@ ExtendedAnnotationParameterValuePubSubType::~ExtendedAnnotationParameterValuePub
 }
 
 bool ExtendedAnnotationParameterValuePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ExtendedAnnotationParameterValue* p_type = static_cast<ExtendedAnnotationParameterValue*>(data);
+    const ExtendedAnnotationParameterValue* p_type = static_cast<const ExtendedAnnotationParameterValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2280,7 +2280,7 @@ bool ExtendedAnnotationParameterValuePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ExtendedAnnotationParameterValuePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2297,7 +2297,7 @@ std::function<uint32_t()> ExtendedAnnotationParameterValuePubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ExtendedAnnotationParameterValue*>(data), current_alignment)) +
+                               *static_cast<const ExtendedAnnotationParameterValue*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2320,7 +2320,7 @@ void ExtendedAnnotationParameterValuePubSubType::deleteData(
 }
 
 bool ExtendedAnnotationParameterValuePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2329,7 +2329,7 @@ bool ExtendedAnnotationParameterValuePubSubType::getKey(
         return false;
     }
 
-    ExtendedAnnotationParameterValue* p_type = static_cast<ExtendedAnnotationParameterValue*>(data);
+    const ExtendedAnnotationParameterValue* p_type = static_cast<const ExtendedAnnotationParameterValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2399,11 +2399,11 @@ AppliedAnnotationParameterPubSubType::~AppliedAnnotationParameterPubSubType()
 }
 
 bool AppliedAnnotationParameterPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppliedAnnotationParameter* p_type = static_cast<AppliedAnnotationParameter*>(data);
+    const AppliedAnnotationParameter* p_type = static_cast<const AppliedAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2475,7 +2475,7 @@ bool AppliedAnnotationParameterPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppliedAnnotationParameterPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2492,7 +2492,7 @@ std::function<uint32_t()> AppliedAnnotationParameterPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppliedAnnotationParameter*>(data), current_alignment)) +
+                               *static_cast<const AppliedAnnotationParameter*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2515,7 +2515,7 @@ void AppliedAnnotationParameterPubSubType::deleteData(
 }
 
 bool AppliedAnnotationParameterPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2524,7 +2524,7 @@ bool AppliedAnnotationParameterPubSubType::getKey(
         return false;
     }
 
-    AppliedAnnotationParameter* p_type = static_cast<AppliedAnnotationParameter*>(data);
+    const AppliedAnnotationParameter* p_type = static_cast<const AppliedAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2594,11 +2594,11 @@ AppliedAnnotationPubSubType::~AppliedAnnotationPubSubType()
 }
 
 bool AppliedAnnotationPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppliedAnnotation* p_type = static_cast<AppliedAnnotation*>(data);
+    const AppliedAnnotation* p_type = static_cast<const AppliedAnnotation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2670,7 +2670,7 @@ bool AppliedAnnotationPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppliedAnnotationPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2687,7 +2687,7 @@ std::function<uint32_t()> AppliedAnnotationPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppliedAnnotation*>(data), current_alignment)) +
+                               *static_cast<const AppliedAnnotation*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2710,7 +2710,7 @@ void AppliedAnnotationPubSubType::deleteData(
 }
 
 bool AppliedAnnotationPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2719,7 +2719,7 @@ bool AppliedAnnotationPubSubType::getKey(
         return false;
     }
 
-    AppliedAnnotation* p_type = static_cast<AppliedAnnotation*>(data);
+    const AppliedAnnotation* p_type = static_cast<const AppliedAnnotation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2789,11 +2789,11 @@ AppliedVerbatimAnnotationPubSubType::~AppliedVerbatimAnnotationPubSubType()
 }
 
 bool AppliedVerbatimAnnotationPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppliedVerbatimAnnotation* p_type = static_cast<AppliedVerbatimAnnotation*>(data);
+    const AppliedVerbatimAnnotation* p_type = static_cast<const AppliedVerbatimAnnotation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2865,7 +2865,7 @@ bool AppliedVerbatimAnnotationPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppliedVerbatimAnnotationPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2882,7 +2882,7 @@ std::function<uint32_t()> AppliedVerbatimAnnotationPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppliedVerbatimAnnotation*>(data), current_alignment)) +
+                               *static_cast<const AppliedVerbatimAnnotation*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2905,7 +2905,7 @@ void AppliedVerbatimAnnotationPubSubType::deleteData(
 }
 
 bool AppliedVerbatimAnnotationPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2914,7 +2914,7 @@ bool AppliedVerbatimAnnotationPubSubType::getKey(
         return false;
     }
 
-    AppliedVerbatimAnnotation* p_type = static_cast<AppliedVerbatimAnnotation*>(data);
+    const AppliedVerbatimAnnotation* p_type = static_cast<const AppliedVerbatimAnnotation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2983,11 +2983,11 @@ AppliedBuiltinMemberAnnotationsPubSubType::~AppliedBuiltinMemberAnnotationsPubSu
 }
 
 bool AppliedBuiltinMemberAnnotationsPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppliedBuiltinMemberAnnotations* p_type = static_cast<AppliedBuiltinMemberAnnotations*>(data);
+    const AppliedBuiltinMemberAnnotations* p_type = static_cast<const AppliedBuiltinMemberAnnotations*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3059,7 +3059,7 @@ bool AppliedBuiltinMemberAnnotationsPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppliedBuiltinMemberAnnotationsPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3076,7 +3076,7 @@ std::function<uint32_t()> AppliedBuiltinMemberAnnotationsPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppliedBuiltinMemberAnnotations*>(data), current_alignment)) +
+                               *static_cast<const AppliedBuiltinMemberAnnotations*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3099,7 +3099,7 @@ void AppliedBuiltinMemberAnnotationsPubSubType::deleteData(
 }
 
 bool AppliedBuiltinMemberAnnotationsPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3108,7 +3108,7 @@ bool AppliedBuiltinMemberAnnotationsPubSubType::getKey(
         return false;
     }
 
-    AppliedBuiltinMemberAnnotations* p_type = static_cast<AppliedBuiltinMemberAnnotations*>(data);
+    const AppliedBuiltinMemberAnnotations* p_type = static_cast<const AppliedBuiltinMemberAnnotations*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3177,11 +3177,11 @@ CommonStructMemberPubSubType::~CommonStructMemberPubSubType()
 }
 
 bool CommonStructMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonStructMember* p_type = static_cast<CommonStructMember*>(data);
+    const CommonStructMember* p_type = static_cast<const CommonStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3253,7 +3253,7 @@ bool CommonStructMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonStructMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3270,7 +3270,7 @@ std::function<uint32_t()> CommonStructMemberPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonStructMember*>(data), current_alignment)) +
+                               *static_cast<const CommonStructMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3293,7 +3293,7 @@ void CommonStructMemberPubSubType::deleteData(
 }
 
 bool CommonStructMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3302,7 +3302,7 @@ bool CommonStructMemberPubSubType::getKey(
         return false;
     }
 
-    CommonStructMember* p_type = static_cast<CommonStructMember*>(data);
+    const CommonStructMember* p_type = static_cast<const CommonStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3371,11 +3371,11 @@ CompleteMemberDetailPubSubType::~CompleteMemberDetailPubSubType()
 }
 
 bool CompleteMemberDetailPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteMemberDetail* p_type = static_cast<CompleteMemberDetail*>(data);
+    const CompleteMemberDetail* p_type = static_cast<const CompleteMemberDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3447,7 +3447,7 @@ bool CompleteMemberDetailPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteMemberDetailPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3464,7 +3464,7 @@ std::function<uint32_t()> CompleteMemberDetailPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteMemberDetail*>(data), current_alignment)) +
+                               *static_cast<const CompleteMemberDetail*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3487,7 +3487,7 @@ void CompleteMemberDetailPubSubType::deleteData(
 }
 
 bool CompleteMemberDetailPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3496,7 +3496,7 @@ bool CompleteMemberDetailPubSubType::getKey(
         return false;
     }
 
-    CompleteMemberDetail* p_type = static_cast<CompleteMemberDetail*>(data);
+    const CompleteMemberDetail* p_type = static_cast<const CompleteMemberDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3565,11 +3565,11 @@ MinimalMemberDetailPubSubType::~MinimalMemberDetailPubSubType()
 }
 
 bool MinimalMemberDetailPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalMemberDetail* p_type = static_cast<MinimalMemberDetail*>(data);
+    const MinimalMemberDetail* p_type = static_cast<const MinimalMemberDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3641,7 +3641,7 @@ bool MinimalMemberDetailPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalMemberDetailPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3658,7 +3658,7 @@ std::function<uint32_t()> MinimalMemberDetailPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalMemberDetail*>(data), current_alignment)) +
+                               *static_cast<const MinimalMemberDetail*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3681,7 +3681,7 @@ void MinimalMemberDetailPubSubType::deleteData(
 }
 
 bool MinimalMemberDetailPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3690,7 +3690,7 @@ bool MinimalMemberDetailPubSubType::getKey(
         return false;
     }
 
-    MinimalMemberDetail* p_type = static_cast<MinimalMemberDetail*>(data);
+    const MinimalMemberDetail* p_type = static_cast<const MinimalMemberDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3759,11 +3759,11 @@ CompleteStructMemberPubSubType::~CompleteStructMemberPubSubType()
 }
 
 bool CompleteStructMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteStructMember* p_type = static_cast<CompleteStructMember*>(data);
+    const CompleteStructMember* p_type = static_cast<const CompleteStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3835,7 +3835,7 @@ bool CompleteStructMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteStructMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3852,7 +3852,7 @@ std::function<uint32_t()> CompleteStructMemberPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteStructMember*>(data), current_alignment)) +
+                               *static_cast<const CompleteStructMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3875,7 +3875,7 @@ void CompleteStructMemberPubSubType::deleteData(
 }
 
 bool CompleteStructMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3884,7 +3884,7 @@ bool CompleteStructMemberPubSubType::getKey(
         return false;
     }
 
-    CompleteStructMember* p_type = static_cast<CompleteStructMember*>(data);
+    const CompleteStructMember* p_type = static_cast<const CompleteStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3954,11 +3954,11 @@ MinimalStructMemberPubSubType::~MinimalStructMemberPubSubType()
 }
 
 bool MinimalStructMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalStructMember* p_type = static_cast<MinimalStructMember*>(data);
+    const MinimalStructMember* p_type = static_cast<const MinimalStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4030,7 +4030,7 @@ bool MinimalStructMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalStructMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4047,7 +4047,7 @@ std::function<uint32_t()> MinimalStructMemberPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalStructMember*>(data), current_alignment)) +
+                               *static_cast<const MinimalStructMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4070,7 +4070,7 @@ void MinimalStructMemberPubSubType::deleteData(
 }
 
 bool MinimalStructMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4079,7 +4079,7 @@ bool MinimalStructMemberPubSubType::getKey(
         return false;
     }
 
-    MinimalStructMember* p_type = static_cast<MinimalStructMember*>(data);
+    const MinimalStructMember* p_type = static_cast<const MinimalStructMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4149,11 +4149,11 @@ AppliedBuiltinTypeAnnotationsPubSubType::~AppliedBuiltinTypeAnnotationsPubSubTyp
 }
 
 bool AppliedBuiltinTypeAnnotationsPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppliedBuiltinTypeAnnotations* p_type = static_cast<AppliedBuiltinTypeAnnotations*>(data);
+    const AppliedBuiltinTypeAnnotations* p_type = static_cast<const AppliedBuiltinTypeAnnotations*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4225,7 +4225,7 @@ bool AppliedBuiltinTypeAnnotationsPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppliedBuiltinTypeAnnotationsPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4242,7 +4242,7 @@ std::function<uint32_t()> AppliedBuiltinTypeAnnotationsPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppliedBuiltinTypeAnnotations*>(data), current_alignment)) +
+                               *static_cast<const AppliedBuiltinTypeAnnotations*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4265,7 +4265,7 @@ void AppliedBuiltinTypeAnnotationsPubSubType::deleteData(
 }
 
 bool AppliedBuiltinTypeAnnotationsPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4274,7 +4274,7 @@ bool AppliedBuiltinTypeAnnotationsPubSubType::getKey(
         return false;
     }
 
-    AppliedBuiltinTypeAnnotations* p_type = static_cast<AppliedBuiltinTypeAnnotations*>(data);
+    const AppliedBuiltinTypeAnnotations* p_type = static_cast<const AppliedBuiltinTypeAnnotations*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4343,11 +4343,11 @@ MinimalTypeDetailPubSubType::~MinimalTypeDetailPubSubType()
 }
 
 bool MinimalTypeDetailPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalTypeDetail* p_type = static_cast<MinimalTypeDetail*>(data);
+    const MinimalTypeDetail* p_type = static_cast<const MinimalTypeDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4419,7 +4419,7 @@ bool MinimalTypeDetailPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalTypeDetailPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4436,7 +4436,7 @@ std::function<uint32_t()> MinimalTypeDetailPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalTypeDetail*>(data), current_alignment)) +
+                               *static_cast<const MinimalTypeDetail*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4459,7 +4459,7 @@ void MinimalTypeDetailPubSubType::deleteData(
 }
 
 bool MinimalTypeDetailPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4468,7 +4468,7 @@ bool MinimalTypeDetailPubSubType::getKey(
         return false;
     }
 
-    MinimalTypeDetail* p_type = static_cast<MinimalTypeDetail*>(data);
+    const MinimalTypeDetail* p_type = static_cast<const MinimalTypeDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4537,11 +4537,11 @@ CompleteTypeDetailPubSubType::~CompleteTypeDetailPubSubType()
 }
 
 bool CompleteTypeDetailPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteTypeDetail* p_type = static_cast<CompleteTypeDetail*>(data);
+    const CompleteTypeDetail* p_type = static_cast<const CompleteTypeDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4613,7 +4613,7 @@ bool CompleteTypeDetailPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteTypeDetailPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4630,7 +4630,7 @@ std::function<uint32_t()> CompleteTypeDetailPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteTypeDetail*>(data), current_alignment)) +
+                               *static_cast<const CompleteTypeDetail*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4653,7 +4653,7 @@ void CompleteTypeDetailPubSubType::deleteData(
 }
 
 bool CompleteTypeDetailPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4662,7 +4662,7 @@ bool CompleteTypeDetailPubSubType::getKey(
         return false;
     }
 
-    CompleteTypeDetail* p_type = static_cast<CompleteTypeDetail*>(data);
+    const CompleteTypeDetail* p_type = static_cast<const CompleteTypeDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4731,11 +4731,11 @@ CompleteStructHeaderPubSubType::~CompleteStructHeaderPubSubType()
 }
 
 bool CompleteStructHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteStructHeader* p_type = static_cast<CompleteStructHeader*>(data);
+    const CompleteStructHeader* p_type = static_cast<const CompleteStructHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4807,7 +4807,7 @@ bool CompleteStructHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteStructHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4824,7 +4824,7 @@ std::function<uint32_t()> CompleteStructHeaderPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteStructHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteStructHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4847,7 +4847,7 @@ void CompleteStructHeaderPubSubType::deleteData(
 }
 
 bool CompleteStructHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4856,7 +4856,7 @@ bool CompleteStructHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteStructHeader* p_type = static_cast<CompleteStructHeader*>(data);
+    const CompleteStructHeader* p_type = static_cast<const CompleteStructHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4925,11 +4925,11 @@ MinimalStructHeaderPubSubType::~MinimalStructHeaderPubSubType()
 }
 
 bool MinimalStructHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalStructHeader* p_type = static_cast<MinimalStructHeader*>(data);
+    const MinimalStructHeader* p_type = static_cast<const MinimalStructHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5001,7 +5001,7 @@ bool MinimalStructHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalStructHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5018,7 +5018,7 @@ std::function<uint32_t()> MinimalStructHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalStructHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalStructHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5041,7 +5041,7 @@ void MinimalStructHeaderPubSubType::deleteData(
 }
 
 bool MinimalStructHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5050,7 +5050,7 @@ bool MinimalStructHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalStructHeader* p_type = static_cast<MinimalStructHeader*>(data);
+    const MinimalStructHeader* p_type = static_cast<const MinimalStructHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5119,11 +5119,11 @@ CompleteStructTypePubSubType::~CompleteStructTypePubSubType()
 }
 
 bool CompleteStructTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteStructType* p_type = static_cast<CompleteStructType*>(data);
+    const CompleteStructType* p_type = static_cast<const CompleteStructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5195,7 +5195,7 @@ bool CompleteStructTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteStructTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5212,7 +5212,7 @@ std::function<uint32_t()> CompleteStructTypePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteStructType*>(data), current_alignment)) +
+                               *static_cast<const CompleteStructType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5235,7 +5235,7 @@ void CompleteStructTypePubSubType::deleteData(
 }
 
 bool CompleteStructTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5244,7 +5244,7 @@ bool CompleteStructTypePubSubType::getKey(
         return false;
     }
 
-    CompleteStructType* p_type = static_cast<CompleteStructType*>(data);
+    const CompleteStructType* p_type = static_cast<const CompleteStructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5313,11 +5313,11 @@ MinimalStructTypePubSubType::~MinimalStructTypePubSubType()
 }
 
 bool MinimalStructTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalStructType* p_type = static_cast<MinimalStructType*>(data);
+    const MinimalStructType* p_type = static_cast<const MinimalStructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5389,7 +5389,7 @@ bool MinimalStructTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalStructTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5406,7 +5406,7 @@ std::function<uint32_t()> MinimalStructTypePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalStructType*>(data), current_alignment)) +
+                               *static_cast<const MinimalStructType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5429,7 +5429,7 @@ void MinimalStructTypePubSubType::deleteData(
 }
 
 bool MinimalStructTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5438,7 +5438,7 @@ bool MinimalStructTypePubSubType::getKey(
         return false;
     }
 
-    MinimalStructType* p_type = static_cast<MinimalStructType*>(data);
+    const MinimalStructType* p_type = static_cast<const MinimalStructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5508,11 +5508,11 @@ CommonUnionMemberPubSubType::~CommonUnionMemberPubSubType()
 }
 
 bool CommonUnionMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonUnionMember* p_type = static_cast<CommonUnionMember*>(data);
+    const CommonUnionMember* p_type = static_cast<const CommonUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5584,7 +5584,7 @@ bool CommonUnionMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonUnionMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5601,7 +5601,7 @@ std::function<uint32_t()> CommonUnionMemberPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonUnionMember*>(data), current_alignment)) +
+                               *static_cast<const CommonUnionMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5624,7 +5624,7 @@ void CommonUnionMemberPubSubType::deleteData(
 }
 
 bool CommonUnionMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5633,7 +5633,7 @@ bool CommonUnionMemberPubSubType::getKey(
         return false;
     }
 
-    CommonUnionMember* p_type = static_cast<CommonUnionMember*>(data);
+    const CommonUnionMember* p_type = static_cast<const CommonUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5702,11 +5702,11 @@ CompleteUnionMemberPubSubType::~CompleteUnionMemberPubSubType()
 }
 
 bool CompleteUnionMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteUnionMember* p_type = static_cast<CompleteUnionMember*>(data);
+    const CompleteUnionMember* p_type = static_cast<const CompleteUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5778,7 +5778,7 @@ bool CompleteUnionMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteUnionMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5795,7 +5795,7 @@ std::function<uint32_t()> CompleteUnionMemberPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteUnionMember*>(data), current_alignment)) +
+                               *static_cast<const CompleteUnionMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5818,7 +5818,7 @@ void CompleteUnionMemberPubSubType::deleteData(
 }
 
 bool CompleteUnionMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5827,7 +5827,7 @@ bool CompleteUnionMemberPubSubType::getKey(
         return false;
     }
 
-    CompleteUnionMember* p_type = static_cast<CompleteUnionMember*>(data);
+    const CompleteUnionMember* p_type = static_cast<const CompleteUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5897,11 +5897,11 @@ MinimalUnionMemberPubSubType::~MinimalUnionMemberPubSubType()
 }
 
 bool MinimalUnionMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalUnionMember* p_type = static_cast<MinimalUnionMember*>(data);
+    const MinimalUnionMember* p_type = static_cast<const MinimalUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5973,7 +5973,7 @@ bool MinimalUnionMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalUnionMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5990,7 +5990,7 @@ std::function<uint32_t()> MinimalUnionMemberPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalUnionMember*>(data), current_alignment)) +
+                               *static_cast<const MinimalUnionMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6013,7 +6013,7 @@ void MinimalUnionMemberPubSubType::deleteData(
 }
 
 bool MinimalUnionMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6022,7 +6022,7 @@ bool MinimalUnionMemberPubSubType::getKey(
         return false;
     }
 
-    MinimalUnionMember* p_type = static_cast<MinimalUnionMember*>(data);
+    const MinimalUnionMember* p_type = static_cast<const MinimalUnionMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6092,11 +6092,11 @@ CommonDiscriminatorMemberPubSubType::~CommonDiscriminatorMemberPubSubType()
 }
 
 bool CommonDiscriminatorMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonDiscriminatorMember* p_type = static_cast<CommonDiscriminatorMember*>(data);
+    const CommonDiscriminatorMember* p_type = static_cast<const CommonDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6168,7 +6168,7 @@ bool CommonDiscriminatorMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonDiscriminatorMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6185,7 +6185,7 @@ std::function<uint32_t()> CommonDiscriminatorMemberPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonDiscriminatorMember*>(data), current_alignment)) +
+                               *static_cast<const CommonDiscriminatorMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6208,7 +6208,7 @@ void CommonDiscriminatorMemberPubSubType::deleteData(
 }
 
 bool CommonDiscriminatorMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6217,7 +6217,7 @@ bool CommonDiscriminatorMemberPubSubType::getKey(
         return false;
     }
 
-    CommonDiscriminatorMember* p_type = static_cast<CommonDiscriminatorMember*>(data);
+    const CommonDiscriminatorMember* p_type = static_cast<const CommonDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6286,11 +6286,11 @@ CompleteDiscriminatorMemberPubSubType::~CompleteDiscriminatorMemberPubSubType()
 }
 
 bool CompleteDiscriminatorMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteDiscriminatorMember* p_type = static_cast<CompleteDiscriminatorMember*>(data);
+    const CompleteDiscriminatorMember* p_type = static_cast<const CompleteDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6362,7 +6362,7 @@ bool CompleteDiscriminatorMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteDiscriminatorMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6379,7 +6379,7 @@ std::function<uint32_t()> CompleteDiscriminatorMemberPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteDiscriminatorMember*>(data), current_alignment)) +
+                               *static_cast<const CompleteDiscriminatorMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6402,7 +6402,7 @@ void CompleteDiscriminatorMemberPubSubType::deleteData(
 }
 
 bool CompleteDiscriminatorMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6411,7 +6411,7 @@ bool CompleteDiscriminatorMemberPubSubType::getKey(
         return false;
     }
 
-    CompleteDiscriminatorMember* p_type = static_cast<CompleteDiscriminatorMember*>(data);
+    const CompleteDiscriminatorMember* p_type = static_cast<const CompleteDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6480,11 +6480,11 @@ MinimalDiscriminatorMemberPubSubType::~MinimalDiscriminatorMemberPubSubType()
 }
 
 bool MinimalDiscriminatorMemberPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalDiscriminatorMember* p_type = static_cast<MinimalDiscriminatorMember*>(data);
+    const MinimalDiscriminatorMember* p_type = static_cast<const MinimalDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6556,7 +6556,7 @@ bool MinimalDiscriminatorMemberPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalDiscriminatorMemberPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6573,7 +6573,7 @@ std::function<uint32_t()> MinimalDiscriminatorMemberPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalDiscriminatorMember*>(data), current_alignment)) +
+                               *static_cast<const MinimalDiscriminatorMember*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6596,7 +6596,7 @@ void MinimalDiscriminatorMemberPubSubType::deleteData(
 }
 
 bool MinimalDiscriminatorMemberPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6605,7 +6605,7 @@ bool MinimalDiscriminatorMemberPubSubType::getKey(
         return false;
     }
 
-    MinimalDiscriminatorMember* p_type = static_cast<MinimalDiscriminatorMember*>(data);
+    const MinimalDiscriminatorMember* p_type = static_cast<const MinimalDiscriminatorMember*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6674,11 +6674,11 @@ CompleteUnionHeaderPubSubType::~CompleteUnionHeaderPubSubType()
 }
 
 bool CompleteUnionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteUnionHeader* p_type = static_cast<CompleteUnionHeader*>(data);
+    const CompleteUnionHeader* p_type = static_cast<const CompleteUnionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6750,7 +6750,7 @@ bool CompleteUnionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteUnionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6767,7 +6767,7 @@ std::function<uint32_t()> CompleteUnionHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteUnionHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteUnionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6790,7 +6790,7 @@ void CompleteUnionHeaderPubSubType::deleteData(
 }
 
 bool CompleteUnionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6799,7 +6799,7 @@ bool CompleteUnionHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteUnionHeader* p_type = static_cast<CompleteUnionHeader*>(data);
+    const CompleteUnionHeader* p_type = static_cast<const CompleteUnionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6868,11 +6868,11 @@ MinimalUnionHeaderPubSubType::~MinimalUnionHeaderPubSubType()
 }
 
 bool MinimalUnionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalUnionHeader* p_type = static_cast<MinimalUnionHeader*>(data);
+    const MinimalUnionHeader* p_type = static_cast<const MinimalUnionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6944,7 +6944,7 @@ bool MinimalUnionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalUnionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6961,7 +6961,7 @@ std::function<uint32_t()> MinimalUnionHeaderPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalUnionHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalUnionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6984,7 +6984,7 @@ void MinimalUnionHeaderPubSubType::deleteData(
 }
 
 bool MinimalUnionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6993,7 +6993,7 @@ bool MinimalUnionHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalUnionHeader* p_type = static_cast<MinimalUnionHeader*>(data);
+    const MinimalUnionHeader* p_type = static_cast<const MinimalUnionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7062,11 +7062,11 @@ CompleteUnionTypePubSubType::~CompleteUnionTypePubSubType()
 }
 
 bool CompleteUnionTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteUnionType* p_type = static_cast<CompleteUnionType*>(data);
+    const CompleteUnionType* p_type = static_cast<const CompleteUnionType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7138,7 +7138,7 @@ bool CompleteUnionTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteUnionTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7155,7 +7155,7 @@ std::function<uint32_t()> CompleteUnionTypePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteUnionType*>(data), current_alignment)) +
+                               *static_cast<const CompleteUnionType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7178,7 +7178,7 @@ void CompleteUnionTypePubSubType::deleteData(
 }
 
 bool CompleteUnionTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7187,7 +7187,7 @@ bool CompleteUnionTypePubSubType::getKey(
         return false;
     }
 
-    CompleteUnionType* p_type = static_cast<CompleteUnionType*>(data);
+    const CompleteUnionType* p_type = static_cast<const CompleteUnionType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7256,11 +7256,11 @@ MinimalUnionTypePubSubType::~MinimalUnionTypePubSubType()
 }
 
 bool MinimalUnionTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalUnionType* p_type = static_cast<MinimalUnionType*>(data);
+    const MinimalUnionType* p_type = static_cast<const MinimalUnionType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7332,7 +7332,7 @@ bool MinimalUnionTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalUnionTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7349,7 +7349,7 @@ std::function<uint32_t()> MinimalUnionTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalUnionType*>(data), current_alignment)) +
+                               *static_cast<const MinimalUnionType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7372,7 +7372,7 @@ void MinimalUnionTypePubSubType::deleteData(
 }
 
 bool MinimalUnionTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7381,7 +7381,7 @@ bool MinimalUnionTypePubSubType::getKey(
         return false;
     }
 
-    MinimalUnionType* p_type = static_cast<MinimalUnionType*>(data);
+    const MinimalUnionType* p_type = static_cast<const MinimalUnionType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7450,11 +7450,11 @@ CommonAnnotationParameterPubSubType::~CommonAnnotationParameterPubSubType()
 }
 
 bool CommonAnnotationParameterPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonAnnotationParameter* p_type = static_cast<CommonAnnotationParameter*>(data);
+    const CommonAnnotationParameter* p_type = static_cast<const CommonAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7526,7 +7526,7 @@ bool CommonAnnotationParameterPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonAnnotationParameterPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7543,7 +7543,7 @@ std::function<uint32_t()> CommonAnnotationParameterPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonAnnotationParameter*>(data), current_alignment)) +
+                               *static_cast<const CommonAnnotationParameter*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7566,7 +7566,7 @@ void CommonAnnotationParameterPubSubType::deleteData(
 }
 
 bool CommonAnnotationParameterPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7575,7 +7575,7 @@ bool CommonAnnotationParameterPubSubType::getKey(
         return false;
     }
 
-    CommonAnnotationParameter* p_type = static_cast<CommonAnnotationParameter*>(data);
+    const CommonAnnotationParameter* p_type = static_cast<const CommonAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7644,11 +7644,11 @@ CompleteAnnotationParameterPubSubType::~CompleteAnnotationParameterPubSubType()
 }
 
 bool CompleteAnnotationParameterPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAnnotationParameter* p_type = static_cast<CompleteAnnotationParameter*>(data);
+    const CompleteAnnotationParameter* p_type = static_cast<const CompleteAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7720,7 +7720,7 @@ bool CompleteAnnotationParameterPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAnnotationParameterPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7737,7 +7737,7 @@ std::function<uint32_t()> CompleteAnnotationParameterPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAnnotationParameter*>(data), current_alignment)) +
+                               *static_cast<const CompleteAnnotationParameter*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7760,7 +7760,7 @@ void CompleteAnnotationParameterPubSubType::deleteData(
 }
 
 bool CompleteAnnotationParameterPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7769,7 +7769,7 @@ bool CompleteAnnotationParameterPubSubType::getKey(
         return false;
     }
 
-    CompleteAnnotationParameter* p_type = static_cast<CompleteAnnotationParameter*>(data);
+    const CompleteAnnotationParameter* p_type = static_cast<const CompleteAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7839,11 +7839,11 @@ MinimalAnnotationParameterPubSubType::~MinimalAnnotationParameterPubSubType()
 }
 
 bool MinimalAnnotationParameterPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAnnotationParameter* p_type = static_cast<MinimalAnnotationParameter*>(data);
+    const MinimalAnnotationParameter* p_type = static_cast<const MinimalAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7915,7 +7915,7 @@ bool MinimalAnnotationParameterPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAnnotationParameterPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7932,7 +7932,7 @@ std::function<uint32_t()> MinimalAnnotationParameterPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAnnotationParameter*>(data), current_alignment)) +
+                               *static_cast<const MinimalAnnotationParameter*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7955,7 +7955,7 @@ void MinimalAnnotationParameterPubSubType::deleteData(
 }
 
 bool MinimalAnnotationParameterPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7964,7 +7964,7 @@ bool MinimalAnnotationParameterPubSubType::getKey(
         return false;
     }
 
-    MinimalAnnotationParameter* p_type = static_cast<MinimalAnnotationParameter*>(data);
+    const MinimalAnnotationParameter* p_type = static_cast<const MinimalAnnotationParameter*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8034,11 +8034,11 @@ CompleteAnnotationHeaderPubSubType::~CompleteAnnotationHeaderPubSubType()
 }
 
 bool CompleteAnnotationHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAnnotationHeader* p_type = static_cast<CompleteAnnotationHeader*>(data);
+    const CompleteAnnotationHeader* p_type = static_cast<const CompleteAnnotationHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8110,7 +8110,7 @@ bool CompleteAnnotationHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAnnotationHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8127,7 +8127,7 @@ std::function<uint32_t()> CompleteAnnotationHeaderPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAnnotationHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteAnnotationHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8150,7 +8150,7 @@ void CompleteAnnotationHeaderPubSubType::deleteData(
 }
 
 bool CompleteAnnotationHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8159,7 +8159,7 @@ bool CompleteAnnotationHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteAnnotationHeader* p_type = static_cast<CompleteAnnotationHeader*>(data);
+    const CompleteAnnotationHeader* p_type = static_cast<const CompleteAnnotationHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8228,11 +8228,11 @@ MinimalAnnotationHeaderPubSubType::~MinimalAnnotationHeaderPubSubType()
 }
 
 bool MinimalAnnotationHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAnnotationHeader* p_type = static_cast<MinimalAnnotationHeader*>(data);
+    const MinimalAnnotationHeader* p_type = static_cast<const MinimalAnnotationHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8304,7 +8304,7 @@ bool MinimalAnnotationHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAnnotationHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8321,7 +8321,7 @@ std::function<uint32_t()> MinimalAnnotationHeaderPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAnnotationHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalAnnotationHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8344,7 +8344,7 @@ void MinimalAnnotationHeaderPubSubType::deleteData(
 }
 
 bool MinimalAnnotationHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8353,7 +8353,7 @@ bool MinimalAnnotationHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalAnnotationHeader* p_type = static_cast<MinimalAnnotationHeader*>(data);
+    const MinimalAnnotationHeader* p_type = static_cast<const MinimalAnnotationHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8422,11 +8422,11 @@ CompleteAnnotationTypePubSubType::~CompleteAnnotationTypePubSubType()
 }
 
 bool CompleteAnnotationTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAnnotationType* p_type = static_cast<CompleteAnnotationType*>(data);
+    const CompleteAnnotationType* p_type = static_cast<const CompleteAnnotationType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8498,7 +8498,7 @@ bool CompleteAnnotationTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAnnotationTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8515,7 +8515,7 @@ std::function<uint32_t()> CompleteAnnotationTypePubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAnnotationType*>(data), current_alignment)) +
+                               *static_cast<const CompleteAnnotationType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8538,7 +8538,7 @@ void CompleteAnnotationTypePubSubType::deleteData(
 }
 
 bool CompleteAnnotationTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8547,7 +8547,7 @@ bool CompleteAnnotationTypePubSubType::getKey(
         return false;
     }
 
-    CompleteAnnotationType* p_type = static_cast<CompleteAnnotationType*>(data);
+    const CompleteAnnotationType* p_type = static_cast<const CompleteAnnotationType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8616,11 +8616,11 @@ MinimalAnnotationTypePubSubType::~MinimalAnnotationTypePubSubType()
 }
 
 bool MinimalAnnotationTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAnnotationType* p_type = static_cast<MinimalAnnotationType*>(data);
+    const MinimalAnnotationType* p_type = static_cast<const MinimalAnnotationType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8692,7 +8692,7 @@ bool MinimalAnnotationTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAnnotationTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8709,7 +8709,7 @@ std::function<uint32_t()> MinimalAnnotationTypePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAnnotationType*>(data), current_alignment)) +
+                               *static_cast<const MinimalAnnotationType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8732,7 +8732,7 @@ void MinimalAnnotationTypePubSubType::deleteData(
 }
 
 bool MinimalAnnotationTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8741,7 +8741,7 @@ bool MinimalAnnotationTypePubSubType::getKey(
         return false;
     }
 
-    MinimalAnnotationType* p_type = static_cast<MinimalAnnotationType*>(data);
+    const MinimalAnnotationType* p_type = static_cast<const MinimalAnnotationType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8810,11 +8810,11 @@ CommonAliasBodyPubSubType::~CommonAliasBodyPubSubType()
 }
 
 bool CommonAliasBodyPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonAliasBody* p_type = static_cast<CommonAliasBody*>(data);
+    const CommonAliasBody* p_type = static_cast<const CommonAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8886,7 +8886,7 @@ bool CommonAliasBodyPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonAliasBodyPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8903,7 +8903,7 @@ std::function<uint32_t()> CommonAliasBodyPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonAliasBody*>(data), current_alignment)) +
+                               *static_cast<const CommonAliasBody*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8926,7 +8926,7 @@ void CommonAliasBodyPubSubType::deleteData(
 }
 
 bool CommonAliasBodyPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8935,7 +8935,7 @@ bool CommonAliasBodyPubSubType::getKey(
         return false;
     }
 
-    CommonAliasBody* p_type = static_cast<CommonAliasBody*>(data);
+    const CommonAliasBody* p_type = static_cast<const CommonAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9004,11 +9004,11 @@ CompleteAliasBodyPubSubType::~CompleteAliasBodyPubSubType()
 }
 
 bool CompleteAliasBodyPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAliasBody* p_type = static_cast<CompleteAliasBody*>(data);
+    const CompleteAliasBody* p_type = static_cast<const CompleteAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9080,7 +9080,7 @@ bool CompleteAliasBodyPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAliasBodyPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9097,7 +9097,7 @@ std::function<uint32_t()> CompleteAliasBodyPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAliasBody*>(data), current_alignment)) +
+                               *static_cast<const CompleteAliasBody*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9120,7 +9120,7 @@ void CompleteAliasBodyPubSubType::deleteData(
 }
 
 bool CompleteAliasBodyPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9129,7 +9129,7 @@ bool CompleteAliasBodyPubSubType::getKey(
         return false;
     }
 
-    CompleteAliasBody* p_type = static_cast<CompleteAliasBody*>(data);
+    const CompleteAliasBody* p_type = static_cast<const CompleteAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9198,11 +9198,11 @@ MinimalAliasBodyPubSubType::~MinimalAliasBodyPubSubType()
 }
 
 bool MinimalAliasBodyPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAliasBody* p_type = static_cast<MinimalAliasBody*>(data);
+    const MinimalAliasBody* p_type = static_cast<const MinimalAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9274,7 +9274,7 @@ bool MinimalAliasBodyPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAliasBodyPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9291,7 +9291,7 @@ std::function<uint32_t()> MinimalAliasBodyPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAliasBody*>(data), current_alignment)) +
+                               *static_cast<const MinimalAliasBody*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9314,7 +9314,7 @@ void MinimalAliasBodyPubSubType::deleteData(
 }
 
 bool MinimalAliasBodyPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9323,7 +9323,7 @@ bool MinimalAliasBodyPubSubType::getKey(
         return false;
     }
 
-    MinimalAliasBody* p_type = static_cast<MinimalAliasBody*>(data);
+    const MinimalAliasBody* p_type = static_cast<const MinimalAliasBody*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9392,11 +9392,11 @@ CompleteAliasHeaderPubSubType::~CompleteAliasHeaderPubSubType()
 }
 
 bool CompleteAliasHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAliasHeader* p_type = static_cast<CompleteAliasHeader*>(data);
+    const CompleteAliasHeader* p_type = static_cast<const CompleteAliasHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9468,7 +9468,7 @@ bool CompleteAliasHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAliasHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9485,7 +9485,7 @@ std::function<uint32_t()> CompleteAliasHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAliasHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteAliasHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9508,7 +9508,7 @@ void CompleteAliasHeaderPubSubType::deleteData(
 }
 
 bool CompleteAliasHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9517,7 +9517,7 @@ bool CompleteAliasHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteAliasHeader* p_type = static_cast<CompleteAliasHeader*>(data);
+    const CompleteAliasHeader* p_type = static_cast<const CompleteAliasHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9586,11 +9586,11 @@ MinimalAliasHeaderPubSubType::~MinimalAliasHeaderPubSubType()
 }
 
 bool MinimalAliasHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAliasHeader* p_type = static_cast<MinimalAliasHeader*>(data);
+    const MinimalAliasHeader* p_type = static_cast<const MinimalAliasHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9662,7 +9662,7 @@ bool MinimalAliasHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAliasHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9679,7 +9679,7 @@ std::function<uint32_t()> MinimalAliasHeaderPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAliasHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalAliasHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9702,7 +9702,7 @@ void MinimalAliasHeaderPubSubType::deleteData(
 }
 
 bool MinimalAliasHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9711,7 +9711,7 @@ bool MinimalAliasHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalAliasHeader* p_type = static_cast<MinimalAliasHeader*>(data);
+    const MinimalAliasHeader* p_type = static_cast<const MinimalAliasHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9780,11 +9780,11 @@ CompleteAliasTypePubSubType::~CompleteAliasTypePubSubType()
 }
 
 bool CompleteAliasTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteAliasType* p_type = static_cast<CompleteAliasType*>(data);
+    const CompleteAliasType* p_type = static_cast<const CompleteAliasType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9856,7 +9856,7 @@ bool CompleteAliasTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteAliasTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9873,7 +9873,7 @@ std::function<uint32_t()> CompleteAliasTypePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteAliasType*>(data), current_alignment)) +
+                               *static_cast<const CompleteAliasType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9896,7 +9896,7 @@ void CompleteAliasTypePubSubType::deleteData(
 }
 
 bool CompleteAliasTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9905,7 +9905,7 @@ bool CompleteAliasTypePubSubType::getKey(
         return false;
     }
 
-    CompleteAliasType* p_type = static_cast<CompleteAliasType*>(data);
+    const CompleteAliasType* p_type = static_cast<const CompleteAliasType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9974,11 +9974,11 @@ MinimalAliasTypePubSubType::~MinimalAliasTypePubSubType()
 }
 
 bool MinimalAliasTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalAliasType* p_type = static_cast<MinimalAliasType*>(data);
+    const MinimalAliasType* p_type = static_cast<const MinimalAliasType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10050,7 +10050,7 @@ bool MinimalAliasTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalAliasTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10067,7 +10067,7 @@ std::function<uint32_t()> MinimalAliasTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalAliasType*>(data), current_alignment)) +
+                               *static_cast<const MinimalAliasType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10090,7 +10090,7 @@ void MinimalAliasTypePubSubType::deleteData(
 }
 
 bool MinimalAliasTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10099,7 +10099,7 @@ bool MinimalAliasTypePubSubType::getKey(
         return false;
     }
 
-    MinimalAliasType* p_type = static_cast<MinimalAliasType*>(data);
+    const MinimalAliasType* p_type = static_cast<const MinimalAliasType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10168,11 +10168,11 @@ CompleteElementDetailPubSubType::~CompleteElementDetailPubSubType()
 }
 
 bool CompleteElementDetailPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteElementDetail* p_type = static_cast<CompleteElementDetail*>(data);
+    const CompleteElementDetail* p_type = static_cast<const CompleteElementDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10244,7 +10244,7 @@ bool CompleteElementDetailPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteElementDetailPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10261,7 +10261,7 @@ std::function<uint32_t()> CompleteElementDetailPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteElementDetail*>(data), current_alignment)) +
+                               *static_cast<const CompleteElementDetail*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10284,7 +10284,7 @@ void CompleteElementDetailPubSubType::deleteData(
 }
 
 bool CompleteElementDetailPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10293,7 +10293,7 @@ bool CompleteElementDetailPubSubType::getKey(
         return false;
     }
 
-    CompleteElementDetail* p_type = static_cast<CompleteElementDetail*>(data);
+    const CompleteElementDetail* p_type = static_cast<const CompleteElementDetail*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10362,11 +10362,11 @@ CommonCollectionElementPubSubType::~CommonCollectionElementPubSubType()
 }
 
 bool CommonCollectionElementPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonCollectionElement* p_type = static_cast<CommonCollectionElement*>(data);
+    const CommonCollectionElement* p_type = static_cast<const CommonCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10438,7 +10438,7 @@ bool CommonCollectionElementPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonCollectionElementPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10455,7 +10455,7 @@ std::function<uint32_t()> CommonCollectionElementPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonCollectionElement*>(data), current_alignment)) +
+                               *static_cast<const CommonCollectionElement*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10478,7 +10478,7 @@ void CommonCollectionElementPubSubType::deleteData(
 }
 
 bool CommonCollectionElementPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10487,7 +10487,7 @@ bool CommonCollectionElementPubSubType::getKey(
         return false;
     }
 
-    CommonCollectionElement* p_type = static_cast<CommonCollectionElement*>(data);
+    const CommonCollectionElement* p_type = static_cast<const CommonCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10556,11 +10556,11 @@ CompleteCollectionElementPubSubType::~CompleteCollectionElementPubSubType()
 }
 
 bool CompleteCollectionElementPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteCollectionElement* p_type = static_cast<CompleteCollectionElement*>(data);
+    const CompleteCollectionElement* p_type = static_cast<const CompleteCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10632,7 +10632,7 @@ bool CompleteCollectionElementPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteCollectionElementPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10649,7 +10649,7 @@ std::function<uint32_t()> CompleteCollectionElementPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteCollectionElement*>(data), current_alignment)) +
+                               *static_cast<const CompleteCollectionElement*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10672,7 +10672,7 @@ void CompleteCollectionElementPubSubType::deleteData(
 }
 
 bool CompleteCollectionElementPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10681,7 +10681,7 @@ bool CompleteCollectionElementPubSubType::getKey(
         return false;
     }
 
-    CompleteCollectionElement* p_type = static_cast<CompleteCollectionElement*>(data);
+    const CompleteCollectionElement* p_type = static_cast<const CompleteCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10750,11 +10750,11 @@ MinimalCollectionElementPubSubType::~MinimalCollectionElementPubSubType()
 }
 
 bool MinimalCollectionElementPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalCollectionElement* p_type = static_cast<MinimalCollectionElement*>(data);
+    const MinimalCollectionElement* p_type = static_cast<const MinimalCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10826,7 +10826,7 @@ bool MinimalCollectionElementPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalCollectionElementPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10843,7 +10843,7 @@ std::function<uint32_t()> MinimalCollectionElementPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalCollectionElement*>(data), current_alignment)) +
+                               *static_cast<const MinimalCollectionElement*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10866,7 +10866,7 @@ void MinimalCollectionElementPubSubType::deleteData(
 }
 
 bool MinimalCollectionElementPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10875,7 +10875,7 @@ bool MinimalCollectionElementPubSubType::getKey(
         return false;
     }
 
-    MinimalCollectionElement* p_type = static_cast<MinimalCollectionElement*>(data);
+    const MinimalCollectionElement* p_type = static_cast<const MinimalCollectionElement*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10944,11 +10944,11 @@ CommonCollectionHeaderPubSubType::~CommonCollectionHeaderPubSubType()
 }
 
 bool CommonCollectionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonCollectionHeader* p_type = static_cast<CommonCollectionHeader*>(data);
+    const CommonCollectionHeader* p_type = static_cast<const CommonCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11020,7 +11020,7 @@ bool CommonCollectionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonCollectionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11037,7 +11037,7 @@ std::function<uint32_t()> CommonCollectionHeaderPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonCollectionHeader*>(data), current_alignment)) +
+                               *static_cast<const CommonCollectionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11060,7 +11060,7 @@ void CommonCollectionHeaderPubSubType::deleteData(
 }
 
 bool CommonCollectionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11069,7 +11069,7 @@ bool CommonCollectionHeaderPubSubType::getKey(
         return false;
     }
 
-    CommonCollectionHeader* p_type = static_cast<CommonCollectionHeader*>(data);
+    const CommonCollectionHeader* p_type = static_cast<const CommonCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11138,11 +11138,11 @@ CompleteCollectionHeaderPubSubType::~CompleteCollectionHeaderPubSubType()
 }
 
 bool CompleteCollectionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteCollectionHeader* p_type = static_cast<CompleteCollectionHeader*>(data);
+    const CompleteCollectionHeader* p_type = static_cast<const CompleteCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11214,7 +11214,7 @@ bool CompleteCollectionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteCollectionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11231,7 +11231,7 @@ std::function<uint32_t()> CompleteCollectionHeaderPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteCollectionHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteCollectionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11254,7 +11254,7 @@ void CompleteCollectionHeaderPubSubType::deleteData(
 }
 
 bool CompleteCollectionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11263,7 +11263,7 @@ bool CompleteCollectionHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteCollectionHeader* p_type = static_cast<CompleteCollectionHeader*>(data);
+    const CompleteCollectionHeader* p_type = static_cast<const CompleteCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11332,11 +11332,11 @@ MinimalCollectionHeaderPubSubType::~MinimalCollectionHeaderPubSubType()
 }
 
 bool MinimalCollectionHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalCollectionHeader* p_type = static_cast<MinimalCollectionHeader*>(data);
+    const MinimalCollectionHeader* p_type = static_cast<const MinimalCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11408,7 +11408,7 @@ bool MinimalCollectionHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalCollectionHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11425,7 +11425,7 @@ std::function<uint32_t()> MinimalCollectionHeaderPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalCollectionHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalCollectionHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11448,7 +11448,7 @@ void MinimalCollectionHeaderPubSubType::deleteData(
 }
 
 bool MinimalCollectionHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11457,7 +11457,7 @@ bool MinimalCollectionHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalCollectionHeader* p_type = static_cast<MinimalCollectionHeader*>(data);
+    const MinimalCollectionHeader* p_type = static_cast<const MinimalCollectionHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11526,11 +11526,11 @@ CompleteSequenceTypePubSubType::~CompleteSequenceTypePubSubType()
 }
 
 bool CompleteSequenceTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteSequenceType* p_type = static_cast<CompleteSequenceType*>(data);
+    const CompleteSequenceType* p_type = static_cast<const CompleteSequenceType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11602,7 +11602,7 @@ bool CompleteSequenceTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteSequenceTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11619,7 +11619,7 @@ std::function<uint32_t()> CompleteSequenceTypePubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteSequenceType*>(data), current_alignment)) +
+                               *static_cast<const CompleteSequenceType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11642,7 +11642,7 @@ void CompleteSequenceTypePubSubType::deleteData(
 }
 
 bool CompleteSequenceTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11651,7 +11651,7 @@ bool CompleteSequenceTypePubSubType::getKey(
         return false;
     }
 
-    CompleteSequenceType* p_type = static_cast<CompleteSequenceType*>(data);
+    const CompleteSequenceType* p_type = static_cast<const CompleteSequenceType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11720,11 +11720,11 @@ MinimalSequenceTypePubSubType::~MinimalSequenceTypePubSubType()
 }
 
 bool MinimalSequenceTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalSequenceType* p_type = static_cast<MinimalSequenceType*>(data);
+    const MinimalSequenceType* p_type = static_cast<const MinimalSequenceType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11796,7 +11796,7 @@ bool MinimalSequenceTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalSequenceTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11813,7 +11813,7 @@ std::function<uint32_t()> MinimalSequenceTypePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalSequenceType*>(data), current_alignment)) +
+                               *static_cast<const MinimalSequenceType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11836,7 +11836,7 @@ void MinimalSequenceTypePubSubType::deleteData(
 }
 
 bool MinimalSequenceTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11845,7 +11845,7 @@ bool MinimalSequenceTypePubSubType::getKey(
         return false;
     }
 
-    MinimalSequenceType* p_type = static_cast<MinimalSequenceType*>(data);
+    const MinimalSequenceType* p_type = static_cast<const MinimalSequenceType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11914,11 +11914,11 @@ CommonArrayHeaderPubSubType::~CommonArrayHeaderPubSubType()
 }
 
 bool CommonArrayHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonArrayHeader* p_type = static_cast<CommonArrayHeader*>(data);
+    const CommonArrayHeader* p_type = static_cast<const CommonArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11990,7 +11990,7 @@ bool CommonArrayHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonArrayHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12007,7 +12007,7 @@ std::function<uint32_t()> CommonArrayHeaderPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonArrayHeader*>(data), current_alignment)) +
+                               *static_cast<const CommonArrayHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12030,7 +12030,7 @@ void CommonArrayHeaderPubSubType::deleteData(
 }
 
 bool CommonArrayHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12039,7 +12039,7 @@ bool CommonArrayHeaderPubSubType::getKey(
         return false;
     }
 
-    CommonArrayHeader* p_type = static_cast<CommonArrayHeader*>(data);
+    const CommonArrayHeader* p_type = static_cast<const CommonArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12108,11 +12108,11 @@ CompleteArrayHeaderPubSubType::~CompleteArrayHeaderPubSubType()
 }
 
 bool CompleteArrayHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteArrayHeader* p_type = static_cast<CompleteArrayHeader*>(data);
+    const CompleteArrayHeader* p_type = static_cast<const CompleteArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12184,7 +12184,7 @@ bool CompleteArrayHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteArrayHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12201,7 +12201,7 @@ std::function<uint32_t()> CompleteArrayHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteArrayHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteArrayHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12224,7 +12224,7 @@ void CompleteArrayHeaderPubSubType::deleteData(
 }
 
 bool CompleteArrayHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12233,7 +12233,7 @@ bool CompleteArrayHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteArrayHeader* p_type = static_cast<CompleteArrayHeader*>(data);
+    const CompleteArrayHeader* p_type = static_cast<const CompleteArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12302,11 +12302,11 @@ MinimalArrayHeaderPubSubType::~MinimalArrayHeaderPubSubType()
 }
 
 bool MinimalArrayHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalArrayHeader* p_type = static_cast<MinimalArrayHeader*>(data);
+    const MinimalArrayHeader* p_type = static_cast<const MinimalArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12378,7 +12378,7 @@ bool MinimalArrayHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalArrayHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12395,7 +12395,7 @@ std::function<uint32_t()> MinimalArrayHeaderPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalArrayHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalArrayHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12418,7 +12418,7 @@ void MinimalArrayHeaderPubSubType::deleteData(
 }
 
 bool MinimalArrayHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12427,7 +12427,7 @@ bool MinimalArrayHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalArrayHeader* p_type = static_cast<MinimalArrayHeader*>(data);
+    const MinimalArrayHeader* p_type = static_cast<const MinimalArrayHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12496,11 +12496,11 @@ CompleteArrayTypePubSubType::~CompleteArrayTypePubSubType()
 }
 
 bool CompleteArrayTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteArrayType* p_type = static_cast<CompleteArrayType*>(data);
+    const CompleteArrayType* p_type = static_cast<const CompleteArrayType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12572,7 +12572,7 @@ bool CompleteArrayTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteArrayTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12589,7 +12589,7 @@ std::function<uint32_t()> CompleteArrayTypePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteArrayType*>(data), current_alignment)) +
+                               *static_cast<const CompleteArrayType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12612,7 +12612,7 @@ void CompleteArrayTypePubSubType::deleteData(
 }
 
 bool CompleteArrayTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12621,7 +12621,7 @@ bool CompleteArrayTypePubSubType::getKey(
         return false;
     }
 
-    CompleteArrayType* p_type = static_cast<CompleteArrayType*>(data);
+    const CompleteArrayType* p_type = static_cast<const CompleteArrayType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12690,11 +12690,11 @@ MinimalArrayTypePubSubType::~MinimalArrayTypePubSubType()
 }
 
 bool MinimalArrayTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalArrayType* p_type = static_cast<MinimalArrayType*>(data);
+    const MinimalArrayType* p_type = static_cast<const MinimalArrayType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12766,7 +12766,7 @@ bool MinimalArrayTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalArrayTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12783,7 +12783,7 @@ std::function<uint32_t()> MinimalArrayTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalArrayType*>(data), current_alignment)) +
+                               *static_cast<const MinimalArrayType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12806,7 +12806,7 @@ void MinimalArrayTypePubSubType::deleteData(
 }
 
 bool MinimalArrayTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12815,7 +12815,7 @@ bool MinimalArrayTypePubSubType::getKey(
         return false;
     }
 
-    MinimalArrayType* p_type = static_cast<MinimalArrayType*>(data);
+    const MinimalArrayType* p_type = static_cast<const MinimalArrayType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12884,11 +12884,11 @@ CompleteMapTypePubSubType::~CompleteMapTypePubSubType()
 }
 
 bool CompleteMapTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteMapType* p_type = static_cast<CompleteMapType*>(data);
+    const CompleteMapType* p_type = static_cast<const CompleteMapType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12960,7 +12960,7 @@ bool CompleteMapTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteMapTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12977,7 +12977,7 @@ std::function<uint32_t()> CompleteMapTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteMapType*>(data), current_alignment)) +
+                               *static_cast<const CompleteMapType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13000,7 +13000,7 @@ void CompleteMapTypePubSubType::deleteData(
 }
 
 bool CompleteMapTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13009,7 +13009,7 @@ bool CompleteMapTypePubSubType::getKey(
         return false;
     }
 
-    CompleteMapType* p_type = static_cast<CompleteMapType*>(data);
+    const CompleteMapType* p_type = static_cast<const CompleteMapType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13078,11 +13078,11 @@ MinimalMapTypePubSubType::~MinimalMapTypePubSubType()
 }
 
 bool MinimalMapTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalMapType* p_type = static_cast<MinimalMapType*>(data);
+    const MinimalMapType* p_type = static_cast<const MinimalMapType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13154,7 +13154,7 @@ bool MinimalMapTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalMapTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13171,7 +13171,7 @@ std::function<uint32_t()> MinimalMapTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalMapType*>(data), current_alignment)) +
+                               *static_cast<const MinimalMapType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13194,7 +13194,7 @@ void MinimalMapTypePubSubType::deleteData(
 }
 
 bool MinimalMapTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13203,7 +13203,7 @@ bool MinimalMapTypePubSubType::getKey(
         return false;
     }
 
-    MinimalMapType* p_type = static_cast<MinimalMapType*>(data);
+    const MinimalMapType* p_type = static_cast<const MinimalMapType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13273,11 +13273,11 @@ CommonEnumeratedLiteralPubSubType::~CommonEnumeratedLiteralPubSubType()
 }
 
 bool CommonEnumeratedLiteralPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonEnumeratedLiteral* p_type = static_cast<CommonEnumeratedLiteral*>(data);
+    const CommonEnumeratedLiteral* p_type = static_cast<const CommonEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13349,7 +13349,7 @@ bool CommonEnumeratedLiteralPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonEnumeratedLiteralPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13366,7 +13366,7 @@ std::function<uint32_t()> CommonEnumeratedLiteralPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonEnumeratedLiteral*>(data), current_alignment)) +
+                               *static_cast<const CommonEnumeratedLiteral*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13389,7 +13389,7 @@ void CommonEnumeratedLiteralPubSubType::deleteData(
 }
 
 bool CommonEnumeratedLiteralPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13398,7 +13398,7 @@ bool CommonEnumeratedLiteralPubSubType::getKey(
         return false;
     }
 
-    CommonEnumeratedLiteral* p_type = static_cast<CommonEnumeratedLiteral*>(data);
+    const CommonEnumeratedLiteral* p_type = static_cast<const CommonEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13467,11 +13467,11 @@ CompleteEnumeratedLiteralPubSubType::~CompleteEnumeratedLiteralPubSubType()
 }
 
 bool CompleteEnumeratedLiteralPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteEnumeratedLiteral* p_type = static_cast<CompleteEnumeratedLiteral*>(data);
+    const CompleteEnumeratedLiteral* p_type = static_cast<const CompleteEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13543,7 +13543,7 @@ bool CompleteEnumeratedLiteralPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteEnumeratedLiteralPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13560,7 +13560,7 @@ std::function<uint32_t()> CompleteEnumeratedLiteralPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteEnumeratedLiteral*>(data), current_alignment)) +
+                               *static_cast<const CompleteEnumeratedLiteral*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13583,7 +13583,7 @@ void CompleteEnumeratedLiteralPubSubType::deleteData(
 }
 
 bool CompleteEnumeratedLiteralPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13592,7 +13592,7 @@ bool CompleteEnumeratedLiteralPubSubType::getKey(
         return false;
     }
 
-    CompleteEnumeratedLiteral* p_type = static_cast<CompleteEnumeratedLiteral*>(data);
+    const CompleteEnumeratedLiteral* p_type = static_cast<const CompleteEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13662,11 +13662,11 @@ MinimalEnumeratedLiteralPubSubType::~MinimalEnumeratedLiteralPubSubType()
 }
 
 bool MinimalEnumeratedLiteralPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalEnumeratedLiteral* p_type = static_cast<MinimalEnumeratedLiteral*>(data);
+    const MinimalEnumeratedLiteral* p_type = static_cast<const MinimalEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13738,7 +13738,7 @@ bool MinimalEnumeratedLiteralPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalEnumeratedLiteralPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13755,7 +13755,7 @@ std::function<uint32_t()> MinimalEnumeratedLiteralPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalEnumeratedLiteral*>(data), current_alignment)) +
+                               *static_cast<const MinimalEnumeratedLiteral*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13778,7 +13778,7 @@ void MinimalEnumeratedLiteralPubSubType::deleteData(
 }
 
 bool MinimalEnumeratedLiteralPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13787,7 +13787,7 @@ bool MinimalEnumeratedLiteralPubSubType::getKey(
         return false;
     }
 
-    MinimalEnumeratedLiteral* p_type = static_cast<MinimalEnumeratedLiteral*>(data);
+    const MinimalEnumeratedLiteral* p_type = static_cast<const MinimalEnumeratedLiteral*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13857,11 +13857,11 @@ CommonEnumeratedHeaderPubSubType::~CommonEnumeratedHeaderPubSubType()
 }
 
 bool CommonEnumeratedHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonEnumeratedHeader* p_type = static_cast<CommonEnumeratedHeader*>(data);
+    const CommonEnumeratedHeader* p_type = static_cast<const CommonEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13933,7 +13933,7 @@ bool CommonEnumeratedHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonEnumeratedHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13950,7 +13950,7 @@ std::function<uint32_t()> CommonEnumeratedHeaderPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonEnumeratedHeader*>(data), current_alignment)) +
+                               *static_cast<const CommonEnumeratedHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13973,7 +13973,7 @@ void CommonEnumeratedHeaderPubSubType::deleteData(
 }
 
 bool CommonEnumeratedHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13982,7 +13982,7 @@ bool CommonEnumeratedHeaderPubSubType::getKey(
         return false;
     }
 
-    CommonEnumeratedHeader* p_type = static_cast<CommonEnumeratedHeader*>(data);
+    const CommonEnumeratedHeader* p_type = static_cast<const CommonEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14051,11 +14051,11 @@ CompleteEnumeratedHeaderPubSubType::~CompleteEnumeratedHeaderPubSubType()
 }
 
 bool CompleteEnumeratedHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteEnumeratedHeader* p_type = static_cast<CompleteEnumeratedHeader*>(data);
+    const CompleteEnumeratedHeader* p_type = static_cast<const CompleteEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14127,7 +14127,7 @@ bool CompleteEnumeratedHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteEnumeratedHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14144,7 +14144,7 @@ std::function<uint32_t()> CompleteEnumeratedHeaderPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteEnumeratedHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteEnumeratedHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14167,7 +14167,7 @@ void CompleteEnumeratedHeaderPubSubType::deleteData(
 }
 
 bool CompleteEnumeratedHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14176,7 +14176,7 @@ bool CompleteEnumeratedHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteEnumeratedHeader* p_type = static_cast<CompleteEnumeratedHeader*>(data);
+    const CompleteEnumeratedHeader* p_type = static_cast<const CompleteEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14245,11 +14245,11 @@ MinimalEnumeratedHeaderPubSubType::~MinimalEnumeratedHeaderPubSubType()
 }
 
 bool MinimalEnumeratedHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalEnumeratedHeader* p_type = static_cast<MinimalEnumeratedHeader*>(data);
+    const MinimalEnumeratedHeader* p_type = static_cast<const MinimalEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14321,7 +14321,7 @@ bool MinimalEnumeratedHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalEnumeratedHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14338,7 +14338,7 @@ std::function<uint32_t()> MinimalEnumeratedHeaderPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalEnumeratedHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalEnumeratedHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14361,7 +14361,7 @@ void MinimalEnumeratedHeaderPubSubType::deleteData(
 }
 
 bool MinimalEnumeratedHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14370,7 +14370,7 @@ bool MinimalEnumeratedHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalEnumeratedHeader* p_type = static_cast<MinimalEnumeratedHeader*>(data);
+    const MinimalEnumeratedHeader* p_type = static_cast<const MinimalEnumeratedHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14439,11 +14439,11 @@ CompleteEnumeratedTypePubSubType::~CompleteEnumeratedTypePubSubType()
 }
 
 bool CompleteEnumeratedTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteEnumeratedType* p_type = static_cast<CompleteEnumeratedType*>(data);
+    const CompleteEnumeratedType* p_type = static_cast<const CompleteEnumeratedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14515,7 +14515,7 @@ bool CompleteEnumeratedTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteEnumeratedTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14532,7 +14532,7 @@ std::function<uint32_t()> CompleteEnumeratedTypePubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteEnumeratedType*>(data), current_alignment)) +
+                               *static_cast<const CompleteEnumeratedType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14555,7 +14555,7 @@ void CompleteEnumeratedTypePubSubType::deleteData(
 }
 
 bool CompleteEnumeratedTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14564,7 +14564,7 @@ bool CompleteEnumeratedTypePubSubType::getKey(
         return false;
     }
 
-    CompleteEnumeratedType* p_type = static_cast<CompleteEnumeratedType*>(data);
+    const CompleteEnumeratedType* p_type = static_cast<const CompleteEnumeratedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14633,11 +14633,11 @@ MinimalEnumeratedTypePubSubType::~MinimalEnumeratedTypePubSubType()
 }
 
 bool MinimalEnumeratedTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalEnumeratedType* p_type = static_cast<MinimalEnumeratedType*>(data);
+    const MinimalEnumeratedType* p_type = static_cast<const MinimalEnumeratedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14709,7 +14709,7 @@ bool MinimalEnumeratedTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalEnumeratedTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14726,7 +14726,7 @@ std::function<uint32_t()> MinimalEnumeratedTypePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalEnumeratedType*>(data), current_alignment)) +
+                               *static_cast<const MinimalEnumeratedType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14749,7 +14749,7 @@ void MinimalEnumeratedTypePubSubType::deleteData(
 }
 
 bool MinimalEnumeratedTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14758,7 +14758,7 @@ bool MinimalEnumeratedTypePubSubType::getKey(
         return false;
     }
 
-    MinimalEnumeratedType* p_type = static_cast<MinimalEnumeratedType*>(data);
+    const MinimalEnumeratedType* p_type = static_cast<const MinimalEnumeratedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14827,11 +14827,11 @@ CommonBitflagPubSubType::~CommonBitflagPubSubType()
 }
 
 bool CommonBitflagPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonBitflag* p_type = static_cast<CommonBitflag*>(data);
+    const CommonBitflag* p_type = static_cast<const CommonBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14903,7 +14903,7 @@ bool CommonBitflagPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonBitflagPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14920,7 +14920,7 @@ std::function<uint32_t()> CommonBitflagPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonBitflag*>(data), current_alignment)) +
+                               *static_cast<const CommonBitflag*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14943,7 +14943,7 @@ void CommonBitflagPubSubType::deleteData(
 }
 
 bool CommonBitflagPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14952,7 +14952,7 @@ bool CommonBitflagPubSubType::getKey(
         return false;
     }
 
-    CommonBitflag* p_type = static_cast<CommonBitflag*>(data);
+    const CommonBitflag* p_type = static_cast<const CommonBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15021,11 +15021,11 @@ CompleteBitflagPubSubType::~CompleteBitflagPubSubType()
 }
 
 bool CompleteBitflagPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteBitflag* p_type = static_cast<CompleteBitflag*>(data);
+    const CompleteBitflag* p_type = static_cast<const CompleteBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15097,7 +15097,7 @@ bool CompleteBitflagPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteBitflagPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15114,7 +15114,7 @@ std::function<uint32_t()> CompleteBitflagPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteBitflag*>(data), current_alignment)) +
+                               *static_cast<const CompleteBitflag*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15137,7 +15137,7 @@ void CompleteBitflagPubSubType::deleteData(
 }
 
 bool CompleteBitflagPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15146,7 +15146,7 @@ bool CompleteBitflagPubSubType::getKey(
         return false;
     }
 
-    CompleteBitflag* p_type = static_cast<CompleteBitflag*>(data);
+    const CompleteBitflag* p_type = static_cast<const CompleteBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15216,11 +15216,11 @@ MinimalBitflagPubSubType::~MinimalBitflagPubSubType()
 }
 
 bool MinimalBitflagPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalBitflag* p_type = static_cast<MinimalBitflag*>(data);
+    const MinimalBitflag* p_type = static_cast<const MinimalBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15292,7 +15292,7 @@ bool MinimalBitflagPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalBitflagPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15309,7 +15309,7 @@ std::function<uint32_t()> MinimalBitflagPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalBitflag*>(data), current_alignment)) +
+                               *static_cast<const MinimalBitflag*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15332,7 +15332,7 @@ void MinimalBitflagPubSubType::deleteData(
 }
 
 bool MinimalBitflagPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15341,7 +15341,7 @@ bool MinimalBitflagPubSubType::getKey(
         return false;
     }
 
-    MinimalBitflag* p_type = static_cast<MinimalBitflag*>(data);
+    const MinimalBitflag* p_type = static_cast<const MinimalBitflag*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15411,11 +15411,11 @@ CommonBitmaskHeaderPubSubType::~CommonBitmaskHeaderPubSubType()
 }
 
 bool CommonBitmaskHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonBitmaskHeader* p_type = static_cast<CommonBitmaskHeader*>(data);
+    const CommonBitmaskHeader* p_type = static_cast<const CommonBitmaskHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15487,7 +15487,7 @@ bool CommonBitmaskHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonBitmaskHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15504,7 +15504,7 @@ std::function<uint32_t()> CommonBitmaskHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonBitmaskHeader*>(data), current_alignment)) +
+                               *static_cast<const CommonBitmaskHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15527,7 +15527,7 @@ void CommonBitmaskHeaderPubSubType::deleteData(
 }
 
 bool CommonBitmaskHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15536,7 +15536,7 @@ bool CommonBitmaskHeaderPubSubType::getKey(
         return false;
     }
 
-    CommonBitmaskHeader* p_type = static_cast<CommonBitmaskHeader*>(data);
+    const CommonBitmaskHeader* p_type = static_cast<const CommonBitmaskHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15607,11 +15607,11 @@ CompleteBitmaskTypePubSubType::~CompleteBitmaskTypePubSubType()
 }
 
 bool CompleteBitmaskTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteBitmaskType* p_type = static_cast<CompleteBitmaskType*>(data);
+    const CompleteBitmaskType* p_type = static_cast<const CompleteBitmaskType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15683,7 +15683,7 @@ bool CompleteBitmaskTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteBitmaskTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15700,7 +15700,7 @@ std::function<uint32_t()> CompleteBitmaskTypePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteBitmaskType*>(data), current_alignment)) +
+                               *static_cast<const CompleteBitmaskType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15723,7 +15723,7 @@ void CompleteBitmaskTypePubSubType::deleteData(
 }
 
 bool CompleteBitmaskTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15732,7 +15732,7 @@ bool CompleteBitmaskTypePubSubType::getKey(
         return false;
     }
 
-    CompleteBitmaskType* p_type = static_cast<CompleteBitmaskType*>(data);
+    const CompleteBitmaskType* p_type = static_cast<const CompleteBitmaskType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15801,11 +15801,11 @@ MinimalBitmaskTypePubSubType::~MinimalBitmaskTypePubSubType()
 }
 
 bool MinimalBitmaskTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalBitmaskType* p_type = static_cast<MinimalBitmaskType*>(data);
+    const MinimalBitmaskType* p_type = static_cast<const MinimalBitmaskType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15877,7 +15877,7 @@ bool MinimalBitmaskTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalBitmaskTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15894,7 +15894,7 @@ std::function<uint32_t()> MinimalBitmaskTypePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalBitmaskType*>(data), current_alignment)) +
+                               *static_cast<const MinimalBitmaskType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15917,7 +15917,7 @@ void MinimalBitmaskTypePubSubType::deleteData(
 }
 
 bool MinimalBitmaskTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15926,7 +15926,7 @@ bool MinimalBitmaskTypePubSubType::getKey(
         return false;
     }
 
-    MinimalBitmaskType* p_type = static_cast<MinimalBitmaskType*>(data);
+    const MinimalBitmaskType* p_type = static_cast<const MinimalBitmaskType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15995,11 +15995,11 @@ CommonBitfieldPubSubType::~CommonBitfieldPubSubType()
 }
 
 bool CommonBitfieldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CommonBitfield* p_type = static_cast<CommonBitfield*>(data);
+    const CommonBitfield* p_type = static_cast<const CommonBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16071,7 +16071,7 @@ bool CommonBitfieldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CommonBitfieldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16088,7 +16088,7 @@ std::function<uint32_t()> CommonBitfieldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CommonBitfield*>(data), current_alignment)) +
+                               *static_cast<const CommonBitfield*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16111,7 +16111,7 @@ void CommonBitfieldPubSubType::deleteData(
 }
 
 bool CommonBitfieldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16120,7 +16120,7 @@ bool CommonBitfieldPubSubType::getKey(
         return false;
     }
 
-    CommonBitfield* p_type = static_cast<CommonBitfield*>(data);
+    const CommonBitfield* p_type = static_cast<const CommonBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16189,11 +16189,11 @@ CompleteBitfieldPubSubType::~CompleteBitfieldPubSubType()
 }
 
 bool CompleteBitfieldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteBitfield* p_type = static_cast<CompleteBitfield*>(data);
+    const CompleteBitfield* p_type = static_cast<const CompleteBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16265,7 +16265,7 @@ bool CompleteBitfieldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteBitfieldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16282,7 +16282,7 @@ std::function<uint32_t()> CompleteBitfieldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteBitfield*>(data), current_alignment)) +
+                               *static_cast<const CompleteBitfield*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16305,7 +16305,7 @@ void CompleteBitfieldPubSubType::deleteData(
 }
 
 bool CompleteBitfieldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16314,7 +16314,7 @@ bool CompleteBitfieldPubSubType::getKey(
         return false;
     }
 
-    CompleteBitfield* p_type = static_cast<CompleteBitfield*>(data);
+    const CompleteBitfield* p_type = static_cast<const CompleteBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16384,11 +16384,11 @@ MinimalBitfieldPubSubType::~MinimalBitfieldPubSubType()
 }
 
 bool MinimalBitfieldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalBitfield* p_type = static_cast<MinimalBitfield*>(data);
+    const MinimalBitfield* p_type = static_cast<const MinimalBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16460,7 +16460,7 @@ bool MinimalBitfieldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalBitfieldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16477,7 +16477,7 @@ std::function<uint32_t()> MinimalBitfieldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalBitfield*>(data), current_alignment)) +
+                               *static_cast<const MinimalBitfield*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16500,7 +16500,7 @@ void MinimalBitfieldPubSubType::deleteData(
 }
 
 bool MinimalBitfieldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16509,7 +16509,7 @@ bool MinimalBitfieldPubSubType::getKey(
         return false;
     }
 
-    MinimalBitfield* p_type = static_cast<MinimalBitfield*>(data);
+    const MinimalBitfield* p_type = static_cast<const MinimalBitfield*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16579,11 +16579,11 @@ CompleteBitsetHeaderPubSubType::~CompleteBitsetHeaderPubSubType()
 }
 
 bool CompleteBitsetHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteBitsetHeader* p_type = static_cast<CompleteBitsetHeader*>(data);
+    const CompleteBitsetHeader* p_type = static_cast<const CompleteBitsetHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16655,7 +16655,7 @@ bool CompleteBitsetHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteBitsetHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16672,7 +16672,7 @@ std::function<uint32_t()> CompleteBitsetHeaderPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteBitsetHeader*>(data), current_alignment)) +
+                               *static_cast<const CompleteBitsetHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16695,7 +16695,7 @@ void CompleteBitsetHeaderPubSubType::deleteData(
 }
 
 bool CompleteBitsetHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16704,7 +16704,7 @@ bool CompleteBitsetHeaderPubSubType::getKey(
         return false;
     }
 
-    CompleteBitsetHeader* p_type = static_cast<CompleteBitsetHeader*>(data);
+    const CompleteBitsetHeader* p_type = static_cast<const CompleteBitsetHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16773,11 +16773,11 @@ MinimalBitsetHeaderPubSubType::~MinimalBitsetHeaderPubSubType()
 }
 
 bool MinimalBitsetHeaderPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalBitsetHeader* p_type = static_cast<MinimalBitsetHeader*>(data);
+    const MinimalBitsetHeader* p_type = static_cast<const MinimalBitsetHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16849,7 +16849,7 @@ bool MinimalBitsetHeaderPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalBitsetHeaderPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16866,7 +16866,7 @@ std::function<uint32_t()> MinimalBitsetHeaderPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalBitsetHeader*>(data), current_alignment)) +
+                               *static_cast<const MinimalBitsetHeader*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16889,7 +16889,7 @@ void MinimalBitsetHeaderPubSubType::deleteData(
 }
 
 bool MinimalBitsetHeaderPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16898,7 +16898,7 @@ bool MinimalBitsetHeaderPubSubType::getKey(
         return false;
     }
 
-    MinimalBitsetHeader* p_type = static_cast<MinimalBitsetHeader*>(data);
+    const MinimalBitsetHeader* p_type = static_cast<const MinimalBitsetHeader*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16967,11 +16967,11 @@ CompleteBitsetTypePubSubType::~CompleteBitsetTypePubSubType()
 }
 
 bool CompleteBitsetTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteBitsetType* p_type = static_cast<CompleteBitsetType*>(data);
+    const CompleteBitsetType* p_type = static_cast<const CompleteBitsetType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17043,7 +17043,7 @@ bool CompleteBitsetTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteBitsetTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17060,7 +17060,7 @@ std::function<uint32_t()> CompleteBitsetTypePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteBitsetType*>(data), current_alignment)) +
+                               *static_cast<const CompleteBitsetType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17083,7 +17083,7 @@ void CompleteBitsetTypePubSubType::deleteData(
 }
 
 bool CompleteBitsetTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17092,7 +17092,7 @@ bool CompleteBitsetTypePubSubType::getKey(
         return false;
     }
 
-    CompleteBitsetType* p_type = static_cast<CompleteBitsetType*>(data);
+    const CompleteBitsetType* p_type = static_cast<const CompleteBitsetType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17161,11 +17161,11 @@ MinimalBitsetTypePubSubType::~MinimalBitsetTypePubSubType()
 }
 
 bool MinimalBitsetTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalBitsetType* p_type = static_cast<MinimalBitsetType*>(data);
+    const MinimalBitsetType* p_type = static_cast<const MinimalBitsetType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17237,7 +17237,7 @@ bool MinimalBitsetTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalBitsetTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17254,7 +17254,7 @@ std::function<uint32_t()> MinimalBitsetTypePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalBitsetType*>(data), current_alignment)) +
+                               *static_cast<const MinimalBitsetType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17277,7 +17277,7 @@ void MinimalBitsetTypePubSubType::deleteData(
 }
 
 bool MinimalBitsetTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17286,7 +17286,7 @@ bool MinimalBitsetTypePubSubType::getKey(
         return false;
     }
 
-    MinimalBitsetType* p_type = static_cast<MinimalBitsetType*>(data);
+    const MinimalBitsetType* p_type = static_cast<const MinimalBitsetType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17355,11 +17355,11 @@ CompleteExtendedTypePubSubType::~CompleteExtendedTypePubSubType()
 }
 
 bool CompleteExtendedTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CompleteExtendedType* p_type = static_cast<CompleteExtendedType*>(data);
+    const CompleteExtendedType* p_type = static_cast<const CompleteExtendedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17431,7 +17431,7 @@ bool CompleteExtendedTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> CompleteExtendedTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17448,7 +17448,7 @@ std::function<uint32_t()> CompleteExtendedTypePubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CompleteExtendedType*>(data), current_alignment)) +
+                               *static_cast<const CompleteExtendedType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17471,7 +17471,7 @@ void CompleteExtendedTypePubSubType::deleteData(
 }
 
 bool CompleteExtendedTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17480,7 +17480,7 @@ bool CompleteExtendedTypePubSubType::getKey(
         return false;
     }
 
-    CompleteExtendedType* p_type = static_cast<CompleteExtendedType*>(data);
+    const CompleteExtendedType* p_type = static_cast<const CompleteExtendedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17550,11 +17550,11 @@ MinimalExtendedTypePubSubType::~MinimalExtendedTypePubSubType()
 }
 
 bool MinimalExtendedTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MinimalExtendedType* p_type = static_cast<MinimalExtendedType*>(data);
+    const MinimalExtendedType* p_type = static_cast<const MinimalExtendedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17626,7 +17626,7 @@ bool MinimalExtendedTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MinimalExtendedTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17643,7 +17643,7 @@ std::function<uint32_t()> MinimalExtendedTypePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MinimalExtendedType*>(data), current_alignment)) +
+                               *static_cast<const MinimalExtendedType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17666,7 +17666,7 @@ void MinimalExtendedTypePubSubType::deleteData(
 }
 
 bool MinimalExtendedTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17675,7 +17675,7 @@ bool MinimalExtendedTypePubSubType::getKey(
         return false;
     }
 
-    MinimalExtendedType* p_type = static_cast<MinimalExtendedType*>(data);
+    const MinimalExtendedType* p_type = static_cast<const MinimalExtendedType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17748,11 +17748,11 @@ TypeIdentifierTypeObjectPairPubSubType::~TypeIdentifierTypeObjectPairPubSubType(
 }
 
 bool TypeIdentifierTypeObjectPairPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TypeIdentifierTypeObjectPair* p_type = static_cast<TypeIdentifierTypeObjectPair*>(data);
+    const TypeIdentifierTypeObjectPair* p_type = static_cast<const TypeIdentifierTypeObjectPair*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17824,7 +17824,7 @@ bool TypeIdentifierTypeObjectPairPubSubType::deserialize(
 }
 
 std::function<uint32_t()> TypeIdentifierTypeObjectPairPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17841,7 +17841,7 @@ std::function<uint32_t()> TypeIdentifierTypeObjectPairPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TypeIdentifierTypeObjectPair*>(data), current_alignment)) +
+                               *static_cast<const TypeIdentifierTypeObjectPair*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17864,7 +17864,7 @@ void TypeIdentifierTypeObjectPairPubSubType::deleteData(
 }
 
 bool TypeIdentifierTypeObjectPairPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17873,7 +17873,7 @@ bool TypeIdentifierTypeObjectPairPubSubType::getKey(
         return false;
     }
 
-    TypeIdentifierTypeObjectPair* p_type = static_cast<TypeIdentifierTypeObjectPair*>(data);
+    const TypeIdentifierTypeObjectPair* p_type = static_cast<const TypeIdentifierTypeObjectPair*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17943,11 +17943,11 @@ TypeIdentifierPairPubSubType::~TypeIdentifierPairPubSubType()
 }
 
 bool TypeIdentifierPairPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TypeIdentifierPair* p_type = static_cast<TypeIdentifierPair*>(data);
+    const TypeIdentifierPair* p_type = static_cast<const TypeIdentifierPair*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18019,7 +18019,7 @@ bool TypeIdentifierPairPubSubType::deserialize(
 }
 
 std::function<uint32_t()> TypeIdentifierPairPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18036,7 +18036,7 @@ std::function<uint32_t()> TypeIdentifierPairPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TypeIdentifierPair*>(data), current_alignment)) +
+                               *static_cast<const TypeIdentifierPair*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18059,7 +18059,7 @@ void TypeIdentifierPairPubSubType::deleteData(
 }
 
 bool TypeIdentifierPairPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18068,7 +18068,7 @@ bool TypeIdentifierPairPubSubType::getKey(
         return false;
     }
 
-    TypeIdentifierPair* p_type = static_cast<TypeIdentifierPair*>(data);
+    const TypeIdentifierPair* p_type = static_cast<const TypeIdentifierPair*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18138,11 +18138,11 @@ TypeIdentfierWithSizePubSubType::~TypeIdentfierWithSizePubSubType()
 }
 
 bool TypeIdentfierWithSizePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TypeIdentfierWithSize* p_type = static_cast<TypeIdentfierWithSize*>(data);
+    const TypeIdentfierWithSize* p_type = static_cast<const TypeIdentfierWithSize*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18214,7 +18214,7 @@ bool TypeIdentfierWithSizePubSubType::deserialize(
 }
 
 std::function<uint32_t()> TypeIdentfierWithSizePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18231,7 +18231,7 @@ std::function<uint32_t()> TypeIdentfierWithSizePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TypeIdentfierWithSize*>(data), current_alignment)) +
+                               *static_cast<const TypeIdentfierWithSize*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18254,7 +18254,7 @@ void TypeIdentfierWithSizePubSubType::deleteData(
 }
 
 bool TypeIdentfierWithSizePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18263,7 +18263,7 @@ bool TypeIdentfierWithSizePubSubType::getKey(
         return false;
     }
 
-    TypeIdentfierWithSize* p_type = static_cast<TypeIdentfierWithSize*>(data);
+    const TypeIdentfierWithSize* p_type = static_cast<const TypeIdentfierWithSize*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18333,11 +18333,11 @@ TypeIdentifierWithDependenciesPubSubType::~TypeIdentifierWithDependenciesPubSubT
 }
 
 bool TypeIdentifierWithDependenciesPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TypeIdentifierWithDependencies* p_type = static_cast<TypeIdentifierWithDependencies*>(data);
+    const TypeIdentifierWithDependencies* p_type = static_cast<const TypeIdentifierWithDependencies*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18409,7 +18409,7 @@ bool TypeIdentifierWithDependenciesPubSubType::deserialize(
 }
 
 std::function<uint32_t()> TypeIdentifierWithDependenciesPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18426,7 +18426,7 @@ std::function<uint32_t()> TypeIdentifierWithDependenciesPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TypeIdentifierWithDependencies*>(data), current_alignment)) +
+                               *static_cast<const TypeIdentifierWithDependencies*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18449,7 +18449,7 @@ void TypeIdentifierWithDependenciesPubSubType::deleteData(
 }
 
 bool TypeIdentifierWithDependenciesPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18458,7 +18458,7 @@ bool TypeIdentifierWithDependenciesPubSubType::getKey(
         return false;
     }
 
-    TypeIdentifierWithDependencies* p_type = static_cast<TypeIdentifierWithDependencies*>(data);
+    const TypeIdentifierWithDependencies* p_type = static_cast<const TypeIdentifierWithDependencies*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18528,11 +18528,11 @@ TypeInformationPubSubType::~TypeInformationPubSubType()
 }
 
 bool TypeInformationPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TypeInformation* p_type = static_cast<TypeInformation*>(data);
+    const TypeInformation* p_type = static_cast<const TypeInformation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18604,7 +18604,7 @@ bool TypeInformationPubSubType::deserialize(
 }
 
 std::function<uint32_t()> TypeInformationPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18621,7 +18621,7 @@ std::function<uint32_t()> TypeInformationPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TypeInformation*>(data), current_alignment)) +
+                               *static_cast<const TypeInformation*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18644,7 +18644,7 @@ void TypeInformationPubSubType::deleteData(
 }
 
 bool TypeInformationPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18653,7 +18653,7 @@ bool TypeInformationPubSubType::getKey(
         return false;
     }
 
-    TypeInformation* p_type = static_cast<TypeInformation*>(data);
+    const TypeInformation* p_type = static_cast<const TypeInformation*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -60,11 +60,11 @@ namespace eprosima {
             }
 
             bool ConnectionPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Connection* p_type = static_cast<Connection*>(data);
+                const Connection* p_type = static_cast<const Connection*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -136,7 +136,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> ConnectionPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -153,7 +153,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Connection*>(data), current_alignment)) +
+                                           *static_cast<const Connection*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -176,7 +176,7 @@ namespace eprosima {
             }
 
             bool ConnectionPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -185,7 +185,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Connection* p_type = static_cast<Connection*>(data);
+                const Connection* p_type = static_cast<const Connection*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -253,11 +253,11 @@ namespace eprosima {
             }
 
             bool QosPolicyCount_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                QosPolicyCount_s* p_type = static_cast<QosPolicyCount_s*>(data);
+                const QosPolicyCount_s* p_type = static_cast<const QosPolicyCount_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -329,7 +329,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> QosPolicyCount_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -346,7 +346,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<QosPolicyCount_s*>(data), current_alignment)) +
+                                           *static_cast<const QosPolicyCount_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -369,7 +369,7 @@ namespace eprosima {
             }
 
             bool QosPolicyCount_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -378,7 +378,7 @@ namespace eprosima {
                     return false;
                 }
 
-                QosPolicyCount_s* p_type = static_cast<QosPolicyCount_s*>(data);
+                const QosPolicyCount_s* p_type = static_cast<const QosPolicyCount_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -446,11 +446,11 @@ namespace eprosima {
             }
 
             bool BaseStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                BaseStatus_s* p_type = static_cast<BaseStatus_s*>(data);
+                const BaseStatus_s* p_type = static_cast<const BaseStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -522,7 +522,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> BaseStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -539,7 +539,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<BaseStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const BaseStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -562,7 +562,7 @@ namespace eprosima {
             }
 
             bool BaseStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -571,7 +571,7 @@ namespace eprosima {
                     return false;
                 }
 
-                BaseStatus_s* p_type = static_cast<BaseStatus_s*>(data);
+                const BaseStatus_s* p_type = static_cast<const BaseStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -640,11 +640,11 @@ namespace eprosima {
             }
 
             bool IncompatibleQoSStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                IncompatibleQoSStatus_s* p_type = static_cast<IncompatibleQoSStatus_s*>(data);
+                const IncompatibleQoSStatus_s* p_type = static_cast<const IncompatibleQoSStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -716,7 +716,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> IncompatibleQoSStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -733,7 +733,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<IncompatibleQoSStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const IncompatibleQoSStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -756,7 +756,7 @@ namespace eprosima {
             }
 
             bool IncompatibleQoSStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -765,7 +765,7 @@ namespace eprosima {
                     return false;
                 }
 
-                IncompatibleQoSStatus_s* p_type = static_cast<IncompatibleQoSStatus_s*>(data);
+                const IncompatibleQoSStatus_s* p_type = static_cast<const IncompatibleQoSStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -833,11 +833,11 @@ namespace eprosima {
             }
 
             bool LivelinessChangedStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                LivelinessChangedStatus_s* p_type = static_cast<LivelinessChangedStatus_s*>(data);
+                const LivelinessChangedStatus_s* p_type = static_cast<const LivelinessChangedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -909,7 +909,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> LivelinessChangedStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -926,7 +926,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<LivelinessChangedStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const LivelinessChangedStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -949,7 +949,7 @@ namespace eprosima {
             }
 
             bool LivelinessChangedStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -958,7 +958,7 @@ namespace eprosima {
                     return false;
                 }
 
-                LivelinessChangedStatus_s* p_type = static_cast<LivelinessChangedStatus_s*>(data);
+                const LivelinessChangedStatus_s* p_type = static_cast<const LivelinessChangedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1026,11 +1026,11 @@ namespace eprosima {
             }
 
             bool DeadlineMissedStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                DeadlineMissedStatus_s* p_type = static_cast<DeadlineMissedStatus_s*>(data);
+                const DeadlineMissedStatus_s* p_type = static_cast<const DeadlineMissedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1102,7 +1102,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> DeadlineMissedStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1119,7 +1119,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<DeadlineMissedStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const DeadlineMissedStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1142,7 +1142,7 @@ namespace eprosima {
             }
 
             bool DeadlineMissedStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1151,7 +1151,7 @@ namespace eprosima {
                     return false;
                 }
 
-                DeadlineMissedStatus_s* p_type = static_cast<DeadlineMissedStatus_s*>(data);
+                const DeadlineMissedStatus_s* p_type = static_cast<const DeadlineMissedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1226,11 +1226,11 @@ namespace eprosima {
             }
 
             bool MonitorServiceStatusDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                MonitorServiceStatusData* p_type = static_cast<MonitorServiceStatusData*>(data);
+                const MonitorServiceStatusData* p_type = static_cast<const MonitorServiceStatusData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1302,7 +1302,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> MonitorServiceStatusDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1319,7 +1319,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<MonitorServiceStatusData*>(data), current_alignment)) +
+                                           *static_cast<const MonitorServiceStatusData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1342,7 +1342,7 @@ namespace eprosima {
             }
 
             bool MonitorServiceStatusDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1351,7 +1351,7 @@ namespace eprosima {
                     return false;
                 }
 
-                MonitorServiceStatusData* p_type = static_cast<MonitorServiceStatusData*>(data);
+                const MonitorServiceStatusData* p_type = static_cast<const MonitorServiceStatusData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.h
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.h
@@ -60,14 +60,14 @@ namespace eprosima
                 eProsima_user_DllExport ~ConnectionPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -76,17 +76,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -151,14 +151,14 @@ namespace eprosima
                 eProsima_user_DllExport ~QosPolicyCount_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -167,17 +167,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -242,14 +242,14 @@ namespace eprosima
                 eProsima_user_DllExport ~BaseStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -258,17 +258,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -334,14 +334,14 @@ namespace eprosima
                 eProsima_user_DllExport ~IncompatibleQoSStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -350,17 +350,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -425,14 +425,14 @@ namespace eprosima
                 eProsima_user_DllExport ~LivelinessChangedStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -441,17 +441,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -516,14 +516,14 @@ namespace eprosima
                 eProsima_user_DllExport ~DeadlineMissedStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -532,17 +532,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -624,14 +624,14 @@ namespace eprosima
                 eProsima_user_DllExport ~MonitorServiceStatusDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -640,17 +640,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 

--- a/src/cpp/statistics/types/typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/typesPubSubTypes.cxx
@@ -61,11 +61,11 @@ namespace eprosima {
                 }
 
                 bool EntityId_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    EntityId_s* p_type = static_cast<EntityId_s*>(data);
+                    const EntityId_s* p_type = static_cast<const EntityId_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -137,7 +137,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> EntityId_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -154,7 +154,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<EntityId_s*>(data), current_alignment)) +
+                                               *static_cast<const EntityId_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -177,7 +177,7 @@ namespace eprosima {
                 }
 
                 bool EntityId_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -186,7 +186,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    EntityId_s* p_type = static_cast<EntityId_s*>(data);
+                    const EntityId_s* p_type = static_cast<const EntityId_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -254,11 +254,11 @@ namespace eprosima {
                 }
 
                 bool GuidPrefix_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    GuidPrefix_s* p_type = static_cast<GuidPrefix_s*>(data);
+                    const GuidPrefix_s* p_type = static_cast<const GuidPrefix_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -330,7 +330,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> GuidPrefix_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -347,7 +347,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<GuidPrefix_s*>(data), current_alignment)) +
+                                               *static_cast<const GuidPrefix_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -370,7 +370,7 @@ namespace eprosima {
                 }
 
                 bool GuidPrefix_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -379,7 +379,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    GuidPrefix_s* p_type = static_cast<GuidPrefix_s*>(data);
+                    const GuidPrefix_s* p_type = static_cast<const GuidPrefix_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -447,11 +447,11 @@ namespace eprosima {
                 }
 
                 bool GUID_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    GUID_s* p_type = static_cast<GUID_s*>(data);
+                    const GUID_s* p_type = static_cast<const GUID_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -523,7 +523,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> GUID_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -540,7 +540,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<GUID_s*>(data), current_alignment)) +
+                                               *static_cast<const GUID_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -563,7 +563,7 @@ namespace eprosima {
                 }
 
                 bool GUID_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -572,7 +572,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    GUID_s* p_type = static_cast<GUID_s*>(data);
+                    const GUID_s* p_type = static_cast<const GUID_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -640,11 +640,11 @@ namespace eprosima {
                 }
 
                 bool SequenceNumber_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    SequenceNumber_s* p_type = static_cast<SequenceNumber_s*>(data);
+                    const SequenceNumber_s* p_type = static_cast<const SequenceNumber_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -716,7 +716,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> SequenceNumber_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -733,7 +733,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<SequenceNumber_s*>(data), current_alignment)) +
+                                               *static_cast<const SequenceNumber_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -756,7 +756,7 @@ namespace eprosima {
                 }
 
                 bool SequenceNumber_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -765,7 +765,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    SequenceNumber_s* p_type = static_cast<SequenceNumber_s*>(data);
+                    const SequenceNumber_s* p_type = static_cast<const SequenceNumber_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -833,11 +833,11 @@ namespace eprosima {
                 }
 
                 bool SampleIdentity_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    SampleIdentity_s* p_type = static_cast<SampleIdentity_s*>(data);
+                    const SampleIdentity_s* p_type = static_cast<const SampleIdentity_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -909,7 +909,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> SampleIdentity_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -926,7 +926,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<SampleIdentity_s*>(data), current_alignment)) +
+                                               *static_cast<const SampleIdentity_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -949,7 +949,7 @@ namespace eprosima {
                 }
 
                 bool SampleIdentity_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -958,7 +958,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    SampleIdentity_s* p_type = static_cast<SampleIdentity_s*>(data);
+                    const SampleIdentity_s* p_type = static_cast<const SampleIdentity_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1026,11 +1026,11 @@ namespace eprosima {
                 }
 
                 bool Locator_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    Locator_s* p_type = static_cast<Locator_s*>(data);
+                    const Locator_s* p_type = static_cast<const Locator_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1102,7 +1102,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> Locator_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -1119,7 +1119,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<Locator_s*>(data), current_alignment)) +
+                                               *static_cast<const Locator_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1142,7 +1142,7 @@ namespace eprosima {
                 }
 
                 bool Locator_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -1151,7 +1151,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    Locator_s* p_type = static_cast<Locator_s*>(data);
+                    const Locator_s* p_type = static_cast<const Locator_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1221,11 +1221,11 @@ namespace eprosima {
             }
 
             bool DiscoveryTimePubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                DiscoveryTime* p_type = static_cast<DiscoveryTime*>(data);
+                const DiscoveryTime* p_type = static_cast<const DiscoveryTime*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1297,7 +1297,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> DiscoveryTimePubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1314,7 +1314,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<DiscoveryTime*>(data), current_alignment)) +
+                                           *static_cast<const DiscoveryTime*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1337,7 +1337,7 @@ namespace eprosima {
             }
 
             bool DiscoveryTimePubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1346,7 +1346,7 @@ namespace eprosima {
                     return false;
                 }
 
-                DiscoveryTime* p_type = static_cast<DiscoveryTime*>(data);
+                const DiscoveryTime* p_type = static_cast<const DiscoveryTime*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1414,11 +1414,11 @@ namespace eprosima {
             }
 
             bool EntityCountPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                EntityCount* p_type = static_cast<EntityCount*>(data);
+                const EntityCount* p_type = static_cast<const EntityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1490,7 +1490,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> EntityCountPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1507,7 +1507,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<EntityCount*>(data), current_alignment)) +
+                                           *static_cast<const EntityCount*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1530,7 +1530,7 @@ namespace eprosima {
             }
 
             bool EntityCountPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1539,7 +1539,7 @@ namespace eprosima {
                     return false;
                 }
 
-                EntityCount* p_type = static_cast<EntityCount*>(data);
+                const EntityCount* p_type = static_cast<const EntityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1607,11 +1607,11 @@ namespace eprosima {
             }
 
             bool SampleIdentityCountPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                SampleIdentityCount* p_type = static_cast<SampleIdentityCount*>(data);
+                const SampleIdentityCount* p_type = static_cast<const SampleIdentityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1683,7 +1683,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> SampleIdentityCountPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1700,7 +1700,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<SampleIdentityCount*>(data), current_alignment)) +
+                                           *static_cast<const SampleIdentityCount*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1723,7 +1723,7 @@ namespace eprosima {
             }
 
             bool SampleIdentityCountPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1732,7 +1732,7 @@ namespace eprosima {
                     return false;
                 }
 
-                SampleIdentityCount* p_type = static_cast<SampleIdentityCount*>(data);
+                const SampleIdentityCount* p_type = static_cast<const SampleIdentityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1800,11 +1800,11 @@ namespace eprosima {
             }
 
             bool Entity2LocatorTrafficPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Entity2LocatorTraffic* p_type = static_cast<Entity2LocatorTraffic*>(data);
+                const Entity2LocatorTraffic* p_type = static_cast<const Entity2LocatorTraffic*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1876,7 +1876,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> Entity2LocatorTrafficPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1893,7 +1893,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Entity2LocatorTraffic*>(data), current_alignment)) +
+                                           *static_cast<const Entity2LocatorTraffic*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1916,7 +1916,7 @@ namespace eprosima {
             }
 
             bool Entity2LocatorTrafficPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1925,7 +1925,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Entity2LocatorTraffic* p_type = static_cast<Entity2LocatorTraffic*>(data);
+                const Entity2LocatorTraffic* p_type = static_cast<const Entity2LocatorTraffic*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1993,11 +1993,11 @@ namespace eprosima {
             }
 
             bool WriterReaderDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                WriterReaderData* p_type = static_cast<WriterReaderData*>(data);
+                const WriterReaderData* p_type = static_cast<const WriterReaderData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2069,7 +2069,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> WriterReaderDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2086,7 +2086,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<WriterReaderData*>(data), current_alignment)) +
+                                           *static_cast<const WriterReaderData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2109,7 +2109,7 @@ namespace eprosima {
             }
 
             bool WriterReaderDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2118,7 +2118,7 @@ namespace eprosima {
                     return false;
                 }
 
-                WriterReaderData* p_type = static_cast<WriterReaderData*>(data);
+                const WriterReaderData* p_type = static_cast<const WriterReaderData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2186,11 +2186,11 @@ namespace eprosima {
             }
 
             bool Locator2LocatorDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Locator2LocatorData* p_type = static_cast<Locator2LocatorData*>(data);
+                const Locator2LocatorData* p_type = static_cast<const Locator2LocatorData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2262,7 +2262,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> Locator2LocatorDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2279,7 +2279,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Locator2LocatorData*>(data), current_alignment)) +
+                                           *static_cast<const Locator2LocatorData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2302,7 +2302,7 @@ namespace eprosima {
             }
 
             bool Locator2LocatorDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2311,7 +2311,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Locator2LocatorData* p_type = static_cast<Locator2LocatorData*>(data);
+                const Locator2LocatorData* p_type = static_cast<const Locator2LocatorData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2379,11 +2379,11 @@ namespace eprosima {
             }
 
             bool EntityDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                EntityData* p_type = static_cast<EntityData*>(data);
+                const EntityData* p_type = static_cast<const EntityData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2455,7 +2455,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> EntityDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2472,7 +2472,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<EntityData*>(data), current_alignment)) +
+                                           *static_cast<const EntityData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2495,7 +2495,7 @@ namespace eprosima {
             }
 
             bool EntityDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2504,7 +2504,7 @@ namespace eprosima {
                     return false;
                 }
 
-                EntityData* p_type = static_cast<EntityData*>(data);
+                const EntityData* p_type = static_cast<const EntityData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2572,11 +2572,11 @@ namespace eprosima {
             }
 
             bool PhysicalDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                PhysicalData* p_type = static_cast<PhysicalData*>(data);
+                const PhysicalData* p_type = static_cast<const PhysicalData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2648,7 +2648,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> PhysicalDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2665,7 +2665,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<PhysicalData*>(data), current_alignment)) +
+                                           *static_cast<const PhysicalData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2688,7 +2688,7 @@ namespace eprosima {
             }
 
             bool PhysicalDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2697,7 +2697,7 @@ namespace eprosima {
                     return false;
                 }
 
-                PhysicalData* p_type = static_cast<PhysicalData*>(data);
+                const PhysicalData* p_type = static_cast<const PhysicalData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/src/cpp/statistics/types/typesPubSubTypes.h
+++ b/src/cpp/statistics/types/typesPubSubTypes.h
@@ -61,14 +61,14 @@ namespace eprosima
                     eProsima_user_DllExport ~EntityId_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -77,17 +77,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -152,14 +152,14 @@ namespace eprosima
                     eProsima_user_DllExport ~GuidPrefix_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -168,17 +168,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -243,14 +243,14 @@ namespace eprosima
                     eProsima_user_DllExport ~GUID_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -259,17 +259,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -334,14 +334,14 @@ namespace eprosima
                     eProsima_user_DllExport ~SequenceNumber_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -350,17 +350,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -425,14 +425,14 @@ namespace eprosima
                     eProsima_user_DllExport ~SampleIdentity_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -441,17 +441,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -516,14 +516,14 @@ namespace eprosima
                     eProsima_user_DllExport ~Locator_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -532,17 +532,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -608,14 +608,14 @@ namespace eprosima
                 eProsima_user_DllExport ~DiscoveryTimePubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -624,17 +624,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -699,14 +699,14 @@ namespace eprosima
                 eProsima_user_DllExport ~EntityCountPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -715,17 +715,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -790,14 +790,14 @@ namespace eprosima
                 eProsima_user_DllExport ~SampleIdentityCountPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -806,17 +806,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -881,14 +881,14 @@ namespace eprosima
                 eProsima_user_DllExport ~Entity2LocatorTrafficPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -897,17 +897,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -972,14 +972,14 @@ namespace eprosima
                 eProsima_user_DllExport ~WriterReaderDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -988,17 +988,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1063,14 +1063,14 @@ namespace eprosima
                 eProsima_user_DllExport ~Locator2LocatorDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1079,17 +1079,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1154,14 +1154,14 @@ namespace eprosima
                 eProsima_user_DllExport ~EntityDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1170,17 +1170,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1245,14 +1245,14 @@ namespace eprosima
                 eProsima_user_DllExport ~PhysicalDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1261,17 +1261,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -901,6 +901,31 @@ TEST(DDSBasic, max_output_message_size_writer)
 
 }
 
+/**
+ * @test This test checks that it is possible to register two TypeSupport instances of the same type
+ *       under the same DomainParticipant.
+ */
+TEST(DDSBasic, register_two_identical_typesupports)
+{
+    // Set DomainParticipantFactory to create disabled entities
+    DomainParticipantFactory* factory = DomainParticipantFactory::get_instance();
+    ASSERT_NE(nullptr, factory);
+
+    // Create a disabled DomainParticipant, setting it to in turn create disable entities
+    DomainParticipant* participant = factory->create_participant((uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, participant);
+
+    // Register a type support
+    TypeSupport type_support_1;
+    type_support_1.reset(new HelloWorldPubSubType());
+    EXPECT_EQ(RETCODE_OK, participant->register_type(type_support_1));
+
+    // Register a second instance of the type support with the same TopicDataType
+    TypeSupport type_support_2;
+    type_support_2.reset(new HelloWorldPubSubType());
+    EXPECT_EQ(RETCODE_OK, participant->register_type(type_support_2));
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/test/blackbox/common/DDSBlackboxTestsDataRepresentationQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataRepresentationQos.cpp
@@ -31,7 +31,7 @@ class MockHelloWorldPubSubType : public HelloWorldPubSubType
 public:
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             DataRepresentationId_t data_representation) override
     {

--- a/test/blackbox/common/DDSBlackboxTestsFindTopic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsFindTopic.cpp
@@ -58,7 +58,7 @@ class DDSFindTopicTest : public testing::Test
         }
 
         bool serialize(
-                void*,
+                const void* const,
                 fastdds::rtps::SerializedPayload_t*) override
         {
             return true;
@@ -72,7 +72,7 @@ class DDSFindTopicTest : public testing::Test
         }
 
         std::function<uint32_t()> getSerializedSizeProvider(
-                void*) override
+                const void* const) override
         {
             return {};
         }
@@ -88,7 +88,7 @@ class DDSFindTopicTest : public testing::Test
         }
 
         bool getKey(
-                void*,
+                const void* const,
                 fastdds::rtps::InstanceHandle_t*,
                 bool) override
         {

--- a/test/blackbox/types/Data1mbPubSubTypes.cxx
+++ b/test/blackbox/types/Data1mbPubSubTypes.cxx
@@ -57,11 +57,11 @@ Data1mbPubSubType::~Data1mbPubSubType()
 }
 
 bool Data1mbPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Data1mb* p_type = static_cast<Data1mb*>(data);
+    const Data1mb* p_type = static_cast<const Data1mb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool Data1mbPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Data1mbPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> Data1mbPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Data1mb*>(data), current_alignment)) +
+                               *static_cast<const Data1mb*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void Data1mbPubSubType::deleteData(
 }
 
 bool Data1mbPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool Data1mbPubSubType::getKey(
         return false;
     }
 
-    Data1mb* p_type = static_cast<Data1mb*>(data);
+    const Data1mb* p_type = static_cast<const Data1mb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/Data1mbPubSubTypes.h
+++ b/test/blackbox/types/Data1mbPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~Data1mbPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/Data64kbPubSubTypes.cxx
+++ b/test/blackbox/types/Data64kbPubSubTypes.cxx
@@ -57,11 +57,11 @@ Data64kbPubSubType::~Data64kbPubSubType()
 }
 
 bool Data64kbPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Data64kb* p_type = static_cast<Data64kb*>(data);
+    const Data64kb* p_type = static_cast<const Data64kb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool Data64kbPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Data64kbPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> Data64kbPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Data64kb*>(data), current_alignment)) +
+                               *static_cast<const Data64kb*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void Data64kbPubSubType::deleteData(
 }
 
 bool Data64kbPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool Data64kbPubSubType::getKey(
         return false;
     }
 
-    Data64kb* p_type = static_cast<Data64kb*>(data);
+    const Data64kb* p_type = static_cast<const Data64kb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/Data64kbPubSubTypes.h
+++ b/test/blackbox/types/Data64kbPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~Data64kbPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/FixedSizedPubSubTypes.cxx
+++ b/test/blackbox/types/FixedSizedPubSubTypes.cxx
@@ -57,11 +57,11 @@ FixedSizedPubSubType::~FixedSizedPubSubType()
 }
 
 bool FixedSizedPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixedSized* p_type = static_cast<FixedSized*>(data);
+    const FixedSized* p_type = static_cast<const FixedSized*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool FixedSizedPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixedSizedPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> FixedSizedPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixedSized*>(data), current_alignment)) +
+                               *static_cast<const FixedSized*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void FixedSizedPubSubType::deleteData(
 }
 
 bool FixedSizedPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool FixedSizedPubSubType::getKey(
         return false;
     }
 
-    FixedSized* p_type = static_cast<FixedSized*>(data);
+    const FixedSized* p_type = static_cast<const FixedSized*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/FixedSizedPubSubTypes.h
+++ b/test/blackbox/types/FixedSizedPubSubTypes.h
@@ -86,14 +86,14 @@ public:
     eProsima_user_DllExport ~FixedSizedPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -102,17 +102,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/HelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/HelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ HelloWorldPubSubType::~HelloWorldPubSubType()
 }
 
 bool HelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool HelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> HelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<HelloWorld*>(data), current_alignment)) +
+                               *static_cast<const HelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void HelloWorldPubSubType::deleteData(
 }
 
 bool HelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool HelloWorldPubSubType::getKey(
         return false;
     }
 
-    HelloWorld* p_type = static_cast<HelloWorld*>(data);
+    const HelloWorld* p_type = static_cast<const HelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/HelloWorldPubSubTypes.h
+++ b/test/blackbox/types/HelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~HelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
@@ -57,11 +57,11 @@ KeyedData1mbPubSubType::~KeyedData1mbPubSubType()
 }
 
 bool KeyedData1mbPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedData1mb* p_type = static_cast<KeyedData1mb*>(data);
+    const KeyedData1mb* p_type = static_cast<const KeyedData1mb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool KeyedData1mbPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedData1mbPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> KeyedData1mbPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedData1mb*>(data), current_alignment)) +
+                               *static_cast<const KeyedData1mb*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void KeyedData1mbPubSubType::deleteData(
 }
 
 bool KeyedData1mbPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool KeyedData1mbPubSubType::getKey(
         return false;
     }
 
-    KeyedData1mb* p_type = static_cast<KeyedData1mb*>(data);
+    const KeyedData1mb* p_type = static_cast<const KeyedData1mb*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.h
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~KeyedData1mbPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ KeyedHelloWorldPubSubType::~KeyedHelloWorldPubSubType()
 }
 
 bool KeyedHelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedHelloWorld* p_type = static_cast<KeyedHelloWorld*>(data);
+    const KeyedHelloWorld* p_type = static_cast<const KeyedHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool KeyedHelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedHelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> KeyedHelloWorldPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedHelloWorld*>(data), current_alignment)) +
+                               *static_cast<const KeyedHelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void KeyedHelloWorldPubSubType::deleteData(
 }
 
 bool KeyedHelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool KeyedHelloWorldPubSubType::getKey(
         return false;
     }
 
-    KeyedHelloWorld* p_type = static_cast<KeyedHelloWorld*>(data);
+    const KeyedHelloWorld* p_type = static_cast<const KeyedHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.h
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~KeyedHelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/StringTestPubSubTypes.cxx
+++ b/test/blackbox/types/StringTestPubSubTypes.cxx
@@ -57,11 +57,11 @@ StringTestPubSubType::~StringTestPubSubType()
 }
 
 bool StringTestPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StringTest* p_type = static_cast<StringTest*>(data);
+    const StringTest* p_type = static_cast<const StringTest*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool StringTestPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StringTestPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> StringTestPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StringTest*>(data), current_alignment)) +
+                               *static_cast<const StringTest*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void StringTestPubSubType::deleteData(
 }
 
 bool StringTestPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool StringTestPubSubType::getKey(
         return false;
     }
 
-    StringTest* p_type = static_cast<StringTest*>(data);
+    const StringTest* p_type = static_cast<const StringTest*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/StringTestPubSubTypes.h
+++ b/test/blackbox/types/StringTestPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~StringTestPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/TestRegression3361PubSubTypes.cxx
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.cxx
@@ -57,11 +57,11 @@ TestRegression3361PubSubType::~TestRegression3361PubSubType()
 }
 
 bool TestRegression3361PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    TestRegression3361* p_type = static_cast<TestRegression3361*>(data);
+    const TestRegression3361* p_type = static_cast<const TestRegression3361*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool TestRegression3361PubSubType::deserialize(
 }
 
 std::function<uint32_t()> TestRegression3361PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> TestRegression3361PubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<TestRegression3361*>(data), current_alignment)) +
+                               *static_cast<const TestRegression3361*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void TestRegression3361PubSubType::deleteData(
 }
 
 bool TestRegression3361PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool TestRegression3361PubSubType::getKey(
         return false;
     }
 
-    TestRegression3361* p_type = static_cast<TestRegression3361*>(data);
+    const TestRegression3361* p_type = static_cast<const TestRegression3361*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/TestRegression3361PubSubTypes.h
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~TestRegression3361PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
@@ -57,11 +57,11 @@ UnboundedHelloWorldPubSubType::~UnboundedHelloWorldPubSubType()
 }
 
 bool UnboundedHelloWorldPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnboundedHelloWorld* p_type = static_cast<UnboundedHelloWorld*>(data);
+    const UnboundedHelloWorld* p_type = static_cast<const UnboundedHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool UnboundedHelloWorldPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnboundedHelloWorldPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> UnboundedHelloWorldPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnboundedHelloWorld*>(data), current_alignment)) +
+                               *static_cast<const UnboundedHelloWorld*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void UnboundedHelloWorldPubSubType::deleteData(
 }
 
 bool UnboundedHelloWorldPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool UnboundedHelloWorldPubSubType::getKey(
         return false;
     }
 
-    UnboundedHelloWorld* p_type = static_cast<UnboundedHelloWorld*>(data);
+    const UnboundedHelloWorld* p_type = static_cast<const UnboundedHelloWorld*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.h
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~UnboundedHelloWorldPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -60,11 +60,11 @@ namespace eprosima {
             }
 
             bool ConnectionPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Connection* p_type = static_cast<Connection*>(data);
+                const Connection* p_type = static_cast<const Connection*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -136,7 +136,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> ConnectionPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -153,7 +153,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Connection*>(data), current_alignment)) +
+                                           *static_cast<const Connection*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -176,7 +176,7 @@ namespace eprosima {
             }
 
             bool ConnectionPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -185,7 +185,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Connection* p_type = static_cast<Connection*>(data);
+                const Connection* p_type = static_cast<const Connection*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -253,11 +253,11 @@ namespace eprosima {
             }
 
             bool QosPolicyCount_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                QosPolicyCount_s* p_type = static_cast<QosPolicyCount_s*>(data);
+                const QosPolicyCount_s* p_type = static_cast<const QosPolicyCount_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -329,7 +329,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> QosPolicyCount_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -346,7 +346,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<QosPolicyCount_s*>(data), current_alignment)) +
+                                           *static_cast<const QosPolicyCount_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -369,7 +369,7 @@ namespace eprosima {
             }
 
             bool QosPolicyCount_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -378,7 +378,7 @@ namespace eprosima {
                     return false;
                 }
 
-                QosPolicyCount_s* p_type = static_cast<QosPolicyCount_s*>(data);
+                const QosPolicyCount_s* p_type = static_cast<const QosPolicyCount_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -446,11 +446,11 @@ namespace eprosima {
             }
 
             bool BaseStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                BaseStatus_s* p_type = static_cast<BaseStatus_s*>(data);
+                const BaseStatus_s* p_type = static_cast<const BaseStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -522,7 +522,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> BaseStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -539,7 +539,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<BaseStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const BaseStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -562,7 +562,7 @@ namespace eprosima {
             }
 
             bool BaseStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -571,7 +571,7 @@ namespace eprosima {
                     return false;
                 }
 
-                BaseStatus_s* p_type = static_cast<BaseStatus_s*>(data);
+                const BaseStatus_s* p_type = static_cast<const BaseStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -640,11 +640,11 @@ namespace eprosima {
             }
 
             bool IncompatibleQoSStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                IncompatibleQoSStatus_s* p_type = static_cast<IncompatibleQoSStatus_s*>(data);
+                const IncompatibleQoSStatus_s* p_type = static_cast<const IncompatibleQoSStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -716,7 +716,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> IncompatibleQoSStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -733,7 +733,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<IncompatibleQoSStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const IncompatibleQoSStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -756,7 +756,7 @@ namespace eprosima {
             }
 
             bool IncompatibleQoSStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -765,7 +765,7 @@ namespace eprosima {
                     return false;
                 }
 
-                IncompatibleQoSStatus_s* p_type = static_cast<IncompatibleQoSStatus_s*>(data);
+                const IncompatibleQoSStatus_s* p_type = static_cast<const IncompatibleQoSStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -833,11 +833,11 @@ namespace eprosima {
             }
 
             bool LivelinessChangedStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                LivelinessChangedStatus_s* p_type = static_cast<LivelinessChangedStatus_s*>(data);
+                const LivelinessChangedStatus_s* p_type = static_cast<const LivelinessChangedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -909,7 +909,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> LivelinessChangedStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -926,7 +926,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<LivelinessChangedStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const LivelinessChangedStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -949,7 +949,7 @@ namespace eprosima {
             }
 
             bool LivelinessChangedStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -958,7 +958,7 @@ namespace eprosima {
                     return false;
                 }
 
-                LivelinessChangedStatus_s* p_type = static_cast<LivelinessChangedStatus_s*>(data);
+                const LivelinessChangedStatus_s* p_type = static_cast<const LivelinessChangedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1026,11 +1026,11 @@ namespace eprosima {
             }
 
             bool DeadlineMissedStatus_sPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                DeadlineMissedStatus_s* p_type = static_cast<DeadlineMissedStatus_s*>(data);
+                const DeadlineMissedStatus_s* p_type = static_cast<const DeadlineMissedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1102,7 +1102,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> DeadlineMissedStatus_sPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1119,7 +1119,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<DeadlineMissedStatus_s*>(data), current_alignment)) +
+                                           *static_cast<const DeadlineMissedStatus_s*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1142,7 +1142,7 @@ namespace eprosima {
             }
 
             bool DeadlineMissedStatus_sPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1151,7 +1151,7 @@ namespace eprosima {
                     return false;
                 }
 
-                DeadlineMissedStatus_s* p_type = static_cast<DeadlineMissedStatus_s*>(data);
+                const DeadlineMissedStatus_s* p_type = static_cast<const DeadlineMissedStatus_s*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1226,11 +1226,11 @@ namespace eprosima {
             }
 
             bool MonitorServiceStatusDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                MonitorServiceStatusData* p_type = static_cast<MonitorServiceStatusData*>(data);
+                const MonitorServiceStatusData* p_type = static_cast<const MonitorServiceStatusData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1302,7 +1302,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> MonitorServiceStatusDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1319,7 +1319,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<MonitorServiceStatusData*>(data), current_alignment)) +
+                                           *static_cast<const MonitorServiceStatusData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1342,7 +1342,7 @@ namespace eprosima {
             }
 
             bool MonitorServiceStatusDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1351,7 +1351,7 @@ namespace eprosima {
                     return false;
                 }
 
-                MonitorServiceStatusData* p_type = static_cast<MonitorServiceStatusData*>(data);
+                const MonitorServiceStatusData* p_type = static_cast<const MonitorServiceStatusData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.h
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.h
@@ -60,14 +60,14 @@ namespace eprosima
                 eProsima_user_DllExport ~ConnectionPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -76,17 +76,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -151,14 +151,14 @@ namespace eprosima
                 eProsima_user_DllExport ~QosPolicyCount_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -167,17 +167,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -242,14 +242,14 @@ namespace eprosima
                 eProsima_user_DllExport ~BaseStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -258,17 +258,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -334,14 +334,14 @@ namespace eprosima
                 eProsima_user_DllExport ~IncompatibleQoSStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -350,17 +350,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -425,14 +425,14 @@ namespace eprosima
                 eProsima_user_DllExport ~LivelinessChangedStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -441,17 +441,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -516,14 +516,14 @@ namespace eprosima
                 eProsima_user_DllExport ~DeadlineMissedStatus_sPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -532,17 +532,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -624,14 +624,14 @@ namespace eprosima
                 eProsima_user_DllExport ~MonitorServiceStatusDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -640,17 +640,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 

--- a/test/blackbox/types/statistics/typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/typesPubSubTypes.cxx
@@ -61,11 +61,11 @@ namespace eprosima {
                 }
 
                 bool EntityId_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    EntityId_s* p_type = static_cast<EntityId_s*>(data);
+                    const EntityId_s* p_type = static_cast<const EntityId_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -137,7 +137,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> EntityId_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -154,7 +154,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<EntityId_s*>(data), current_alignment)) +
+                                               *static_cast<const EntityId_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -177,7 +177,7 @@ namespace eprosima {
                 }
 
                 bool EntityId_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -186,7 +186,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    EntityId_s* p_type = static_cast<EntityId_s*>(data);
+                    const EntityId_s* p_type = static_cast<const EntityId_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -254,11 +254,11 @@ namespace eprosima {
                 }
 
                 bool GuidPrefix_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    GuidPrefix_s* p_type = static_cast<GuidPrefix_s*>(data);
+                    const GuidPrefix_s* p_type = static_cast<const GuidPrefix_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -330,7 +330,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> GuidPrefix_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -347,7 +347,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<GuidPrefix_s*>(data), current_alignment)) +
+                                               *static_cast<const GuidPrefix_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -370,7 +370,7 @@ namespace eprosima {
                 }
 
                 bool GuidPrefix_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -379,7 +379,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    GuidPrefix_s* p_type = static_cast<GuidPrefix_s*>(data);
+                    const GuidPrefix_s* p_type = static_cast<const GuidPrefix_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -447,11 +447,11 @@ namespace eprosima {
                 }
 
                 bool GUID_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    GUID_s* p_type = static_cast<GUID_s*>(data);
+                    const GUID_s* p_type = static_cast<const GUID_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -523,7 +523,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> GUID_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -540,7 +540,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<GUID_s*>(data), current_alignment)) +
+                                               *static_cast<const GUID_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -563,7 +563,7 @@ namespace eprosima {
                 }
 
                 bool GUID_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -572,7 +572,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    GUID_s* p_type = static_cast<GUID_s*>(data);
+                    const GUID_s* p_type = static_cast<const GUID_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -640,11 +640,11 @@ namespace eprosima {
                 }
 
                 bool SequenceNumber_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    SequenceNumber_s* p_type = static_cast<SequenceNumber_s*>(data);
+                    const SequenceNumber_s* p_type = static_cast<const SequenceNumber_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -716,7 +716,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> SequenceNumber_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -733,7 +733,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<SequenceNumber_s*>(data), current_alignment)) +
+                                               *static_cast<const SequenceNumber_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -756,7 +756,7 @@ namespace eprosima {
                 }
 
                 bool SequenceNumber_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -765,7 +765,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    SequenceNumber_s* p_type = static_cast<SequenceNumber_s*>(data);
+                    const SequenceNumber_s* p_type = static_cast<const SequenceNumber_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -833,11 +833,11 @@ namespace eprosima {
                 }
 
                 bool SampleIdentity_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    SampleIdentity_s* p_type = static_cast<SampleIdentity_s*>(data);
+                    const SampleIdentity_s* p_type = static_cast<const SampleIdentity_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -909,7 +909,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> SampleIdentity_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -926,7 +926,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<SampleIdentity_s*>(data), current_alignment)) +
+                                               *static_cast<const SampleIdentity_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -949,7 +949,7 @@ namespace eprosima {
                 }
 
                 bool SampleIdentity_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -958,7 +958,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    SampleIdentity_s* p_type = static_cast<SampleIdentity_s*>(data);
+                    const SampleIdentity_s* p_type = static_cast<const SampleIdentity_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1026,11 +1026,11 @@ namespace eprosima {
                 }
 
                 bool Locator_sPubSubType::serialize(
-                        void* data,
+                        const void* const data,
                         SerializedPayload_t* payload,
                         DataRepresentationId_t data_representation)
                 {
-                    Locator_s* p_type = static_cast<Locator_s*>(data);
+                    const Locator_s* p_type = static_cast<const Locator_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1102,7 +1102,7 @@ namespace eprosima {
                 }
 
                 std::function<uint32_t()> Locator_sPubSubType::getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         DataRepresentationId_t data_representation)
                 {
                     return [data, data_representation]() -> uint32_t
@@ -1119,7 +1119,7 @@ namespace eprosima {
                                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                    size_t current_alignment {0};
                                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                               *static_cast<Locator_s*>(data), current_alignment)) +
+                                               *static_cast<const Locator_s*>(data), current_alignment)) +
                                            4u /*encapsulation*/;
                                }
                                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1142,7 +1142,7 @@ namespace eprosima {
                 }
 
                 bool Locator_sPubSubType::getKey(
-                        void* data,
+                        const void* const data,
                         InstanceHandle_t* handle,
                         bool force_md5)
                 {
@@ -1151,7 +1151,7 @@ namespace eprosima {
                         return false;
                     }
 
-                    Locator_s* p_type = static_cast<Locator_s*>(data);
+                    const Locator_s* p_type = static_cast<const Locator_s*>(data);
 
                     // Object that manages the raw buffer.
                     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1221,11 +1221,11 @@ namespace eprosima {
             }
 
             bool DiscoveryTimePubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                DiscoveryTime* p_type = static_cast<DiscoveryTime*>(data);
+                const DiscoveryTime* p_type = static_cast<const DiscoveryTime*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1297,7 +1297,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> DiscoveryTimePubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1314,7 +1314,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<DiscoveryTime*>(data), current_alignment)) +
+                                           *static_cast<const DiscoveryTime*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1337,7 +1337,7 @@ namespace eprosima {
             }
 
             bool DiscoveryTimePubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1346,7 +1346,7 @@ namespace eprosima {
                     return false;
                 }
 
-                DiscoveryTime* p_type = static_cast<DiscoveryTime*>(data);
+                const DiscoveryTime* p_type = static_cast<const DiscoveryTime*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1414,11 +1414,11 @@ namespace eprosima {
             }
 
             bool EntityCountPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                EntityCount* p_type = static_cast<EntityCount*>(data);
+                const EntityCount* p_type = static_cast<const EntityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1490,7 +1490,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> EntityCountPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1507,7 +1507,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<EntityCount*>(data), current_alignment)) +
+                                           *static_cast<const EntityCount*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1530,7 +1530,7 @@ namespace eprosima {
             }
 
             bool EntityCountPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1539,7 +1539,7 @@ namespace eprosima {
                     return false;
                 }
 
-                EntityCount* p_type = static_cast<EntityCount*>(data);
+                const EntityCount* p_type = static_cast<const EntityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1607,11 +1607,11 @@ namespace eprosima {
             }
 
             bool SampleIdentityCountPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                SampleIdentityCount* p_type = static_cast<SampleIdentityCount*>(data);
+                const SampleIdentityCount* p_type = static_cast<const SampleIdentityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1683,7 +1683,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> SampleIdentityCountPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1700,7 +1700,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<SampleIdentityCount*>(data), current_alignment)) +
+                                           *static_cast<const SampleIdentityCount*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1723,7 +1723,7 @@ namespace eprosima {
             }
 
             bool SampleIdentityCountPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1732,7 +1732,7 @@ namespace eprosima {
                     return false;
                 }
 
-                SampleIdentityCount* p_type = static_cast<SampleIdentityCount*>(data);
+                const SampleIdentityCount* p_type = static_cast<const SampleIdentityCount*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1800,11 +1800,11 @@ namespace eprosima {
             }
 
             bool Entity2LocatorTrafficPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Entity2LocatorTraffic* p_type = static_cast<Entity2LocatorTraffic*>(data);
+                const Entity2LocatorTraffic* p_type = static_cast<const Entity2LocatorTraffic*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1876,7 +1876,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> Entity2LocatorTrafficPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -1893,7 +1893,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Entity2LocatorTraffic*>(data), current_alignment)) +
+                                           *static_cast<const Entity2LocatorTraffic*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1916,7 +1916,7 @@ namespace eprosima {
             }
 
             bool Entity2LocatorTrafficPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -1925,7 +1925,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Entity2LocatorTraffic* p_type = static_cast<Entity2LocatorTraffic*>(data);
+                const Entity2LocatorTraffic* p_type = static_cast<const Entity2LocatorTraffic*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1993,11 +1993,11 @@ namespace eprosima {
             }
 
             bool WriterReaderDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                WriterReaderData* p_type = static_cast<WriterReaderData*>(data);
+                const WriterReaderData* p_type = static_cast<const WriterReaderData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2069,7 +2069,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> WriterReaderDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2086,7 +2086,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<WriterReaderData*>(data), current_alignment)) +
+                                           *static_cast<const WriterReaderData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2109,7 +2109,7 @@ namespace eprosima {
             }
 
             bool WriterReaderDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2118,7 +2118,7 @@ namespace eprosima {
                     return false;
                 }
 
-                WriterReaderData* p_type = static_cast<WriterReaderData*>(data);
+                const WriterReaderData* p_type = static_cast<const WriterReaderData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2186,11 +2186,11 @@ namespace eprosima {
             }
 
             bool Locator2LocatorDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                Locator2LocatorData* p_type = static_cast<Locator2LocatorData*>(data);
+                const Locator2LocatorData* p_type = static_cast<const Locator2LocatorData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2262,7 +2262,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> Locator2LocatorDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2279,7 +2279,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<Locator2LocatorData*>(data), current_alignment)) +
+                                           *static_cast<const Locator2LocatorData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2302,7 +2302,7 @@ namespace eprosima {
             }
 
             bool Locator2LocatorDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2311,7 +2311,7 @@ namespace eprosima {
                     return false;
                 }
 
-                Locator2LocatorData* p_type = static_cast<Locator2LocatorData*>(data);
+                const Locator2LocatorData* p_type = static_cast<const Locator2LocatorData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2379,11 +2379,11 @@ namespace eprosima {
             }
 
             bool EntityDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                EntityData* p_type = static_cast<EntityData*>(data);
+                const EntityData* p_type = static_cast<const EntityData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2455,7 +2455,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> EntityDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2472,7 +2472,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<EntityData*>(data), current_alignment)) +
+                                           *static_cast<const EntityData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2495,7 +2495,7 @@ namespace eprosima {
             }
 
             bool EntityDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2504,7 +2504,7 @@ namespace eprosima {
                     return false;
                 }
 
-                EntityData* p_type = static_cast<EntityData*>(data);
+                const EntityData* p_type = static_cast<const EntityData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2572,11 +2572,11 @@ namespace eprosima {
             }
 
             bool PhysicalDataPubSubType::serialize(
-                    void* data,
+                    const void* const data,
                     SerializedPayload_t* payload,
                     DataRepresentationId_t data_representation)
             {
-                PhysicalData* p_type = static_cast<PhysicalData*>(data);
+                const PhysicalData* p_type = static_cast<const PhysicalData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2648,7 +2648,7 @@ namespace eprosima {
             }
 
             std::function<uint32_t()> PhysicalDataPubSubType::getSerializedSizeProvider(
-                    void* data,
+                    const void* const data,
                     DataRepresentationId_t data_representation)
             {
                 return [data, data_representation]() -> uint32_t
@@ -2665,7 +2665,7 @@ namespace eprosima {
                                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                                size_t current_alignment {0};
                                return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                           *static_cast<PhysicalData*>(data), current_alignment)) +
+                                           *static_cast<const PhysicalData*>(data), current_alignment)) +
                                        4u /*encapsulation*/;
                            }
                            catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2688,7 +2688,7 @@ namespace eprosima {
             }
 
             bool PhysicalDataPubSubType::getKey(
-                    void* data,
+                    const void* const data,
                     InstanceHandle_t* handle,
                     bool force_md5)
             {
@@ -2697,7 +2697,7 @@ namespace eprosima {
                     return false;
                 }
 
-                PhysicalData* p_type = static_cast<PhysicalData*>(data);
+                const PhysicalData* p_type = static_cast<const PhysicalData*>(data);
 
                 // Object that manages the raw buffer.
                 eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/blackbox/types/statistics/typesPubSubTypes.h
+++ b/test/blackbox/types/statistics/typesPubSubTypes.h
@@ -61,14 +61,14 @@ namespace eprosima
                     eProsima_user_DllExport ~EntityId_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -77,17 +77,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -152,14 +152,14 @@ namespace eprosima
                     eProsima_user_DllExport ~GuidPrefix_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -168,17 +168,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -243,14 +243,14 @@ namespace eprosima
                     eProsima_user_DllExport ~GUID_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -259,17 +259,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -334,14 +334,14 @@ namespace eprosima
                     eProsima_user_DllExport ~SequenceNumber_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -350,17 +350,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -425,14 +425,14 @@ namespace eprosima
                     eProsima_user_DllExport ~SampleIdentity_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -441,17 +441,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -516,14 +516,14 @@ namespace eprosima
                     eProsima_user_DllExport ~Locator_sPubSubType() override;
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                     {
                         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport bool serialize(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::SerializedPayload_t* payload,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -532,17 +532,17 @@ namespace eprosima
                             void* data) override;
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data) override
+                            const void* const data) override
                     {
                         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                     }
 
                     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                     eProsima_user_DllExport bool getKey(
-                            void* data,
+                            const void* const data,
                             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                             bool force_md5 = false) override;
 
@@ -608,14 +608,14 @@ namespace eprosima
                 eProsima_user_DllExport ~DiscoveryTimePubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -624,17 +624,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -699,14 +699,14 @@ namespace eprosima
                 eProsima_user_DllExport ~EntityCountPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -715,17 +715,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -790,14 +790,14 @@ namespace eprosima
                 eProsima_user_DllExport ~SampleIdentityCountPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -806,17 +806,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -881,14 +881,14 @@ namespace eprosima
                 eProsima_user_DllExport ~Entity2LocatorTrafficPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -897,17 +897,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -972,14 +972,14 @@ namespace eprosima
                 eProsima_user_DllExport ~WriterReaderDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -988,17 +988,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1063,14 +1063,14 @@ namespace eprosima
                 eProsima_user_DllExport ~Locator2LocatorDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1079,17 +1079,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1154,14 +1154,14 @@ namespace eprosima
                 eProsima_user_DllExport ~EntityDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1170,17 +1170,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 
@@ -1245,14 +1245,14 @@ namespace eprosima
                 eProsima_user_DllExport ~PhysicalDataPubSubType() override;
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload) override
                 {
                     return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport bool serialize(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::SerializedPayload_t* payload,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1261,17 +1261,17 @@ namespace eprosima
                         void* data) override;
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data) override
+                        const void* const data) override
                 {
                     return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
                 }
 
                 eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
                 eProsima_user_DllExport bool getKey(
-                        void* data,
+                        const void* const data,
                         eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                         bool force_md5 = false) override;
 

--- a/test/dds-types-test/aliasesPubSubTypes.cxx
+++ b/test/dds-types-test/aliasesPubSubTypes.cxx
@@ -57,11 +57,11 @@ AliasInt16PubSubType::~AliasInt16PubSubType()
 }
 
 bool AliasInt16PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasInt16* p_type = static_cast<AliasInt16*>(data);
+    const AliasInt16* p_type = static_cast<const AliasInt16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool AliasInt16PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasInt16PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> AliasInt16PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasInt16*>(data), current_alignment)) +
+                               *static_cast<const AliasInt16*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void AliasInt16PubSubType::deleteData(
 }
 
 bool AliasInt16PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool AliasInt16PubSubType::getKey(
         return false;
     }
 
-    AliasInt16* p_type = static_cast<AliasInt16*>(data);
+    const AliasInt16* p_type = static_cast<const AliasInt16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ AliasUint16PubSubType::~AliasUint16PubSubType()
 }
 
 bool AliasUint16PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasUint16* p_type = static_cast<AliasUint16*>(data);
+    const AliasUint16* p_type = static_cast<const AliasUint16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool AliasUint16PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasUint16PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> AliasUint16PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasUint16*>(data), current_alignment)) +
+                               *static_cast<const AliasUint16*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void AliasUint16PubSubType::deleteData(
 }
 
 bool AliasUint16PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool AliasUint16PubSubType::getKey(
         return false;
     }
 
-    AliasUint16* p_type = static_cast<AliasUint16*>(data);
+    const AliasUint16* p_type = static_cast<const AliasUint16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ AliasInt32PubSubType::~AliasInt32PubSubType()
 }
 
 bool AliasInt32PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasInt32* p_type = static_cast<AliasInt32*>(data);
+    const AliasInt32* p_type = static_cast<const AliasInt32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool AliasInt32PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasInt32PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> AliasInt32PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasInt32*>(data), current_alignment)) +
+                               *static_cast<const AliasInt32*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void AliasInt32PubSubType::deleteData(
 }
 
 bool AliasInt32PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool AliasInt32PubSubType::getKey(
         return false;
     }
 
-    AliasInt32* p_type = static_cast<AliasInt32*>(data);
+    const AliasInt32* p_type = static_cast<const AliasInt32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ AliasUInt32PubSubType::~AliasUInt32PubSubType()
 }
 
 bool AliasUInt32PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasUInt32* p_type = static_cast<AliasUInt32*>(data);
+    const AliasUInt32* p_type = static_cast<const AliasUInt32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool AliasUInt32PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasUInt32PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> AliasUInt32PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasUInt32*>(data), current_alignment)) +
+                               *static_cast<const AliasUInt32*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void AliasUInt32PubSubType::deleteData(
 }
 
 bool AliasUInt32PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool AliasUInt32PubSubType::getKey(
         return false;
     }
 
-    AliasUInt32* p_type = static_cast<AliasUInt32*>(data);
+    const AliasUInt32* p_type = static_cast<const AliasUInt32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ AliasInt64PubSubType::~AliasInt64PubSubType()
 }
 
 bool AliasInt64PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasInt64* p_type = static_cast<AliasInt64*>(data);
+    const AliasInt64* p_type = static_cast<const AliasInt64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool AliasInt64PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasInt64PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> AliasInt64PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasInt64*>(data), current_alignment)) +
+                               *static_cast<const AliasInt64*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void AliasInt64PubSubType::deleteData(
 }
 
 bool AliasInt64PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool AliasInt64PubSubType::getKey(
         return false;
     }
 
-    AliasInt64* p_type = static_cast<AliasInt64*>(data);
+    const AliasInt64* p_type = static_cast<const AliasInt64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ AliasUInt64PubSubType::~AliasUInt64PubSubType()
 }
 
 bool AliasUInt64PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasUInt64* p_type = static_cast<AliasUInt64*>(data);
+    const AliasUInt64* p_type = static_cast<const AliasUInt64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool AliasUInt64PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasUInt64PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> AliasUInt64PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasUInt64*>(data), current_alignment)) +
+                               *static_cast<const AliasUInt64*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void AliasUInt64PubSubType::deleteData(
 }
 
 bool AliasUInt64PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool AliasUInt64PubSubType::getKey(
         return false;
     }
 
-    AliasUInt64* p_type = static_cast<AliasUInt64*>(data);
+    const AliasUInt64* p_type = static_cast<const AliasUInt64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ AliasFloat32PubSubType::~AliasFloat32PubSubType()
 }
 
 bool AliasFloat32PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasFloat32* p_type = static_cast<AliasFloat32*>(data);
+    const AliasFloat32* p_type = static_cast<const AliasFloat32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool AliasFloat32PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasFloat32PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> AliasFloat32PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasFloat32*>(data), current_alignment)) +
+                               *static_cast<const AliasFloat32*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void AliasFloat32PubSubType::deleteData(
 }
 
 bool AliasFloat32PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool AliasFloat32PubSubType::getKey(
         return false;
     }
 
-    AliasFloat32* p_type = static_cast<AliasFloat32*>(data);
+    const AliasFloat32* p_type = static_cast<const AliasFloat32*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ AliasFloat64PubSubType::~AliasFloat64PubSubType()
 }
 
 bool AliasFloat64PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasFloat64* p_type = static_cast<AliasFloat64*>(data);
+    const AliasFloat64* p_type = static_cast<const AliasFloat64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool AliasFloat64PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasFloat64PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> AliasFloat64PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasFloat64*>(data), current_alignment)) +
+                               *static_cast<const AliasFloat64*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void AliasFloat64PubSubType::deleteData(
 }
 
 bool AliasFloat64PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool AliasFloat64PubSubType::getKey(
         return false;
     }
 
-    AliasFloat64* p_type = static_cast<AliasFloat64*>(data);
+    const AliasFloat64* p_type = static_cast<const AliasFloat64*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ AliasFloat128PubSubType::~AliasFloat128PubSubType()
 }
 
 bool AliasFloat128PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasFloat128* p_type = static_cast<AliasFloat128*>(data);
+    const AliasFloat128* p_type = static_cast<const AliasFloat128*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool AliasFloat128PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasFloat128PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> AliasFloat128PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasFloat128*>(data), current_alignment)) +
+                               *static_cast<const AliasFloat128*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void AliasFloat128PubSubType::deleteData(
 }
 
 bool AliasFloat128PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool AliasFloat128PubSubType::getKey(
         return false;
     }
 
-    AliasFloat128* p_type = static_cast<AliasFloat128*>(data);
+    const AliasFloat128* p_type = static_cast<const AliasFloat128*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ AliasBoolPubSubType::~AliasBoolPubSubType()
 }
 
 bool AliasBoolPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasBool* p_type = static_cast<AliasBool*>(data);
+    const AliasBool* p_type = static_cast<const AliasBool*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool AliasBoolPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasBoolPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> AliasBoolPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasBool*>(data), current_alignment)) +
+                               *static_cast<const AliasBool*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void AliasBoolPubSubType::deleteData(
 }
 
 bool AliasBoolPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool AliasBoolPubSubType::getKey(
         return false;
     }
 
-    AliasBool* p_type = static_cast<AliasBool*>(data);
+    const AliasBool* p_type = static_cast<const AliasBool*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ AliasOctetPubSubType::~AliasOctetPubSubType()
 }
 
 bool AliasOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasOctet* p_type = static_cast<AliasOctet*>(data);
+    const AliasOctet* p_type = static_cast<const AliasOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool AliasOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> AliasOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasOctet*>(data), current_alignment)) +
+                               *static_cast<const AliasOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void AliasOctetPubSubType::deleteData(
 }
 
 bool AliasOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool AliasOctetPubSubType::getKey(
         return false;
     }
 
-    AliasOctet* p_type = static_cast<AliasOctet*>(data);
+    const AliasOctet* p_type = static_cast<const AliasOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ AliasChar8PubSubType::~AliasChar8PubSubType()
 }
 
 bool AliasChar8PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasChar8* p_type = static_cast<AliasChar8*>(data);
+    const AliasChar8* p_type = static_cast<const AliasChar8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool AliasChar8PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasChar8PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> AliasChar8PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasChar8*>(data), current_alignment)) +
+                               *static_cast<const AliasChar8*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void AliasChar8PubSubType::deleteData(
 }
 
 bool AliasChar8PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool AliasChar8PubSubType::getKey(
         return false;
     }
 
-    AliasChar8* p_type = static_cast<AliasChar8*>(data);
+    const AliasChar8* p_type = static_cast<const AliasChar8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ AliasChar16PubSubType::~AliasChar16PubSubType()
 }
 
 bool AliasChar16PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasChar16* p_type = static_cast<AliasChar16*>(data);
+    const AliasChar16* p_type = static_cast<const AliasChar16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool AliasChar16PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasChar16PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> AliasChar16PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasChar16*>(data), current_alignment)) +
+                               *static_cast<const AliasChar16*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void AliasChar16PubSubType::deleteData(
 }
 
 bool AliasChar16PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool AliasChar16PubSubType::getKey(
         return false;
     }
 
-    AliasChar16* p_type = static_cast<AliasChar16*>(data);
+    const AliasChar16* p_type = static_cast<const AliasChar16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ AliasString8PubSubType::~AliasString8PubSubType()
 }
 
 bool AliasString8PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasString8* p_type = static_cast<AliasString8*>(data);
+    const AliasString8* p_type = static_cast<const AliasString8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool AliasString8PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasString8PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> AliasString8PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasString8*>(data), current_alignment)) +
+                               *static_cast<const AliasString8*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void AliasString8PubSubType::deleteData(
 }
 
 bool AliasString8PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool AliasString8PubSubType::getKey(
         return false;
     }
 
-    AliasString8* p_type = static_cast<AliasString8*>(data);
+    const AliasString8* p_type = static_cast<const AliasString8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ AliasString16PubSubType::~AliasString16PubSubType()
 }
 
 bool AliasString16PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasString16* p_type = static_cast<AliasString16*>(data);
+    const AliasString16* p_type = static_cast<const AliasString16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool AliasString16PubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasString16PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> AliasString16PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasString16*>(data), current_alignment)) +
+                               *static_cast<const AliasString16*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void AliasString16PubSubType::deleteData(
 }
 
 bool AliasString16PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool AliasString16PubSubType::getKey(
         return false;
     }
 
-    AliasString16* p_type = static_cast<AliasString16*>(data);
+    const AliasString16* p_type = static_cast<const AliasString16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ AliasEnumPubSubType::~AliasEnumPubSubType()
 }
 
 bool AliasEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasEnum* p_type = static_cast<AliasEnum*>(data);
+    const AliasEnum* p_type = static_cast<const AliasEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool AliasEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> AliasEnumPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasEnum*>(data), current_alignment)) +
+                               *static_cast<const AliasEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void AliasEnumPubSubType::deleteData(
 }
 
 bool AliasEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool AliasEnumPubSubType::getKey(
         return false;
     }
 
-    AliasEnum* p_type = static_cast<AliasEnum*>(data);
+    const AliasEnum* p_type = static_cast<const AliasEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ AliasBitmaskPubSubType::~AliasBitmaskPubSubType()
 }
 
 bool AliasBitmaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasBitmask* p_type = static_cast<AliasBitmask*>(data);
+    const AliasBitmask* p_type = static_cast<const AliasBitmask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool AliasBitmaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasBitmaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> AliasBitmaskPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasBitmask*>(data), current_alignment)) +
+                               *static_cast<const AliasBitmask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void AliasBitmaskPubSubType::deleteData(
 }
 
 bool AliasBitmaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool AliasBitmaskPubSubType::getKey(
         return false;
     }
 
-    AliasBitmask* p_type = static_cast<AliasBitmask*>(data);
+    const AliasBitmask* p_type = static_cast<const AliasBitmask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ AliasAliasPubSubType::~AliasAliasPubSubType()
 }
 
 bool AliasAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasAlias* p_type = static_cast<AliasAlias*>(data);
+    const AliasAlias* p_type = static_cast<const AliasAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool AliasAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> AliasAliasPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasAlias*>(data), current_alignment)) +
+                               *static_cast<const AliasAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void AliasAliasPubSubType::deleteData(
 }
 
 bool AliasAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool AliasAliasPubSubType::getKey(
         return false;
     }
 
-    AliasAlias* p_type = static_cast<AliasAlias*>(data);
+    const AliasAlias* p_type = static_cast<const AliasAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ AliasArrayPubSubType::~AliasArrayPubSubType()
 }
 
 bool AliasArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasArray* p_type = static_cast<AliasArray*>(data);
+    const AliasArray* p_type = static_cast<const AliasArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool AliasArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> AliasArrayPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasArray*>(data), current_alignment)) +
+                               *static_cast<const AliasArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void AliasArrayPubSubType::deleteData(
 }
 
 bool AliasArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool AliasArrayPubSubType::getKey(
         return false;
     }
 
-    AliasArray* p_type = static_cast<AliasArray*>(data);
+    const AliasArray* p_type = static_cast<const AliasArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ AliasMultiArrayPubSubType::~AliasMultiArrayPubSubType()
 }
 
 bool AliasMultiArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasMultiArray* p_type = static_cast<AliasMultiArray*>(data);
+    const AliasMultiArray* p_type = static_cast<const AliasMultiArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool AliasMultiArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasMultiArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> AliasMultiArrayPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasMultiArray*>(data), current_alignment)) +
+                               *static_cast<const AliasMultiArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void AliasMultiArrayPubSubType::deleteData(
 }
 
 bool AliasMultiArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool AliasMultiArrayPubSubType::getKey(
         return false;
     }
 
-    AliasMultiArray* p_type = static_cast<AliasMultiArray*>(data);
+    const AliasMultiArray* p_type = static_cast<const AliasMultiArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ AliasSequencePubSubType::~AliasSequencePubSubType()
 }
 
 bool AliasSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasSequence* p_type = static_cast<AliasSequence*>(data);
+    const AliasSequence* p_type = static_cast<const AliasSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool AliasSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> AliasSequencePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasSequence*>(data), current_alignment)) +
+                               *static_cast<const AliasSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void AliasSequencePubSubType::deleteData(
 }
 
 bool AliasSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool AliasSequencePubSubType::getKey(
         return false;
     }
 
-    AliasSequence* p_type = static_cast<AliasSequence*>(data);
+    const AliasSequence* p_type = static_cast<const AliasSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ AliasMapPubSubType::~AliasMapPubSubType()
 }
 
 bool AliasMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasMap* p_type = static_cast<AliasMap*>(data);
+    const AliasMap* p_type = static_cast<const AliasMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool AliasMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> AliasMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasMap*>(data), current_alignment)) +
+                               *static_cast<const AliasMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void AliasMapPubSubType::deleteData(
 }
 
 bool AliasMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool AliasMapPubSubType::getKey(
         return false;
     }
 
-    AliasMap* p_type = static_cast<AliasMap*>(data);
+    const AliasMap* p_type = static_cast<const AliasMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ AliasUnionPubSubType::~AliasUnionPubSubType()
 }
 
 bool AliasUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasUnion* p_type = static_cast<AliasUnion*>(data);
+    const AliasUnion* p_type = static_cast<const AliasUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool AliasUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> AliasUnionPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasUnion*>(data), current_alignment)) +
+                               *static_cast<const AliasUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void AliasUnionPubSubType::deleteData(
 }
 
 bool AliasUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool AliasUnionPubSubType::getKey(
         return false;
     }
 
-    AliasUnion* p_type = static_cast<AliasUnion*>(data);
+    const AliasUnion* p_type = static_cast<const AliasUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ AliasStructPubSubType::~AliasStructPubSubType()
 }
 
 bool AliasStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasStruct* p_type = static_cast<AliasStruct*>(data);
+    const AliasStruct* p_type = static_cast<const AliasStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool AliasStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> AliasStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasStruct*>(data), current_alignment)) +
+                               *static_cast<const AliasStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void AliasStructPubSubType::deleteData(
 }
 
 bool AliasStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool AliasStructPubSubType::getKey(
         return false;
     }
 
-    AliasStruct* p_type = static_cast<AliasStruct*>(data);
+    const AliasStruct* p_type = static_cast<const AliasStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ AliasBitsetPubSubType::~AliasBitsetPubSubType()
 }
 
 bool AliasBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AliasBitset* p_type = static_cast<AliasBitset*>(data);
+    const AliasBitset* p_type = static_cast<const AliasBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool AliasBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AliasBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> AliasBitsetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AliasBitset*>(data), current_alignment)) +
+                               *static_cast<const AliasBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void AliasBitsetPubSubType::deleteData(
 }
 
 bool AliasBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool AliasBitsetPubSubType::getKey(
         return false;
     }
 
-    AliasBitset* p_type = static_cast<AliasBitset*>(data);
+    const AliasBitset* p_type = static_cast<const AliasBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/aliasesPubSubTypes.h
+++ b/test/dds-types-test/aliasesPubSubTypes.h
@@ -79,14 +79,14 @@ public:
     eProsima_user_DllExport ~AliasInt16PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -95,17 +95,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -170,14 +170,14 @@ public:
     eProsima_user_DllExport ~AliasUint16PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -186,17 +186,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -261,14 +261,14 @@ public:
     eProsima_user_DllExport ~AliasInt32PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -277,17 +277,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -352,14 +352,14 @@ public:
     eProsima_user_DllExport ~AliasUInt32PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -368,17 +368,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -443,14 +443,14 @@ public:
     eProsima_user_DllExport ~AliasInt64PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -459,17 +459,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -534,14 +534,14 @@ public:
     eProsima_user_DllExport ~AliasUInt64PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -550,17 +550,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -625,14 +625,14 @@ public:
     eProsima_user_DllExport ~AliasFloat32PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -641,17 +641,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -716,14 +716,14 @@ public:
     eProsima_user_DllExport ~AliasFloat64PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -732,17 +732,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -807,14 +807,14 @@ public:
     eProsima_user_DllExport ~AliasFloat128PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -823,17 +823,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -898,14 +898,14 @@ public:
     eProsima_user_DllExport ~AliasBoolPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -914,17 +914,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -989,14 +989,14 @@ public:
     eProsima_user_DllExport ~AliasOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1005,17 +1005,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1080,14 +1080,14 @@ public:
     eProsima_user_DllExport ~AliasChar8PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1096,17 +1096,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1171,14 +1171,14 @@ public:
     eProsima_user_DllExport ~AliasChar16PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1187,17 +1187,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1262,14 +1262,14 @@ public:
     eProsima_user_DllExport ~AliasString8PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1278,17 +1278,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1353,14 +1353,14 @@ public:
     eProsima_user_DllExport ~AliasString16PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1369,17 +1369,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1444,14 +1444,14 @@ public:
     eProsima_user_DllExport ~AliasEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1460,17 +1460,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1535,14 +1535,14 @@ public:
     eProsima_user_DllExport ~AliasBitmaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1551,17 +1551,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1626,14 +1626,14 @@ public:
     eProsima_user_DllExport ~AliasAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1642,17 +1642,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1717,14 +1717,14 @@ public:
     eProsima_user_DllExport ~AliasArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1733,17 +1733,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1808,14 +1808,14 @@ public:
     eProsima_user_DllExport ~AliasMultiArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1824,17 +1824,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1899,14 +1899,14 @@ public:
     eProsima_user_DllExport ~AliasSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1915,17 +1915,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1990,14 +1990,14 @@ public:
     eProsima_user_DllExport ~AliasMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2006,17 +2006,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2081,14 +2081,14 @@ public:
     eProsima_user_DllExport ~AliasUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2097,17 +2097,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2172,14 +2172,14 @@ public:
     eProsima_user_DllExport ~AliasStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2188,17 +2188,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2263,14 +2263,14 @@ public:
     eProsima_user_DllExport ~AliasBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2279,17 +2279,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/annotationsPubSubTypes.cxx
+++ b/test/dds-types-test/annotationsPubSubTypes.cxx
@@ -57,11 +57,11 @@ AnnotatedStructPubSubType::~AnnotatedStructPubSubType()
 }
 
 bool AnnotatedStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AnnotatedStruct* p_type = static_cast<AnnotatedStruct*>(data);
+    const AnnotatedStruct* p_type = static_cast<const AnnotatedStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool AnnotatedStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AnnotatedStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> AnnotatedStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AnnotatedStruct*>(data), current_alignment)) +
+                               *static_cast<const AnnotatedStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void AnnotatedStructPubSubType::deleteData(
 }
 
 bool AnnotatedStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool AnnotatedStructPubSubType::getKey(
         return false;
     }
 
-    AnnotatedStruct* p_type = static_cast<AnnotatedStruct*>(data);
+    const AnnotatedStruct* p_type = static_cast<const AnnotatedStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ EmptyAnnotatedStructPubSubType::~EmptyAnnotatedStructPubSubType()
 }
 
 bool EmptyAnnotatedStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    EmptyAnnotatedStruct* p_type = static_cast<EmptyAnnotatedStruct*>(data);
+    const EmptyAnnotatedStruct* p_type = static_cast<const EmptyAnnotatedStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool EmptyAnnotatedStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> EmptyAnnotatedStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> EmptyAnnotatedStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<EmptyAnnotatedStruct*>(data), current_alignment)) +
+                               *static_cast<const EmptyAnnotatedStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void EmptyAnnotatedStructPubSubType::deleteData(
 }
 
 bool EmptyAnnotatedStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool EmptyAnnotatedStructPubSubType::getKey(
         return false;
     }
 
-    EmptyAnnotatedStruct* p_type = static_cast<EmptyAnnotatedStruct*>(data);
+    const EmptyAnnotatedStruct* p_type = static_cast<const EmptyAnnotatedStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -444,11 +444,11 @@ BasicAnnotationsStructPubSubType::~BasicAnnotationsStructPubSubType()
 }
 
 bool BasicAnnotationsStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BasicAnnotationsStruct* p_type = static_cast<BasicAnnotationsStruct*>(data);
+    const BasicAnnotationsStruct* p_type = static_cast<const BasicAnnotationsStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -520,7 +520,7 @@ bool BasicAnnotationsStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BasicAnnotationsStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -537,7 +537,7 @@ std::function<uint32_t()> BasicAnnotationsStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BasicAnnotationsStruct*>(data), current_alignment)) +
+                               *static_cast<const BasicAnnotationsStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -560,7 +560,7 @@ void BasicAnnotationsStructPubSubType::deleteData(
 }
 
 bool BasicAnnotationsStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -569,7 +569,7 @@ bool BasicAnnotationsStructPubSubType::getKey(
         return false;
     }
 
-    BasicAnnotationsStruct* p_type = static_cast<BasicAnnotationsStruct*>(data);
+    const BasicAnnotationsStruct* p_type = static_cast<const BasicAnnotationsStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/annotationsPubSubTypes.h
+++ b/test/dds-types-test/annotationsPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~AnnotatedStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~EmptyAnnotatedStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -237,14 +237,14 @@ public:
     eProsima_user_DllExport ~BasicAnnotationsStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -253,17 +253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/appendablePubSubTypes.cxx
+++ b/test/dds-types-test/appendablePubSubTypes.cxx
@@ -57,11 +57,11 @@ AppendableShortStructPubSubType::~AppendableShortStructPubSubType()
 }
 
 bool AppendableShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableShortStruct* p_type = static_cast<AppendableShortStruct*>(data);
+    const AppendableShortStruct* p_type = static_cast<const AppendableShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool AppendableShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> AppendableShortStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableShortStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void AppendableShortStructPubSubType::deleteData(
 }
 
 bool AppendableShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool AppendableShortStructPubSubType::getKey(
         return false;
     }
 
-    AppendableShortStruct* p_type = static_cast<AppendableShortStruct*>(data);
+    const AppendableShortStruct* p_type = static_cast<const AppendableShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ AppendableUShortStructPubSubType::~AppendableUShortStructPubSubType()
 }
 
 bool AppendableUShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableUShortStruct* p_type = static_cast<AppendableUShortStruct*>(data);
+    const AppendableUShortStruct* p_type = static_cast<const AppendableUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool AppendableUShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableUShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> AppendableUShortStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableUShortStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableUShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void AppendableUShortStructPubSubType::deleteData(
 }
 
 bool AppendableUShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool AppendableUShortStructPubSubType::getKey(
         return false;
     }
 
-    AppendableUShortStruct* p_type = static_cast<AppendableUShortStruct*>(data);
+    const AppendableUShortStruct* p_type = static_cast<const AppendableUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ AppendableLongStructPubSubType::~AppendableLongStructPubSubType()
 }
 
 bool AppendableLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableLongStruct* p_type = static_cast<AppendableLongStruct*>(data);
+    const AppendableLongStruct* p_type = static_cast<const AppendableLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool AppendableLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> AppendableLongStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableLongStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void AppendableLongStructPubSubType::deleteData(
 }
 
 bool AppendableLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool AppendableLongStructPubSubType::getKey(
         return false;
     }
 
-    AppendableLongStruct* p_type = static_cast<AppendableLongStruct*>(data);
+    const AppendableLongStruct* p_type = static_cast<const AppendableLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ AppendableULongStructPubSubType::~AppendableULongStructPubSubType()
 }
 
 bool AppendableULongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableULongStruct* p_type = static_cast<AppendableULongStruct*>(data);
+    const AppendableULongStruct* p_type = static_cast<const AppendableULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool AppendableULongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableULongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> AppendableULongStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableULongStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableULongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void AppendableULongStructPubSubType::deleteData(
 }
 
 bool AppendableULongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool AppendableULongStructPubSubType::getKey(
         return false;
     }
 
-    AppendableULongStruct* p_type = static_cast<AppendableULongStruct*>(data);
+    const AppendableULongStruct* p_type = static_cast<const AppendableULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ AppendableLongLongStructPubSubType::~AppendableLongLongStructPubSubType()
 }
 
 bool AppendableLongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableLongLongStruct* p_type = static_cast<AppendableLongLongStruct*>(data);
+    const AppendableLongLongStruct* p_type = static_cast<const AppendableLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool AppendableLongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableLongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> AppendableLongLongStructPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableLongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableLongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void AppendableLongLongStructPubSubType::deleteData(
 }
 
 bool AppendableLongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool AppendableLongLongStructPubSubType::getKey(
         return false;
     }
 
-    AppendableLongLongStruct* p_type = static_cast<AppendableLongLongStruct*>(data);
+    const AppendableLongLongStruct* p_type = static_cast<const AppendableLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ AppendableULongLongStructPubSubType::~AppendableULongLongStructPubSubType()
 }
 
 bool AppendableULongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableULongLongStruct* p_type = static_cast<AppendableULongLongStruct*>(data);
+    const AppendableULongLongStruct* p_type = static_cast<const AppendableULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool AppendableULongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableULongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> AppendableULongLongStructPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableULongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableULongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void AppendableULongLongStructPubSubType::deleteData(
 }
 
 bool AppendableULongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool AppendableULongLongStructPubSubType::getKey(
         return false;
     }
 
-    AppendableULongLongStruct* p_type = static_cast<AppendableULongLongStruct*>(data);
+    const AppendableULongLongStruct* p_type = static_cast<const AppendableULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ AppendableFloatStructPubSubType::~AppendableFloatStructPubSubType()
 }
 
 bool AppendableFloatStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableFloatStruct* p_type = static_cast<AppendableFloatStruct*>(data);
+    const AppendableFloatStruct* p_type = static_cast<const AppendableFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool AppendableFloatStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableFloatStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> AppendableFloatStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableFloatStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableFloatStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void AppendableFloatStructPubSubType::deleteData(
 }
 
 bool AppendableFloatStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool AppendableFloatStructPubSubType::getKey(
         return false;
     }
 
-    AppendableFloatStruct* p_type = static_cast<AppendableFloatStruct*>(data);
+    const AppendableFloatStruct* p_type = static_cast<const AppendableFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ AppendableDoubleStructPubSubType::~AppendableDoubleStructPubSubType()
 }
 
 bool AppendableDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableDoubleStruct* p_type = static_cast<AppendableDoubleStruct*>(data);
+    const AppendableDoubleStruct* p_type = static_cast<const AppendableDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool AppendableDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> AppendableDoubleStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void AppendableDoubleStructPubSubType::deleteData(
 }
 
 bool AppendableDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool AppendableDoubleStructPubSubType::getKey(
         return false;
     }
 
-    AppendableDoubleStruct* p_type = static_cast<AppendableDoubleStruct*>(data);
+    const AppendableDoubleStruct* p_type = static_cast<const AppendableDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ AppendableLongDoubleStructPubSubType::~AppendableLongDoubleStructPubSubType()
 }
 
 bool AppendableLongDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableLongDoubleStruct* p_type = static_cast<AppendableLongDoubleStruct*>(data);
+    const AppendableLongDoubleStruct* p_type = static_cast<const AppendableLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool AppendableLongDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableLongDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> AppendableLongDoubleStructPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableLongDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableLongDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void AppendableLongDoubleStructPubSubType::deleteData(
 }
 
 bool AppendableLongDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool AppendableLongDoubleStructPubSubType::getKey(
         return false;
     }
 
-    AppendableLongDoubleStruct* p_type = static_cast<AppendableLongDoubleStruct*>(data);
+    const AppendableLongDoubleStruct* p_type = static_cast<const AppendableLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ AppendableBooleanStructPubSubType::~AppendableBooleanStructPubSubType()
 }
 
 bool AppendableBooleanStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableBooleanStruct* p_type = static_cast<AppendableBooleanStruct*>(data);
+    const AppendableBooleanStruct* p_type = static_cast<const AppendableBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool AppendableBooleanStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableBooleanStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> AppendableBooleanStructPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableBooleanStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableBooleanStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void AppendableBooleanStructPubSubType::deleteData(
 }
 
 bool AppendableBooleanStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool AppendableBooleanStructPubSubType::getKey(
         return false;
     }
 
-    AppendableBooleanStruct* p_type = static_cast<AppendableBooleanStruct*>(data);
+    const AppendableBooleanStruct* p_type = static_cast<const AppendableBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ AppendableOctetStructPubSubType::~AppendableOctetStructPubSubType()
 }
 
 bool AppendableOctetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableOctetStruct* p_type = static_cast<AppendableOctetStruct*>(data);
+    const AppendableOctetStruct* p_type = static_cast<const AppendableOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool AppendableOctetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableOctetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> AppendableOctetStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableOctetStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableOctetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void AppendableOctetStructPubSubType::deleteData(
 }
 
 bool AppendableOctetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool AppendableOctetStructPubSubType::getKey(
         return false;
     }
 
-    AppendableOctetStruct* p_type = static_cast<AppendableOctetStruct*>(data);
+    const AppendableOctetStruct* p_type = static_cast<const AppendableOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ AppendableCharStructPubSubType::~AppendableCharStructPubSubType()
 }
 
 bool AppendableCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableCharStruct* p_type = static_cast<AppendableCharStruct*>(data);
+    const AppendableCharStruct* p_type = static_cast<const AppendableCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool AppendableCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> AppendableCharStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableCharStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void AppendableCharStructPubSubType::deleteData(
 }
 
 bool AppendableCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool AppendableCharStructPubSubType::getKey(
         return false;
     }
 
-    AppendableCharStruct* p_type = static_cast<AppendableCharStruct*>(data);
+    const AppendableCharStruct* p_type = static_cast<const AppendableCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ AppendableWCharStructPubSubType::~AppendableWCharStructPubSubType()
 }
 
 bool AppendableWCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableWCharStruct* p_type = static_cast<AppendableWCharStruct*>(data);
+    const AppendableWCharStruct* p_type = static_cast<const AppendableWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool AppendableWCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableWCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> AppendableWCharStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableWCharStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableWCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void AppendableWCharStructPubSubType::deleteData(
 }
 
 bool AppendableWCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool AppendableWCharStructPubSubType::getKey(
         return false;
     }
 
-    AppendableWCharStruct* p_type = static_cast<AppendableWCharStruct*>(data);
+    const AppendableWCharStruct* p_type = static_cast<const AppendableWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ AppendableUnionStructPubSubType::~AppendableUnionStructPubSubType()
 }
 
 bool AppendableUnionStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableUnionStruct* p_type = static_cast<AppendableUnionStruct*>(data);
+    const AppendableUnionStruct* p_type = static_cast<const AppendableUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool AppendableUnionStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableUnionStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> AppendableUnionStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableUnionStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableUnionStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void AppendableUnionStructPubSubType::deleteData(
 }
 
 bool AppendableUnionStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool AppendableUnionStructPubSubType::getKey(
         return false;
     }
 
-    AppendableUnionStruct* p_type = static_cast<AppendableUnionStruct*>(data);
+    const AppendableUnionStruct* p_type = static_cast<const AppendableUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ AppendableEmptyStructPubSubType::~AppendableEmptyStructPubSubType()
 }
 
 bool AppendableEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableEmptyStruct* p_type = static_cast<AppendableEmptyStruct*>(data);
+    const AppendableEmptyStruct* p_type = static_cast<const AppendableEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool AppendableEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> AppendableEmptyStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void AppendableEmptyStructPubSubType::deleteData(
 }
 
 bool AppendableEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool AppendableEmptyStructPubSubType::getKey(
         return false;
     }
 
-    AppendableEmptyStruct* p_type = static_cast<AppendableEmptyStruct*>(data);
+    const AppendableEmptyStruct* p_type = static_cast<const AppendableEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ AppendableEmptyInheritanceStructPubSubType::~AppendableEmptyInheritanceStructPub
 }
 
 bool AppendableEmptyInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableEmptyInheritanceStruct* p_type = static_cast<AppendableEmptyInheritanceStruct*>(data);
+    const AppendableEmptyInheritanceStruct* p_type = static_cast<const AppendableEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool AppendableEmptyInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableEmptyInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> AppendableEmptyInheritanceStructPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableEmptyInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableEmptyInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void AppendableEmptyInheritanceStructPubSubType::deleteData(
 }
 
 bool AppendableEmptyInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool AppendableEmptyInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    AppendableEmptyInheritanceStruct* p_type = static_cast<AppendableEmptyInheritanceStruct*>(data);
+    const AppendableEmptyInheritanceStruct* p_type = static_cast<const AppendableEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ AppendableInheritanceStructPubSubType::~AppendableInheritanceStructPubSubType()
 }
 
 bool AppendableInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableInheritanceStruct* p_type = static_cast<AppendableInheritanceStruct*>(data);
+    const AppendableInheritanceStruct* p_type = static_cast<const AppendableInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool AppendableInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> AppendableInheritanceStructPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void AppendableInheritanceStructPubSubType::deleteData(
 }
 
 bool AppendableInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool AppendableInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    AppendableInheritanceStruct* p_type = static_cast<AppendableInheritanceStruct*>(data);
+    const AppendableInheritanceStruct* p_type = static_cast<const AppendableInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ AppendableInheritanceEmptyStructPubSubType::~AppendableInheritanceEmptyStructPub
 }
 
 bool AppendableInheritanceEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableInheritanceEmptyStruct* p_type = static_cast<AppendableInheritanceEmptyStruct*>(data);
+    const AppendableInheritanceEmptyStruct* p_type = static_cast<const AppendableInheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool AppendableInheritanceEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableInheritanceEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> AppendableInheritanceEmptyStructPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableInheritanceEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const AppendableInheritanceEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void AppendableInheritanceEmptyStructPubSubType::deleteData(
 }
 
 bool AppendableInheritanceEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool AppendableInheritanceEmptyStructPubSubType::getKey(
         return false;
     }
 
-    AppendableInheritanceEmptyStruct* p_type = static_cast<AppendableInheritanceEmptyStruct*>(data);
+    const AppendableInheritanceEmptyStruct* p_type = static_cast<const AppendableInheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ AppendableExtensibilityInheritancePubSubType::~AppendableExtensibilityInheritanc
 }
 
 bool AppendableExtensibilityInheritancePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AppendableExtensibilityInheritance* p_type = static_cast<AppendableExtensibilityInheritance*>(data);
+    const AppendableExtensibilityInheritance* p_type = static_cast<const AppendableExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool AppendableExtensibilityInheritancePubSubType::deserialize(
 }
 
 std::function<uint32_t()> AppendableExtensibilityInheritancePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> AppendableExtensibilityInheritancePubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AppendableExtensibilityInheritance*>(data), current_alignment)) +
+                               *static_cast<const AppendableExtensibilityInheritance*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void AppendableExtensibilityInheritancePubSubType::deleteData(
 }
 
 bool AppendableExtensibilityInheritancePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool AppendableExtensibilityInheritancePubSubType::getKey(
         return false;
     }
 
-    AppendableExtensibilityInheritance* p_type = static_cast<AppendableExtensibilityInheritance*>(data);
+    const AppendableExtensibilityInheritance* p_type = static_cast<const AppendableExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/appendablePubSubTypes.h
+++ b/test/dds-types-test/appendablePubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~AppendableShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~AppendableUShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~AppendableLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~AppendableULongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~AppendableLongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~AppendableULongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~AppendableFloatStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~AppendableDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~AppendableLongDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~AppendableBooleanStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~AppendableOctetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~AppendableCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~AppendableWCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~AppendableUnionStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~AppendableEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~AppendableEmptyInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~AppendableInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~AppendableInheritanceEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~AppendableExtensibilityInheritancePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/arraysPubSubTypes.cxx
+++ b/test/dds-types-test/arraysPubSubTypes.cxx
@@ -57,11 +57,11 @@ ArrayShortPubSubType::~ArrayShortPubSubType()
 }
 
 bool ArrayShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayShort* p_type = static_cast<ArrayShort*>(data);
+    const ArrayShort* p_type = static_cast<const ArrayShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool ArrayShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> ArrayShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void ArrayShortPubSubType::deleteData(
 }
 
 bool ArrayShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool ArrayShortPubSubType::getKey(
         return false;
     }
 
-    ArrayShort* p_type = static_cast<ArrayShort*>(data);
+    const ArrayShort* p_type = static_cast<const ArrayShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ ArrayUShortPubSubType::~ArrayUShortPubSubType()
 }
 
 bool ArrayUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayUShort* p_type = static_cast<ArrayUShort*>(data);
+    const ArrayUShort* p_type = static_cast<const ArrayUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool ArrayUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> ArrayUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayUShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void ArrayUShortPubSubType::deleteData(
 }
 
 bool ArrayUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool ArrayUShortPubSubType::getKey(
         return false;
     }
 
-    ArrayUShort* p_type = static_cast<ArrayUShort*>(data);
+    const ArrayUShort* p_type = static_cast<const ArrayUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ ArrayLongPubSubType::~ArrayLongPubSubType()
 }
 
 bool ArrayLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayLong* p_type = static_cast<ArrayLong*>(data);
+    const ArrayLong* p_type = static_cast<const ArrayLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool ArrayLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> ArrayLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void ArrayLongPubSubType::deleteData(
 }
 
 bool ArrayLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool ArrayLongPubSubType::getKey(
         return false;
     }
 
-    ArrayLong* p_type = static_cast<ArrayLong*>(data);
+    const ArrayLong* p_type = static_cast<const ArrayLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ ArrayULongPubSubType::~ArrayULongPubSubType()
 }
 
 bool ArrayULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayULong* p_type = static_cast<ArrayULong*>(data);
+    const ArrayULong* p_type = static_cast<const ArrayULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool ArrayULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> ArrayULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayULong*>(data), current_alignment)) +
+                               *static_cast<const ArrayULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void ArrayULongPubSubType::deleteData(
 }
 
 bool ArrayULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool ArrayULongPubSubType::getKey(
         return false;
     }
 
-    ArrayULong* p_type = static_cast<ArrayULong*>(data);
+    const ArrayULong* p_type = static_cast<const ArrayULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ ArrayLongLongPubSubType::~ArrayLongLongPubSubType()
 }
 
 bool ArrayLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayLongLong* p_type = static_cast<ArrayLongLong*>(data);
+    const ArrayLongLong* p_type = static_cast<const ArrayLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool ArrayLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> ArrayLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayLongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void ArrayLongLongPubSubType::deleteData(
 }
 
 bool ArrayLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool ArrayLongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayLongLong* p_type = static_cast<ArrayLongLong*>(data);
+    const ArrayLongLong* p_type = static_cast<const ArrayLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ ArrayULongLongPubSubType::~ArrayULongLongPubSubType()
 }
 
 bool ArrayULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayULongLong* p_type = static_cast<ArrayULongLong*>(data);
+    const ArrayULongLong* p_type = static_cast<const ArrayULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool ArrayULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> ArrayULongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayULongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void ArrayULongLongPubSubType::deleteData(
 }
 
 bool ArrayULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool ArrayULongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayULongLong* p_type = static_cast<ArrayULongLong*>(data);
+    const ArrayULongLong* p_type = static_cast<const ArrayULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ ArrayFloatPubSubType::~ArrayFloatPubSubType()
 }
 
 bool ArrayFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayFloat* p_type = static_cast<ArrayFloat*>(data);
+    const ArrayFloat* p_type = static_cast<const ArrayFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool ArrayFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> ArrayFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayFloat*>(data), current_alignment)) +
+                               *static_cast<const ArrayFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void ArrayFloatPubSubType::deleteData(
 }
 
 bool ArrayFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool ArrayFloatPubSubType::getKey(
         return false;
     }
 
-    ArrayFloat* p_type = static_cast<ArrayFloat*>(data);
+    const ArrayFloat* p_type = static_cast<const ArrayFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ ArrayDoublePubSubType::~ArrayDoublePubSubType()
 }
 
 bool ArrayDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayDouble* p_type = static_cast<ArrayDouble*>(data);
+    const ArrayDouble* p_type = static_cast<const ArrayDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool ArrayDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> ArrayDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void ArrayDoublePubSubType::deleteData(
 }
 
 bool ArrayDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool ArrayDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayDouble* p_type = static_cast<ArrayDouble*>(data);
+    const ArrayDouble* p_type = static_cast<const ArrayDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ ArrayLongDoublePubSubType::~ArrayLongDoublePubSubType()
 }
 
 bool ArrayLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayLongDouble* p_type = static_cast<ArrayLongDouble*>(data);
+    const ArrayLongDouble* p_type = static_cast<const ArrayLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool ArrayLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> ArrayLongDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayLongDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void ArrayLongDoublePubSubType::deleteData(
 }
 
 bool ArrayLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool ArrayLongDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayLongDouble* p_type = static_cast<ArrayLongDouble*>(data);
+    const ArrayLongDouble* p_type = static_cast<const ArrayLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ ArrayBooleanPubSubType::~ArrayBooleanPubSubType()
 }
 
 bool ArrayBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayBoolean* p_type = static_cast<ArrayBoolean*>(data);
+    const ArrayBoolean* p_type = static_cast<const ArrayBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool ArrayBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> ArrayBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayBoolean*>(data), current_alignment)) +
+                               *static_cast<const ArrayBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void ArrayBooleanPubSubType::deleteData(
 }
 
 bool ArrayBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool ArrayBooleanPubSubType::getKey(
         return false;
     }
 
-    ArrayBoolean* p_type = static_cast<ArrayBoolean*>(data);
+    const ArrayBoolean* p_type = static_cast<const ArrayBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ ArrayOctetPubSubType::~ArrayOctetPubSubType()
 }
 
 bool ArrayOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayOctet* p_type = static_cast<ArrayOctet*>(data);
+    const ArrayOctet* p_type = static_cast<const ArrayOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool ArrayOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> ArrayOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayOctet*>(data), current_alignment)) +
+                               *static_cast<const ArrayOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void ArrayOctetPubSubType::deleteData(
 }
 
 bool ArrayOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool ArrayOctetPubSubType::getKey(
         return false;
     }
 
-    ArrayOctet* p_type = static_cast<ArrayOctet*>(data);
+    const ArrayOctet* p_type = static_cast<const ArrayOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ ArrayCharPubSubType::~ArrayCharPubSubType()
 }
 
 bool ArrayCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayChar* p_type = static_cast<ArrayChar*>(data);
+    const ArrayChar* p_type = static_cast<const ArrayChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool ArrayCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> ArrayCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void ArrayCharPubSubType::deleteData(
 }
 
 bool ArrayCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool ArrayCharPubSubType::getKey(
         return false;
     }
 
-    ArrayChar* p_type = static_cast<ArrayChar*>(data);
+    const ArrayChar* p_type = static_cast<const ArrayChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ ArrayWCharPubSubType::~ArrayWCharPubSubType()
 }
 
 bool ArrayWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayWChar* p_type = static_cast<ArrayWChar*>(data);
+    const ArrayWChar* p_type = static_cast<const ArrayWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool ArrayWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> ArrayWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayWChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void ArrayWCharPubSubType::deleteData(
 }
 
 bool ArrayWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool ArrayWCharPubSubType::getKey(
         return false;
     }
 
-    ArrayWChar* p_type = static_cast<ArrayWChar*>(data);
+    const ArrayWChar* p_type = static_cast<const ArrayWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ ArrayStringPubSubType::~ArrayStringPubSubType()
 }
 
 bool ArrayStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayString* p_type = static_cast<ArrayString*>(data);
+    const ArrayString* p_type = static_cast<const ArrayString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool ArrayStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> ArrayStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayString*>(data), current_alignment)) +
+                               *static_cast<const ArrayString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void ArrayStringPubSubType::deleteData(
 }
 
 bool ArrayStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool ArrayStringPubSubType::getKey(
         return false;
     }
 
-    ArrayString* p_type = static_cast<ArrayString*>(data);
+    const ArrayString* p_type = static_cast<const ArrayString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ ArrayWStringPubSubType::~ArrayWStringPubSubType()
 }
 
 bool ArrayWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayWString* p_type = static_cast<ArrayWString*>(data);
+    const ArrayWString* p_type = static_cast<const ArrayWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool ArrayWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> ArrayWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void ArrayWStringPubSubType::deleteData(
 }
 
 bool ArrayWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool ArrayWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayWString* p_type = static_cast<ArrayWString*>(data);
+    const ArrayWString* p_type = static_cast<const ArrayWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ ArrayBoundedStringPubSubType::~ArrayBoundedStringPubSubType()
 }
 
 bool ArrayBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayBoundedString* p_type = static_cast<ArrayBoundedString*>(data);
+    const ArrayBoundedString* p_type = static_cast<const ArrayBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool ArrayBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> ArrayBoundedStringPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayBoundedString*>(data), current_alignment)) +
+                               *static_cast<const ArrayBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void ArrayBoundedStringPubSubType::deleteData(
 }
 
 bool ArrayBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool ArrayBoundedStringPubSubType::getKey(
         return false;
     }
 
-    ArrayBoundedString* p_type = static_cast<ArrayBoundedString*>(data);
+    const ArrayBoundedString* p_type = static_cast<const ArrayBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ ArrayBoundedWStringPubSubType::~ArrayBoundedWStringPubSubType()
 }
 
 bool ArrayBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayBoundedWString* p_type = static_cast<ArrayBoundedWString*>(data);
+    const ArrayBoundedWString* p_type = static_cast<const ArrayBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool ArrayBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> ArrayBoundedWStringPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void ArrayBoundedWStringPubSubType::deleteData(
 }
 
 bool ArrayBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool ArrayBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayBoundedWString* p_type = static_cast<ArrayBoundedWString*>(data);
+    const ArrayBoundedWString* p_type = static_cast<const ArrayBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ ArrayEnumPubSubType::~ArrayEnumPubSubType()
 }
 
 bool ArrayEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayEnum* p_type = static_cast<ArrayEnum*>(data);
+    const ArrayEnum* p_type = static_cast<const ArrayEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool ArrayEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> ArrayEnumPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayEnum*>(data), current_alignment)) +
+                               *static_cast<const ArrayEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void ArrayEnumPubSubType::deleteData(
 }
 
 bool ArrayEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool ArrayEnumPubSubType::getKey(
         return false;
     }
 
-    ArrayEnum* p_type = static_cast<ArrayEnum*>(data);
+    const ArrayEnum* p_type = static_cast<const ArrayEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ ArrayBitMaskPubSubType::~ArrayBitMaskPubSubType()
 }
 
 bool ArrayBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayBitMask* p_type = static_cast<ArrayBitMask*>(data);
+    const ArrayBitMask* p_type = static_cast<const ArrayBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool ArrayBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> ArrayBitMaskPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayBitMask*>(data), current_alignment)) +
+                               *static_cast<const ArrayBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void ArrayBitMaskPubSubType::deleteData(
 }
 
 bool ArrayBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool ArrayBitMaskPubSubType::getKey(
         return false;
     }
 
-    ArrayBitMask* p_type = static_cast<ArrayBitMask*>(data);
+    const ArrayBitMask* p_type = static_cast<const ArrayBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ ArrayAliasPubSubType::~ArrayAliasPubSubType()
 }
 
 bool ArrayAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayAlias* p_type = static_cast<ArrayAlias*>(data);
+    const ArrayAlias* p_type = static_cast<const ArrayAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool ArrayAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> ArrayAliasPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayAlias*>(data), current_alignment)) +
+                               *static_cast<const ArrayAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void ArrayAliasPubSubType::deleteData(
 }
 
 bool ArrayAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool ArrayAliasPubSubType::getKey(
         return false;
     }
 
-    ArrayAlias* p_type = static_cast<ArrayAlias*>(data);
+    const ArrayAlias* p_type = static_cast<const ArrayAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ ArrayShortArrayPubSubType::~ArrayShortArrayPubSubType()
 }
 
 bool ArrayShortArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayShortArray* p_type = static_cast<ArrayShortArray*>(data);
+    const ArrayShortArray* p_type = static_cast<const ArrayShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool ArrayShortArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayShortArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> ArrayShortArrayPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayShortArray*>(data), current_alignment)) +
+                               *static_cast<const ArrayShortArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void ArrayShortArrayPubSubType::deleteData(
 }
 
 bool ArrayShortArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool ArrayShortArrayPubSubType::getKey(
         return false;
     }
 
-    ArrayShortArray* p_type = static_cast<ArrayShortArray*>(data);
+    const ArrayShortArray* p_type = static_cast<const ArrayShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ ArraySequencePubSubType::~ArraySequencePubSubType()
 }
 
 bool ArraySequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySequence* p_type = static_cast<ArraySequence*>(data);
+    const ArraySequence* p_type = static_cast<const ArraySequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool ArraySequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> ArraySequencePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySequence*>(data), current_alignment)) +
+                               *static_cast<const ArraySequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void ArraySequencePubSubType::deleteData(
 }
 
 bool ArraySequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool ArraySequencePubSubType::getKey(
         return false;
     }
 
-    ArraySequence* p_type = static_cast<ArraySequence*>(data);
+    const ArraySequence* p_type = static_cast<const ArraySequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ ArrayMapPubSubType::~ArrayMapPubSubType()
 }
 
 bool ArrayMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMap* p_type = static_cast<ArrayMap*>(data);
+    const ArrayMap* p_type = static_cast<const ArrayMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool ArrayMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> ArrayMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMap*>(data), current_alignment)) +
+                               *static_cast<const ArrayMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void ArrayMapPubSubType::deleteData(
 }
 
 bool ArrayMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool ArrayMapPubSubType::getKey(
         return false;
     }
 
-    ArrayMap* p_type = static_cast<ArrayMap*>(data);
+    const ArrayMap* p_type = static_cast<const ArrayMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ ArrayUnionPubSubType::~ArrayUnionPubSubType()
 }
 
 bool ArrayUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayUnion* p_type = static_cast<ArrayUnion*>(data);
+    const ArrayUnion* p_type = static_cast<const ArrayUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool ArrayUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> ArrayUnionPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayUnion*>(data), current_alignment)) +
+                               *static_cast<const ArrayUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void ArrayUnionPubSubType::deleteData(
 }
 
 bool ArrayUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool ArrayUnionPubSubType::getKey(
         return false;
     }
 
-    ArrayUnion* p_type = static_cast<ArrayUnion*>(data);
+    const ArrayUnion* p_type = static_cast<const ArrayUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ ArrayStructurePubSubType::~ArrayStructurePubSubType()
 }
 
 bool ArrayStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayStructure* p_type = static_cast<ArrayStructure*>(data);
+    const ArrayStructure* p_type = static_cast<const ArrayStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool ArrayStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> ArrayStructurePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayStructure*>(data), current_alignment)) +
+                               *static_cast<const ArrayStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void ArrayStructurePubSubType::deleteData(
 }
 
 bool ArrayStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool ArrayStructurePubSubType::getKey(
         return false;
     }
 
-    ArrayStructure* p_type = static_cast<ArrayStructure*>(data);
+    const ArrayStructure* p_type = static_cast<const ArrayStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ ArrayBitsetPubSubType::~ArrayBitsetPubSubType()
 }
 
 bool ArrayBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayBitset* p_type = static_cast<ArrayBitset*>(data);
+    const ArrayBitset* p_type = static_cast<const ArrayBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool ArrayBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> ArrayBitsetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayBitset*>(data), current_alignment)) +
+                               *static_cast<const ArrayBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void ArrayBitsetPubSubType::deleteData(
 }
 
 bool ArrayBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool ArrayBitsetPubSubType::getKey(
         return false;
     }
 
-    ArrayBitset* p_type = static_cast<ArrayBitset*>(data);
+    const ArrayBitset* p_type = static_cast<const ArrayBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ ArrayMultiDimensionShortPubSubType::~ArrayMultiDimensionShortPubSubType()
 }
 
 bool ArrayMultiDimensionShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionShort* p_type = static_cast<ArrayMultiDimensionShort*>(data);
+    const ArrayMultiDimensionShort* p_type = static_cast<const ArrayMultiDimensionShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool ArrayMultiDimensionShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> ArrayMultiDimensionShortPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void ArrayMultiDimensionShortPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool ArrayMultiDimensionShortPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionShort* p_type = static_cast<ArrayMultiDimensionShort*>(data);
+    const ArrayMultiDimensionShort* p_type = static_cast<const ArrayMultiDimensionShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ ArrayMultiDimensionUShortPubSubType::~ArrayMultiDimensionUShortPubSubType()
 }
 
 bool ArrayMultiDimensionUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionUShort* p_type = static_cast<ArrayMultiDimensionUShort*>(data);
+    const ArrayMultiDimensionUShort* p_type = static_cast<const ArrayMultiDimensionUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool ArrayMultiDimensionUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> ArrayMultiDimensionUShortPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionUShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void ArrayMultiDimensionUShortPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool ArrayMultiDimensionUShortPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionUShort* p_type = static_cast<ArrayMultiDimensionUShort*>(data);
+    const ArrayMultiDimensionUShort* p_type = static_cast<const ArrayMultiDimensionUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5461,11 +5461,11 @@ ArrayMultiDimensionLongPubSubType::~ArrayMultiDimensionLongPubSubType()
 }
 
 bool ArrayMultiDimensionLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLong* p_type = static_cast<ArrayMultiDimensionLong*>(data);
+    const ArrayMultiDimensionLong* p_type = static_cast<const ArrayMultiDimensionLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5537,7 +5537,7 @@ bool ArrayMultiDimensionLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5554,7 +5554,7 @@ std::function<uint32_t()> ArrayMultiDimensionLongPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5577,7 +5577,7 @@ void ArrayMultiDimensionLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5586,7 +5586,7 @@ bool ArrayMultiDimensionLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLong* p_type = static_cast<ArrayMultiDimensionLong*>(data);
+    const ArrayMultiDimensionLong* p_type = static_cast<const ArrayMultiDimensionLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5654,11 +5654,11 @@ ArrayMultiDimensionULongPubSubType::~ArrayMultiDimensionULongPubSubType()
 }
 
 bool ArrayMultiDimensionULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionULong* p_type = static_cast<ArrayMultiDimensionULong*>(data);
+    const ArrayMultiDimensionULong* p_type = static_cast<const ArrayMultiDimensionULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5730,7 +5730,7 @@ bool ArrayMultiDimensionULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5747,7 +5747,7 @@ std::function<uint32_t()> ArrayMultiDimensionULongPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionULong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5770,7 +5770,7 @@ void ArrayMultiDimensionULongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5779,7 +5779,7 @@ bool ArrayMultiDimensionULongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionULong* p_type = static_cast<ArrayMultiDimensionULong*>(data);
+    const ArrayMultiDimensionULong* p_type = static_cast<const ArrayMultiDimensionULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5847,11 +5847,11 @@ ArrayMultiDimensionLongLongPubSubType::~ArrayMultiDimensionLongLongPubSubType()
 }
 
 bool ArrayMultiDimensionLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLongLong* p_type = static_cast<ArrayMultiDimensionLongLong*>(data);
+    const ArrayMultiDimensionLongLong* p_type = static_cast<const ArrayMultiDimensionLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5923,7 +5923,7 @@ bool ArrayMultiDimensionLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5940,7 +5940,7 @@ std::function<uint32_t()> ArrayMultiDimensionLongLongPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5963,7 +5963,7 @@ void ArrayMultiDimensionLongLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5972,7 +5972,7 @@ bool ArrayMultiDimensionLongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLongLong* p_type = static_cast<ArrayMultiDimensionLongLong*>(data);
+    const ArrayMultiDimensionLongLong* p_type = static_cast<const ArrayMultiDimensionLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6040,11 +6040,11 @@ ArrayMultiDimensionULongLongPubSubType::~ArrayMultiDimensionULongLongPubSubType(
 }
 
 bool ArrayMultiDimensionULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionULongLong* p_type = static_cast<ArrayMultiDimensionULongLong*>(data);
+    const ArrayMultiDimensionULongLong* p_type = static_cast<const ArrayMultiDimensionULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6116,7 +6116,7 @@ bool ArrayMultiDimensionULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6133,7 +6133,7 @@ std::function<uint32_t()> ArrayMultiDimensionULongLongPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionULongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6156,7 +6156,7 @@ void ArrayMultiDimensionULongLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6165,7 +6165,7 @@ bool ArrayMultiDimensionULongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionULongLong* p_type = static_cast<ArrayMultiDimensionULongLong*>(data);
+    const ArrayMultiDimensionULongLong* p_type = static_cast<const ArrayMultiDimensionULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6233,11 +6233,11 @@ ArrayMultiDimensionFloatPubSubType::~ArrayMultiDimensionFloatPubSubType()
 }
 
 bool ArrayMultiDimensionFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionFloat* p_type = static_cast<ArrayMultiDimensionFloat*>(data);
+    const ArrayMultiDimensionFloat* p_type = static_cast<const ArrayMultiDimensionFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6309,7 +6309,7 @@ bool ArrayMultiDimensionFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6326,7 +6326,7 @@ std::function<uint32_t()> ArrayMultiDimensionFloatPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionFloat*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6349,7 +6349,7 @@ void ArrayMultiDimensionFloatPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6358,7 +6358,7 @@ bool ArrayMultiDimensionFloatPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionFloat* p_type = static_cast<ArrayMultiDimensionFloat*>(data);
+    const ArrayMultiDimensionFloat* p_type = static_cast<const ArrayMultiDimensionFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6426,11 +6426,11 @@ ArrayMultiDimensionDoublePubSubType::~ArrayMultiDimensionDoublePubSubType()
 }
 
 bool ArrayMultiDimensionDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionDouble* p_type = static_cast<ArrayMultiDimensionDouble*>(data);
+    const ArrayMultiDimensionDouble* p_type = static_cast<const ArrayMultiDimensionDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6502,7 +6502,7 @@ bool ArrayMultiDimensionDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6519,7 +6519,7 @@ std::function<uint32_t()> ArrayMultiDimensionDoublePubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6542,7 +6542,7 @@ void ArrayMultiDimensionDoublePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6551,7 +6551,7 @@ bool ArrayMultiDimensionDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionDouble* p_type = static_cast<ArrayMultiDimensionDouble*>(data);
+    const ArrayMultiDimensionDouble* p_type = static_cast<const ArrayMultiDimensionDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6619,11 +6619,11 @@ ArrayMultiDimensionLongDoublePubSubType::~ArrayMultiDimensionLongDoublePubSubTyp
 }
 
 bool ArrayMultiDimensionLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLongDouble* p_type = static_cast<ArrayMultiDimensionLongDouble*>(data);
+    const ArrayMultiDimensionLongDouble* p_type = static_cast<const ArrayMultiDimensionLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6695,7 +6695,7 @@ bool ArrayMultiDimensionLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6712,7 +6712,7 @@ std::function<uint32_t()> ArrayMultiDimensionLongDoublePubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLongDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6735,7 +6735,7 @@ void ArrayMultiDimensionLongDoublePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6744,7 +6744,7 @@ bool ArrayMultiDimensionLongDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLongDouble* p_type = static_cast<ArrayMultiDimensionLongDouble*>(data);
+    const ArrayMultiDimensionLongDouble* p_type = static_cast<const ArrayMultiDimensionLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6812,11 +6812,11 @@ ArrayMultiDimensionBooleanPubSubType::~ArrayMultiDimensionBooleanPubSubType()
 }
 
 bool ArrayMultiDimensionBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionBoolean* p_type = static_cast<ArrayMultiDimensionBoolean*>(data);
+    const ArrayMultiDimensionBoolean* p_type = static_cast<const ArrayMultiDimensionBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6888,7 +6888,7 @@ bool ArrayMultiDimensionBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6905,7 +6905,7 @@ std::function<uint32_t()> ArrayMultiDimensionBooleanPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionBoolean*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6928,7 +6928,7 @@ void ArrayMultiDimensionBooleanPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6937,7 +6937,7 @@ bool ArrayMultiDimensionBooleanPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionBoolean* p_type = static_cast<ArrayMultiDimensionBoolean*>(data);
+    const ArrayMultiDimensionBoolean* p_type = static_cast<const ArrayMultiDimensionBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7005,11 +7005,11 @@ ArrayMultiDimensionOctetPubSubType::~ArrayMultiDimensionOctetPubSubType()
 }
 
 bool ArrayMultiDimensionOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionOctet* p_type = static_cast<ArrayMultiDimensionOctet*>(data);
+    const ArrayMultiDimensionOctet* p_type = static_cast<const ArrayMultiDimensionOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7081,7 +7081,7 @@ bool ArrayMultiDimensionOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7098,7 +7098,7 @@ std::function<uint32_t()> ArrayMultiDimensionOctetPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionOctet*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7121,7 +7121,7 @@ void ArrayMultiDimensionOctetPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7130,7 +7130,7 @@ bool ArrayMultiDimensionOctetPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionOctet* p_type = static_cast<ArrayMultiDimensionOctet*>(data);
+    const ArrayMultiDimensionOctet* p_type = static_cast<const ArrayMultiDimensionOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7198,11 +7198,11 @@ ArrayMultiDimensionCharPubSubType::~ArrayMultiDimensionCharPubSubType()
 }
 
 bool ArrayMultiDimensionCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionChar* p_type = static_cast<ArrayMultiDimensionChar*>(data);
+    const ArrayMultiDimensionChar* p_type = static_cast<const ArrayMultiDimensionChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7274,7 +7274,7 @@ bool ArrayMultiDimensionCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7291,7 +7291,7 @@ std::function<uint32_t()> ArrayMultiDimensionCharPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7314,7 +7314,7 @@ void ArrayMultiDimensionCharPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7323,7 +7323,7 @@ bool ArrayMultiDimensionCharPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionChar* p_type = static_cast<ArrayMultiDimensionChar*>(data);
+    const ArrayMultiDimensionChar* p_type = static_cast<const ArrayMultiDimensionChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7391,11 +7391,11 @@ ArrayMultiDimensionWCharPubSubType::~ArrayMultiDimensionWCharPubSubType()
 }
 
 bool ArrayMultiDimensionWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionWChar* p_type = static_cast<ArrayMultiDimensionWChar*>(data);
+    const ArrayMultiDimensionWChar* p_type = static_cast<const ArrayMultiDimensionWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7467,7 +7467,7 @@ bool ArrayMultiDimensionWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7484,7 +7484,7 @@ std::function<uint32_t()> ArrayMultiDimensionWCharPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionWChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7507,7 +7507,7 @@ void ArrayMultiDimensionWCharPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7516,7 +7516,7 @@ bool ArrayMultiDimensionWCharPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionWChar* p_type = static_cast<ArrayMultiDimensionWChar*>(data);
+    const ArrayMultiDimensionWChar* p_type = static_cast<const ArrayMultiDimensionWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7584,11 +7584,11 @@ ArrayMultiDimensionStringPubSubType::~ArrayMultiDimensionStringPubSubType()
 }
 
 bool ArrayMultiDimensionStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionString* p_type = static_cast<ArrayMultiDimensionString*>(data);
+    const ArrayMultiDimensionString* p_type = static_cast<const ArrayMultiDimensionString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7660,7 +7660,7 @@ bool ArrayMultiDimensionStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7677,7 +7677,7 @@ std::function<uint32_t()> ArrayMultiDimensionStringPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7700,7 +7700,7 @@ void ArrayMultiDimensionStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7709,7 +7709,7 @@ bool ArrayMultiDimensionStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionString* p_type = static_cast<ArrayMultiDimensionString*>(data);
+    const ArrayMultiDimensionString* p_type = static_cast<const ArrayMultiDimensionString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7777,11 +7777,11 @@ ArrayMultiDimensionWStringPubSubType::~ArrayMultiDimensionWStringPubSubType()
 }
 
 bool ArrayMultiDimensionWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionWString* p_type = static_cast<ArrayMultiDimensionWString*>(data);
+    const ArrayMultiDimensionWString* p_type = static_cast<const ArrayMultiDimensionWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7853,7 +7853,7 @@ bool ArrayMultiDimensionWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7870,7 +7870,7 @@ std::function<uint32_t()> ArrayMultiDimensionWStringPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7893,7 +7893,7 @@ void ArrayMultiDimensionWStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7902,7 +7902,7 @@ bool ArrayMultiDimensionWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionWString* p_type = static_cast<ArrayMultiDimensionWString*>(data);
+    const ArrayMultiDimensionWString* p_type = static_cast<const ArrayMultiDimensionWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7970,11 +7970,11 @@ ArrayMultiDimensionBoundedStringPubSubType::~ArrayMultiDimensionBoundedStringPub
 }
 
 bool ArrayMultiDimensionBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionBoundedString* p_type = static_cast<ArrayMultiDimensionBoundedString*>(data);
+    const ArrayMultiDimensionBoundedString* p_type = static_cast<const ArrayMultiDimensionBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8046,7 +8046,7 @@ bool ArrayMultiDimensionBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8063,7 +8063,7 @@ std::function<uint32_t()> ArrayMultiDimensionBoundedStringPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionBoundedString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8086,7 +8086,7 @@ void ArrayMultiDimensionBoundedStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8095,7 +8095,7 @@ bool ArrayMultiDimensionBoundedStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionBoundedString* p_type = static_cast<ArrayMultiDimensionBoundedString*>(data);
+    const ArrayMultiDimensionBoundedString* p_type = static_cast<const ArrayMultiDimensionBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8163,11 +8163,11 @@ ArrayMultiDimensionBoundedWStringPubSubType::~ArrayMultiDimensionBoundedWStringP
 }
 
 bool ArrayMultiDimensionBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionBoundedWString* p_type = static_cast<ArrayMultiDimensionBoundedWString*>(data);
+    const ArrayMultiDimensionBoundedWString* p_type = static_cast<const ArrayMultiDimensionBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8239,7 +8239,7 @@ bool ArrayMultiDimensionBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8256,7 +8256,7 @@ std::function<uint32_t()> ArrayMultiDimensionBoundedWStringPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8279,7 +8279,7 @@ void ArrayMultiDimensionBoundedWStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8288,7 +8288,7 @@ bool ArrayMultiDimensionBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionBoundedWString* p_type = static_cast<ArrayMultiDimensionBoundedWString*>(data);
+    const ArrayMultiDimensionBoundedWString* p_type = static_cast<const ArrayMultiDimensionBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8356,11 +8356,11 @@ ArrayMultiDimensionEnumPubSubType::~ArrayMultiDimensionEnumPubSubType()
 }
 
 bool ArrayMultiDimensionEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionEnum* p_type = static_cast<ArrayMultiDimensionEnum*>(data);
+    const ArrayMultiDimensionEnum* p_type = static_cast<const ArrayMultiDimensionEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8432,7 +8432,7 @@ bool ArrayMultiDimensionEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8449,7 +8449,7 @@ std::function<uint32_t()> ArrayMultiDimensionEnumPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionEnum*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8472,7 +8472,7 @@ void ArrayMultiDimensionEnumPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8481,7 +8481,7 @@ bool ArrayMultiDimensionEnumPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionEnum* p_type = static_cast<ArrayMultiDimensionEnum*>(data);
+    const ArrayMultiDimensionEnum* p_type = static_cast<const ArrayMultiDimensionEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8549,11 +8549,11 @@ ArrayMultiDimensionBitMaskPubSubType::~ArrayMultiDimensionBitMaskPubSubType()
 }
 
 bool ArrayMultiDimensionBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionBitMask* p_type = static_cast<ArrayMultiDimensionBitMask*>(data);
+    const ArrayMultiDimensionBitMask* p_type = static_cast<const ArrayMultiDimensionBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8625,7 +8625,7 @@ bool ArrayMultiDimensionBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8642,7 +8642,7 @@ std::function<uint32_t()> ArrayMultiDimensionBitMaskPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionBitMask*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8665,7 +8665,7 @@ void ArrayMultiDimensionBitMaskPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8674,7 +8674,7 @@ bool ArrayMultiDimensionBitMaskPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionBitMask* p_type = static_cast<ArrayMultiDimensionBitMask*>(data);
+    const ArrayMultiDimensionBitMask* p_type = static_cast<const ArrayMultiDimensionBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8742,11 +8742,11 @@ ArrayMultiDimensionAliasPubSubType::~ArrayMultiDimensionAliasPubSubType()
 }
 
 bool ArrayMultiDimensionAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionAlias* p_type = static_cast<ArrayMultiDimensionAlias*>(data);
+    const ArrayMultiDimensionAlias* p_type = static_cast<const ArrayMultiDimensionAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8818,7 +8818,7 @@ bool ArrayMultiDimensionAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8835,7 +8835,7 @@ std::function<uint32_t()> ArrayMultiDimensionAliasPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionAlias*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8858,7 +8858,7 @@ void ArrayMultiDimensionAliasPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8867,7 +8867,7 @@ bool ArrayMultiDimensionAliasPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionAlias* p_type = static_cast<ArrayMultiDimensionAlias*>(data);
+    const ArrayMultiDimensionAlias* p_type = static_cast<const ArrayMultiDimensionAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8935,11 +8935,11 @@ ArrayMultiDimensionSequencePubSubType::~ArrayMultiDimensionSequencePubSubType()
 }
 
 bool ArrayMultiDimensionSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionSequence* p_type = static_cast<ArrayMultiDimensionSequence*>(data);
+    const ArrayMultiDimensionSequence* p_type = static_cast<const ArrayMultiDimensionSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9011,7 +9011,7 @@ bool ArrayMultiDimensionSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9028,7 +9028,7 @@ std::function<uint32_t()> ArrayMultiDimensionSequencePubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionSequence*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9051,7 +9051,7 @@ void ArrayMultiDimensionSequencePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9060,7 +9060,7 @@ bool ArrayMultiDimensionSequencePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionSequence* p_type = static_cast<ArrayMultiDimensionSequence*>(data);
+    const ArrayMultiDimensionSequence* p_type = static_cast<const ArrayMultiDimensionSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9128,11 +9128,11 @@ ArrayMultiDimensionMapPubSubType::~ArrayMultiDimensionMapPubSubType()
 }
 
 bool ArrayMultiDimensionMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionMap* p_type = static_cast<ArrayMultiDimensionMap*>(data);
+    const ArrayMultiDimensionMap* p_type = static_cast<const ArrayMultiDimensionMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9204,7 +9204,7 @@ bool ArrayMultiDimensionMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9221,7 +9221,7 @@ std::function<uint32_t()> ArrayMultiDimensionMapPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionMap*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9244,7 +9244,7 @@ void ArrayMultiDimensionMapPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9253,7 +9253,7 @@ bool ArrayMultiDimensionMapPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionMap* p_type = static_cast<ArrayMultiDimensionMap*>(data);
+    const ArrayMultiDimensionMap* p_type = static_cast<const ArrayMultiDimensionMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9321,11 +9321,11 @@ ArrayMultiDimensionUnionPubSubType::~ArrayMultiDimensionUnionPubSubType()
 }
 
 bool ArrayMultiDimensionUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionUnion* p_type = static_cast<ArrayMultiDimensionUnion*>(data);
+    const ArrayMultiDimensionUnion* p_type = static_cast<const ArrayMultiDimensionUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9397,7 +9397,7 @@ bool ArrayMultiDimensionUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9414,7 +9414,7 @@ std::function<uint32_t()> ArrayMultiDimensionUnionPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionUnion*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9437,7 +9437,7 @@ void ArrayMultiDimensionUnionPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9446,7 +9446,7 @@ bool ArrayMultiDimensionUnionPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionUnion* p_type = static_cast<ArrayMultiDimensionUnion*>(data);
+    const ArrayMultiDimensionUnion* p_type = static_cast<const ArrayMultiDimensionUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9514,11 +9514,11 @@ ArrayMultiDimensionStructurePubSubType::~ArrayMultiDimensionStructurePubSubType(
 }
 
 bool ArrayMultiDimensionStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionStructure* p_type = static_cast<ArrayMultiDimensionStructure*>(data);
+    const ArrayMultiDimensionStructure* p_type = static_cast<const ArrayMultiDimensionStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9590,7 +9590,7 @@ bool ArrayMultiDimensionStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9607,7 +9607,7 @@ std::function<uint32_t()> ArrayMultiDimensionStructurePubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionStructure*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9630,7 +9630,7 @@ void ArrayMultiDimensionStructurePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9639,7 +9639,7 @@ bool ArrayMultiDimensionStructurePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionStructure* p_type = static_cast<ArrayMultiDimensionStructure*>(data);
+    const ArrayMultiDimensionStructure* p_type = static_cast<const ArrayMultiDimensionStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9707,11 +9707,11 @@ ArrayMultiDimensionBitsetPubSubType::~ArrayMultiDimensionBitsetPubSubType()
 }
 
 bool ArrayMultiDimensionBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionBitset* p_type = static_cast<ArrayMultiDimensionBitset*>(data);
+    const ArrayMultiDimensionBitset* p_type = static_cast<const ArrayMultiDimensionBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9783,7 +9783,7 @@ bool ArrayMultiDimensionBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9800,7 +9800,7 @@ std::function<uint32_t()> ArrayMultiDimensionBitsetPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionBitset*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9823,7 +9823,7 @@ void ArrayMultiDimensionBitsetPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9832,7 +9832,7 @@ bool ArrayMultiDimensionBitsetPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionBitset* p_type = static_cast<ArrayMultiDimensionBitset*>(data);
+    const ArrayMultiDimensionBitset* p_type = static_cast<const ArrayMultiDimensionBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9902,11 +9902,11 @@ ArraySingleDimensionLiteralsShortPubSubType::~ArraySingleDimensionLiteralsShortP
 }
 
 bool ArraySingleDimensionLiteralsShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsShort* p_type = static_cast<ArraySingleDimensionLiteralsShort*>(data);
+    const ArraySingleDimensionLiteralsShort* p_type = static_cast<const ArraySingleDimensionLiteralsShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9978,7 +9978,7 @@ bool ArraySingleDimensionLiteralsShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9995,7 +9995,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsShortPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsShort*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10018,7 +10018,7 @@ void ArraySingleDimensionLiteralsShortPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10027,7 +10027,7 @@ bool ArraySingleDimensionLiteralsShortPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsShort* p_type = static_cast<ArraySingleDimensionLiteralsShort*>(data);
+    const ArraySingleDimensionLiteralsShort* p_type = static_cast<const ArraySingleDimensionLiteralsShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10095,11 +10095,11 @@ ArraySingleDimensionLiteralsUnsignedShortPubSubType::~ArraySingleDimensionLitera
 }
 
 bool ArraySingleDimensionLiteralsUnsignedShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsUnsignedShort* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedShort*>(data);
+    const ArraySingleDimensionLiteralsUnsignedShort* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10171,7 +10171,7 @@ bool ArraySingleDimensionLiteralsUnsignedShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10188,7 +10188,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedShortPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsUnsignedShort*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsUnsignedShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10211,7 +10211,7 @@ void ArraySingleDimensionLiteralsUnsignedShortPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsUnsignedShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10220,7 +10220,7 @@ bool ArraySingleDimensionLiteralsUnsignedShortPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsUnsignedShort* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedShort*>(data);
+    const ArraySingleDimensionLiteralsUnsignedShort* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10288,11 +10288,11 @@ ArraySingleDimensionLiteralsLongPubSubType::~ArraySingleDimensionLiteralsLongPub
 }
 
 bool ArraySingleDimensionLiteralsLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsLong* p_type = static_cast<ArraySingleDimensionLiteralsLong*>(data);
+    const ArraySingleDimensionLiteralsLong* p_type = static_cast<const ArraySingleDimensionLiteralsLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10364,7 +10364,7 @@ bool ArraySingleDimensionLiteralsLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10381,7 +10381,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsLongPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsLong*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10404,7 +10404,7 @@ void ArraySingleDimensionLiteralsLongPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10413,7 +10413,7 @@ bool ArraySingleDimensionLiteralsLongPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsLong* p_type = static_cast<ArraySingleDimensionLiteralsLong*>(data);
+    const ArraySingleDimensionLiteralsLong* p_type = static_cast<const ArraySingleDimensionLiteralsLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10481,11 +10481,11 @@ ArraySingleDimensionLiteralsUnsignedLongPubSubType::~ArraySingleDimensionLiteral
 }
 
 bool ArraySingleDimensionLiteralsUnsignedLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsUnsignedLong* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedLong*>(data);
+    const ArraySingleDimensionLiteralsUnsignedLong* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10557,7 +10557,7 @@ bool ArraySingleDimensionLiteralsUnsignedLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10574,7 +10574,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedLongPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsUnsignedLong*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsUnsignedLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10597,7 +10597,7 @@ void ArraySingleDimensionLiteralsUnsignedLongPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsUnsignedLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10606,7 +10606,7 @@ bool ArraySingleDimensionLiteralsUnsignedLongPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsUnsignedLong* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedLong*>(data);
+    const ArraySingleDimensionLiteralsUnsignedLong* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10674,11 +10674,11 @@ ArraySingleDimensionLiteralsLongLongPubSubType::~ArraySingleDimensionLiteralsLon
 }
 
 bool ArraySingleDimensionLiteralsLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsLongLong* p_type = static_cast<ArraySingleDimensionLiteralsLongLong*>(data);
+    const ArraySingleDimensionLiteralsLongLong* p_type = static_cast<const ArraySingleDimensionLiteralsLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10750,7 +10750,7 @@ bool ArraySingleDimensionLiteralsLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10767,7 +10767,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsLongLongPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsLongLong*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10790,7 +10790,7 @@ void ArraySingleDimensionLiteralsLongLongPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10799,7 +10799,7 @@ bool ArraySingleDimensionLiteralsLongLongPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsLongLong* p_type = static_cast<ArraySingleDimensionLiteralsLongLong*>(data);
+    const ArraySingleDimensionLiteralsLongLong* p_type = static_cast<const ArraySingleDimensionLiteralsLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10867,11 +10867,11 @@ ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::~ArraySingleDimensionLit
 }
 
 bool ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsUnsignedLongLong* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedLongLong*>(data);
+    const ArraySingleDimensionLiteralsUnsignedLongLong* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10943,7 +10943,7 @@ bool ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10960,7 +10960,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsUnsignedLongLongPubSubType
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsUnsignedLongLong*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsUnsignedLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10983,7 +10983,7 @@ void ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10992,7 +10992,7 @@ bool ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsUnsignedLongLong* p_type = static_cast<ArraySingleDimensionLiteralsUnsignedLongLong*>(data);
+    const ArraySingleDimensionLiteralsUnsignedLongLong* p_type = static_cast<const ArraySingleDimensionLiteralsUnsignedLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11060,11 +11060,11 @@ ArraySingleDimensionLiteralsFloatPubSubType::~ArraySingleDimensionLiteralsFloatP
 }
 
 bool ArraySingleDimensionLiteralsFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsFloat* p_type = static_cast<ArraySingleDimensionLiteralsFloat*>(data);
+    const ArraySingleDimensionLiteralsFloat* p_type = static_cast<const ArraySingleDimensionLiteralsFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11136,7 +11136,7 @@ bool ArraySingleDimensionLiteralsFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11153,7 +11153,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsFloatPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsFloat*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11176,7 +11176,7 @@ void ArraySingleDimensionLiteralsFloatPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11185,7 +11185,7 @@ bool ArraySingleDimensionLiteralsFloatPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsFloat* p_type = static_cast<ArraySingleDimensionLiteralsFloat*>(data);
+    const ArraySingleDimensionLiteralsFloat* p_type = static_cast<const ArraySingleDimensionLiteralsFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11253,11 +11253,11 @@ ArraySingleDimensionLiteralsDoublePubSubType::~ArraySingleDimensionLiteralsDoubl
 }
 
 bool ArraySingleDimensionLiteralsDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsDouble* p_type = static_cast<ArraySingleDimensionLiteralsDouble*>(data);
+    const ArraySingleDimensionLiteralsDouble* p_type = static_cast<const ArraySingleDimensionLiteralsDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11329,7 +11329,7 @@ bool ArraySingleDimensionLiteralsDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11346,7 +11346,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsDoublePubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsDouble*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11369,7 +11369,7 @@ void ArraySingleDimensionLiteralsDoublePubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11378,7 +11378,7 @@ bool ArraySingleDimensionLiteralsDoublePubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsDouble* p_type = static_cast<ArraySingleDimensionLiteralsDouble*>(data);
+    const ArraySingleDimensionLiteralsDouble* p_type = static_cast<const ArraySingleDimensionLiteralsDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11446,11 +11446,11 @@ ArraySingleDimensionLiteralsLongDoublePubSubType::~ArraySingleDimensionLiteralsL
 }
 
 bool ArraySingleDimensionLiteralsLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsLongDouble* p_type = static_cast<ArraySingleDimensionLiteralsLongDouble*>(data);
+    const ArraySingleDimensionLiteralsLongDouble* p_type = static_cast<const ArraySingleDimensionLiteralsLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11522,7 +11522,7 @@ bool ArraySingleDimensionLiteralsLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11539,7 +11539,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsLongDoublePubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsLongDouble*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11562,7 +11562,7 @@ void ArraySingleDimensionLiteralsLongDoublePubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11571,7 +11571,7 @@ bool ArraySingleDimensionLiteralsLongDoublePubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsLongDouble* p_type = static_cast<ArraySingleDimensionLiteralsLongDouble*>(data);
+    const ArraySingleDimensionLiteralsLongDouble* p_type = static_cast<const ArraySingleDimensionLiteralsLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11639,11 +11639,11 @@ ArraySingleDimensionLiteralsBooleanPubSubType::~ArraySingleDimensionLiteralsBool
 }
 
 bool ArraySingleDimensionLiteralsBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsBoolean* p_type = static_cast<ArraySingleDimensionLiteralsBoolean*>(data);
+    const ArraySingleDimensionLiteralsBoolean* p_type = static_cast<const ArraySingleDimensionLiteralsBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11715,7 +11715,7 @@ bool ArraySingleDimensionLiteralsBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11732,7 +11732,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsBooleanPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsBoolean*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11755,7 +11755,7 @@ void ArraySingleDimensionLiteralsBooleanPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11764,7 +11764,7 @@ bool ArraySingleDimensionLiteralsBooleanPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsBoolean* p_type = static_cast<ArraySingleDimensionLiteralsBoolean*>(data);
+    const ArraySingleDimensionLiteralsBoolean* p_type = static_cast<const ArraySingleDimensionLiteralsBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11832,11 +11832,11 @@ ArraySingleDimensionLiteralsOctetPubSubType::~ArraySingleDimensionLiteralsOctetP
 }
 
 bool ArraySingleDimensionLiteralsOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsOctet* p_type = static_cast<ArraySingleDimensionLiteralsOctet*>(data);
+    const ArraySingleDimensionLiteralsOctet* p_type = static_cast<const ArraySingleDimensionLiteralsOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11908,7 +11908,7 @@ bool ArraySingleDimensionLiteralsOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11925,7 +11925,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsOctetPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsOctet*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11948,7 +11948,7 @@ void ArraySingleDimensionLiteralsOctetPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11957,7 +11957,7 @@ bool ArraySingleDimensionLiteralsOctetPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsOctet* p_type = static_cast<ArraySingleDimensionLiteralsOctet*>(data);
+    const ArraySingleDimensionLiteralsOctet* p_type = static_cast<const ArraySingleDimensionLiteralsOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12025,11 +12025,11 @@ ArraySingleDimensionLiteralsCharPubSubType::~ArraySingleDimensionLiteralsCharPub
 }
 
 bool ArraySingleDimensionLiteralsCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsChar* p_type = static_cast<ArraySingleDimensionLiteralsChar*>(data);
+    const ArraySingleDimensionLiteralsChar* p_type = static_cast<const ArraySingleDimensionLiteralsChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12101,7 +12101,7 @@ bool ArraySingleDimensionLiteralsCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12118,7 +12118,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsCharPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsChar*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12141,7 +12141,7 @@ void ArraySingleDimensionLiteralsCharPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12150,7 +12150,7 @@ bool ArraySingleDimensionLiteralsCharPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsChar* p_type = static_cast<ArraySingleDimensionLiteralsChar*>(data);
+    const ArraySingleDimensionLiteralsChar* p_type = static_cast<const ArraySingleDimensionLiteralsChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12218,11 +12218,11 @@ ArraySingleDimensionLiteralsWCharPubSubType::~ArraySingleDimensionLiteralsWCharP
 }
 
 bool ArraySingleDimensionLiteralsWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsWChar* p_type = static_cast<ArraySingleDimensionLiteralsWChar*>(data);
+    const ArraySingleDimensionLiteralsWChar* p_type = static_cast<const ArraySingleDimensionLiteralsWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12294,7 +12294,7 @@ bool ArraySingleDimensionLiteralsWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12311,7 +12311,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsWCharPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsWChar*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12334,7 +12334,7 @@ void ArraySingleDimensionLiteralsWCharPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12343,7 +12343,7 @@ bool ArraySingleDimensionLiteralsWCharPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsWChar* p_type = static_cast<ArraySingleDimensionLiteralsWChar*>(data);
+    const ArraySingleDimensionLiteralsWChar* p_type = static_cast<const ArraySingleDimensionLiteralsWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12411,11 +12411,11 @@ ArraySingleDimensionLiteralsStringPubSubType::~ArraySingleDimensionLiteralsStrin
 }
 
 bool ArraySingleDimensionLiteralsStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsString* p_type = static_cast<ArraySingleDimensionLiteralsString*>(data);
+    const ArraySingleDimensionLiteralsString* p_type = static_cast<const ArraySingleDimensionLiteralsString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12487,7 +12487,7 @@ bool ArraySingleDimensionLiteralsStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12504,7 +12504,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsStringPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsString*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12527,7 +12527,7 @@ void ArraySingleDimensionLiteralsStringPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12536,7 +12536,7 @@ bool ArraySingleDimensionLiteralsStringPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsString* p_type = static_cast<ArraySingleDimensionLiteralsString*>(data);
+    const ArraySingleDimensionLiteralsString* p_type = static_cast<const ArraySingleDimensionLiteralsString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12604,11 +12604,11 @@ ArraySingleDimensionLiteralsWStringPubSubType::~ArraySingleDimensionLiteralsWStr
 }
 
 bool ArraySingleDimensionLiteralsWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsWString* p_type = static_cast<ArraySingleDimensionLiteralsWString*>(data);
+    const ArraySingleDimensionLiteralsWString* p_type = static_cast<const ArraySingleDimensionLiteralsWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12680,7 +12680,7 @@ bool ArraySingleDimensionLiteralsWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12697,7 +12697,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsWStringPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsWString*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12720,7 +12720,7 @@ void ArraySingleDimensionLiteralsWStringPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12729,7 +12729,7 @@ bool ArraySingleDimensionLiteralsWStringPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsWString* p_type = static_cast<ArraySingleDimensionLiteralsWString*>(data);
+    const ArraySingleDimensionLiteralsWString* p_type = static_cast<const ArraySingleDimensionLiteralsWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12797,11 +12797,11 @@ ArraySingleDimensionLiteralsBoundedStringPubSubType::~ArraySingleDimensionLitera
 }
 
 bool ArraySingleDimensionLiteralsBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsBoundedString* p_type = static_cast<ArraySingleDimensionLiteralsBoundedString*>(data);
+    const ArraySingleDimensionLiteralsBoundedString* p_type = static_cast<const ArraySingleDimensionLiteralsBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12873,7 +12873,7 @@ bool ArraySingleDimensionLiteralsBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12890,7 +12890,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsBoundedStringPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsBoundedString*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12913,7 +12913,7 @@ void ArraySingleDimensionLiteralsBoundedStringPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12922,7 +12922,7 @@ bool ArraySingleDimensionLiteralsBoundedStringPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsBoundedString* p_type = static_cast<ArraySingleDimensionLiteralsBoundedString*>(data);
+    const ArraySingleDimensionLiteralsBoundedString* p_type = static_cast<const ArraySingleDimensionLiteralsBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12990,11 +12990,11 @@ ArraySingleDimensionLiteralsBoundedWStringPubSubType::~ArraySingleDimensionLiter
 }
 
 bool ArraySingleDimensionLiteralsBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsBoundedWString* p_type = static_cast<ArraySingleDimensionLiteralsBoundedWString*>(data);
+    const ArraySingleDimensionLiteralsBoundedWString* p_type = static_cast<const ArraySingleDimensionLiteralsBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13066,7 +13066,7 @@ bool ArraySingleDimensionLiteralsBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13083,7 +13083,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsBoundedWStringPubSubType::
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13106,7 +13106,7 @@ void ArraySingleDimensionLiteralsBoundedWStringPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13115,7 +13115,7 @@ bool ArraySingleDimensionLiteralsBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsBoundedWString* p_type = static_cast<ArraySingleDimensionLiteralsBoundedWString*>(data);
+    const ArraySingleDimensionLiteralsBoundedWString* p_type = static_cast<const ArraySingleDimensionLiteralsBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13183,11 +13183,11 @@ ArraySingleDimensionLiteralsEnumPubSubType::~ArraySingleDimensionLiteralsEnumPub
 }
 
 bool ArraySingleDimensionLiteralsEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsEnum* p_type = static_cast<ArraySingleDimensionLiteralsEnum*>(data);
+    const ArraySingleDimensionLiteralsEnum* p_type = static_cast<const ArraySingleDimensionLiteralsEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13259,7 +13259,7 @@ bool ArraySingleDimensionLiteralsEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13276,7 +13276,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsEnumPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsEnum*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13299,7 +13299,7 @@ void ArraySingleDimensionLiteralsEnumPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13308,7 +13308,7 @@ bool ArraySingleDimensionLiteralsEnumPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsEnum* p_type = static_cast<ArraySingleDimensionLiteralsEnum*>(data);
+    const ArraySingleDimensionLiteralsEnum* p_type = static_cast<const ArraySingleDimensionLiteralsEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13376,11 +13376,11 @@ ArraySingleDimensionLiteralsBitMaskPubSubType::~ArraySingleDimensionLiteralsBitM
 }
 
 bool ArraySingleDimensionLiteralsBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsBitMask* p_type = static_cast<ArraySingleDimensionLiteralsBitMask*>(data);
+    const ArraySingleDimensionLiteralsBitMask* p_type = static_cast<const ArraySingleDimensionLiteralsBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13452,7 +13452,7 @@ bool ArraySingleDimensionLiteralsBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13469,7 +13469,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsBitMaskPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsBitMask*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13492,7 +13492,7 @@ void ArraySingleDimensionLiteralsBitMaskPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13501,7 +13501,7 @@ bool ArraySingleDimensionLiteralsBitMaskPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsBitMask* p_type = static_cast<ArraySingleDimensionLiteralsBitMask*>(data);
+    const ArraySingleDimensionLiteralsBitMask* p_type = static_cast<const ArraySingleDimensionLiteralsBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13569,11 +13569,11 @@ ArraySingleDimensionLiteralsAliasPubSubType::~ArraySingleDimensionLiteralsAliasP
 }
 
 bool ArraySingleDimensionLiteralsAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsAlias* p_type = static_cast<ArraySingleDimensionLiteralsAlias*>(data);
+    const ArraySingleDimensionLiteralsAlias* p_type = static_cast<const ArraySingleDimensionLiteralsAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13645,7 +13645,7 @@ bool ArraySingleDimensionLiteralsAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13662,7 +13662,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsAliasPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsAlias*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13685,7 +13685,7 @@ void ArraySingleDimensionLiteralsAliasPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13694,7 +13694,7 @@ bool ArraySingleDimensionLiteralsAliasPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsAlias* p_type = static_cast<ArraySingleDimensionLiteralsAlias*>(data);
+    const ArraySingleDimensionLiteralsAlias* p_type = static_cast<const ArraySingleDimensionLiteralsAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13762,11 +13762,11 @@ ArraySingleDimensionLiteralsShortArrayPubSubType::~ArraySingleDimensionLiteralsS
 }
 
 bool ArraySingleDimensionLiteralsShortArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsShortArray* p_type = static_cast<ArraySingleDimensionLiteralsShortArray*>(data);
+    const ArraySingleDimensionLiteralsShortArray* p_type = static_cast<const ArraySingleDimensionLiteralsShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13838,7 +13838,7 @@ bool ArraySingleDimensionLiteralsShortArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsShortArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13855,7 +13855,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsShortArrayPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsShortArray*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsShortArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13878,7 +13878,7 @@ void ArraySingleDimensionLiteralsShortArrayPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsShortArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13887,7 +13887,7 @@ bool ArraySingleDimensionLiteralsShortArrayPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsShortArray* p_type = static_cast<ArraySingleDimensionLiteralsShortArray*>(data);
+    const ArraySingleDimensionLiteralsShortArray* p_type = static_cast<const ArraySingleDimensionLiteralsShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13955,11 +13955,11 @@ ArraySingleDimensionLiteralsSequencePubSubType::~ArraySingleDimensionLiteralsSeq
 }
 
 bool ArraySingleDimensionLiteralsSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsSequence* p_type = static_cast<ArraySingleDimensionLiteralsSequence*>(data);
+    const ArraySingleDimensionLiteralsSequence* p_type = static_cast<const ArraySingleDimensionLiteralsSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14031,7 +14031,7 @@ bool ArraySingleDimensionLiteralsSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14048,7 +14048,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsSequencePubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsSequence*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14071,7 +14071,7 @@ void ArraySingleDimensionLiteralsSequencePubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14080,7 +14080,7 @@ bool ArraySingleDimensionLiteralsSequencePubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsSequence* p_type = static_cast<ArraySingleDimensionLiteralsSequence*>(data);
+    const ArraySingleDimensionLiteralsSequence* p_type = static_cast<const ArraySingleDimensionLiteralsSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14148,11 +14148,11 @@ ArraySingleDimensionLiteralsMapPubSubType::~ArraySingleDimensionLiteralsMapPubSu
 }
 
 bool ArraySingleDimensionLiteralsMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsMap* p_type = static_cast<ArraySingleDimensionLiteralsMap*>(data);
+    const ArraySingleDimensionLiteralsMap* p_type = static_cast<const ArraySingleDimensionLiteralsMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14224,7 +14224,7 @@ bool ArraySingleDimensionLiteralsMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14241,7 +14241,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsMapPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsMap*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14264,7 +14264,7 @@ void ArraySingleDimensionLiteralsMapPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14273,7 +14273,7 @@ bool ArraySingleDimensionLiteralsMapPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsMap* p_type = static_cast<ArraySingleDimensionLiteralsMap*>(data);
+    const ArraySingleDimensionLiteralsMap* p_type = static_cast<const ArraySingleDimensionLiteralsMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14341,11 +14341,11 @@ ArraySingleDimensionLiteralsUnionPubSubType::~ArraySingleDimensionLiteralsUnionP
 }
 
 bool ArraySingleDimensionLiteralsUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsUnion* p_type = static_cast<ArraySingleDimensionLiteralsUnion*>(data);
+    const ArraySingleDimensionLiteralsUnion* p_type = static_cast<const ArraySingleDimensionLiteralsUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14417,7 +14417,7 @@ bool ArraySingleDimensionLiteralsUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14434,7 +14434,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsUnionPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsUnion*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14457,7 +14457,7 @@ void ArraySingleDimensionLiteralsUnionPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14466,7 +14466,7 @@ bool ArraySingleDimensionLiteralsUnionPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsUnion* p_type = static_cast<ArraySingleDimensionLiteralsUnion*>(data);
+    const ArraySingleDimensionLiteralsUnion* p_type = static_cast<const ArraySingleDimensionLiteralsUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14534,11 +14534,11 @@ ArraySingleDimensionLiteralsStructurePubSubType::~ArraySingleDimensionLiteralsSt
 }
 
 bool ArraySingleDimensionLiteralsStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsStructure* p_type = static_cast<ArraySingleDimensionLiteralsStructure*>(data);
+    const ArraySingleDimensionLiteralsStructure* p_type = static_cast<const ArraySingleDimensionLiteralsStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14610,7 +14610,7 @@ bool ArraySingleDimensionLiteralsStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14627,7 +14627,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsStructurePubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsStructure*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14650,7 +14650,7 @@ void ArraySingleDimensionLiteralsStructurePubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14659,7 +14659,7 @@ bool ArraySingleDimensionLiteralsStructurePubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsStructure* p_type = static_cast<ArraySingleDimensionLiteralsStructure*>(data);
+    const ArraySingleDimensionLiteralsStructure* p_type = static_cast<const ArraySingleDimensionLiteralsStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14727,11 +14727,11 @@ ArraySingleDimensionLiteralsBitsetPubSubType::~ArraySingleDimensionLiteralsBitse
 }
 
 bool ArraySingleDimensionLiteralsBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArraySingleDimensionLiteralsBitset* p_type = static_cast<ArraySingleDimensionLiteralsBitset*>(data);
+    const ArraySingleDimensionLiteralsBitset* p_type = static_cast<const ArraySingleDimensionLiteralsBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14803,7 +14803,7 @@ bool ArraySingleDimensionLiteralsBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArraySingleDimensionLiteralsBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14820,7 +14820,7 @@ std::function<uint32_t()> ArraySingleDimensionLiteralsBitsetPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArraySingleDimensionLiteralsBitset*>(data), current_alignment)) +
+                               *static_cast<const ArraySingleDimensionLiteralsBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14843,7 +14843,7 @@ void ArraySingleDimensionLiteralsBitsetPubSubType::deleteData(
 }
 
 bool ArraySingleDimensionLiteralsBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14852,7 +14852,7 @@ bool ArraySingleDimensionLiteralsBitsetPubSubType::getKey(
         return false;
     }
 
-    ArraySingleDimensionLiteralsBitset* p_type = static_cast<ArraySingleDimensionLiteralsBitset*>(data);
+    const ArraySingleDimensionLiteralsBitset* p_type = static_cast<const ArraySingleDimensionLiteralsBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14920,11 +14920,11 @@ ArrayMultiDimensionLiteralsShortPubSubType::~ArrayMultiDimensionLiteralsShortPub
 }
 
 bool ArrayMultiDimensionLiteralsShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsShort* p_type = static_cast<ArrayMultiDimensionLiteralsShort*>(data);
+    const ArrayMultiDimensionLiteralsShort* p_type = static_cast<const ArrayMultiDimensionLiteralsShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14996,7 +14996,7 @@ bool ArrayMultiDimensionLiteralsShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15013,7 +15013,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsShortPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15036,7 +15036,7 @@ void ArrayMultiDimensionLiteralsShortPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15045,7 +15045,7 @@ bool ArrayMultiDimensionLiteralsShortPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsShort* p_type = static_cast<ArrayMultiDimensionLiteralsShort*>(data);
+    const ArrayMultiDimensionLiteralsShort* p_type = static_cast<const ArrayMultiDimensionLiteralsShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15113,11 +15113,11 @@ ArrayMultiDimensionLiteralsUShortPubSubType::~ArrayMultiDimensionLiteralsUShortP
 }
 
 bool ArrayMultiDimensionLiteralsUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsUShort* p_type = static_cast<ArrayMultiDimensionLiteralsUShort*>(data);
+    const ArrayMultiDimensionLiteralsUShort* p_type = static_cast<const ArrayMultiDimensionLiteralsUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15189,7 +15189,7 @@ bool ArrayMultiDimensionLiteralsUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15206,7 +15206,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsUShortPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsUShort*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15229,7 +15229,7 @@ void ArrayMultiDimensionLiteralsUShortPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15238,7 +15238,7 @@ bool ArrayMultiDimensionLiteralsUShortPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsUShort* p_type = static_cast<ArrayMultiDimensionLiteralsUShort*>(data);
+    const ArrayMultiDimensionLiteralsUShort* p_type = static_cast<const ArrayMultiDimensionLiteralsUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15306,11 +15306,11 @@ ArrayMultiDimensionLiteralsLongPubSubType::~ArrayMultiDimensionLiteralsLongPubSu
 }
 
 bool ArrayMultiDimensionLiteralsLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsLong* p_type = static_cast<ArrayMultiDimensionLiteralsLong*>(data);
+    const ArrayMultiDimensionLiteralsLong* p_type = static_cast<const ArrayMultiDimensionLiteralsLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15382,7 +15382,7 @@ bool ArrayMultiDimensionLiteralsLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15399,7 +15399,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsLongPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15422,7 +15422,7 @@ void ArrayMultiDimensionLiteralsLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15431,7 +15431,7 @@ bool ArrayMultiDimensionLiteralsLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsLong* p_type = static_cast<ArrayMultiDimensionLiteralsLong*>(data);
+    const ArrayMultiDimensionLiteralsLong* p_type = static_cast<const ArrayMultiDimensionLiteralsLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15499,11 +15499,11 @@ ArrayMultiDimensionLiteralsULongPubSubType::~ArrayMultiDimensionLiteralsULongPub
 }
 
 bool ArrayMultiDimensionLiteralsULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsULong* p_type = static_cast<ArrayMultiDimensionLiteralsULong*>(data);
+    const ArrayMultiDimensionLiteralsULong* p_type = static_cast<const ArrayMultiDimensionLiteralsULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15575,7 +15575,7 @@ bool ArrayMultiDimensionLiteralsULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15592,7 +15592,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsULongPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsULong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15615,7 +15615,7 @@ void ArrayMultiDimensionLiteralsULongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15624,7 +15624,7 @@ bool ArrayMultiDimensionLiteralsULongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsULong* p_type = static_cast<ArrayMultiDimensionLiteralsULong*>(data);
+    const ArrayMultiDimensionLiteralsULong* p_type = static_cast<const ArrayMultiDimensionLiteralsULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15692,11 +15692,11 @@ ArrayMultiDimensionLiteralsLongLongPubSubType::~ArrayMultiDimensionLiteralsLongL
 }
 
 bool ArrayMultiDimensionLiteralsLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsLongLong* p_type = static_cast<ArrayMultiDimensionLiteralsLongLong*>(data);
+    const ArrayMultiDimensionLiteralsLongLong* p_type = static_cast<const ArrayMultiDimensionLiteralsLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15768,7 +15768,7 @@ bool ArrayMultiDimensionLiteralsLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15785,7 +15785,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsLongLongPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsLongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15808,7 +15808,7 @@ void ArrayMultiDimensionLiteralsLongLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15817,7 +15817,7 @@ bool ArrayMultiDimensionLiteralsLongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsLongLong* p_type = static_cast<ArrayMultiDimensionLiteralsLongLong*>(data);
+    const ArrayMultiDimensionLiteralsLongLong* p_type = static_cast<const ArrayMultiDimensionLiteralsLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15885,11 +15885,11 @@ ArrayMultiDimensionLiteralsULongLongPubSubType::~ArrayMultiDimensionLiteralsULon
 }
 
 bool ArrayMultiDimensionLiteralsULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsULongLong* p_type = static_cast<ArrayMultiDimensionLiteralsULongLong*>(data);
+    const ArrayMultiDimensionLiteralsULongLong* p_type = static_cast<const ArrayMultiDimensionLiteralsULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15961,7 +15961,7 @@ bool ArrayMultiDimensionLiteralsULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15978,7 +15978,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsULongLongPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsULongLong*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16001,7 +16001,7 @@ void ArrayMultiDimensionLiteralsULongLongPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16010,7 +16010,7 @@ bool ArrayMultiDimensionLiteralsULongLongPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsULongLong* p_type = static_cast<ArrayMultiDimensionLiteralsULongLong*>(data);
+    const ArrayMultiDimensionLiteralsULongLong* p_type = static_cast<const ArrayMultiDimensionLiteralsULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16078,11 +16078,11 @@ ArrayMultiDimensionLiteralsFloatPubSubType::~ArrayMultiDimensionLiteralsFloatPub
 }
 
 bool ArrayMultiDimensionLiteralsFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsFloat* p_type = static_cast<ArrayMultiDimensionLiteralsFloat*>(data);
+    const ArrayMultiDimensionLiteralsFloat* p_type = static_cast<const ArrayMultiDimensionLiteralsFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16154,7 +16154,7 @@ bool ArrayMultiDimensionLiteralsFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16171,7 +16171,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsFloatPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsFloat*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16194,7 +16194,7 @@ void ArrayMultiDimensionLiteralsFloatPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16203,7 +16203,7 @@ bool ArrayMultiDimensionLiteralsFloatPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsFloat* p_type = static_cast<ArrayMultiDimensionLiteralsFloat*>(data);
+    const ArrayMultiDimensionLiteralsFloat* p_type = static_cast<const ArrayMultiDimensionLiteralsFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16271,11 +16271,11 @@ ArrayMultiDimensionLiteralsDoublePubSubType::~ArrayMultiDimensionLiteralsDoubleP
 }
 
 bool ArrayMultiDimensionLiteralsDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsDouble* p_type = static_cast<ArrayMultiDimensionLiteralsDouble*>(data);
+    const ArrayMultiDimensionLiteralsDouble* p_type = static_cast<const ArrayMultiDimensionLiteralsDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16347,7 +16347,7 @@ bool ArrayMultiDimensionLiteralsDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16364,7 +16364,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsDoublePubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16387,7 +16387,7 @@ void ArrayMultiDimensionLiteralsDoublePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16396,7 +16396,7 @@ bool ArrayMultiDimensionLiteralsDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsDouble* p_type = static_cast<ArrayMultiDimensionLiteralsDouble*>(data);
+    const ArrayMultiDimensionLiteralsDouble* p_type = static_cast<const ArrayMultiDimensionLiteralsDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16464,11 +16464,11 @@ ArrayMultiDimensionLiteralsLongDoublePubSubType::~ArrayMultiDimensionLiteralsLon
 }
 
 bool ArrayMultiDimensionLiteralsLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsLongDouble* p_type = static_cast<ArrayMultiDimensionLiteralsLongDouble*>(data);
+    const ArrayMultiDimensionLiteralsLongDouble* p_type = static_cast<const ArrayMultiDimensionLiteralsLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16540,7 +16540,7 @@ bool ArrayMultiDimensionLiteralsLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16557,7 +16557,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsLongDoublePubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsLongDouble*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16580,7 +16580,7 @@ void ArrayMultiDimensionLiteralsLongDoublePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16589,7 +16589,7 @@ bool ArrayMultiDimensionLiteralsLongDoublePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsLongDouble* p_type = static_cast<ArrayMultiDimensionLiteralsLongDouble*>(data);
+    const ArrayMultiDimensionLiteralsLongDouble* p_type = static_cast<const ArrayMultiDimensionLiteralsLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16657,11 +16657,11 @@ ArrayMultiDimensionLiteralsBooleanPubSubType::~ArrayMultiDimensionLiteralsBoolea
 }
 
 bool ArrayMultiDimensionLiteralsBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsBoolean* p_type = static_cast<ArrayMultiDimensionLiteralsBoolean*>(data);
+    const ArrayMultiDimensionLiteralsBoolean* p_type = static_cast<const ArrayMultiDimensionLiteralsBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16733,7 +16733,7 @@ bool ArrayMultiDimensionLiteralsBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16750,7 +16750,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsBooleanPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsBoolean*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16773,7 +16773,7 @@ void ArrayMultiDimensionLiteralsBooleanPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16782,7 +16782,7 @@ bool ArrayMultiDimensionLiteralsBooleanPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsBoolean* p_type = static_cast<ArrayMultiDimensionLiteralsBoolean*>(data);
+    const ArrayMultiDimensionLiteralsBoolean* p_type = static_cast<const ArrayMultiDimensionLiteralsBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16850,11 +16850,11 @@ ArrayMultiDimensionLiteralsOctetPubSubType::~ArrayMultiDimensionLiteralsOctetPub
 }
 
 bool ArrayMultiDimensionLiteralsOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsOctet* p_type = static_cast<ArrayMultiDimensionLiteralsOctet*>(data);
+    const ArrayMultiDimensionLiteralsOctet* p_type = static_cast<const ArrayMultiDimensionLiteralsOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16926,7 +16926,7 @@ bool ArrayMultiDimensionLiteralsOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16943,7 +16943,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsOctetPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsOctet*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16966,7 +16966,7 @@ void ArrayMultiDimensionLiteralsOctetPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16975,7 +16975,7 @@ bool ArrayMultiDimensionLiteralsOctetPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsOctet* p_type = static_cast<ArrayMultiDimensionLiteralsOctet*>(data);
+    const ArrayMultiDimensionLiteralsOctet* p_type = static_cast<const ArrayMultiDimensionLiteralsOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17043,11 +17043,11 @@ ArrayMultiDimensionLiteralsCharPubSubType::~ArrayMultiDimensionLiteralsCharPubSu
 }
 
 bool ArrayMultiDimensionLiteralsCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsChar* p_type = static_cast<ArrayMultiDimensionLiteralsChar*>(data);
+    const ArrayMultiDimensionLiteralsChar* p_type = static_cast<const ArrayMultiDimensionLiteralsChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17119,7 +17119,7 @@ bool ArrayMultiDimensionLiteralsCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17136,7 +17136,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsCharPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17159,7 +17159,7 @@ void ArrayMultiDimensionLiteralsCharPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17168,7 +17168,7 @@ bool ArrayMultiDimensionLiteralsCharPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsChar* p_type = static_cast<ArrayMultiDimensionLiteralsChar*>(data);
+    const ArrayMultiDimensionLiteralsChar* p_type = static_cast<const ArrayMultiDimensionLiteralsChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17236,11 +17236,11 @@ ArrayMultiDimensionLiteralsWCharPubSubType::~ArrayMultiDimensionLiteralsWCharPub
 }
 
 bool ArrayMultiDimensionLiteralsWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsWChar* p_type = static_cast<ArrayMultiDimensionLiteralsWChar*>(data);
+    const ArrayMultiDimensionLiteralsWChar* p_type = static_cast<const ArrayMultiDimensionLiteralsWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17312,7 +17312,7 @@ bool ArrayMultiDimensionLiteralsWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17329,7 +17329,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsWCharPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsWChar*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17352,7 +17352,7 @@ void ArrayMultiDimensionLiteralsWCharPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17361,7 +17361,7 @@ bool ArrayMultiDimensionLiteralsWCharPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsWChar* p_type = static_cast<ArrayMultiDimensionLiteralsWChar*>(data);
+    const ArrayMultiDimensionLiteralsWChar* p_type = static_cast<const ArrayMultiDimensionLiteralsWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17429,11 +17429,11 @@ ArrayMultiDimensionLiteralsStringPubSubType::~ArrayMultiDimensionLiteralsStringP
 }
 
 bool ArrayMultiDimensionLiteralsStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsString* p_type = static_cast<ArrayMultiDimensionLiteralsString*>(data);
+    const ArrayMultiDimensionLiteralsString* p_type = static_cast<const ArrayMultiDimensionLiteralsString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17505,7 +17505,7 @@ bool ArrayMultiDimensionLiteralsStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17522,7 +17522,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsStringPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17545,7 +17545,7 @@ void ArrayMultiDimensionLiteralsStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17554,7 +17554,7 @@ bool ArrayMultiDimensionLiteralsStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsString* p_type = static_cast<ArrayMultiDimensionLiteralsString*>(data);
+    const ArrayMultiDimensionLiteralsString* p_type = static_cast<const ArrayMultiDimensionLiteralsString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17622,11 +17622,11 @@ ArrayMultiDimensionLiteralsWStringPubSubType::~ArrayMultiDimensionLiteralsWStrin
 }
 
 bool ArrayMultiDimensionLiteralsWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsWString* p_type = static_cast<ArrayMultiDimensionLiteralsWString*>(data);
+    const ArrayMultiDimensionLiteralsWString* p_type = static_cast<const ArrayMultiDimensionLiteralsWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17698,7 +17698,7 @@ bool ArrayMultiDimensionLiteralsWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17715,7 +17715,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsWStringPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17738,7 +17738,7 @@ void ArrayMultiDimensionLiteralsWStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17747,7 +17747,7 @@ bool ArrayMultiDimensionLiteralsWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsWString* p_type = static_cast<ArrayMultiDimensionLiteralsWString*>(data);
+    const ArrayMultiDimensionLiteralsWString* p_type = static_cast<const ArrayMultiDimensionLiteralsWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17815,11 +17815,11 @@ ArrayMultiDimensionLiteralsBoundedStringPubSubType::~ArrayMultiDimensionLiterals
 }
 
 bool ArrayMultiDimensionLiteralsBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsBoundedString* p_type = static_cast<ArrayMultiDimensionLiteralsBoundedString*>(data);
+    const ArrayMultiDimensionLiteralsBoundedString* p_type = static_cast<const ArrayMultiDimensionLiteralsBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17891,7 +17891,7 @@ bool ArrayMultiDimensionLiteralsBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17908,7 +17908,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsBoundedStringPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsBoundedString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17931,7 +17931,7 @@ void ArrayMultiDimensionLiteralsBoundedStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17940,7 +17940,7 @@ bool ArrayMultiDimensionLiteralsBoundedStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsBoundedString* p_type = static_cast<ArrayMultiDimensionLiteralsBoundedString*>(data);
+    const ArrayMultiDimensionLiteralsBoundedString* p_type = static_cast<const ArrayMultiDimensionLiteralsBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18008,11 +18008,11 @@ ArrayMultiDimensionLiteralsBoundedWStringPubSubType::~ArrayMultiDimensionLiteral
 }
 
 bool ArrayMultiDimensionLiteralsBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsBoundedWString* p_type = static_cast<ArrayMultiDimensionLiteralsBoundedWString*>(data);
+    const ArrayMultiDimensionLiteralsBoundedWString* p_type = static_cast<const ArrayMultiDimensionLiteralsBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18084,7 +18084,7 @@ bool ArrayMultiDimensionLiteralsBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18101,7 +18101,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsBoundedWStringPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18124,7 +18124,7 @@ void ArrayMultiDimensionLiteralsBoundedWStringPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18133,7 +18133,7 @@ bool ArrayMultiDimensionLiteralsBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsBoundedWString* p_type = static_cast<ArrayMultiDimensionLiteralsBoundedWString*>(data);
+    const ArrayMultiDimensionLiteralsBoundedWString* p_type = static_cast<const ArrayMultiDimensionLiteralsBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18201,11 +18201,11 @@ ArrayMultiDimensionLiteralsEnumPubSubType::~ArrayMultiDimensionLiteralsEnumPubSu
 }
 
 bool ArrayMultiDimensionLiteralsEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsEnum* p_type = static_cast<ArrayMultiDimensionLiteralsEnum*>(data);
+    const ArrayMultiDimensionLiteralsEnum* p_type = static_cast<const ArrayMultiDimensionLiteralsEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18277,7 +18277,7 @@ bool ArrayMultiDimensionLiteralsEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18294,7 +18294,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsEnumPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsEnum*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18317,7 +18317,7 @@ void ArrayMultiDimensionLiteralsEnumPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18326,7 +18326,7 @@ bool ArrayMultiDimensionLiteralsEnumPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsEnum* p_type = static_cast<ArrayMultiDimensionLiteralsEnum*>(data);
+    const ArrayMultiDimensionLiteralsEnum* p_type = static_cast<const ArrayMultiDimensionLiteralsEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18394,11 +18394,11 @@ ArrayMultiDimensionLiteralsBitMaskPubSubType::~ArrayMultiDimensionLiteralsBitMas
 }
 
 bool ArrayMultiDimensionLiteralsBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsBitMask* p_type = static_cast<ArrayMultiDimensionLiteralsBitMask*>(data);
+    const ArrayMultiDimensionLiteralsBitMask* p_type = static_cast<const ArrayMultiDimensionLiteralsBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18470,7 +18470,7 @@ bool ArrayMultiDimensionLiteralsBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18487,7 +18487,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsBitMaskPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsBitMask*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18510,7 +18510,7 @@ void ArrayMultiDimensionLiteralsBitMaskPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18519,7 +18519,7 @@ bool ArrayMultiDimensionLiteralsBitMaskPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsBitMask* p_type = static_cast<ArrayMultiDimensionLiteralsBitMask*>(data);
+    const ArrayMultiDimensionLiteralsBitMask* p_type = static_cast<const ArrayMultiDimensionLiteralsBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18587,11 +18587,11 @@ ArrayMultiDimensionLiteralsAliasPubSubType::~ArrayMultiDimensionLiteralsAliasPub
 }
 
 bool ArrayMultiDimensionLiteralsAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsAlias* p_type = static_cast<ArrayMultiDimensionLiteralsAlias*>(data);
+    const ArrayMultiDimensionLiteralsAlias* p_type = static_cast<const ArrayMultiDimensionLiteralsAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18663,7 +18663,7 @@ bool ArrayMultiDimensionLiteralsAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18680,7 +18680,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsAliasPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsAlias*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18703,7 +18703,7 @@ void ArrayMultiDimensionLiteralsAliasPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18712,7 +18712,7 @@ bool ArrayMultiDimensionLiteralsAliasPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsAlias* p_type = static_cast<ArrayMultiDimensionLiteralsAlias*>(data);
+    const ArrayMultiDimensionLiteralsAlias* p_type = static_cast<const ArrayMultiDimensionLiteralsAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18780,11 +18780,11 @@ ArrayMultiDimensionLiteralsSequencePubSubType::~ArrayMultiDimensionLiteralsSeque
 }
 
 bool ArrayMultiDimensionLiteralsSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsSequence* p_type = static_cast<ArrayMultiDimensionLiteralsSequence*>(data);
+    const ArrayMultiDimensionLiteralsSequence* p_type = static_cast<const ArrayMultiDimensionLiteralsSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18856,7 +18856,7 @@ bool ArrayMultiDimensionLiteralsSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18873,7 +18873,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsSequencePubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsSequence*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18896,7 +18896,7 @@ void ArrayMultiDimensionLiteralsSequencePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18905,7 +18905,7 @@ bool ArrayMultiDimensionLiteralsSequencePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsSequence* p_type = static_cast<ArrayMultiDimensionLiteralsSequence*>(data);
+    const ArrayMultiDimensionLiteralsSequence* p_type = static_cast<const ArrayMultiDimensionLiteralsSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18973,11 +18973,11 @@ ArrayMultiDimensionLiteralsMapPubSubType::~ArrayMultiDimensionLiteralsMapPubSubT
 }
 
 bool ArrayMultiDimensionLiteralsMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsMap* p_type = static_cast<ArrayMultiDimensionLiteralsMap*>(data);
+    const ArrayMultiDimensionLiteralsMap* p_type = static_cast<const ArrayMultiDimensionLiteralsMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19049,7 +19049,7 @@ bool ArrayMultiDimensionLiteralsMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19066,7 +19066,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsMapPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsMap*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19089,7 +19089,7 @@ void ArrayMultiDimensionLiteralsMapPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19098,7 +19098,7 @@ bool ArrayMultiDimensionLiteralsMapPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsMap* p_type = static_cast<ArrayMultiDimensionLiteralsMap*>(data);
+    const ArrayMultiDimensionLiteralsMap* p_type = static_cast<const ArrayMultiDimensionLiteralsMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19166,11 +19166,11 @@ ArrayMultiDimensionLiteralsUnionPubSubType::~ArrayMultiDimensionLiteralsUnionPub
 }
 
 bool ArrayMultiDimensionLiteralsUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsUnion* p_type = static_cast<ArrayMultiDimensionLiteralsUnion*>(data);
+    const ArrayMultiDimensionLiteralsUnion* p_type = static_cast<const ArrayMultiDimensionLiteralsUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19242,7 +19242,7 @@ bool ArrayMultiDimensionLiteralsUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19259,7 +19259,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsUnionPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsUnion*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19282,7 +19282,7 @@ void ArrayMultiDimensionLiteralsUnionPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19291,7 +19291,7 @@ bool ArrayMultiDimensionLiteralsUnionPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsUnion* p_type = static_cast<ArrayMultiDimensionLiteralsUnion*>(data);
+    const ArrayMultiDimensionLiteralsUnion* p_type = static_cast<const ArrayMultiDimensionLiteralsUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19359,11 +19359,11 @@ ArrayMultiDimensionLiteralsStructurePubSubType::~ArrayMultiDimensionLiteralsStru
 }
 
 bool ArrayMultiDimensionLiteralsStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsStructure* p_type = static_cast<ArrayMultiDimensionLiteralsStructure*>(data);
+    const ArrayMultiDimensionLiteralsStructure* p_type = static_cast<const ArrayMultiDimensionLiteralsStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19435,7 +19435,7 @@ bool ArrayMultiDimensionLiteralsStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19452,7 +19452,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsStructurePubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsStructure*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19475,7 +19475,7 @@ void ArrayMultiDimensionLiteralsStructurePubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19484,7 +19484,7 @@ bool ArrayMultiDimensionLiteralsStructurePubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsStructure* p_type = static_cast<ArrayMultiDimensionLiteralsStructure*>(data);
+    const ArrayMultiDimensionLiteralsStructure* p_type = static_cast<const ArrayMultiDimensionLiteralsStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19552,11 +19552,11 @@ ArrayMultiDimensionLiteralsBitSetPubSubType::~ArrayMultiDimensionLiteralsBitSetP
 }
 
 bool ArrayMultiDimensionLiteralsBitSetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ArrayMultiDimensionLiteralsBitSet* p_type = static_cast<ArrayMultiDimensionLiteralsBitSet*>(data);
+    const ArrayMultiDimensionLiteralsBitSet* p_type = static_cast<const ArrayMultiDimensionLiteralsBitSet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19628,7 +19628,7 @@ bool ArrayMultiDimensionLiteralsBitSetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ArrayMultiDimensionLiteralsBitSetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19645,7 +19645,7 @@ std::function<uint32_t()> ArrayMultiDimensionLiteralsBitSetPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ArrayMultiDimensionLiteralsBitSet*>(data), current_alignment)) +
+                               *static_cast<const ArrayMultiDimensionLiteralsBitSet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19668,7 +19668,7 @@ void ArrayMultiDimensionLiteralsBitSetPubSubType::deleteData(
 }
 
 bool ArrayMultiDimensionLiteralsBitSetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19677,7 +19677,7 @@ bool ArrayMultiDimensionLiteralsBitSetPubSubType::getKey(
         return false;
     }
 
-    ArrayMultiDimensionLiteralsBitSet* p_type = static_cast<ArrayMultiDimensionLiteralsBitSet*>(data);
+    const ArrayMultiDimensionLiteralsBitSet* p_type = static_cast<const ArrayMultiDimensionLiteralsBitSet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19745,11 +19745,11 @@ BoundedSmallArraysPubSubType::~BoundedSmallArraysPubSubType()
 }
 
 bool BoundedSmallArraysPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedSmallArrays* p_type = static_cast<BoundedSmallArrays*>(data);
+    const BoundedSmallArrays* p_type = static_cast<const BoundedSmallArrays*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19821,7 +19821,7 @@ bool BoundedSmallArraysPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedSmallArraysPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19838,7 +19838,7 @@ std::function<uint32_t()> BoundedSmallArraysPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedSmallArrays*>(data), current_alignment)) +
+                               *static_cast<const BoundedSmallArrays*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19861,7 +19861,7 @@ void BoundedSmallArraysPubSubType::deleteData(
 }
 
 bool BoundedSmallArraysPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19870,7 +19870,7 @@ bool BoundedSmallArraysPubSubType::getKey(
         return false;
     }
 
-    BoundedSmallArrays* p_type = static_cast<BoundedSmallArrays*>(data);
+    const BoundedSmallArrays* p_type = static_cast<const BoundedSmallArrays*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19938,11 +19938,11 @@ BoundedBigArraysPubSubType::~BoundedBigArraysPubSubType()
 }
 
 bool BoundedBigArraysPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedBigArrays* p_type = static_cast<BoundedBigArrays*>(data);
+    const BoundedBigArrays* p_type = static_cast<const BoundedBigArrays*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20014,7 +20014,7 @@ bool BoundedBigArraysPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedBigArraysPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20031,7 +20031,7 @@ std::function<uint32_t()> BoundedBigArraysPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedBigArrays*>(data), current_alignment)) +
+                               *static_cast<const BoundedBigArrays*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20054,7 +20054,7 @@ void BoundedBigArraysPubSubType::deleteData(
 }
 
 bool BoundedBigArraysPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20063,7 +20063,7 @@ bool BoundedBigArraysPubSubType::getKey(
         return false;
     }
 
-    BoundedBigArrays* p_type = static_cast<BoundedBigArrays*>(data);
+    const BoundedBigArrays* p_type = static_cast<const BoundedBigArrays*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/arraysPubSubTypes.h
+++ b/test/dds-types-test/arraysPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~ArrayShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~ArrayUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~ArrayLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~ArrayULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~ArrayLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~ArrayULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~ArrayFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~ArrayDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~ArrayLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~ArrayBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~ArrayOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~ArrayCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~ArrayWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~ArrayStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~ArrayWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~ArrayBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~ArrayBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~ArrayEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~ArrayBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~ArrayAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~ArrayShortArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~ArraySequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~ArrayMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~ArrayUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~ArrayStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~ArrayBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2602,14 +2602,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2618,17 +2618,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2693,14 +2693,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2709,17 +2709,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2784,14 +2784,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2800,17 +2800,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2875,14 +2875,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2891,17 +2891,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2966,14 +2966,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2982,17 +2982,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3057,14 +3057,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3073,17 +3073,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3148,14 +3148,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3164,17 +3164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3239,14 +3239,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3255,17 +3255,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3330,14 +3330,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3346,17 +3346,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3421,14 +3421,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3437,17 +3437,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3512,14 +3512,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3528,17 +3528,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3603,14 +3603,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3619,17 +3619,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3694,14 +3694,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3710,17 +3710,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3785,14 +3785,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3801,17 +3801,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3876,14 +3876,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3892,17 +3892,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3967,14 +3967,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3983,17 +3983,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4058,14 +4058,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4074,17 +4074,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4149,14 +4149,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4165,17 +4165,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4240,14 +4240,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4256,17 +4256,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4331,14 +4331,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4347,17 +4347,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4422,14 +4422,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4438,17 +4438,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4513,14 +4513,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4529,17 +4529,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4604,14 +4604,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4620,17 +4620,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4697,14 +4697,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4713,17 +4713,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4788,14 +4788,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsUnsignedShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4804,17 +4804,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4879,14 +4879,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4895,17 +4895,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4970,14 +4970,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsUnsignedLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4986,17 +4986,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5061,14 +5061,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5077,17 +5077,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5152,14 +5152,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsUnsignedLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5168,17 +5168,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5243,14 +5243,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5259,17 +5259,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5334,14 +5334,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5350,17 +5350,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5425,14 +5425,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5441,17 +5441,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5516,14 +5516,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5532,17 +5532,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5607,14 +5607,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5623,17 +5623,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5698,14 +5698,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5714,17 +5714,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5789,14 +5789,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5805,17 +5805,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5880,14 +5880,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5896,17 +5896,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5971,14 +5971,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5987,17 +5987,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6062,14 +6062,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6078,17 +6078,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6153,14 +6153,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6169,17 +6169,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6244,14 +6244,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6260,17 +6260,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6335,14 +6335,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6351,17 +6351,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6426,14 +6426,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6442,17 +6442,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6517,14 +6517,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsShortArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6533,17 +6533,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6608,14 +6608,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6624,17 +6624,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6699,14 +6699,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6715,17 +6715,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6790,14 +6790,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6806,17 +6806,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6881,14 +6881,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6897,17 +6897,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6972,14 +6972,14 @@ public:
     eProsima_user_DllExport ~ArraySingleDimensionLiteralsBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6988,17 +6988,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7063,14 +7063,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7079,17 +7079,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7154,14 +7154,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7170,17 +7170,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7245,14 +7245,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7261,17 +7261,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7336,14 +7336,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7352,17 +7352,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7427,14 +7427,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7443,17 +7443,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7518,14 +7518,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7534,17 +7534,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7609,14 +7609,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7625,17 +7625,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7700,14 +7700,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7716,17 +7716,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7791,14 +7791,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7807,17 +7807,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7882,14 +7882,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7898,17 +7898,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7973,14 +7973,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7989,17 +7989,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8064,14 +8064,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8080,17 +8080,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8155,14 +8155,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8171,17 +8171,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8246,14 +8246,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8262,17 +8262,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8337,14 +8337,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8353,17 +8353,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8428,14 +8428,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8444,17 +8444,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8519,14 +8519,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8535,17 +8535,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8610,14 +8610,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8626,17 +8626,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8701,14 +8701,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8717,17 +8717,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8792,14 +8792,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8808,17 +8808,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8883,14 +8883,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8899,17 +8899,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8974,14 +8974,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8990,17 +8990,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9065,14 +9065,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9081,17 +9081,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9156,14 +9156,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9172,17 +9172,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9247,14 +9247,14 @@ public:
     eProsima_user_DllExport ~ArrayMultiDimensionLiteralsBitSetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9263,17 +9263,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9338,14 +9338,14 @@ public:
     eProsima_user_DllExport ~BoundedSmallArraysPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9354,17 +9354,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9429,14 +9429,14 @@ public:
     eProsima_user_DllExport ~BoundedBigArraysPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9445,17 +9445,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/bitsetsPubSubTypes.cxx
+++ b/test/dds-types-test/bitsetsPubSubTypes.cxx
@@ -57,11 +57,11 @@ BitsetStructPubSubType::~BitsetStructPubSubType()
 }
 
 bool BitsetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BitsetStruct* p_type = static_cast<BitsetStruct*>(data);
+    const BitsetStruct* p_type = static_cast<const BitsetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool BitsetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BitsetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> BitsetStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BitsetStruct*>(data), current_alignment)) +
+                               *static_cast<const BitsetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void BitsetStructPubSubType::deleteData(
 }
 
 bool BitsetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool BitsetStructPubSubType::getKey(
         return false;
     }
 
-    BitsetStruct* p_type = static_cast<BitsetStruct*>(data);
+    const BitsetStruct* p_type = static_cast<const BitsetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/bitsetsPubSubTypes.h
+++ b/test/dds-types-test/bitsetsPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~BitsetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/constantsPubSubTypes.cxx
+++ b/test/dds-types-test/constantsPubSubTypes.cxx
@@ -58,11 +58,11 @@ namespace const_module1 {
     }
 
     bool ModuleConstsLiteralsStructPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        ModuleConstsLiteralsStruct* p_type = static_cast<ModuleConstsLiteralsStruct*>(data);
+        const ModuleConstsLiteralsStruct* p_type = static_cast<const ModuleConstsLiteralsStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -134,7 +134,7 @@ namespace const_module1 {
     }
 
     std::function<uint32_t()> ModuleConstsLiteralsStructPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -151,7 +151,7 @@ namespace const_module1 {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<ModuleConstsLiteralsStruct*>(data), current_alignment)) +
+                                   *static_cast<const ModuleConstsLiteralsStruct*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -174,7 +174,7 @@ namespace const_module1 {
     }
 
     bool ModuleConstsLiteralsStructPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -183,7 +183,7 @@ namespace const_module1 {
             return false;
         }
 
-        ModuleConstsLiteralsStruct* p_type = static_cast<ModuleConstsLiteralsStruct*>(data);
+        const ModuleConstsLiteralsStruct* p_type = static_cast<const ModuleConstsLiteralsStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -254,11 +254,11 @@ namespace const_module2 {
     }
 
     bool Module2ConstsLiteralsStructPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        Module2ConstsLiteralsStruct* p_type = static_cast<Module2ConstsLiteralsStruct*>(data);
+        const Module2ConstsLiteralsStruct* p_type = static_cast<const Module2ConstsLiteralsStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -330,7 +330,7 @@ namespace const_module2 {
     }
 
     std::function<uint32_t()> Module2ConstsLiteralsStructPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -347,7 +347,7 @@ namespace const_module2 {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<Module2ConstsLiteralsStruct*>(data), current_alignment)) +
+                                   *static_cast<const Module2ConstsLiteralsStruct*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -370,7 +370,7 @@ namespace const_module2 {
     }
 
     bool Module2ConstsLiteralsStructPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -379,7 +379,7 @@ namespace const_module2 {
             return false;
         }
 
-        Module2ConstsLiteralsStruct* p_type = static_cast<Module2ConstsLiteralsStruct*>(data);
+        const Module2ConstsLiteralsStruct* p_type = static_cast<const Module2ConstsLiteralsStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -449,11 +449,11 @@ ConstsLiteralsStructPubSubType::~ConstsLiteralsStructPubSubType()
 }
 
 bool ConstsLiteralsStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ConstsLiteralsStruct* p_type = static_cast<ConstsLiteralsStruct*>(data);
+    const ConstsLiteralsStruct* p_type = static_cast<const ConstsLiteralsStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -525,7 +525,7 @@ bool ConstsLiteralsStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ConstsLiteralsStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -542,7 +542,7 @@ std::function<uint32_t()> ConstsLiteralsStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ConstsLiteralsStruct*>(data), current_alignment)) +
+                               *static_cast<const ConstsLiteralsStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -565,7 +565,7 @@ void ConstsLiteralsStructPubSubType::deleteData(
 }
 
 bool ConstsLiteralsStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -574,7 +574,7 @@ bool ConstsLiteralsStructPubSubType::getKey(
         return false;
     }
 
-    ConstsLiteralsStruct* p_type = static_cast<ConstsLiteralsStruct*>(data);
+    const ConstsLiteralsStruct* p_type = static_cast<const ConstsLiteralsStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/constantsPubSubTypes.h
+++ b/test/dds-types-test/constantsPubSubTypes.h
@@ -60,14 +60,14 @@ namespace const_module1
         eProsima_user_DllExport ~ModuleConstsLiteralsStructPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -76,17 +76,17 @@ namespace const_module1
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -154,14 +154,14 @@ namespace const_module2
         eProsima_user_DllExport ~Module2ConstsLiteralsStructPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -170,17 +170,17 @@ namespace const_module2
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -246,14 +246,14 @@ public:
     eProsima_user_DllExport ~ConstsLiteralsStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -262,17 +262,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/declarationsPubSubTypes.cxx
+++ b/test/dds-types-test/declarationsPubSubTypes.cxx
@@ -55,11 +55,11 @@ ForwardDeclarationsRecursiveStructPubSubType::~ForwardDeclarationsRecursiveStruc
 }
 
 bool ForwardDeclarationsRecursiveStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ForwardDeclarationsRecursiveStruct* p_type = static_cast<ForwardDeclarationsRecursiveStruct*>(data);
+    const ForwardDeclarationsRecursiveStruct* p_type = static_cast<const ForwardDeclarationsRecursiveStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -131,7 +131,7 @@ bool ForwardDeclarationsRecursiveStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ForwardDeclarationsRecursiveStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -148,7 +148,7 @@ std::function<uint32_t()> ForwardDeclarationsRecursiveStructPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ForwardDeclarationsRecursiveStruct*>(data), current_alignment)) +
+                               *static_cast<const ForwardDeclarationsRecursiveStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -171,7 +171,7 @@ void ForwardDeclarationsRecursiveStructPubSubType::deleteData(
 }
 
 bool ForwardDeclarationsRecursiveStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -180,7 +180,7 @@ bool ForwardDeclarationsRecursiveStructPubSubType::getKey(
         return false;
     }
 
-    ForwardDeclarationsRecursiveStruct* p_type = static_cast<ForwardDeclarationsRecursiveStruct*>(data);
+    const ForwardDeclarationsRecursiveStruct* p_type = static_cast<const ForwardDeclarationsRecursiveStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ ForwardStructPubSubType::~ForwardStructPubSubType()
 }
 
 bool ForwardStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ForwardStruct* p_type = static_cast<ForwardStruct*>(data);
+    const ForwardStruct* p_type = static_cast<const ForwardStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool ForwardStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ForwardStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> ForwardStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ForwardStruct*>(data), current_alignment)) +
+                               *static_cast<const ForwardStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void ForwardStructPubSubType::deleteData(
 }
 
 bool ForwardStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool ForwardStructPubSubType::getKey(
         return false;
     }
 
-    ForwardStruct* p_type = static_cast<ForwardStruct*>(data);
+    const ForwardStruct* p_type = static_cast<const ForwardStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -445,11 +445,11 @@ namespace declarations_module {
     }
 
     bool ForwardStructPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        ForwardStruct* p_type = static_cast<ForwardStruct*>(data);
+        const ForwardStruct* p_type = static_cast<const ForwardStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -521,7 +521,7 @@ namespace declarations_module {
     }
 
     std::function<uint32_t()> ForwardStructPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -538,7 +538,7 @@ namespace declarations_module {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<ForwardStruct*>(data), current_alignment)) +
+                                   *static_cast<const ForwardStruct*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -561,7 +561,7 @@ namespace declarations_module {
     }
 
     bool ForwardStructPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -570,7 +570,7 @@ namespace declarations_module {
             return false;
         }
 
-        ForwardStruct* p_type = static_cast<ForwardStruct*>(data);
+        const ForwardStruct* p_type = static_cast<const ForwardStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -641,11 +641,11 @@ ModuledForwardDeclarationsRecursiveStructPubSubType::~ModuledForwardDeclarations
 }
 
 bool ModuledForwardDeclarationsRecursiveStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ModuledForwardDeclarationsRecursiveStruct* p_type = static_cast<ModuledForwardDeclarationsRecursiveStruct*>(data);
+    const ModuledForwardDeclarationsRecursiveStruct* p_type = static_cast<const ModuledForwardDeclarationsRecursiveStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -717,7 +717,7 @@ bool ModuledForwardDeclarationsRecursiveStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ModuledForwardDeclarationsRecursiveStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -734,7 +734,7 @@ std::function<uint32_t()> ModuledForwardDeclarationsRecursiveStructPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ModuledForwardDeclarationsRecursiveStruct*>(data), current_alignment)) +
+                               *static_cast<const ModuledForwardDeclarationsRecursiveStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -757,7 +757,7 @@ void ModuledForwardDeclarationsRecursiveStructPubSubType::deleteData(
 }
 
 bool ModuledForwardDeclarationsRecursiveStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -766,7 +766,7 @@ bool ModuledForwardDeclarationsRecursiveStructPubSubType::getKey(
         return false;
     }
 
-    ModuledForwardDeclarationsRecursiveStruct* p_type = static_cast<ModuledForwardDeclarationsRecursiveStruct*>(data);
+    const ModuledForwardDeclarationsRecursiveStruct* p_type = static_cast<const ModuledForwardDeclarationsRecursiveStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -836,11 +836,11 @@ namespace declarations_module {
     }
 
     bool ModuledForwardStructPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        ModuledForwardStruct* p_type = static_cast<ModuledForwardStruct*>(data);
+        const ModuledForwardStruct* p_type = static_cast<const ModuledForwardStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -912,7 +912,7 @@ namespace declarations_module {
     }
 
     std::function<uint32_t()> ModuledForwardStructPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -929,7 +929,7 @@ namespace declarations_module {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<ModuledForwardStruct*>(data), current_alignment)) +
+                                   *static_cast<const ModuledForwardStruct*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -952,7 +952,7 @@ namespace declarations_module {
     }
 
     bool ModuledForwardStructPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -961,7 +961,7 @@ namespace declarations_module {
             return false;
         }
 
-        ModuledForwardStruct* p_type = static_cast<ModuledForwardStruct*>(data);
+        const ModuledForwardStruct* p_type = static_cast<const ModuledForwardStruct*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1034,11 +1034,11 @@ ModuledCommonNameStructurePubSubType::~ModuledCommonNameStructurePubSubType()
 }
 
 bool ModuledCommonNameStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ModuledCommonNameStructure* p_type = static_cast<ModuledCommonNameStructure*>(data);
+    const ModuledCommonNameStructure* p_type = static_cast<const ModuledCommonNameStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1110,7 +1110,7 @@ bool ModuledCommonNameStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ModuledCommonNameStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1127,7 +1127,7 @@ std::function<uint32_t()> ModuledCommonNameStructurePubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ModuledCommonNameStructure*>(data), current_alignment)) +
+                               *static_cast<const ModuledCommonNameStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1150,7 +1150,7 @@ void ModuledCommonNameStructurePubSubType::deleteData(
 }
 
 bool ModuledCommonNameStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1159,7 +1159,7 @@ bool ModuledCommonNameStructurePubSubType::getKey(
         return false;
     }
 
-    ModuledCommonNameStructure* p_type = static_cast<ModuledCommonNameStructure*>(data);
+    const ModuledCommonNameStructure* p_type = static_cast<const ModuledCommonNameStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/declarationsPubSubTypes.h
+++ b/test/dds-types-test/declarationsPubSubTypes.h
@@ -58,14 +58,14 @@ public:
     eProsima_user_DllExport ~ForwardDeclarationsRecursiveStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -74,17 +74,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -150,14 +150,14 @@ public:
     eProsima_user_DllExport ~ForwardStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -166,17 +166,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -247,14 +247,14 @@ namespace declarations_module
         eProsima_user_DllExport ~ForwardStructPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -263,17 +263,17 @@ namespace declarations_module
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -339,14 +339,14 @@ public:
     eProsima_user_DllExport ~ModuledForwardDeclarationsRecursiveStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -355,17 +355,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -432,14 +432,14 @@ namespace declarations_module
         eProsima_user_DllExport ~ModuledForwardStructPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -448,17 +448,17 @@ namespace declarations_module
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -526,14 +526,14 @@ public:
     eProsima_user_DllExport ~ModuledCommonNameStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -542,17 +542,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/enumerationsPubSubTypes.cxx
+++ b/test/dds-types-test/enumerationsPubSubTypes.cxx
@@ -60,11 +60,11 @@ EnumStructurePubSubType::~EnumStructurePubSubType()
 }
 
 bool EnumStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    EnumStructure* p_type = static_cast<EnumStructure*>(data);
+    const EnumStructure* p_type = static_cast<const EnumStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -136,7 +136,7 @@ bool EnumStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> EnumStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -153,7 +153,7 @@ std::function<uint32_t()> EnumStructurePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<EnumStructure*>(data), current_alignment)) +
+                               *static_cast<const EnumStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -176,7 +176,7 @@ void EnumStructurePubSubType::deleteData(
 }
 
 bool EnumStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -185,7 +185,7 @@ bool EnumStructurePubSubType::getKey(
         return false;
     }
 
-    EnumStructure* p_type = static_cast<EnumStructure*>(data);
+    const EnumStructure* p_type = static_cast<const EnumStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -253,11 +253,11 @@ BitMaskStructurePubSubType::~BitMaskStructurePubSubType()
 }
 
 bool BitMaskStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BitMaskStructure* p_type = static_cast<BitMaskStructure*>(data);
+    const BitMaskStructure* p_type = static_cast<const BitMaskStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -329,7 +329,7 @@ bool BitMaskStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> BitMaskStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -346,7 +346,7 @@ std::function<uint32_t()> BitMaskStructurePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BitMaskStructure*>(data), current_alignment)) +
+                               *static_cast<const BitMaskStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -369,7 +369,7 @@ void BitMaskStructurePubSubType::deleteData(
 }
 
 bool BitMaskStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -378,7 +378,7 @@ bool BitMaskStructurePubSubType::getKey(
         return false;
     }
 
-    BitMaskStructure* p_type = static_cast<BitMaskStructure*>(data);
+    const BitMaskStructure* p_type = static_cast<const BitMaskStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -446,11 +446,11 @@ BoundedBitMaskStructurePubSubType::~BoundedBitMaskStructurePubSubType()
 }
 
 bool BoundedBitMaskStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedBitMaskStructure* p_type = static_cast<BoundedBitMaskStructure*>(data);
+    const BoundedBitMaskStructure* p_type = static_cast<const BoundedBitMaskStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -522,7 +522,7 @@ bool BoundedBitMaskStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedBitMaskStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -539,7 +539,7 @@ std::function<uint32_t()> BoundedBitMaskStructurePubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedBitMaskStructure*>(data), current_alignment)) +
+                               *static_cast<const BoundedBitMaskStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -562,7 +562,7 @@ void BoundedBitMaskStructurePubSubType::deleteData(
 }
 
 bool BoundedBitMaskStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -571,7 +571,7 @@ bool BoundedBitMaskStructurePubSubType::getKey(
         return false;
     }
 
-    BoundedBitMaskStructure* p_type = static_cast<BoundedBitMaskStructure*>(data);
+    const BoundedBitMaskStructure* p_type = static_cast<const BoundedBitMaskStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/enumerationsPubSubTypes.h
+++ b/test/dds-types-test/enumerationsPubSubTypes.h
@@ -57,14 +57,14 @@ public:
     eProsima_user_DllExport ~EnumStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -73,17 +73,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -148,14 +148,14 @@ public:
     eProsima_user_DllExport ~BitMaskStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -164,17 +164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -239,14 +239,14 @@ public:
     eProsima_user_DllExport ~BoundedBitMaskStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -255,17 +255,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/externalPubSubTypes.cxx
+++ b/test/dds-types-test/externalPubSubTypes.cxx
@@ -55,11 +55,11 @@ short_externalPubSubType::~short_externalPubSubType()
 }
 
 bool short_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    short_external* p_type = static_cast<short_external*>(data);
+    const short_external* p_type = static_cast<const short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -131,7 +131,7 @@ bool short_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> short_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -148,7 +148,7 @@ std::function<uint32_t()> short_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<short_external*>(data), current_alignment)) +
+                               *static_cast<const short_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -171,7 +171,7 @@ void short_externalPubSubType::deleteData(
 }
 
 bool short_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -180,7 +180,7 @@ bool short_externalPubSubType::getKey(
         return false;
     }
 
-    short_external* p_type = static_cast<short_external*>(data);
+    const short_external* p_type = static_cast<const short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -249,11 +249,11 @@ ushort_externalPubSubType::~ushort_externalPubSubType()
 }
 
 bool ushort_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ushort_external* p_type = static_cast<ushort_external*>(data);
+    const ushort_external* p_type = static_cast<const ushort_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -325,7 +325,7 @@ bool ushort_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ushort_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -342,7 +342,7 @@ std::function<uint32_t()> ushort_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ushort_external*>(data), current_alignment)) +
+                               *static_cast<const ushort_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -365,7 +365,7 @@ void ushort_externalPubSubType::deleteData(
 }
 
 bool ushort_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -374,7 +374,7 @@ bool ushort_externalPubSubType::getKey(
         return false;
     }
 
-    ushort_external* p_type = static_cast<ushort_external*>(data);
+    const ushort_external* p_type = static_cast<const ushort_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ long_externalPubSubType::~long_externalPubSubType()
 }
 
 bool long_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    long_external* p_type = static_cast<long_external*>(data);
+    const long_external* p_type = static_cast<const long_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool long_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> long_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> long_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<long_external*>(data), current_alignment)) +
+                               *static_cast<const long_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void long_externalPubSubType::deleteData(
 }
 
 bool long_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool long_externalPubSubType::getKey(
         return false;
     }
 
-    long_external* p_type = static_cast<long_external*>(data);
+    const long_external* p_type = static_cast<const long_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -637,11 +637,11 @@ ulong_externalPubSubType::~ulong_externalPubSubType()
 }
 
 bool ulong_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulong_external* p_type = static_cast<ulong_external*>(data);
+    const ulong_external* p_type = static_cast<const ulong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -713,7 +713,7 @@ bool ulong_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulong_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -730,7 +730,7 @@ std::function<uint32_t()> ulong_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulong_external*>(data), current_alignment)) +
+                               *static_cast<const ulong_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -753,7 +753,7 @@ void ulong_externalPubSubType::deleteData(
 }
 
 bool ulong_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -762,7 +762,7 @@ bool ulong_externalPubSubType::getKey(
         return false;
     }
 
-    ulong_external* p_type = static_cast<ulong_external*>(data);
+    const ulong_external* p_type = static_cast<const ulong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -831,11 +831,11 @@ longlong_externalPubSubType::~longlong_externalPubSubType()
 }
 
 bool longlong_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longlong_external* p_type = static_cast<longlong_external*>(data);
+    const longlong_external* p_type = static_cast<const longlong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -907,7 +907,7 @@ bool longlong_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longlong_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -924,7 +924,7 @@ std::function<uint32_t()> longlong_externalPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longlong_external*>(data), current_alignment)) +
+                               *static_cast<const longlong_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -947,7 +947,7 @@ void longlong_externalPubSubType::deleteData(
 }
 
 bool longlong_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -956,7 +956,7 @@ bool longlong_externalPubSubType::getKey(
         return false;
     }
 
-    longlong_external* p_type = static_cast<longlong_external*>(data);
+    const longlong_external* p_type = static_cast<const longlong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1025,11 +1025,11 @@ ulonglong_externalPubSubType::~ulonglong_externalPubSubType()
 }
 
 bool ulonglong_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulonglong_external* p_type = static_cast<ulonglong_external*>(data);
+    const ulonglong_external* p_type = static_cast<const ulonglong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1101,7 +1101,7 @@ bool ulonglong_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulonglong_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1118,7 +1118,7 @@ std::function<uint32_t()> ulonglong_externalPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulonglong_external*>(data), current_alignment)) +
+                               *static_cast<const ulonglong_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1141,7 +1141,7 @@ void ulonglong_externalPubSubType::deleteData(
 }
 
 bool ulonglong_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1150,7 +1150,7 @@ bool ulonglong_externalPubSubType::getKey(
         return false;
     }
 
-    ulonglong_external* p_type = static_cast<ulonglong_external*>(data);
+    const ulonglong_external* p_type = static_cast<const ulonglong_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1219,11 +1219,11 @@ float_externalPubSubType::~float_externalPubSubType()
 }
 
 bool float_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    float_external* p_type = static_cast<float_external*>(data);
+    const float_external* p_type = static_cast<const float_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1295,7 +1295,7 @@ bool float_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> float_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1312,7 +1312,7 @@ std::function<uint32_t()> float_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<float_external*>(data), current_alignment)) +
+                               *static_cast<const float_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1335,7 +1335,7 @@ void float_externalPubSubType::deleteData(
 }
 
 bool float_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1344,7 +1344,7 @@ bool float_externalPubSubType::getKey(
         return false;
     }
 
-    float_external* p_type = static_cast<float_external*>(data);
+    const float_external* p_type = static_cast<const float_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1413,11 +1413,11 @@ double_externalPubSubType::~double_externalPubSubType()
 }
 
 bool double_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    double_external* p_type = static_cast<double_external*>(data);
+    const double_external* p_type = static_cast<const double_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1489,7 +1489,7 @@ bool double_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> double_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1506,7 +1506,7 @@ std::function<uint32_t()> double_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<double_external*>(data), current_alignment)) +
+                               *static_cast<const double_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1529,7 +1529,7 @@ void double_externalPubSubType::deleteData(
 }
 
 bool double_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1538,7 +1538,7 @@ bool double_externalPubSubType::getKey(
         return false;
     }
 
-    double_external* p_type = static_cast<double_external*>(data);
+    const double_external* p_type = static_cast<const double_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1607,11 +1607,11 @@ longdouble_externalPubSubType::~longdouble_externalPubSubType()
 }
 
 bool longdouble_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longdouble_external* p_type = static_cast<longdouble_external*>(data);
+    const longdouble_external* p_type = static_cast<const longdouble_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1683,7 +1683,7 @@ bool longdouble_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longdouble_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1700,7 +1700,7 @@ std::function<uint32_t()> longdouble_externalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longdouble_external*>(data), current_alignment)) +
+                               *static_cast<const longdouble_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1723,7 +1723,7 @@ void longdouble_externalPubSubType::deleteData(
 }
 
 bool longdouble_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1732,7 +1732,7 @@ bool longdouble_externalPubSubType::getKey(
         return false;
     }
 
-    longdouble_external* p_type = static_cast<longdouble_external*>(data);
+    const longdouble_external* p_type = static_cast<const longdouble_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1801,11 +1801,11 @@ boolean_externalPubSubType::~boolean_externalPubSubType()
 }
 
 bool boolean_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    boolean_external* p_type = static_cast<boolean_external*>(data);
+    const boolean_external* p_type = static_cast<const boolean_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1877,7 +1877,7 @@ bool boolean_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> boolean_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1894,7 +1894,7 @@ std::function<uint32_t()> boolean_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<boolean_external*>(data), current_alignment)) +
+                               *static_cast<const boolean_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1917,7 +1917,7 @@ void boolean_externalPubSubType::deleteData(
 }
 
 bool boolean_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1926,7 +1926,7 @@ bool boolean_externalPubSubType::getKey(
         return false;
     }
 
-    boolean_external* p_type = static_cast<boolean_external*>(data);
+    const boolean_external* p_type = static_cast<const boolean_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1995,11 +1995,11 @@ octet_externalPubSubType::~octet_externalPubSubType()
 }
 
 bool octet_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    octet_external* p_type = static_cast<octet_external*>(data);
+    const octet_external* p_type = static_cast<const octet_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2071,7 +2071,7 @@ bool octet_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> octet_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2088,7 +2088,7 @@ std::function<uint32_t()> octet_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<octet_external*>(data), current_alignment)) +
+                               *static_cast<const octet_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2111,7 +2111,7 @@ void octet_externalPubSubType::deleteData(
 }
 
 bool octet_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2120,7 +2120,7 @@ bool octet_externalPubSubType::getKey(
         return false;
     }
 
-    octet_external* p_type = static_cast<octet_external*>(data);
+    const octet_external* p_type = static_cast<const octet_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2189,11 +2189,11 @@ char_externalPubSubType::~char_externalPubSubType()
 }
 
 bool char_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    char_external* p_type = static_cast<char_external*>(data);
+    const char_external* p_type = static_cast<const char_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2265,7 +2265,7 @@ bool char_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> char_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2282,7 +2282,7 @@ std::function<uint32_t()> char_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<char_external*>(data), current_alignment)) +
+                               *static_cast<const char_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2305,7 +2305,7 @@ void char_externalPubSubType::deleteData(
 }
 
 bool char_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2314,7 +2314,7 @@ bool char_externalPubSubType::getKey(
         return false;
     }
 
-    char_external* p_type = static_cast<char_external*>(data);
+    const char_external* p_type = static_cast<const char_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2383,11 +2383,11 @@ wchar_externalPubSubType::~wchar_externalPubSubType()
 }
 
 bool wchar_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    wchar_external* p_type = static_cast<wchar_external*>(data);
+    const wchar_external* p_type = static_cast<const wchar_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2459,7 +2459,7 @@ bool wchar_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> wchar_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2476,7 +2476,7 @@ std::function<uint32_t()> wchar_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<wchar_external*>(data), current_alignment)) +
+                               *static_cast<const wchar_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2499,7 +2499,7 @@ void wchar_externalPubSubType::deleteData(
 }
 
 bool wchar_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2508,7 +2508,7 @@ bool wchar_externalPubSubType::getKey(
         return false;
     }
 
-    wchar_external* p_type = static_cast<wchar_external*>(data);
+    const wchar_external* p_type = static_cast<const wchar_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2577,11 +2577,11 @@ sequence_short_externalPubSubType::~sequence_short_externalPubSubType()
 }
 
 bool sequence_short_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sequence_short_external* p_type = static_cast<sequence_short_external*>(data);
+    const sequence_short_external* p_type = static_cast<const sequence_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2653,7 +2653,7 @@ bool sequence_short_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> sequence_short_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2670,7 +2670,7 @@ std::function<uint32_t()> sequence_short_externalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sequence_short_external*>(data), current_alignment)) +
+                               *static_cast<const sequence_short_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2693,7 +2693,7 @@ void sequence_short_externalPubSubType::deleteData(
 }
 
 bool sequence_short_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2702,7 +2702,7 @@ bool sequence_short_externalPubSubType::getKey(
         return false;
     }
 
-    sequence_short_external* p_type = static_cast<sequence_short_external*>(data);
+    const sequence_short_external* p_type = static_cast<const sequence_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2771,11 +2771,11 @@ string_unbounded_externalPubSubType::~string_unbounded_externalPubSubType()
 }
 
 bool string_unbounded_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_unbounded_external* p_type = static_cast<string_unbounded_external*>(data);
+    const string_unbounded_external* p_type = static_cast<const string_unbounded_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2847,7 +2847,7 @@ bool string_unbounded_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_unbounded_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2864,7 +2864,7 @@ std::function<uint32_t()> string_unbounded_externalPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_unbounded_external*>(data), current_alignment)) +
+                               *static_cast<const string_unbounded_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2887,7 +2887,7 @@ void string_unbounded_externalPubSubType::deleteData(
 }
 
 bool string_unbounded_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2896,7 +2896,7 @@ bool string_unbounded_externalPubSubType::getKey(
         return false;
     }
 
-    string_unbounded_external* p_type = static_cast<string_unbounded_external*>(data);
+    const string_unbounded_external* p_type = static_cast<const string_unbounded_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2965,11 +2965,11 @@ string_bounded_externalPubSubType::~string_bounded_externalPubSubType()
 }
 
 bool string_bounded_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_bounded_external* p_type = static_cast<string_bounded_external*>(data);
+    const string_bounded_external* p_type = static_cast<const string_bounded_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3041,7 +3041,7 @@ bool string_bounded_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_bounded_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3058,7 +3058,7 @@ std::function<uint32_t()> string_bounded_externalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_bounded_external*>(data), current_alignment)) +
+                               *static_cast<const string_bounded_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3081,7 +3081,7 @@ void string_bounded_externalPubSubType::deleteData(
 }
 
 bool string_bounded_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3090,7 +3090,7 @@ bool string_bounded_externalPubSubType::getKey(
         return false;
     }
 
-    string_bounded_external* p_type = static_cast<string_bounded_external*>(data);
+    const string_bounded_external* p_type = static_cast<const string_bounded_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3159,11 +3159,11 @@ map_short_externalPubSubType::~map_short_externalPubSubType()
 }
 
 bool map_short_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    map_short_external* p_type = static_cast<map_short_external*>(data);
+    const map_short_external* p_type = static_cast<const map_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3235,7 +3235,7 @@ bool map_short_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> map_short_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3252,7 +3252,7 @@ std::function<uint32_t()> map_short_externalPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<map_short_external*>(data), current_alignment)) +
+                               *static_cast<const map_short_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3275,7 +3275,7 @@ void map_short_externalPubSubType::deleteData(
 }
 
 bool map_short_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3284,7 +3284,7 @@ bool map_short_externalPubSubType::getKey(
         return false;
     }
 
-    map_short_external* p_type = static_cast<map_short_external*>(data);
+    const map_short_external* p_type = static_cast<const map_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3353,11 +3353,11 @@ array_short_externalPubSubType::~array_short_externalPubSubType()
 }
 
 bool array_short_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    array_short_external* p_type = static_cast<array_short_external*>(data);
+    const array_short_external* p_type = static_cast<const array_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3429,7 +3429,7 @@ bool array_short_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> array_short_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3446,7 +3446,7 @@ std::function<uint32_t()> array_short_externalPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<array_short_external*>(data), current_alignment)) +
+                               *static_cast<const array_short_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3469,7 +3469,7 @@ void array_short_externalPubSubType::deleteData(
 }
 
 bool array_short_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3478,7 +3478,7 @@ bool array_short_externalPubSubType::getKey(
         return false;
     }
 
-    array_short_external* p_type = static_cast<array_short_external*>(data);
+    const array_short_external* p_type = static_cast<const array_short_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3547,11 +3547,11 @@ struct_externalPubSubType::~struct_externalPubSubType()
 }
 
 bool struct_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_external* p_type = static_cast<struct_external*>(data);
+    const struct_external* p_type = static_cast<const struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3623,7 +3623,7 @@ bool struct_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3640,7 +3640,7 @@ std::function<uint32_t()> struct_externalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_external*>(data), current_alignment)) +
+                               *static_cast<const struct_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3663,7 +3663,7 @@ void struct_externalPubSubType::deleteData(
 }
 
 bool struct_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3672,7 +3672,7 @@ bool struct_externalPubSubType::getKey(
         return false;
     }
 
-    struct_external* p_type = static_cast<struct_external*>(data);
+    const struct_external* p_type = static_cast<const struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3741,11 +3741,11 @@ InnerStructExternalPubSubType::~InnerStructExternalPubSubType()
 }
 
 bool InnerStructExternalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructExternal* p_type = static_cast<InnerStructExternal*>(data);
+    const InnerStructExternal* p_type = static_cast<const InnerStructExternal*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3817,7 +3817,7 @@ bool InnerStructExternalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructExternalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3834,7 +3834,7 @@ std::function<uint32_t()> InnerStructExternalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructExternal*>(data), current_alignment)) +
+                               *static_cast<const InnerStructExternal*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3857,7 +3857,7 @@ void InnerStructExternalPubSubType::deleteData(
 }
 
 bool InnerStructExternalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3866,7 +3866,7 @@ bool InnerStructExternalPubSubType::getKey(
         return false;
     }
 
-    InnerStructExternal* p_type = static_cast<InnerStructExternal*>(data);
+    const InnerStructExternal* p_type = static_cast<const InnerStructExternal*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3935,11 +3935,11 @@ ext_struct_externalPubSubType::~ext_struct_externalPubSubType()
 }
 
 bool ext_struct_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ext_struct_external* p_type = static_cast<ext_struct_external*>(data);
+    const ext_struct_external* p_type = static_cast<const ext_struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4011,7 +4011,7 @@ bool ext_struct_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ext_struct_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4028,7 +4028,7 @@ std::function<uint32_t()> ext_struct_externalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ext_struct_external*>(data), current_alignment)) +
+                               *static_cast<const ext_struct_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4051,7 +4051,7 @@ void ext_struct_externalPubSubType::deleteData(
 }
 
 bool ext_struct_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4060,7 +4060,7 @@ bool ext_struct_externalPubSubType::getKey(
         return false;
     }
 
-    ext_struct_external* p_type = static_cast<ext_struct_external*>(data);
+    const ext_struct_external* p_type = static_cast<const ext_struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4129,11 +4129,11 @@ ext_and_inner_struct_externalPubSubType::~ext_and_inner_struct_externalPubSubTyp
 }
 
 bool ext_and_inner_struct_externalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ext_and_inner_struct_external* p_type = static_cast<ext_and_inner_struct_external*>(data);
+    const ext_and_inner_struct_external* p_type = static_cast<const ext_and_inner_struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4205,7 +4205,7 @@ bool ext_and_inner_struct_externalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ext_and_inner_struct_externalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4222,7 +4222,7 @@ std::function<uint32_t()> ext_and_inner_struct_externalPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ext_and_inner_struct_external*>(data), current_alignment)) +
+                               *static_cast<const ext_and_inner_struct_external*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4245,7 +4245,7 @@ void ext_and_inner_struct_externalPubSubType::deleteData(
 }
 
 bool ext_and_inner_struct_externalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4254,7 +4254,7 @@ bool ext_and_inner_struct_externalPubSubType::getKey(
         return false;
     }
 
-    ext_and_inner_struct_external* p_type = static_cast<ext_and_inner_struct_external*>(data);
+    const ext_and_inner_struct_external* p_type = static_cast<const ext_and_inner_struct_external*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4323,11 +4323,11 @@ struct_external_optionalPubSubType::~struct_external_optionalPubSubType()
 }
 
 bool struct_external_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_external_optional* p_type = static_cast<struct_external_optional*>(data);
+    const struct_external_optional* p_type = static_cast<const struct_external_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4399,7 +4399,7 @@ bool struct_external_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_external_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4416,7 +4416,7 @@ std::function<uint32_t()> struct_external_optionalPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_external_optional*>(data), current_alignment)) +
+                               *static_cast<const struct_external_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4439,7 +4439,7 @@ void struct_external_optionalPubSubType::deleteData(
 }
 
 bool struct_external_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4448,7 +4448,7 @@ bool struct_external_optionalPubSubType::getKey(
         return false;
     }
 
-    struct_external_optional* p_type = static_cast<struct_external_optional*>(data);
+    const struct_external_optional* p_type = static_cast<const struct_external_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4518,11 +4518,11 @@ recursive_union_containerPubSubType::~recursive_union_containerPubSubType()
 }
 
 bool recursive_union_containerPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    recursive_union_container* p_type = static_cast<recursive_union_container*>(data);
+    const recursive_union_container* p_type = static_cast<const recursive_union_container*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4594,7 +4594,7 @@ bool recursive_union_containerPubSubType::deserialize(
 }
 
 std::function<uint32_t()> recursive_union_containerPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4611,7 +4611,7 @@ std::function<uint32_t()> recursive_union_containerPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<recursive_union_container*>(data), current_alignment)) +
+                               *static_cast<const recursive_union_container*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4634,7 +4634,7 @@ void recursive_union_containerPubSubType::deleteData(
 }
 
 bool recursive_union_containerPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4643,7 +4643,7 @@ bool recursive_union_containerPubSubType::getKey(
         return false;
     }
 
-    recursive_union_container* p_type = static_cast<recursive_union_container*>(data);
+    const recursive_union_container* p_type = static_cast<const recursive_union_container*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4713,11 +4713,11 @@ recursive_test_1PubSubType::~recursive_test_1PubSubType()
 }
 
 bool recursive_test_1PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    recursive_test_1* p_type = static_cast<recursive_test_1*>(data);
+    const recursive_test_1* p_type = static_cast<const recursive_test_1*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4789,7 +4789,7 @@ bool recursive_test_1PubSubType::deserialize(
 }
 
 std::function<uint32_t()> recursive_test_1PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4806,7 +4806,7 @@ std::function<uint32_t()> recursive_test_1PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<recursive_test_1*>(data), current_alignment)) +
+                               *static_cast<const recursive_test_1*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4829,7 +4829,7 @@ void recursive_test_1PubSubType::deleteData(
 }
 
 bool recursive_test_1PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4838,7 +4838,7 @@ bool recursive_test_1PubSubType::getKey(
         return false;
     }
 
-    recursive_test_1* p_type = static_cast<recursive_test_1*>(data);
+    const recursive_test_1* p_type = static_cast<const recursive_test_1*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4909,11 +4909,11 @@ recursive_structurePubSubType::~recursive_structurePubSubType()
 }
 
 bool recursive_structurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    recursive_structure* p_type = static_cast<recursive_structure*>(data);
+    const recursive_structure* p_type = static_cast<const recursive_structure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4985,7 +4985,7 @@ bool recursive_structurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> recursive_structurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5002,7 +5002,7 @@ std::function<uint32_t()> recursive_structurePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<recursive_structure*>(data), current_alignment)) +
+                               *static_cast<const recursive_structure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5025,7 +5025,7 @@ void recursive_structurePubSubType::deleteData(
 }
 
 bool recursive_structurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5034,7 +5034,7 @@ bool recursive_structurePubSubType::getKey(
         return false;
     }
 
-    recursive_structure* p_type = static_cast<recursive_structure*>(data);
+    const recursive_structure* p_type = static_cast<const recursive_structure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5103,11 +5103,11 @@ recursive_test_2PubSubType::~recursive_test_2PubSubType()
 }
 
 bool recursive_test_2PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    recursive_test_2* p_type = static_cast<recursive_test_2*>(data);
+    const recursive_test_2* p_type = static_cast<const recursive_test_2*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5179,7 +5179,7 @@ bool recursive_test_2PubSubType::deserialize(
 }
 
 std::function<uint32_t()> recursive_test_2PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5196,7 +5196,7 @@ std::function<uint32_t()> recursive_test_2PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<recursive_test_2*>(data), current_alignment)) +
+                               *static_cast<const recursive_test_2*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5219,7 +5219,7 @@ void recursive_test_2PubSubType::deleteData(
 }
 
 bool recursive_test_2PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5228,7 +5228,7 @@ bool recursive_test_2PubSubType::getKey(
         return false;
     }
 
-    recursive_test_2* p_type = static_cast<recursive_test_2*>(data);
+    const recursive_test_2* p_type = static_cast<const recursive_test_2*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/externalPubSubTypes.h
+++ b/test/dds-types-test/externalPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~short_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~ushort_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~long_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~ulong_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~longlong_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~ulonglong_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~float_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~double_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~longdouble_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~boolean_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~octet_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~char_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~wchar_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~sequence_short_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~string_unbounded_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~string_bounded_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~map_short_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~array_short_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~struct_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~InnerStructExternalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~ext_struct_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~ext_and_inner_struct_externalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~struct_external_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2148,14 +2148,14 @@ public:
     eProsima_user_DllExport ~recursive_union_containerPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2164,17 +2164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2240,14 +2240,14 @@ public:
     eProsima_user_DllExport ~recursive_test_1PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2256,17 +2256,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2333,14 +2333,14 @@ public:
     eProsima_user_DllExport ~recursive_structurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2349,17 +2349,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2424,14 +2424,14 @@ public:
     eProsima_user_DllExport ~recursive_test_2PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2440,17 +2440,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/finalPubSubTypes.cxx
+++ b/test/dds-types-test/finalPubSubTypes.cxx
@@ -57,11 +57,11 @@ FinalShortStructPubSubType::~FinalShortStructPubSubType()
 }
 
 bool FinalShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalShortStruct* p_type = static_cast<FinalShortStruct*>(data);
+    const FinalShortStruct* p_type = static_cast<const FinalShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool FinalShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> FinalShortStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalShortStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void FinalShortStructPubSubType::deleteData(
 }
 
 bool FinalShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool FinalShortStructPubSubType::getKey(
         return false;
     }
 
-    FinalShortStruct* p_type = static_cast<FinalShortStruct*>(data);
+    const FinalShortStruct* p_type = static_cast<const FinalShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ FinalUShortStructPubSubType::~FinalUShortStructPubSubType()
 }
 
 bool FinalUShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalUShortStruct* p_type = static_cast<FinalUShortStruct*>(data);
+    const FinalUShortStruct* p_type = static_cast<const FinalUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool FinalUShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalUShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> FinalUShortStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalUShortStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalUShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void FinalUShortStructPubSubType::deleteData(
 }
 
 bool FinalUShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool FinalUShortStructPubSubType::getKey(
         return false;
     }
 
-    FinalUShortStruct* p_type = static_cast<FinalUShortStruct*>(data);
+    const FinalUShortStruct* p_type = static_cast<const FinalUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ FinalLongStructPubSubType::~FinalLongStructPubSubType()
 }
 
 bool FinalLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalLongStruct* p_type = static_cast<FinalLongStruct*>(data);
+    const FinalLongStruct* p_type = static_cast<const FinalLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool FinalLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> FinalLongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalLongStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void FinalLongStructPubSubType::deleteData(
 }
 
 bool FinalLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool FinalLongStructPubSubType::getKey(
         return false;
     }
 
-    FinalLongStruct* p_type = static_cast<FinalLongStruct*>(data);
+    const FinalLongStruct* p_type = static_cast<const FinalLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ FinalULongStructPubSubType::~FinalULongStructPubSubType()
 }
 
 bool FinalULongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalULongStruct* p_type = static_cast<FinalULongStruct*>(data);
+    const FinalULongStruct* p_type = static_cast<const FinalULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool FinalULongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalULongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> FinalULongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalULongStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalULongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void FinalULongStructPubSubType::deleteData(
 }
 
 bool FinalULongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool FinalULongStructPubSubType::getKey(
         return false;
     }
 
-    FinalULongStruct* p_type = static_cast<FinalULongStruct*>(data);
+    const FinalULongStruct* p_type = static_cast<const FinalULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ FinalLongLongStructPubSubType::~FinalLongLongStructPubSubType()
 }
 
 bool FinalLongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalLongLongStruct* p_type = static_cast<FinalLongLongStruct*>(data);
+    const FinalLongLongStruct* p_type = static_cast<const FinalLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool FinalLongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalLongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> FinalLongLongStructPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalLongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalLongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void FinalLongLongStructPubSubType::deleteData(
 }
 
 bool FinalLongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool FinalLongLongStructPubSubType::getKey(
         return false;
     }
 
-    FinalLongLongStruct* p_type = static_cast<FinalLongLongStruct*>(data);
+    const FinalLongLongStruct* p_type = static_cast<const FinalLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ FinalULongLongStructPubSubType::~FinalULongLongStructPubSubType()
 }
 
 bool FinalULongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalULongLongStruct* p_type = static_cast<FinalULongLongStruct*>(data);
+    const FinalULongLongStruct* p_type = static_cast<const FinalULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool FinalULongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalULongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> FinalULongLongStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalULongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalULongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void FinalULongLongStructPubSubType::deleteData(
 }
 
 bool FinalULongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool FinalULongLongStructPubSubType::getKey(
         return false;
     }
 
-    FinalULongLongStruct* p_type = static_cast<FinalULongLongStruct*>(data);
+    const FinalULongLongStruct* p_type = static_cast<const FinalULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ FinalFloatStructPubSubType::~FinalFloatStructPubSubType()
 }
 
 bool FinalFloatStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalFloatStruct* p_type = static_cast<FinalFloatStruct*>(data);
+    const FinalFloatStruct* p_type = static_cast<const FinalFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool FinalFloatStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalFloatStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> FinalFloatStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalFloatStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalFloatStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void FinalFloatStructPubSubType::deleteData(
 }
 
 bool FinalFloatStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool FinalFloatStructPubSubType::getKey(
         return false;
     }
 
-    FinalFloatStruct* p_type = static_cast<FinalFloatStruct*>(data);
+    const FinalFloatStruct* p_type = static_cast<const FinalFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ FinalDoubleStructPubSubType::~FinalDoubleStructPubSubType()
 }
 
 bool FinalDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalDoubleStruct* p_type = static_cast<FinalDoubleStruct*>(data);
+    const FinalDoubleStruct* p_type = static_cast<const FinalDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool FinalDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> FinalDoubleStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void FinalDoubleStructPubSubType::deleteData(
 }
 
 bool FinalDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool FinalDoubleStructPubSubType::getKey(
         return false;
     }
 
-    FinalDoubleStruct* p_type = static_cast<FinalDoubleStruct*>(data);
+    const FinalDoubleStruct* p_type = static_cast<const FinalDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ FinalLongDoubleStructPubSubType::~FinalLongDoubleStructPubSubType()
 }
 
 bool FinalLongDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalLongDoubleStruct* p_type = static_cast<FinalLongDoubleStruct*>(data);
+    const FinalLongDoubleStruct* p_type = static_cast<const FinalLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool FinalLongDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalLongDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> FinalLongDoubleStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalLongDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalLongDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void FinalLongDoubleStructPubSubType::deleteData(
 }
 
 bool FinalLongDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool FinalLongDoubleStructPubSubType::getKey(
         return false;
     }
 
-    FinalLongDoubleStruct* p_type = static_cast<FinalLongDoubleStruct*>(data);
+    const FinalLongDoubleStruct* p_type = static_cast<const FinalLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ FinalBooleanStructPubSubType::~FinalBooleanStructPubSubType()
 }
 
 bool FinalBooleanStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalBooleanStruct* p_type = static_cast<FinalBooleanStruct*>(data);
+    const FinalBooleanStruct* p_type = static_cast<const FinalBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool FinalBooleanStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalBooleanStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> FinalBooleanStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalBooleanStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalBooleanStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void FinalBooleanStructPubSubType::deleteData(
 }
 
 bool FinalBooleanStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool FinalBooleanStructPubSubType::getKey(
         return false;
     }
 
-    FinalBooleanStruct* p_type = static_cast<FinalBooleanStruct*>(data);
+    const FinalBooleanStruct* p_type = static_cast<const FinalBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ FinalOctetStructPubSubType::~FinalOctetStructPubSubType()
 }
 
 bool FinalOctetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalOctetStruct* p_type = static_cast<FinalOctetStruct*>(data);
+    const FinalOctetStruct* p_type = static_cast<const FinalOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool FinalOctetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalOctetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> FinalOctetStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalOctetStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalOctetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void FinalOctetStructPubSubType::deleteData(
 }
 
 bool FinalOctetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool FinalOctetStructPubSubType::getKey(
         return false;
     }
 
-    FinalOctetStruct* p_type = static_cast<FinalOctetStruct*>(data);
+    const FinalOctetStruct* p_type = static_cast<const FinalOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ FinalCharStructPubSubType::~FinalCharStructPubSubType()
 }
 
 bool FinalCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalCharStruct* p_type = static_cast<FinalCharStruct*>(data);
+    const FinalCharStruct* p_type = static_cast<const FinalCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool FinalCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> FinalCharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalCharStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void FinalCharStructPubSubType::deleteData(
 }
 
 bool FinalCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool FinalCharStructPubSubType::getKey(
         return false;
     }
 
-    FinalCharStruct* p_type = static_cast<FinalCharStruct*>(data);
+    const FinalCharStruct* p_type = static_cast<const FinalCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ FinalWCharStructPubSubType::~FinalWCharStructPubSubType()
 }
 
 bool FinalWCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalWCharStruct* p_type = static_cast<FinalWCharStruct*>(data);
+    const FinalWCharStruct* p_type = static_cast<const FinalWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool FinalWCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalWCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> FinalWCharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalWCharStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalWCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void FinalWCharStructPubSubType::deleteData(
 }
 
 bool FinalWCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool FinalWCharStructPubSubType::getKey(
         return false;
     }
 
-    FinalWCharStruct* p_type = static_cast<FinalWCharStruct*>(data);
+    const FinalWCharStruct* p_type = static_cast<const FinalWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ FinalUnionStructPubSubType::~FinalUnionStructPubSubType()
 }
 
 bool FinalUnionStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalUnionStruct* p_type = static_cast<FinalUnionStruct*>(data);
+    const FinalUnionStruct* p_type = static_cast<const FinalUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool FinalUnionStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalUnionStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> FinalUnionStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalUnionStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalUnionStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void FinalUnionStructPubSubType::deleteData(
 }
 
 bool FinalUnionStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool FinalUnionStructPubSubType::getKey(
         return false;
     }
 
-    FinalUnionStruct* p_type = static_cast<FinalUnionStruct*>(data);
+    const FinalUnionStruct* p_type = static_cast<const FinalUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ FinalEmptyStructPubSubType::~FinalEmptyStructPubSubType()
 }
 
 bool FinalEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalEmptyStruct* p_type = static_cast<FinalEmptyStruct*>(data);
+    const FinalEmptyStruct* p_type = static_cast<const FinalEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool FinalEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> FinalEmptyStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void FinalEmptyStructPubSubType::deleteData(
 }
 
 bool FinalEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool FinalEmptyStructPubSubType::getKey(
         return false;
     }
 
-    FinalEmptyStruct* p_type = static_cast<FinalEmptyStruct*>(data);
+    const FinalEmptyStruct* p_type = static_cast<const FinalEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ FinalEmptyInheritanceStructPubSubType::~FinalEmptyInheritanceStructPubSubType()
 }
 
 bool FinalEmptyInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalEmptyInheritanceStruct* p_type = static_cast<FinalEmptyInheritanceStruct*>(data);
+    const FinalEmptyInheritanceStruct* p_type = static_cast<const FinalEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool FinalEmptyInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalEmptyInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> FinalEmptyInheritanceStructPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalEmptyInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalEmptyInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void FinalEmptyInheritanceStructPubSubType::deleteData(
 }
 
 bool FinalEmptyInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool FinalEmptyInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    FinalEmptyInheritanceStruct* p_type = static_cast<FinalEmptyInheritanceStruct*>(data);
+    const FinalEmptyInheritanceStruct* p_type = static_cast<const FinalEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ FinalInheritanceStructPubSubType::~FinalInheritanceStructPubSubType()
 }
 
 bool FinalInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalInheritanceStruct* p_type = static_cast<FinalInheritanceStruct*>(data);
+    const FinalInheritanceStruct* p_type = static_cast<const FinalInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool FinalInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> FinalInheritanceStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const FinalInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void FinalInheritanceStructPubSubType::deleteData(
 }
 
 bool FinalInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool FinalInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    FinalInheritanceStruct* p_type = static_cast<FinalInheritanceStruct*>(data);
+    const FinalInheritanceStruct* p_type = static_cast<const FinalInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ InheritanceEmptyStructPubSubType::~InheritanceEmptyStructPubSubType()
 }
 
 bool InheritanceEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InheritanceEmptyStruct* p_type = static_cast<InheritanceEmptyStruct*>(data);
+    const InheritanceEmptyStruct* p_type = static_cast<const InheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool InheritanceEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InheritanceEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> InheritanceEmptyStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InheritanceEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const InheritanceEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void InheritanceEmptyStructPubSubType::deleteData(
 }
 
 bool InheritanceEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool InheritanceEmptyStructPubSubType::getKey(
         return false;
     }
 
-    InheritanceEmptyStruct* p_type = static_cast<InheritanceEmptyStruct*>(data);
+    const InheritanceEmptyStruct* p_type = static_cast<const InheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ FinalExtensibilityInheritancePubSubType::~FinalExtensibilityInheritancePubSubTyp
 }
 
 bool FinalExtensibilityInheritancePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FinalExtensibilityInheritance* p_type = static_cast<FinalExtensibilityInheritance*>(data);
+    const FinalExtensibilityInheritance* p_type = static_cast<const FinalExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool FinalExtensibilityInheritancePubSubType::deserialize(
 }
 
 std::function<uint32_t()> FinalExtensibilityInheritancePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> FinalExtensibilityInheritancePubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FinalExtensibilityInheritance*>(data), current_alignment)) +
+                               *static_cast<const FinalExtensibilityInheritance*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void FinalExtensibilityInheritancePubSubType::deleteData(
 }
 
 bool FinalExtensibilityInheritancePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool FinalExtensibilityInheritancePubSubType::getKey(
         return false;
     }
 
-    FinalExtensibilityInheritance* p_type = static_cast<FinalExtensibilityInheritance*>(data);
+    const FinalExtensibilityInheritance* p_type = static_cast<const FinalExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/finalPubSubTypes.h
+++ b/test/dds-types-test/finalPubSubTypes.h
@@ -87,14 +87,14 @@ public:
     eProsima_user_DllExport ~FinalShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -103,17 +103,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -233,14 +233,14 @@ public:
     eProsima_user_DllExport ~FinalUShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -249,17 +249,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -379,14 +379,14 @@ public:
     eProsima_user_DllExport ~FinalLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -395,17 +395,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -525,14 +525,14 @@ public:
     eProsima_user_DllExport ~FinalULongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -541,17 +541,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -671,14 +671,14 @@ public:
     eProsima_user_DllExport ~FinalLongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -687,17 +687,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -817,14 +817,14 @@ public:
     eProsima_user_DllExport ~FinalULongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -833,17 +833,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -963,14 +963,14 @@ public:
     eProsima_user_DllExport ~FinalFloatStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -979,17 +979,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1109,14 +1109,14 @@ public:
     eProsima_user_DllExport ~FinalDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1125,17 +1125,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1255,14 +1255,14 @@ public:
     eProsima_user_DllExport ~FinalLongDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1271,17 +1271,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1401,14 +1401,14 @@ public:
     eProsima_user_DllExport ~FinalBooleanStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1417,17 +1417,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1547,14 +1547,14 @@ public:
     eProsima_user_DllExport ~FinalOctetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1563,17 +1563,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1693,14 +1693,14 @@ public:
     eProsima_user_DllExport ~FinalCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1709,17 +1709,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1839,14 +1839,14 @@ public:
     eProsima_user_DllExport ~FinalWCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1855,17 +1855,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1952,14 +1952,14 @@ public:
     eProsima_user_DllExport ~FinalUnionStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1968,17 +1968,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2043,14 +2043,14 @@ public:
     eProsima_user_DllExport ~FinalEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2059,17 +2059,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2152,14 +2152,14 @@ public:
     eProsima_user_DllExport ~FinalEmptyInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2168,17 +2168,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2243,14 +2243,14 @@ public:
     eProsima_user_DllExport ~FinalInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2259,17 +2259,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2334,14 +2334,14 @@ public:
     eProsima_user_DllExport ~InheritanceEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2350,17 +2350,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2480,14 +2480,14 @@ public:
     eProsima_user_DllExport ~FinalExtensibilityInheritancePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2496,17 +2496,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.cxx
+++ b/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.cxx
@@ -57,11 +57,11 @@ InnerStructureHelperPubSubType::~InnerStructureHelperPubSubType()
 }
 
 bool InnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructureHelper* p_type = static_cast<InnerStructureHelper*>(data);
+    const InnerStructureHelper* p_type = static_cast<const InnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool InnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> InnerStructureHelperPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const InnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void InnerStructureHelperPubSubType::deleteData(
 }
 
 bool InnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool InnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    InnerStructureHelper* p_type = static_cast<InnerStructureHelper*>(data);
+    const InnerStructureHelper* p_type = static_cast<const InnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ InnerEmptyStructureHelperPubSubType::~InnerEmptyStructureHelperPubSubType()
 }
 
 bool InnerEmptyStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerEmptyStructureHelper* p_type = static_cast<InnerEmptyStructureHelper*>(data);
+    const InnerEmptyStructureHelper* p_type = static_cast<const InnerEmptyStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool InnerEmptyStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerEmptyStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> InnerEmptyStructureHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerEmptyStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const InnerEmptyStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void InnerEmptyStructureHelperPubSubType::deleteData(
 }
 
 bool InnerEmptyStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool InnerEmptyStructureHelperPubSubType::getKey(
         return false;
     }
 
-    InnerEmptyStructureHelper* p_type = static_cast<InnerEmptyStructureHelper*>(data);
+    const InnerEmptyStructureHelper* p_type = static_cast<const InnerEmptyStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.h
+++ b/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~InnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~InnerEmptyStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/inheritancePubSubTypes.cxx
+++ b/test/dds-types-test/inheritancePubSubTypes.cxx
@@ -57,11 +57,11 @@ InnerStructureHelperChildPubSubType::~InnerStructureHelperChildPubSubType()
 }
 
 bool InnerStructureHelperChildPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructureHelperChild* p_type = static_cast<InnerStructureHelperChild*>(data);
+    const InnerStructureHelperChild* p_type = static_cast<const InnerStructureHelperChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool InnerStructureHelperChildPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructureHelperChildPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> InnerStructureHelperChildPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructureHelperChild*>(data), current_alignment)) +
+                               *static_cast<const InnerStructureHelperChild*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void InnerStructureHelperChildPubSubType::deleteData(
 }
 
 bool InnerStructureHelperChildPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool InnerStructureHelperChildPubSubType::getKey(
         return false;
     }
 
-    InnerStructureHelperChild* p_type = static_cast<InnerStructureHelperChild*>(data);
+    const InnerStructureHelperChild* p_type = static_cast<const InnerStructureHelperChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ InnerStructureHelperChildChildPubSubType::~InnerStructureHelperChildChildPubSubT
 }
 
 bool InnerStructureHelperChildChildPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructureHelperChildChild* p_type = static_cast<InnerStructureHelperChildChild*>(data);
+    const InnerStructureHelperChildChild* p_type = static_cast<const InnerStructureHelperChildChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool InnerStructureHelperChildChildPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructureHelperChildChildPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> InnerStructureHelperChildChildPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructureHelperChildChild*>(data), current_alignment)) +
+                               *static_cast<const InnerStructureHelperChildChild*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void InnerStructureHelperChildChildPubSubType::deleteData(
 }
 
 bool InnerStructureHelperChildChildPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool InnerStructureHelperChildChildPubSubType::getKey(
         return false;
     }
 
-    InnerStructureHelperChildChild* p_type = static_cast<InnerStructureHelperChildChild*>(data);
+    const InnerStructureHelperChildChild* p_type = static_cast<const InnerStructureHelperChildChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ InnerStructureHelperEmptyChildPubSubType::~InnerStructureHelperEmptyChildPubSubT
 }
 
 bool InnerStructureHelperEmptyChildPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructureHelperEmptyChild* p_type = static_cast<InnerStructureHelperEmptyChild*>(data);
+    const InnerStructureHelperEmptyChild* p_type = static_cast<const InnerStructureHelperEmptyChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool InnerStructureHelperEmptyChildPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructureHelperEmptyChildPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> InnerStructureHelperEmptyChildPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructureHelperEmptyChild*>(data), current_alignment)) +
+                               *static_cast<const InnerStructureHelperEmptyChild*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void InnerStructureHelperEmptyChildPubSubType::deleteData(
 }
 
 bool InnerStructureHelperEmptyChildPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool InnerStructureHelperEmptyChildPubSubType::getKey(
         return false;
     }
 
-    InnerStructureHelperEmptyChild* p_type = static_cast<InnerStructureHelperEmptyChild*>(data);
+    const InnerStructureHelperEmptyChild* p_type = static_cast<const InnerStructureHelperEmptyChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ InnerStructureHelperEmptyChildChildPubSubType::~InnerStructureHelperEmptyChildCh
 }
 
 bool InnerStructureHelperEmptyChildChildPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructureHelperEmptyChildChild* p_type = static_cast<InnerStructureHelperEmptyChildChild*>(data);
+    const InnerStructureHelperEmptyChildChild* p_type = static_cast<const InnerStructureHelperEmptyChildChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool InnerStructureHelperEmptyChildChildPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructureHelperEmptyChildChildPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> InnerStructureHelperEmptyChildChildPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructureHelperEmptyChildChild*>(data), current_alignment)) +
+                               *static_cast<const InnerStructureHelperEmptyChildChild*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void InnerStructureHelperEmptyChildChildPubSubType::deleteData(
 }
 
 bool InnerStructureHelperEmptyChildChildPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool InnerStructureHelperEmptyChildChildPubSubType::getKey(
         return false;
     }
 
-    InnerStructureHelperEmptyChildChild* p_type = static_cast<InnerStructureHelperEmptyChildChild*>(data);
+    const InnerStructureHelperEmptyChildChild* p_type = static_cast<const InnerStructureHelperEmptyChildChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ InnerEmptyStructureHelperChildPubSubType::~InnerEmptyStructureHelperChildPubSubT
 }
 
 bool InnerEmptyStructureHelperChildPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerEmptyStructureHelperChild* p_type = static_cast<InnerEmptyStructureHelperChild*>(data);
+    const InnerEmptyStructureHelperChild* p_type = static_cast<const InnerEmptyStructureHelperChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool InnerEmptyStructureHelperChildPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerEmptyStructureHelperChildPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> InnerEmptyStructureHelperChildPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerEmptyStructureHelperChild*>(data), current_alignment)) +
+                               *static_cast<const InnerEmptyStructureHelperChild*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void InnerEmptyStructureHelperChildPubSubType::deleteData(
 }
 
 bool InnerEmptyStructureHelperChildPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool InnerEmptyStructureHelperChildPubSubType::getKey(
         return false;
     }
 
-    InnerEmptyStructureHelperChild* p_type = static_cast<InnerEmptyStructureHelperChild*>(data);
+    const InnerEmptyStructureHelperChild* p_type = static_cast<const InnerEmptyStructureHelperChild*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ StructAliasInheritanceStructPubSubType::~StructAliasInheritanceStructPubSubType(
 }
 
 bool StructAliasInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructAliasInheritanceStruct* p_type = static_cast<StructAliasInheritanceStruct*>(data);
+    const StructAliasInheritanceStruct* p_type = static_cast<const StructAliasInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool StructAliasInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructAliasInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> StructAliasInheritanceStructPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructAliasInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const StructAliasInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void StructAliasInheritanceStructPubSubType::deleteData(
 }
 
 bool StructAliasInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool StructAliasInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    StructAliasInheritanceStruct* p_type = static_cast<StructAliasInheritanceStruct*>(data);
+    const StructAliasInheritanceStruct* p_type = static_cast<const StructAliasInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ StructuresInheritanceStructPubSubType::~StructuresInheritanceStructPubSubType()
 }
 
 bool StructuresInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructuresInheritanceStruct* p_type = static_cast<StructuresInheritanceStruct*>(data);
+    const StructuresInheritanceStruct* p_type = static_cast<const StructuresInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool StructuresInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructuresInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> StructuresInheritanceStructPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructuresInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const StructuresInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void StructuresInheritanceStructPubSubType::deleteData(
 }
 
 bool StructuresInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool StructuresInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    StructuresInheritanceStruct* p_type = static_cast<StructuresInheritanceStruct*>(data);
+    const StructuresInheritanceStruct* p_type = static_cast<const StructuresInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1411,11 +1411,11 @@ BitsetsChildInheritanceStructPubSubType::~BitsetsChildInheritanceStructPubSubTyp
 }
 
 bool BitsetsChildInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BitsetsChildInheritanceStruct* p_type = static_cast<BitsetsChildInheritanceStruct*>(data);
+    const BitsetsChildInheritanceStruct* p_type = static_cast<const BitsetsChildInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1487,7 +1487,7 @@ bool BitsetsChildInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BitsetsChildInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1504,7 +1504,7 @@ std::function<uint32_t()> BitsetsChildInheritanceStructPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BitsetsChildInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const BitsetsChildInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1527,7 +1527,7 @@ void BitsetsChildInheritanceStructPubSubType::deleteData(
 }
 
 bool BitsetsChildInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1536,7 +1536,7 @@ bool BitsetsChildInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    BitsetsChildInheritanceStruct* p_type = static_cast<BitsetsChildInheritanceStruct*>(data);
+    const BitsetsChildInheritanceStruct* p_type = static_cast<const BitsetsChildInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/inheritancePubSubTypes.h
+++ b/test/dds-types-test/inheritancePubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~InnerStructureHelperChildPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~InnerStructureHelperChildChildPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~InnerStructureHelperEmptyChildPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~InnerStructureHelperEmptyChildChildPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~InnerEmptyStructureHelperChildPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~StructAliasInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~StructuresInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -694,14 +694,14 @@ public:
     eProsima_user_DllExport ~BitsetsChildInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -710,17 +710,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/keyPubSubTypes.cxx
+++ b/test/dds-types-test/keyPubSubTypes.cxx
@@ -57,11 +57,11 @@ KeyedShortStructPubSubType::~KeyedShortStructPubSubType()
 }
 
 bool KeyedShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedShortStruct* p_type = static_cast<KeyedShortStruct*>(data);
+    const KeyedShortStruct* p_type = static_cast<const KeyedShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool KeyedShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> KeyedShortStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedShortStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void KeyedShortStructPubSubType::deleteData(
 }
 
 bool KeyedShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool KeyedShortStructPubSubType::getKey(
         return false;
     }
 
-    KeyedShortStruct* p_type = static_cast<KeyedShortStruct*>(data);
+    const KeyedShortStruct* p_type = static_cast<const KeyedShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ KeyedUShortStructPubSubType::~KeyedUShortStructPubSubType()
 }
 
 bool KeyedUShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedUShortStruct* p_type = static_cast<KeyedUShortStruct*>(data);
+    const KeyedUShortStruct* p_type = static_cast<const KeyedUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool KeyedUShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedUShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> KeyedUShortStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedUShortStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedUShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void KeyedUShortStructPubSubType::deleteData(
 }
 
 bool KeyedUShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool KeyedUShortStructPubSubType::getKey(
         return false;
     }
 
-    KeyedUShortStruct* p_type = static_cast<KeyedUShortStruct*>(data);
+    const KeyedUShortStruct* p_type = static_cast<const KeyedUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ KeyedLongStructPubSubType::~KeyedLongStructPubSubType()
 }
 
 bool KeyedLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedLongStruct* p_type = static_cast<KeyedLongStruct*>(data);
+    const KeyedLongStruct* p_type = static_cast<const KeyedLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool KeyedLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> KeyedLongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedLongStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void KeyedLongStructPubSubType::deleteData(
 }
 
 bool KeyedLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool KeyedLongStructPubSubType::getKey(
         return false;
     }
 
-    KeyedLongStruct* p_type = static_cast<KeyedLongStruct*>(data);
+    const KeyedLongStruct* p_type = static_cast<const KeyedLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ KeyedULongStructPubSubType::~KeyedULongStructPubSubType()
 }
 
 bool KeyedULongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedULongStruct* p_type = static_cast<KeyedULongStruct*>(data);
+    const KeyedULongStruct* p_type = static_cast<const KeyedULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool KeyedULongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedULongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> KeyedULongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedULongStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedULongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void KeyedULongStructPubSubType::deleteData(
 }
 
 bool KeyedULongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool KeyedULongStructPubSubType::getKey(
         return false;
     }
 
-    KeyedULongStruct* p_type = static_cast<KeyedULongStruct*>(data);
+    const KeyedULongStruct* p_type = static_cast<const KeyedULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ KeyedLongLongStructPubSubType::~KeyedLongLongStructPubSubType()
 }
 
 bool KeyedLongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedLongLongStruct* p_type = static_cast<KeyedLongLongStruct*>(data);
+    const KeyedLongLongStruct* p_type = static_cast<const KeyedLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool KeyedLongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedLongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> KeyedLongLongStructPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedLongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedLongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void KeyedLongLongStructPubSubType::deleteData(
 }
 
 bool KeyedLongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool KeyedLongLongStructPubSubType::getKey(
         return false;
     }
 
-    KeyedLongLongStruct* p_type = static_cast<KeyedLongLongStruct*>(data);
+    const KeyedLongLongStruct* p_type = static_cast<const KeyedLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ KeyedULongLongStructPubSubType::~KeyedULongLongStructPubSubType()
 }
 
 bool KeyedULongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedULongLongStruct* p_type = static_cast<KeyedULongLongStruct*>(data);
+    const KeyedULongLongStruct* p_type = static_cast<const KeyedULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool KeyedULongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedULongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> KeyedULongLongStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedULongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedULongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void KeyedULongLongStructPubSubType::deleteData(
 }
 
 bool KeyedULongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool KeyedULongLongStructPubSubType::getKey(
         return false;
     }
 
-    KeyedULongLongStruct* p_type = static_cast<KeyedULongLongStruct*>(data);
+    const KeyedULongLongStruct* p_type = static_cast<const KeyedULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ KeyedFloatStructPubSubType::~KeyedFloatStructPubSubType()
 }
 
 bool KeyedFloatStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedFloatStruct* p_type = static_cast<KeyedFloatStruct*>(data);
+    const KeyedFloatStruct* p_type = static_cast<const KeyedFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool KeyedFloatStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedFloatStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> KeyedFloatStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedFloatStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedFloatStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void KeyedFloatStructPubSubType::deleteData(
 }
 
 bool KeyedFloatStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool KeyedFloatStructPubSubType::getKey(
         return false;
     }
 
-    KeyedFloatStruct* p_type = static_cast<KeyedFloatStruct*>(data);
+    const KeyedFloatStruct* p_type = static_cast<const KeyedFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ KeyedDoubleStructPubSubType::~KeyedDoubleStructPubSubType()
 }
 
 bool KeyedDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedDoubleStruct* p_type = static_cast<KeyedDoubleStruct*>(data);
+    const KeyedDoubleStruct* p_type = static_cast<const KeyedDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool KeyedDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> KeyedDoubleStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void KeyedDoubleStructPubSubType::deleteData(
 }
 
 bool KeyedDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool KeyedDoubleStructPubSubType::getKey(
         return false;
     }
 
-    KeyedDoubleStruct* p_type = static_cast<KeyedDoubleStruct*>(data);
+    const KeyedDoubleStruct* p_type = static_cast<const KeyedDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ KeyedLongDoubleStructPubSubType::~KeyedLongDoubleStructPubSubType()
 }
 
 bool KeyedLongDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedLongDoubleStruct* p_type = static_cast<KeyedLongDoubleStruct*>(data);
+    const KeyedLongDoubleStruct* p_type = static_cast<const KeyedLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool KeyedLongDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedLongDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> KeyedLongDoubleStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedLongDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedLongDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void KeyedLongDoubleStructPubSubType::deleteData(
 }
 
 bool KeyedLongDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool KeyedLongDoubleStructPubSubType::getKey(
         return false;
     }
 
-    KeyedLongDoubleStruct* p_type = static_cast<KeyedLongDoubleStruct*>(data);
+    const KeyedLongDoubleStruct* p_type = static_cast<const KeyedLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ KeyedBooleanStructPubSubType::~KeyedBooleanStructPubSubType()
 }
 
 bool KeyedBooleanStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedBooleanStruct* p_type = static_cast<KeyedBooleanStruct*>(data);
+    const KeyedBooleanStruct* p_type = static_cast<const KeyedBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool KeyedBooleanStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedBooleanStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> KeyedBooleanStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedBooleanStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedBooleanStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void KeyedBooleanStructPubSubType::deleteData(
 }
 
 bool KeyedBooleanStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool KeyedBooleanStructPubSubType::getKey(
         return false;
     }
 
-    KeyedBooleanStruct* p_type = static_cast<KeyedBooleanStruct*>(data);
+    const KeyedBooleanStruct* p_type = static_cast<const KeyedBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ KeyedOctetStructPubSubType::~KeyedOctetStructPubSubType()
 }
 
 bool KeyedOctetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedOctetStruct* p_type = static_cast<KeyedOctetStruct*>(data);
+    const KeyedOctetStruct* p_type = static_cast<const KeyedOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool KeyedOctetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedOctetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> KeyedOctetStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedOctetStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedOctetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void KeyedOctetStructPubSubType::deleteData(
 }
 
 bool KeyedOctetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool KeyedOctetStructPubSubType::getKey(
         return false;
     }
 
-    KeyedOctetStruct* p_type = static_cast<KeyedOctetStruct*>(data);
+    const KeyedOctetStruct* p_type = static_cast<const KeyedOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ KeyedCharStructPubSubType::~KeyedCharStructPubSubType()
 }
 
 bool KeyedCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedCharStruct* p_type = static_cast<KeyedCharStruct*>(data);
+    const KeyedCharStruct* p_type = static_cast<const KeyedCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool KeyedCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> KeyedCharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedCharStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void KeyedCharStructPubSubType::deleteData(
 }
 
 bool KeyedCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool KeyedCharStructPubSubType::getKey(
         return false;
     }
 
-    KeyedCharStruct* p_type = static_cast<KeyedCharStruct*>(data);
+    const KeyedCharStruct* p_type = static_cast<const KeyedCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ KeyedWCharStructPubSubType::~KeyedWCharStructPubSubType()
 }
 
 bool KeyedWCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedWCharStruct* p_type = static_cast<KeyedWCharStruct*>(data);
+    const KeyedWCharStruct* p_type = static_cast<const KeyedWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool KeyedWCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedWCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> KeyedWCharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedWCharStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedWCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void KeyedWCharStructPubSubType::deleteData(
 }
 
 bool KeyedWCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool KeyedWCharStructPubSubType::getKey(
         return false;
     }
 
-    KeyedWCharStruct* p_type = static_cast<KeyedWCharStruct*>(data);
+    const KeyedWCharStruct* p_type = static_cast<const KeyedWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ KeyedEmptyStructPubSubType::~KeyedEmptyStructPubSubType()
 }
 
 bool KeyedEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedEmptyStruct* p_type = static_cast<KeyedEmptyStruct*>(data);
+    const KeyedEmptyStruct* p_type = static_cast<const KeyedEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool KeyedEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> KeyedEmptyStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void KeyedEmptyStructPubSubType::deleteData(
 }
 
 bool KeyedEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool KeyedEmptyStructPubSubType::getKey(
         return false;
     }
 
-    KeyedEmptyStruct* p_type = static_cast<KeyedEmptyStruct*>(data);
+    const KeyedEmptyStruct* p_type = static_cast<const KeyedEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ KeyedEmptyInheritanceStructPubSubType::~KeyedEmptyInheritanceStructPubSubType()
 }
 
 bool KeyedEmptyInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedEmptyInheritanceStruct* p_type = static_cast<KeyedEmptyInheritanceStruct*>(data);
+    const KeyedEmptyInheritanceStruct* p_type = static_cast<const KeyedEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool KeyedEmptyInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedEmptyInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> KeyedEmptyInheritanceStructPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedEmptyInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedEmptyInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void KeyedEmptyInheritanceStructPubSubType::deleteData(
 }
 
 bool KeyedEmptyInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool KeyedEmptyInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    KeyedEmptyInheritanceStruct* p_type = static_cast<KeyedEmptyInheritanceStruct*>(data);
+    const KeyedEmptyInheritanceStruct* p_type = static_cast<const KeyedEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ KeyedInheritanceStructPubSubType::~KeyedInheritanceStructPubSubType()
 }
 
 bool KeyedInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    KeyedInheritanceStruct* p_type = static_cast<KeyedInheritanceStruct*>(data);
+    const KeyedInheritanceStruct* p_type = static_cast<const KeyedInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool KeyedInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> KeyedInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> KeyedInheritanceStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<KeyedInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const KeyedInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void KeyedInheritanceStructPubSubType::deleteData(
 }
 
 bool KeyedInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool KeyedInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    KeyedInheritanceStruct* p_type = static_cast<KeyedInheritanceStruct*>(data);
+    const KeyedInheritanceStruct* p_type = static_cast<const KeyedInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ InheritanceKeyedEmptyStructPubSubType::~InheritanceKeyedEmptyStructPubSubType()
 }
 
 bool InheritanceKeyedEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InheritanceKeyedEmptyStruct* p_type = static_cast<InheritanceKeyedEmptyStruct*>(data);
+    const InheritanceKeyedEmptyStruct* p_type = static_cast<const InheritanceKeyedEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool InheritanceKeyedEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InheritanceKeyedEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> InheritanceKeyedEmptyStructPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InheritanceKeyedEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const InheritanceKeyedEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void InheritanceKeyedEmptyStructPubSubType::deleteData(
 }
 
 bool InheritanceKeyedEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool InheritanceKeyedEmptyStructPubSubType::getKey(
         return false;
     }
 
-    InheritanceKeyedEmptyStruct* p_type = static_cast<InheritanceKeyedEmptyStruct*>(data);
+    const InheritanceKeyedEmptyStruct* p_type = static_cast<const InheritanceKeyedEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/keyPubSubTypes.h
+++ b/test/dds-types-test/keyPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~KeyedShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -144,14 +144,14 @@ public:
     eProsima_user_DllExport ~KeyedUShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -160,17 +160,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -235,14 +235,14 @@ public:
     eProsima_user_DllExport ~KeyedLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -251,17 +251,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -326,14 +326,14 @@ public:
     eProsima_user_DllExport ~KeyedULongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -342,17 +342,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -417,14 +417,14 @@ public:
     eProsima_user_DllExport ~KeyedLongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -433,17 +433,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -508,14 +508,14 @@ public:
     eProsima_user_DllExport ~KeyedULongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -524,17 +524,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -599,14 +599,14 @@ public:
     eProsima_user_DllExport ~KeyedFloatStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -615,17 +615,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -690,14 +690,14 @@ public:
     eProsima_user_DllExport ~KeyedDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -706,17 +706,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -781,14 +781,14 @@ public:
     eProsima_user_DllExport ~KeyedLongDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -797,17 +797,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -872,14 +872,14 @@ public:
     eProsima_user_DllExport ~KeyedBooleanStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -888,17 +888,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -963,14 +963,14 @@ public:
     eProsima_user_DllExport ~KeyedOctetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -979,17 +979,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1054,14 +1054,14 @@ public:
     eProsima_user_DllExport ~KeyedCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1070,17 +1070,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1145,14 +1145,14 @@ public:
     eProsima_user_DllExport ~KeyedWCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1161,17 +1161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1236,14 +1236,14 @@ public:
     eProsima_user_DllExport ~KeyedEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1252,17 +1252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1327,14 +1327,14 @@ public:
     eProsima_user_DllExport ~KeyedEmptyInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1343,17 +1343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1418,14 +1418,14 @@ public:
     eProsima_user_DllExport ~KeyedInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1434,17 +1434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1509,14 +1509,14 @@ public:
     eProsima_user_DllExport ~InheritanceKeyedEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1525,17 +1525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/mapsPubSubTypes.cxx
+++ b/test/dds-types-test/mapsPubSubTypes.cxx
@@ -57,11 +57,11 @@ MapShortShortPubSubType::~MapShortShortPubSubType()
 }
 
 bool MapShortShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortShort* p_type = static_cast<MapShortShort*>(data);
+    const MapShortShort* p_type = static_cast<const MapShortShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool MapShortShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> MapShortShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortShort*>(data), current_alignment)) +
+                               *static_cast<const MapShortShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void MapShortShortPubSubType::deleteData(
 }
 
 bool MapShortShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool MapShortShortPubSubType::getKey(
         return false;
     }
 
-    MapShortShort* p_type = static_cast<MapShortShort*>(data);
+    const MapShortShort* p_type = static_cast<const MapShortShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ MapShortUShortPubSubType::~MapShortUShortPubSubType()
 }
 
 bool MapShortUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortUShort* p_type = static_cast<MapShortUShort*>(data);
+    const MapShortUShort* p_type = static_cast<const MapShortUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool MapShortUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> MapShortUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortUShort*>(data), current_alignment)) +
+                               *static_cast<const MapShortUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void MapShortUShortPubSubType::deleteData(
 }
 
 bool MapShortUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool MapShortUShortPubSubType::getKey(
         return false;
     }
 
-    MapShortUShort* p_type = static_cast<MapShortUShort*>(data);
+    const MapShortUShort* p_type = static_cast<const MapShortUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ MapShortLongPubSubType::~MapShortLongPubSubType()
 }
 
 bool MapShortLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortLong* p_type = static_cast<MapShortLong*>(data);
+    const MapShortLong* p_type = static_cast<const MapShortLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool MapShortLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> MapShortLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortLong*>(data), current_alignment)) +
+                               *static_cast<const MapShortLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void MapShortLongPubSubType::deleteData(
 }
 
 bool MapShortLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool MapShortLongPubSubType::getKey(
         return false;
     }
 
-    MapShortLong* p_type = static_cast<MapShortLong*>(data);
+    const MapShortLong* p_type = static_cast<const MapShortLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ MapShortULongPubSubType::~MapShortULongPubSubType()
 }
 
 bool MapShortULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortULong* p_type = static_cast<MapShortULong*>(data);
+    const MapShortULong* p_type = static_cast<const MapShortULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool MapShortULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> MapShortULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortULong*>(data), current_alignment)) +
+                               *static_cast<const MapShortULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void MapShortULongPubSubType::deleteData(
 }
 
 bool MapShortULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool MapShortULongPubSubType::getKey(
         return false;
     }
 
-    MapShortULong* p_type = static_cast<MapShortULong*>(data);
+    const MapShortULong* p_type = static_cast<const MapShortULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ MapShortLongLongPubSubType::~MapShortLongLongPubSubType()
 }
 
 bool MapShortLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortLongLong* p_type = static_cast<MapShortLongLong*>(data);
+    const MapShortLongLong* p_type = static_cast<const MapShortLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool MapShortLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> MapShortLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapShortLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void MapShortLongLongPubSubType::deleteData(
 }
 
 bool MapShortLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool MapShortLongLongPubSubType::getKey(
         return false;
     }
 
-    MapShortLongLong* p_type = static_cast<MapShortLongLong*>(data);
+    const MapShortLongLong* p_type = static_cast<const MapShortLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ MapShortULongLongPubSubType::~MapShortULongLongPubSubType()
 }
 
 bool MapShortULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortULongLong* p_type = static_cast<MapShortULongLong*>(data);
+    const MapShortULongLong* p_type = static_cast<const MapShortULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool MapShortULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> MapShortULongLongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapShortULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void MapShortULongLongPubSubType::deleteData(
 }
 
 bool MapShortULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool MapShortULongLongPubSubType::getKey(
         return false;
     }
 
-    MapShortULongLong* p_type = static_cast<MapShortULongLong*>(data);
+    const MapShortULongLong* p_type = static_cast<const MapShortULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ MapShortFloatPubSubType::~MapShortFloatPubSubType()
 }
 
 bool MapShortFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortFloat* p_type = static_cast<MapShortFloat*>(data);
+    const MapShortFloat* p_type = static_cast<const MapShortFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool MapShortFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> MapShortFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortFloat*>(data), current_alignment)) +
+                               *static_cast<const MapShortFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void MapShortFloatPubSubType::deleteData(
 }
 
 bool MapShortFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool MapShortFloatPubSubType::getKey(
         return false;
     }
 
-    MapShortFloat* p_type = static_cast<MapShortFloat*>(data);
+    const MapShortFloat* p_type = static_cast<const MapShortFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ MapShortDoublePubSubType::~MapShortDoublePubSubType()
 }
 
 bool MapShortDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortDouble* p_type = static_cast<MapShortDouble*>(data);
+    const MapShortDouble* p_type = static_cast<const MapShortDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool MapShortDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> MapShortDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortDouble*>(data), current_alignment)) +
+                               *static_cast<const MapShortDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void MapShortDoublePubSubType::deleteData(
 }
 
 bool MapShortDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool MapShortDoublePubSubType::getKey(
         return false;
     }
 
-    MapShortDouble* p_type = static_cast<MapShortDouble*>(data);
+    const MapShortDouble* p_type = static_cast<const MapShortDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ MapShortLongDoublePubSubType::~MapShortLongDoublePubSubType()
 }
 
 bool MapShortLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortLongDouble* p_type = static_cast<MapShortLongDouble*>(data);
+    const MapShortLongDouble* p_type = static_cast<const MapShortLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool MapShortLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> MapShortLongDoublePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapShortLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void MapShortLongDoublePubSubType::deleteData(
 }
 
 bool MapShortLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool MapShortLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapShortLongDouble* p_type = static_cast<MapShortLongDouble*>(data);
+    const MapShortLongDouble* p_type = static_cast<const MapShortLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ MapShortBooleanPubSubType::~MapShortBooleanPubSubType()
 }
 
 bool MapShortBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortBoolean* p_type = static_cast<MapShortBoolean*>(data);
+    const MapShortBoolean* p_type = static_cast<const MapShortBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool MapShortBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> MapShortBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapShortBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void MapShortBooleanPubSubType::deleteData(
 }
 
 bool MapShortBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool MapShortBooleanPubSubType::getKey(
         return false;
     }
 
-    MapShortBoolean* p_type = static_cast<MapShortBoolean*>(data);
+    const MapShortBoolean* p_type = static_cast<const MapShortBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ MapShortOctetPubSubType::~MapShortOctetPubSubType()
 }
 
 bool MapShortOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortOctet* p_type = static_cast<MapShortOctet*>(data);
+    const MapShortOctet* p_type = static_cast<const MapShortOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool MapShortOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> MapShortOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortOctet*>(data), current_alignment)) +
+                               *static_cast<const MapShortOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void MapShortOctetPubSubType::deleteData(
 }
 
 bool MapShortOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool MapShortOctetPubSubType::getKey(
         return false;
     }
 
-    MapShortOctet* p_type = static_cast<MapShortOctet*>(data);
+    const MapShortOctet* p_type = static_cast<const MapShortOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ MapShortCharPubSubType::~MapShortCharPubSubType()
 }
 
 bool MapShortCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortChar* p_type = static_cast<MapShortChar*>(data);
+    const MapShortChar* p_type = static_cast<const MapShortChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool MapShortCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> MapShortCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortChar*>(data), current_alignment)) +
+                               *static_cast<const MapShortChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void MapShortCharPubSubType::deleteData(
 }
 
 bool MapShortCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool MapShortCharPubSubType::getKey(
         return false;
     }
 
-    MapShortChar* p_type = static_cast<MapShortChar*>(data);
+    const MapShortChar* p_type = static_cast<const MapShortChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ MapShortWCharPubSubType::~MapShortWCharPubSubType()
 }
 
 bool MapShortWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortWChar* p_type = static_cast<MapShortWChar*>(data);
+    const MapShortWChar* p_type = static_cast<const MapShortWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool MapShortWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> MapShortWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortWChar*>(data), current_alignment)) +
+                               *static_cast<const MapShortWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void MapShortWCharPubSubType::deleteData(
 }
 
 bool MapShortWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool MapShortWCharPubSubType::getKey(
         return false;
     }
 
-    MapShortWChar* p_type = static_cast<MapShortWChar*>(data);
+    const MapShortWChar* p_type = static_cast<const MapShortWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ MapShortStringPubSubType::~MapShortStringPubSubType()
 }
 
 bool MapShortStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortString* p_type = static_cast<MapShortString*>(data);
+    const MapShortString* p_type = static_cast<const MapShortString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool MapShortStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> MapShortStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortString*>(data), current_alignment)) +
+                               *static_cast<const MapShortString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void MapShortStringPubSubType::deleteData(
 }
 
 bool MapShortStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool MapShortStringPubSubType::getKey(
         return false;
     }
 
-    MapShortString* p_type = static_cast<MapShortString*>(data);
+    const MapShortString* p_type = static_cast<const MapShortString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ MapShortWStringPubSubType::~MapShortWStringPubSubType()
 }
 
 bool MapShortWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortWString* p_type = static_cast<MapShortWString*>(data);
+    const MapShortWString* p_type = static_cast<const MapShortWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool MapShortWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> MapShortWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortWString*>(data), current_alignment)) +
+                               *static_cast<const MapShortWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void MapShortWStringPubSubType::deleteData(
 }
 
 bool MapShortWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool MapShortWStringPubSubType::getKey(
         return false;
     }
 
-    MapShortWString* p_type = static_cast<MapShortWString*>(data);
+    const MapShortWString* p_type = static_cast<const MapShortWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ MapShortInnerAliasBoundedStringHelperPubSubType::~MapShortInnerAliasBoundedStrin
 }
 
 bool MapShortInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasBoundedStringHelper* p_type = static_cast<MapShortInnerAliasBoundedStringHelper*>(data);
+    const MapShortInnerAliasBoundedStringHelper* p_type = static_cast<const MapShortInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool MapShortInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> MapShortInnerAliasBoundedStringHelperPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void MapShortInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool MapShortInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasBoundedStringHelper* p_type = static_cast<MapShortInnerAliasBoundedStringHelper*>(data);
+    const MapShortInnerAliasBoundedStringHelper* p_type = static_cast<const MapShortInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ MapShortInnerAliasBoundedWStringHelperPubSubType::~MapShortInnerAliasBoundedWStr
 }
 
 bool MapShortInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasBoundedWStringHelper* p_type = static_cast<MapShortInnerAliasBoundedWStringHelper*>(data);
+    const MapShortInnerAliasBoundedWStringHelper* p_type = static_cast<const MapShortInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool MapShortInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> MapShortInnerAliasBoundedWStringHelperPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void MapShortInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool MapShortInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasBoundedWStringHelper* p_type = static_cast<MapShortInnerAliasBoundedWStringHelper*>(data);
+    const MapShortInnerAliasBoundedWStringHelper* p_type = static_cast<const MapShortInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ MapShortInnerEnumHelperPubSubType::~MapShortInnerEnumHelperPubSubType()
 }
 
 bool MapShortInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerEnumHelper* p_type = static_cast<MapShortInnerEnumHelper*>(data);
+    const MapShortInnerEnumHelper* p_type = static_cast<const MapShortInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool MapShortInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> MapShortInnerEnumHelperPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void MapShortInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool MapShortInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerEnumHelper* p_type = static_cast<MapShortInnerEnumHelper*>(data);
+    const MapShortInnerEnumHelper* p_type = static_cast<const MapShortInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ MapShortInnerBitMaskHelperPubSubType::~MapShortInnerBitMaskHelperPubSubType()
 }
 
 bool MapShortInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerBitMaskHelper* p_type = static_cast<MapShortInnerBitMaskHelper*>(data);
+    const MapShortInnerBitMaskHelper* p_type = static_cast<const MapShortInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool MapShortInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> MapShortInnerBitMaskHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void MapShortInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool MapShortInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerBitMaskHelper* p_type = static_cast<MapShortInnerBitMaskHelper*>(data);
+    const MapShortInnerBitMaskHelper* p_type = static_cast<const MapShortInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ MapShortInnerAliasHelperPubSubType::~MapShortInnerAliasHelperPubSubType()
 }
 
 bool MapShortInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasHelper* p_type = static_cast<MapShortInnerAliasHelper*>(data);
+    const MapShortInnerAliasHelper* p_type = static_cast<const MapShortInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool MapShortInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> MapShortInnerAliasHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void MapShortInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool MapShortInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasHelper* p_type = static_cast<MapShortInnerAliasHelper*>(data);
+    const MapShortInnerAliasHelper* p_type = static_cast<const MapShortInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ MapShortInnerAliasArrayHelperPubSubType::~MapShortInnerAliasArrayHelperPubSubTyp
 }
 
 bool MapShortInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasArrayHelper* p_type = static_cast<MapShortInnerAliasArrayHelper*>(data);
+    const MapShortInnerAliasArrayHelper* p_type = static_cast<const MapShortInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool MapShortInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> MapShortInnerAliasArrayHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void MapShortInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool MapShortInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasArrayHelper* p_type = static_cast<MapShortInnerAliasArrayHelper*>(data);
+    const MapShortInnerAliasArrayHelper* p_type = static_cast<const MapShortInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ MapShortInnerAliasSequenceHelperPubSubType::~MapShortInnerAliasSequenceHelperPub
 }
 
 bool MapShortInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasSequenceHelper* p_type = static_cast<MapShortInnerAliasSequenceHelper*>(data);
+    const MapShortInnerAliasSequenceHelper* p_type = static_cast<const MapShortInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool MapShortInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> MapShortInnerAliasSequenceHelperPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void MapShortInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool MapShortInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasSequenceHelper* p_type = static_cast<MapShortInnerAliasSequenceHelper*>(data);
+    const MapShortInnerAliasSequenceHelper* p_type = static_cast<const MapShortInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ MapShortInnerAliasMapHelperPubSubType::~MapShortInnerAliasMapHelperPubSubType()
 }
 
 bool MapShortInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerAliasMapHelper* p_type = static_cast<MapShortInnerAliasMapHelper*>(data);
+    const MapShortInnerAliasMapHelper* p_type = static_cast<const MapShortInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool MapShortInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> MapShortInnerAliasMapHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void MapShortInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool MapShortInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerAliasMapHelper* p_type = static_cast<MapShortInnerAliasMapHelper*>(data);
+    const MapShortInnerAliasMapHelper* p_type = static_cast<const MapShortInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ MapShortInnerUnionHelperPubSubType::~MapShortInnerUnionHelperPubSubType()
 }
 
 bool MapShortInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerUnionHelper* p_type = static_cast<MapShortInnerUnionHelper*>(data);
+    const MapShortInnerUnionHelper* p_type = static_cast<const MapShortInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool MapShortInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> MapShortInnerUnionHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void MapShortInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool MapShortInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerUnionHelper* p_type = static_cast<MapShortInnerUnionHelper*>(data);
+    const MapShortInnerUnionHelper* p_type = static_cast<const MapShortInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ MapShortInnerStructureHelperPubSubType::~MapShortInnerStructureHelperPubSubType(
 }
 
 bool MapShortInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerStructureHelper* p_type = static_cast<MapShortInnerStructureHelper*>(data);
+    const MapShortInnerStructureHelper* p_type = static_cast<const MapShortInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool MapShortInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> MapShortInnerStructureHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void MapShortInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool MapShortInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerStructureHelper* p_type = static_cast<MapShortInnerStructureHelper*>(data);
+    const MapShortInnerStructureHelper* p_type = static_cast<const MapShortInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ MapShortInnerBitsetHelperPubSubType::~MapShortInnerBitsetHelperPubSubType()
 }
 
 bool MapShortInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapShortInnerBitsetHelper* p_type = static_cast<MapShortInnerBitsetHelper*>(data);
+    const MapShortInnerBitsetHelper* p_type = static_cast<const MapShortInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool MapShortInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapShortInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> MapShortInnerBitsetHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapShortInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapShortInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void MapShortInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapShortInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool MapShortInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapShortInnerBitsetHelper* p_type = static_cast<MapShortInnerBitsetHelper*>(data);
+    const MapShortInnerBitsetHelper* p_type = static_cast<const MapShortInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ MapUShortShortPubSubType::~MapUShortShortPubSubType()
 }
 
 bool MapUShortShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortShort* p_type = static_cast<MapUShortShort*>(data);
+    const MapUShortShort* p_type = static_cast<const MapUShortShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool MapUShortShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> MapUShortShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortShort*>(data), current_alignment)) +
+                               *static_cast<const MapUShortShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void MapUShortShortPubSubType::deleteData(
 }
 
 bool MapUShortShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool MapUShortShortPubSubType::getKey(
         return false;
     }
 
-    MapUShortShort* p_type = static_cast<MapUShortShort*>(data);
+    const MapUShortShort* p_type = static_cast<const MapUShortShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ MapUShortUShortPubSubType::~MapUShortUShortPubSubType()
 }
 
 bool MapUShortUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortUShort* p_type = static_cast<MapUShortUShort*>(data);
+    const MapUShortUShort* p_type = static_cast<const MapUShortUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool MapUShortUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> MapUShortUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortUShort*>(data), current_alignment)) +
+                               *static_cast<const MapUShortUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void MapUShortUShortPubSubType::deleteData(
 }
 
 bool MapUShortUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool MapUShortUShortPubSubType::getKey(
         return false;
     }
 
-    MapUShortUShort* p_type = static_cast<MapUShortUShort*>(data);
+    const MapUShortUShort* p_type = static_cast<const MapUShortUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5461,11 +5461,11 @@ MapUShortLongPubSubType::~MapUShortLongPubSubType()
 }
 
 bool MapUShortLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortLong* p_type = static_cast<MapUShortLong*>(data);
+    const MapUShortLong* p_type = static_cast<const MapUShortLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5537,7 +5537,7 @@ bool MapUShortLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5554,7 +5554,7 @@ std::function<uint32_t()> MapUShortLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortLong*>(data), current_alignment)) +
+                               *static_cast<const MapUShortLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5577,7 +5577,7 @@ void MapUShortLongPubSubType::deleteData(
 }
 
 bool MapUShortLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5586,7 +5586,7 @@ bool MapUShortLongPubSubType::getKey(
         return false;
     }
 
-    MapUShortLong* p_type = static_cast<MapUShortLong*>(data);
+    const MapUShortLong* p_type = static_cast<const MapUShortLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5654,11 +5654,11 @@ MapUShortULongPubSubType::~MapUShortULongPubSubType()
 }
 
 bool MapUShortULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortULong* p_type = static_cast<MapUShortULong*>(data);
+    const MapUShortULong* p_type = static_cast<const MapUShortULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5730,7 +5730,7 @@ bool MapUShortULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5747,7 +5747,7 @@ std::function<uint32_t()> MapUShortULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortULong*>(data), current_alignment)) +
+                               *static_cast<const MapUShortULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5770,7 +5770,7 @@ void MapUShortULongPubSubType::deleteData(
 }
 
 bool MapUShortULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5779,7 +5779,7 @@ bool MapUShortULongPubSubType::getKey(
         return false;
     }
 
-    MapUShortULong* p_type = static_cast<MapUShortULong*>(data);
+    const MapUShortULong* p_type = static_cast<const MapUShortULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5847,11 +5847,11 @@ MapUShortLongLongPubSubType::~MapUShortLongLongPubSubType()
 }
 
 bool MapUShortLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortLongLong* p_type = static_cast<MapUShortLongLong*>(data);
+    const MapUShortLongLong* p_type = static_cast<const MapUShortLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5923,7 +5923,7 @@ bool MapUShortLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5940,7 +5940,7 @@ std::function<uint32_t()> MapUShortLongLongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapUShortLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5963,7 +5963,7 @@ void MapUShortLongLongPubSubType::deleteData(
 }
 
 bool MapUShortLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5972,7 +5972,7 @@ bool MapUShortLongLongPubSubType::getKey(
         return false;
     }
 
-    MapUShortLongLong* p_type = static_cast<MapUShortLongLong*>(data);
+    const MapUShortLongLong* p_type = static_cast<const MapUShortLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6040,11 +6040,11 @@ MapUShortULongLongPubSubType::~MapUShortULongLongPubSubType()
 }
 
 bool MapUShortULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortULongLong* p_type = static_cast<MapUShortULongLong*>(data);
+    const MapUShortULongLong* p_type = static_cast<const MapUShortULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6116,7 +6116,7 @@ bool MapUShortULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6133,7 +6133,7 @@ std::function<uint32_t()> MapUShortULongLongPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapUShortULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6156,7 +6156,7 @@ void MapUShortULongLongPubSubType::deleteData(
 }
 
 bool MapUShortULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6165,7 +6165,7 @@ bool MapUShortULongLongPubSubType::getKey(
         return false;
     }
 
-    MapUShortULongLong* p_type = static_cast<MapUShortULongLong*>(data);
+    const MapUShortULongLong* p_type = static_cast<const MapUShortULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6233,11 +6233,11 @@ MapUShortFloatPubSubType::~MapUShortFloatPubSubType()
 }
 
 bool MapUShortFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortFloat* p_type = static_cast<MapUShortFloat*>(data);
+    const MapUShortFloat* p_type = static_cast<const MapUShortFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6309,7 +6309,7 @@ bool MapUShortFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6326,7 +6326,7 @@ std::function<uint32_t()> MapUShortFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortFloat*>(data), current_alignment)) +
+                               *static_cast<const MapUShortFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6349,7 +6349,7 @@ void MapUShortFloatPubSubType::deleteData(
 }
 
 bool MapUShortFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6358,7 +6358,7 @@ bool MapUShortFloatPubSubType::getKey(
         return false;
     }
 
-    MapUShortFloat* p_type = static_cast<MapUShortFloat*>(data);
+    const MapUShortFloat* p_type = static_cast<const MapUShortFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6426,11 +6426,11 @@ MapUShortDoublePubSubType::~MapUShortDoublePubSubType()
 }
 
 bool MapUShortDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortDouble* p_type = static_cast<MapUShortDouble*>(data);
+    const MapUShortDouble* p_type = static_cast<const MapUShortDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6502,7 +6502,7 @@ bool MapUShortDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6519,7 +6519,7 @@ std::function<uint32_t()> MapUShortDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortDouble*>(data), current_alignment)) +
+                               *static_cast<const MapUShortDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6542,7 +6542,7 @@ void MapUShortDoublePubSubType::deleteData(
 }
 
 bool MapUShortDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6551,7 +6551,7 @@ bool MapUShortDoublePubSubType::getKey(
         return false;
     }
 
-    MapUShortDouble* p_type = static_cast<MapUShortDouble*>(data);
+    const MapUShortDouble* p_type = static_cast<const MapUShortDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6619,11 +6619,11 @@ MapUShortLongDoublePubSubType::~MapUShortLongDoublePubSubType()
 }
 
 bool MapUShortLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortLongDouble* p_type = static_cast<MapUShortLongDouble*>(data);
+    const MapUShortLongDouble* p_type = static_cast<const MapUShortLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6695,7 +6695,7 @@ bool MapUShortLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6712,7 +6712,7 @@ std::function<uint32_t()> MapUShortLongDoublePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapUShortLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6735,7 +6735,7 @@ void MapUShortLongDoublePubSubType::deleteData(
 }
 
 bool MapUShortLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6744,7 +6744,7 @@ bool MapUShortLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapUShortLongDouble* p_type = static_cast<MapUShortLongDouble*>(data);
+    const MapUShortLongDouble* p_type = static_cast<const MapUShortLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6812,11 +6812,11 @@ MapUShortBooleanPubSubType::~MapUShortBooleanPubSubType()
 }
 
 bool MapUShortBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortBoolean* p_type = static_cast<MapUShortBoolean*>(data);
+    const MapUShortBoolean* p_type = static_cast<const MapUShortBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6888,7 +6888,7 @@ bool MapUShortBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6905,7 +6905,7 @@ std::function<uint32_t()> MapUShortBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapUShortBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6928,7 +6928,7 @@ void MapUShortBooleanPubSubType::deleteData(
 }
 
 bool MapUShortBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6937,7 +6937,7 @@ bool MapUShortBooleanPubSubType::getKey(
         return false;
     }
 
-    MapUShortBoolean* p_type = static_cast<MapUShortBoolean*>(data);
+    const MapUShortBoolean* p_type = static_cast<const MapUShortBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7005,11 +7005,11 @@ MapUShortOctetPubSubType::~MapUShortOctetPubSubType()
 }
 
 bool MapUShortOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortOctet* p_type = static_cast<MapUShortOctet*>(data);
+    const MapUShortOctet* p_type = static_cast<const MapUShortOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7081,7 +7081,7 @@ bool MapUShortOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7098,7 +7098,7 @@ std::function<uint32_t()> MapUShortOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortOctet*>(data), current_alignment)) +
+                               *static_cast<const MapUShortOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7121,7 +7121,7 @@ void MapUShortOctetPubSubType::deleteData(
 }
 
 bool MapUShortOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7130,7 +7130,7 @@ bool MapUShortOctetPubSubType::getKey(
         return false;
     }
 
-    MapUShortOctet* p_type = static_cast<MapUShortOctet*>(data);
+    const MapUShortOctet* p_type = static_cast<const MapUShortOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7198,11 +7198,11 @@ MapUShortCharPubSubType::~MapUShortCharPubSubType()
 }
 
 bool MapUShortCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortChar* p_type = static_cast<MapUShortChar*>(data);
+    const MapUShortChar* p_type = static_cast<const MapUShortChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7274,7 +7274,7 @@ bool MapUShortCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7291,7 +7291,7 @@ std::function<uint32_t()> MapUShortCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortChar*>(data), current_alignment)) +
+                               *static_cast<const MapUShortChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7314,7 +7314,7 @@ void MapUShortCharPubSubType::deleteData(
 }
 
 bool MapUShortCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7323,7 +7323,7 @@ bool MapUShortCharPubSubType::getKey(
         return false;
     }
 
-    MapUShortChar* p_type = static_cast<MapUShortChar*>(data);
+    const MapUShortChar* p_type = static_cast<const MapUShortChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7391,11 +7391,11 @@ MapUShortWCharPubSubType::~MapUShortWCharPubSubType()
 }
 
 bool MapUShortWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortWChar* p_type = static_cast<MapUShortWChar*>(data);
+    const MapUShortWChar* p_type = static_cast<const MapUShortWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7467,7 +7467,7 @@ bool MapUShortWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7484,7 +7484,7 @@ std::function<uint32_t()> MapUShortWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortWChar*>(data), current_alignment)) +
+                               *static_cast<const MapUShortWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7507,7 +7507,7 @@ void MapUShortWCharPubSubType::deleteData(
 }
 
 bool MapUShortWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7516,7 +7516,7 @@ bool MapUShortWCharPubSubType::getKey(
         return false;
     }
 
-    MapUShortWChar* p_type = static_cast<MapUShortWChar*>(data);
+    const MapUShortWChar* p_type = static_cast<const MapUShortWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7584,11 +7584,11 @@ MapUShortStringPubSubType::~MapUShortStringPubSubType()
 }
 
 bool MapUShortStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortString* p_type = static_cast<MapUShortString*>(data);
+    const MapUShortString* p_type = static_cast<const MapUShortString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7660,7 +7660,7 @@ bool MapUShortStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7677,7 +7677,7 @@ std::function<uint32_t()> MapUShortStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortString*>(data), current_alignment)) +
+                               *static_cast<const MapUShortString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7700,7 +7700,7 @@ void MapUShortStringPubSubType::deleteData(
 }
 
 bool MapUShortStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7709,7 +7709,7 @@ bool MapUShortStringPubSubType::getKey(
         return false;
     }
 
-    MapUShortString* p_type = static_cast<MapUShortString*>(data);
+    const MapUShortString* p_type = static_cast<const MapUShortString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7777,11 +7777,11 @@ MapUShortWStringPubSubType::~MapUShortWStringPubSubType()
 }
 
 bool MapUShortWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortWString* p_type = static_cast<MapUShortWString*>(data);
+    const MapUShortWString* p_type = static_cast<const MapUShortWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7853,7 +7853,7 @@ bool MapUShortWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7870,7 +7870,7 @@ std::function<uint32_t()> MapUShortWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortWString*>(data), current_alignment)) +
+                               *static_cast<const MapUShortWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7893,7 +7893,7 @@ void MapUShortWStringPubSubType::deleteData(
 }
 
 bool MapUShortWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7902,7 +7902,7 @@ bool MapUShortWStringPubSubType::getKey(
         return false;
     }
 
-    MapUShortWString* p_type = static_cast<MapUShortWString*>(data);
+    const MapUShortWString* p_type = static_cast<const MapUShortWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7970,11 +7970,11 @@ MapUShortInnerAliasBoundedStringHelperPubSubType::~MapUShortInnerAliasBoundedStr
 }
 
 bool MapUShortInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasBoundedStringHelper* p_type = static_cast<MapUShortInnerAliasBoundedStringHelper*>(data);
+    const MapUShortInnerAliasBoundedStringHelper* p_type = static_cast<const MapUShortInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8046,7 +8046,7 @@ bool MapUShortInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8063,7 +8063,7 @@ std::function<uint32_t()> MapUShortInnerAliasBoundedStringHelperPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8086,7 +8086,7 @@ void MapUShortInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8095,7 +8095,7 @@ bool MapUShortInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasBoundedStringHelper* p_type = static_cast<MapUShortInnerAliasBoundedStringHelper*>(data);
+    const MapUShortInnerAliasBoundedStringHelper* p_type = static_cast<const MapUShortInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8163,11 +8163,11 @@ MapUShortInnerAliasBoundedWStringHelperPubSubType::~MapUShortInnerAliasBoundedWS
 }
 
 bool MapUShortInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasBoundedWStringHelper* p_type = static_cast<MapUShortInnerAliasBoundedWStringHelper*>(data);
+    const MapUShortInnerAliasBoundedWStringHelper* p_type = static_cast<const MapUShortInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8239,7 +8239,7 @@ bool MapUShortInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8256,7 +8256,7 @@ std::function<uint32_t()> MapUShortInnerAliasBoundedWStringHelperPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8279,7 +8279,7 @@ void MapUShortInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8288,7 +8288,7 @@ bool MapUShortInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasBoundedWStringHelper* p_type = static_cast<MapUShortInnerAliasBoundedWStringHelper*>(data);
+    const MapUShortInnerAliasBoundedWStringHelper* p_type = static_cast<const MapUShortInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8356,11 +8356,11 @@ MapUShortInnerEnumHelperPubSubType::~MapUShortInnerEnumHelperPubSubType()
 }
 
 bool MapUShortInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerEnumHelper* p_type = static_cast<MapUShortInnerEnumHelper*>(data);
+    const MapUShortInnerEnumHelper* p_type = static_cast<const MapUShortInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8432,7 +8432,7 @@ bool MapUShortInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8449,7 +8449,7 @@ std::function<uint32_t()> MapUShortInnerEnumHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8472,7 +8472,7 @@ void MapUShortInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8481,7 +8481,7 @@ bool MapUShortInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerEnumHelper* p_type = static_cast<MapUShortInnerEnumHelper*>(data);
+    const MapUShortInnerEnumHelper* p_type = static_cast<const MapUShortInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8549,11 +8549,11 @@ MapUShortInnerBitMaskHelperPubSubType::~MapUShortInnerBitMaskHelperPubSubType()
 }
 
 bool MapUShortInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerBitMaskHelper* p_type = static_cast<MapUShortInnerBitMaskHelper*>(data);
+    const MapUShortInnerBitMaskHelper* p_type = static_cast<const MapUShortInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8625,7 +8625,7 @@ bool MapUShortInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8642,7 +8642,7 @@ std::function<uint32_t()> MapUShortInnerBitMaskHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8665,7 +8665,7 @@ void MapUShortInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8674,7 +8674,7 @@ bool MapUShortInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerBitMaskHelper* p_type = static_cast<MapUShortInnerBitMaskHelper*>(data);
+    const MapUShortInnerBitMaskHelper* p_type = static_cast<const MapUShortInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8742,11 +8742,11 @@ MapUShortInnerAliasHelperPubSubType::~MapUShortInnerAliasHelperPubSubType()
 }
 
 bool MapUShortInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasHelper* p_type = static_cast<MapUShortInnerAliasHelper*>(data);
+    const MapUShortInnerAliasHelper* p_type = static_cast<const MapUShortInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8818,7 +8818,7 @@ bool MapUShortInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8835,7 +8835,7 @@ std::function<uint32_t()> MapUShortInnerAliasHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8858,7 +8858,7 @@ void MapUShortInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8867,7 +8867,7 @@ bool MapUShortInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasHelper* p_type = static_cast<MapUShortInnerAliasHelper*>(data);
+    const MapUShortInnerAliasHelper* p_type = static_cast<const MapUShortInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8935,11 +8935,11 @@ MapUShortInnerAliasArrayHelperPubSubType::~MapUShortInnerAliasArrayHelperPubSubT
 }
 
 bool MapUShortInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasArrayHelper* p_type = static_cast<MapUShortInnerAliasArrayHelper*>(data);
+    const MapUShortInnerAliasArrayHelper* p_type = static_cast<const MapUShortInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9011,7 +9011,7 @@ bool MapUShortInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9028,7 +9028,7 @@ std::function<uint32_t()> MapUShortInnerAliasArrayHelperPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9051,7 +9051,7 @@ void MapUShortInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9060,7 +9060,7 @@ bool MapUShortInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasArrayHelper* p_type = static_cast<MapUShortInnerAliasArrayHelper*>(data);
+    const MapUShortInnerAliasArrayHelper* p_type = static_cast<const MapUShortInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9128,11 +9128,11 @@ MapUShortInnerAliasSequenceHelperPubSubType::~MapUShortInnerAliasSequenceHelperP
 }
 
 bool MapUShortInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasSequenceHelper* p_type = static_cast<MapUShortInnerAliasSequenceHelper*>(data);
+    const MapUShortInnerAliasSequenceHelper* p_type = static_cast<const MapUShortInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9204,7 +9204,7 @@ bool MapUShortInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9221,7 +9221,7 @@ std::function<uint32_t()> MapUShortInnerAliasSequenceHelperPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9244,7 +9244,7 @@ void MapUShortInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9253,7 +9253,7 @@ bool MapUShortInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasSequenceHelper* p_type = static_cast<MapUShortInnerAliasSequenceHelper*>(data);
+    const MapUShortInnerAliasSequenceHelper* p_type = static_cast<const MapUShortInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9321,11 +9321,11 @@ MapUShortInnerAliasMapHelperPubSubType::~MapUShortInnerAliasMapHelperPubSubType(
 }
 
 bool MapUShortInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerAliasMapHelper* p_type = static_cast<MapUShortInnerAliasMapHelper*>(data);
+    const MapUShortInnerAliasMapHelper* p_type = static_cast<const MapUShortInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9397,7 +9397,7 @@ bool MapUShortInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9414,7 +9414,7 @@ std::function<uint32_t()> MapUShortInnerAliasMapHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9437,7 +9437,7 @@ void MapUShortInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9446,7 +9446,7 @@ bool MapUShortInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerAliasMapHelper* p_type = static_cast<MapUShortInnerAliasMapHelper*>(data);
+    const MapUShortInnerAliasMapHelper* p_type = static_cast<const MapUShortInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9514,11 +9514,11 @@ MapUShortInnerUnionHelperPubSubType::~MapUShortInnerUnionHelperPubSubType()
 }
 
 bool MapUShortInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerUnionHelper* p_type = static_cast<MapUShortInnerUnionHelper*>(data);
+    const MapUShortInnerUnionHelper* p_type = static_cast<const MapUShortInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9590,7 +9590,7 @@ bool MapUShortInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9607,7 +9607,7 @@ std::function<uint32_t()> MapUShortInnerUnionHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9630,7 +9630,7 @@ void MapUShortInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9639,7 +9639,7 @@ bool MapUShortInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerUnionHelper* p_type = static_cast<MapUShortInnerUnionHelper*>(data);
+    const MapUShortInnerUnionHelper* p_type = static_cast<const MapUShortInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9707,11 +9707,11 @@ MapUShortInnerStructureHelperPubSubType::~MapUShortInnerStructureHelperPubSubTyp
 }
 
 bool MapUShortInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerStructureHelper* p_type = static_cast<MapUShortInnerStructureHelper*>(data);
+    const MapUShortInnerStructureHelper* p_type = static_cast<const MapUShortInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9783,7 +9783,7 @@ bool MapUShortInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9800,7 +9800,7 @@ std::function<uint32_t()> MapUShortInnerStructureHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9823,7 +9823,7 @@ void MapUShortInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9832,7 +9832,7 @@ bool MapUShortInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerStructureHelper* p_type = static_cast<MapUShortInnerStructureHelper*>(data);
+    const MapUShortInnerStructureHelper* p_type = static_cast<const MapUShortInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9900,11 +9900,11 @@ MapUShortInnerBitsetHelperPubSubType::~MapUShortInnerBitsetHelperPubSubType()
 }
 
 bool MapUShortInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapUShortInnerBitsetHelper* p_type = static_cast<MapUShortInnerBitsetHelper*>(data);
+    const MapUShortInnerBitsetHelper* p_type = static_cast<const MapUShortInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9976,7 +9976,7 @@ bool MapUShortInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapUShortInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9993,7 +9993,7 @@ std::function<uint32_t()> MapUShortInnerBitsetHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapUShortInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapUShortInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10016,7 +10016,7 @@ void MapUShortInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapUShortInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10025,7 +10025,7 @@ bool MapUShortInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapUShortInnerBitsetHelper* p_type = static_cast<MapUShortInnerBitsetHelper*>(data);
+    const MapUShortInnerBitsetHelper* p_type = static_cast<const MapUShortInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10093,11 +10093,11 @@ MapLongShortPubSubType::~MapLongShortPubSubType()
 }
 
 bool MapLongShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongShort* p_type = static_cast<MapLongShort*>(data);
+    const MapLongShort* p_type = static_cast<const MapLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10169,7 +10169,7 @@ bool MapLongShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10186,7 +10186,7 @@ std::function<uint32_t()> MapLongShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongShort*>(data), current_alignment)) +
+                               *static_cast<const MapLongShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10209,7 +10209,7 @@ void MapLongShortPubSubType::deleteData(
 }
 
 bool MapLongShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10218,7 +10218,7 @@ bool MapLongShortPubSubType::getKey(
         return false;
     }
 
-    MapLongShort* p_type = static_cast<MapLongShort*>(data);
+    const MapLongShort* p_type = static_cast<const MapLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10286,11 +10286,11 @@ MapLongUShortPubSubType::~MapLongUShortPubSubType()
 }
 
 bool MapLongUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongUShort* p_type = static_cast<MapLongUShort*>(data);
+    const MapLongUShort* p_type = static_cast<const MapLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10362,7 +10362,7 @@ bool MapLongUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10379,7 +10379,7 @@ std::function<uint32_t()> MapLongUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongUShort*>(data), current_alignment)) +
+                               *static_cast<const MapLongUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10402,7 +10402,7 @@ void MapLongUShortPubSubType::deleteData(
 }
 
 bool MapLongUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10411,7 +10411,7 @@ bool MapLongUShortPubSubType::getKey(
         return false;
     }
 
-    MapLongUShort* p_type = static_cast<MapLongUShort*>(data);
+    const MapLongUShort* p_type = static_cast<const MapLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10479,11 +10479,11 @@ MapLongLongPubSubType::~MapLongLongPubSubType()
 }
 
 bool MapLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLong* p_type = static_cast<MapLongLong*>(data);
+    const MapLongLong* p_type = static_cast<const MapLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10555,7 +10555,7 @@ bool MapLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10572,7 +10572,7 @@ std::function<uint32_t()> MapLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10595,7 +10595,7 @@ void MapLongLongPubSubType::deleteData(
 }
 
 bool MapLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10604,7 +10604,7 @@ bool MapLongLongPubSubType::getKey(
         return false;
     }
 
-    MapLongLong* p_type = static_cast<MapLongLong*>(data);
+    const MapLongLong* p_type = static_cast<const MapLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10672,11 +10672,11 @@ MapLongULongPubSubType::~MapLongULongPubSubType()
 }
 
 bool MapLongULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongULong* p_type = static_cast<MapLongULong*>(data);
+    const MapLongULong* p_type = static_cast<const MapLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10748,7 +10748,7 @@ bool MapLongULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10765,7 +10765,7 @@ std::function<uint32_t()> MapLongULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongULong*>(data), current_alignment)) +
+                               *static_cast<const MapLongULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10788,7 +10788,7 @@ void MapLongULongPubSubType::deleteData(
 }
 
 bool MapLongULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10797,7 +10797,7 @@ bool MapLongULongPubSubType::getKey(
         return false;
     }
 
-    MapLongULong* p_type = static_cast<MapLongULong*>(data);
+    const MapLongULong* p_type = static_cast<const MapLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10865,11 +10865,11 @@ MapLongKeyLongLongValuePubSubType::~MapLongKeyLongLongValuePubSubType()
 }
 
 bool MapLongKeyLongLongValuePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongKeyLongLongValue* p_type = static_cast<MapLongKeyLongLongValue*>(data);
+    const MapLongKeyLongLongValue* p_type = static_cast<const MapLongKeyLongLongValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10941,7 +10941,7 @@ bool MapLongKeyLongLongValuePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongKeyLongLongValuePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10958,7 +10958,7 @@ std::function<uint32_t()> MapLongKeyLongLongValuePubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongKeyLongLongValue*>(data), current_alignment)) +
+                               *static_cast<const MapLongKeyLongLongValue*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10981,7 +10981,7 @@ void MapLongKeyLongLongValuePubSubType::deleteData(
 }
 
 bool MapLongKeyLongLongValuePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10990,7 +10990,7 @@ bool MapLongKeyLongLongValuePubSubType::getKey(
         return false;
     }
 
-    MapLongKeyLongLongValue* p_type = static_cast<MapLongKeyLongLongValue*>(data);
+    const MapLongKeyLongLongValue* p_type = static_cast<const MapLongKeyLongLongValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11058,11 +11058,11 @@ MapLongULongLongPubSubType::~MapLongULongLongPubSubType()
 }
 
 bool MapLongULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongULongLong* p_type = static_cast<MapLongULongLong*>(data);
+    const MapLongULongLong* p_type = static_cast<const MapLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11134,7 +11134,7 @@ bool MapLongULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11151,7 +11151,7 @@ std::function<uint32_t()> MapLongULongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapLongULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11174,7 +11174,7 @@ void MapLongULongLongPubSubType::deleteData(
 }
 
 bool MapLongULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11183,7 +11183,7 @@ bool MapLongULongLongPubSubType::getKey(
         return false;
     }
 
-    MapLongULongLong* p_type = static_cast<MapLongULongLong*>(data);
+    const MapLongULongLong* p_type = static_cast<const MapLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11251,11 +11251,11 @@ MapLongFloatPubSubType::~MapLongFloatPubSubType()
 }
 
 bool MapLongFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongFloat* p_type = static_cast<MapLongFloat*>(data);
+    const MapLongFloat* p_type = static_cast<const MapLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11327,7 +11327,7 @@ bool MapLongFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11344,7 +11344,7 @@ std::function<uint32_t()> MapLongFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongFloat*>(data), current_alignment)) +
+                               *static_cast<const MapLongFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11367,7 +11367,7 @@ void MapLongFloatPubSubType::deleteData(
 }
 
 bool MapLongFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11376,7 +11376,7 @@ bool MapLongFloatPubSubType::getKey(
         return false;
     }
 
-    MapLongFloat* p_type = static_cast<MapLongFloat*>(data);
+    const MapLongFloat* p_type = static_cast<const MapLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11444,11 +11444,11 @@ MapLongDoublePubSubType::~MapLongDoublePubSubType()
 }
 
 bool MapLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongDouble* p_type = static_cast<MapLongDouble*>(data);
+    const MapLongDouble* p_type = static_cast<const MapLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11520,7 +11520,7 @@ bool MapLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11537,7 +11537,7 @@ std::function<uint32_t()> MapLongDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11560,7 +11560,7 @@ void MapLongDoublePubSubType::deleteData(
 }
 
 bool MapLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11569,7 +11569,7 @@ bool MapLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapLongDouble* p_type = static_cast<MapLongDouble*>(data);
+    const MapLongDouble* p_type = static_cast<const MapLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11637,11 +11637,11 @@ MapLongKeyLongDoubleValuePubSubType::~MapLongKeyLongDoubleValuePubSubType()
 }
 
 bool MapLongKeyLongDoubleValuePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongKeyLongDoubleValue* p_type = static_cast<MapLongKeyLongDoubleValue*>(data);
+    const MapLongKeyLongDoubleValue* p_type = static_cast<const MapLongKeyLongDoubleValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11713,7 +11713,7 @@ bool MapLongKeyLongDoubleValuePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongKeyLongDoubleValuePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11730,7 +11730,7 @@ std::function<uint32_t()> MapLongKeyLongDoubleValuePubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongKeyLongDoubleValue*>(data), current_alignment)) +
+                               *static_cast<const MapLongKeyLongDoubleValue*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11753,7 +11753,7 @@ void MapLongKeyLongDoubleValuePubSubType::deleteData(
 }
 
 bool MapLongKeyLongDoubleValuePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11762,7 +11762,7 @@ bool MapLongKeyLongDoubleValuePubSubType::getKey(
         return false;
     }
 
-    MapLongKeyLongDoubleValue* p_type = static_cast<MapLongKeyLongDoubleValue*>(data);
+    const MapLongKeyLongDoubleValue* p_type = static_cast<const MapLongKeyLongDoubleValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11830,11 +11830,11 @@ MapLongBooleanPubSubType::~MapLongBooleanPubSubType()
 }
 
 bool MapLongBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongBoolean* p_type = static_cast<MapLongBoolean*>(data);
+    const MapLongBoolean* p_type = static_cast<const MapLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11906,7 +11906,7 @@ bool MapLongBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11923,7 +11923,7 @@ std::function<uint32_t()> MapLongBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapLongBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11946,7 +11946,7 @@ void MapLongBooleanPubSubType::deleteData(
 }
 
 bool MapLongBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11955,7 +11955,7 @@ bool MapLongBooleanPubSubType::getKey(
         return false;
     }
 
-    MapLongBoolean* p_type = static_cast<MapLongBoolean*>(data);
+    const MapLongBoolean* p_type = static_cast<const MapLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12023,11 +12023,11 @@ MapLongOctetPubSubType::~MapLongOctetPubSubType()
 }
 
 bool MapLongOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongOctet* p_type = static_cast<MapLongOctet*>(data);
+    const MapLongOctet* p_type = static_cast<const MapLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12099,7 +12099,7 @@ bool MapLongOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12116,7 +12116,7 @@ std::function<uint32_t()> MapLongOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongOctet*>(data), current_alignment)) +
+                               *static_cast<const MapLongOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12139,7 +12139,7 @@ void MapLongOctetPubSubType::deleteData(
 }
 
 bool MapLongOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12148,7 +12148,7 @@ bool MapLongOctetPubSubType::getKey(
         return false;
     }
 
-    MapLongOctet* p_type = static_cast<MapLongOctet*>(data);
+    const MapLongOctet* p_type = static_cast<const MapLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12216,11 +12216,11 @@ MapLongCharPubSubType::~MapLongCharPubSubType()
 }
 
 bool MapLongCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongChar* p_type = static_cast<MapLongChar*>(data);
+    const MapLongChar* p_type = static_cast<const MapLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12292,7 +12292,7 @@ bool MapLongCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12309,7 +12309,7 @@ std::function<uint32_t()> MapLongCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongChar*>(data), current_alignment)) +
+                               *static_cast<const MapLongChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12332,7 +12332,7 @@ void MapLongCharPubSubType::deleteData(
 }
 
 bool MapLongCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12341,7 +12341,7 @@ bool MapLongCharPubSubType::getKey(
         return false;
     }
 
-    MapLongChar* p_type = static_cast<MapLongChar*>(data);
+    const MapLongChar* p_type = static_cast<const MapLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12409,11 +12409,11 @@ MapLongWCharPubSubType::~MapLongWCharPubSubType()
 }
 
 bool MapLongWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongWChar* p_type = static_cast<MapLongWChar*>(data);
+    const MapLongWChar* p_type = static_cast<const MapLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12485,7 +12485,7 @@ bool MapLongWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12502,7 +12502,7 @@ std::function<uint32_t()> MapLongWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongWChar*>(data), current_alignment)) +
+                               *static_cast<const MapLongWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12525,7 +12525,7 @@ void MapLongWCharPubSubType::deleteData(
 }
 
 bool MapLongWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12534,7 +12534,7 @@ bool MapLongWCharPubSubType::getKey(
         return false;
     }
 
-    MapLongWChar* p_type = static_cast<MapLongWChar*>(data);
+    const MapLongWChar* p_type = static_cast<const MapLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12602,11 +12602,11 @@ MapLongStringPubSubType::~MapLongStringPubSubType()
 }
 
 bool MapLongStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongString* p_type = static_cast<MapLongString*>(data);
+    const MapLongString* p_type = static_cast<const MapLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12678,7 +12678,7 @@ bool MapLongStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12695,7 +12695,7 @@ std::function<uint32_t()> MapLongStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongString*>(data), current_alignment)) +
+                               *static_cast<const MapLongString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12718,7 +12718,7 @@ void MapLongStringPubSubType::deleteData(
 }
 
 bool MapLongStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12727,7 +12727,7 @@ bool MapLongStringPubSubType::getKey(
         return false;
     }
 
-    MapLongString* p_type = static_cast<MapLongString*>(data);
+    const MapLongString* p_type = static_cast<const MapLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12795,11 +12795,11 @@ MapLongWStringPubSubType::~MapLongWStringPubSubType()
 }
 
 bool MapLongWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongWString* p_type = static_cast<MapLongWString*>(data);
+    const MapLongWString* p_type = static_cast<const MapLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12871,7 +12871,7 @@ bool MapLongWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12888,7 +12888,7 @@ std::function<uint32_t()> MapLongWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongWString*>(data), current_alignment)) +
+                               *static_cast<const MapLongWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12911,7 +12911,7 @@ void MapLongWStringPubSubType::deleteData(
 }
 
 bool MapLongWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12920,7 +12920,7 @@ bool MapLongWStringPubSubType::getKey(
         return false;
     }
 
-    MapLongWString* p_type = static_cast<MapLongWString*>(data);
+    const MapLongWString* p_type = static_cast<const MapLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12988,11 +12988,11 @@ MapLongInnerAliasBoundedStringHelperPubSubType::~MapLongInnerAliasBoundedStringH
 }
 
 bool MapLongInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasBoundedStringHelper* p_type = static_cast<MapLongInnerAliasBoundedStringHelper*>(data);
+    const MapLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13064,7 +13064,7 @@ bool MapLongInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13081,7 +13081,7 @@ std::function<uint32_t()> MapLongInnerAliasBoundedStringHelperPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13104,7 +13104,7 @@ void MapLongInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13113,7 +13113,7 @@ bool MapLongInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasBoundedStringHelper* p_type = static_cast<MapLongInnerAliasBoundedStringHelper*>(data);
+    const MapLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13181,11 +13181,11 @@ MapLongInnerAliasBoundedWStringHelperPubSubType::~MapLongInnerAliasBoundedWStrin
 }
 
 bool MapLongInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapLongInnerAliasBoundedWStringHelper*>(data);
+    const MapLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13257,7 +13257,7 @@ bool MapLongInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13274,7 +13274,7 @@ std::function<uint32_t()> MapLongInnerAliasBoundedWStringHelperPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13297,7 +13297,7 @@ void MapLongInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13306,7 +13306,7 @@ bool MapLongInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapLongInnerAliasBoundedWStringHelper*>(data);
+    const MapLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13374,11 +13374,11 @@ MapLongInnerEnumHelperPubSubType::~MapLongInnerEnumHelperPubSubType()
 }
 
 bool MapLongInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerEnumHelper* p_type = static_cast<MapLongInnerEnumHelper*>(data);
+    const MapLongInnerEnumHelper* p_type = static_cast<const MapLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13450,7 +13450,7 @@ bool MapLongInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13467,7 +13467,7 @@ std::function<uint32_t()> MapLongInnerEnumHelperPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13490,7 +13490,7 @@ void MapLongInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13499,7 +13499,7 @@ bool MapLongInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerEnumHelper* p_type = static_cast<MapLongInnerEnumHelper*>(data);
+    const MapLongInnerEnumHelper* p_type = static_cast<const MapLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13567,11 +13567,11 @@ MapLongInnerBitMaskHelperPubSubType::~MapLongInnerBitMaskHelperPubSubType()
 }
 
 bool MapLongInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerBitMaskHelper* p_type = static_cast<MapLongInnerBitMaskHelper*>(data);
+    const MapLongInnerBitMaskHelper* p_type = static_cast<const MapLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13643,7 +13643,7 @@ bool MapLongInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13660,7 +13660,7 @@ std::function<uint32_t()> MapLongInnerBitMaskHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13683,7 +13683,7 @@ void MapLongInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13692,7 +13692,7 @@ bool MapLongInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerBitMaskHelper* p_type = static_cast<MapLongInnerBitMaskHelper*>(data);
+    const MapLongInnerBitMaskHelper* p_type = static_cast<const MapLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13760,11 +13760,11 @@ MapLongInnerAliasHelperPubSubType::~MapLongInnerAliasHelperPubSubType()
 }
 
 bool MapLongInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasHelper* p_type = static_cast<MapLongInnerAliasHelper*>(data);
+    const MapLongInnerAliasHelper* p_type = static_cast<const MapLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13836,7 +13836,7 @@ bool MapLongInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13853,7 +13853,7 @@ std::function<uint32_t()> MapLongInnerAliasHelperPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13876,7 +13876,7 @@ void MapLongInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13885,7 +13885,7 @@ bool MapLongInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasHelper* p_type = static_cast<MapLongInnerAliasHelper*>(data);
+    const MapLongInnerAliasHelper* p_type = static_cast<const MapLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13953,11 +13953,11 @@ MapLongInnerAliasArrayHelperPubSubType::~MapLongInnerAliasArrayHelperPubSubType(
 }
 
 bool MapLongInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasArrayHelper* p_type = static_cast<MapLongInnerAliasArrayHelper*>(data);
+    const MapLongInnerAliasArrayHelper* p_type = static_cast<const MapLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14029,7 +14029,7 @@ bool MapLongInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14046,7 +14046,7 @@ std::function<uint32_t()> MapLongInnerAliasArrayHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14069,7 +14069,7 @@ void MapLongInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14078,7 +14078,7 @@ bool MapLongInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasArrayHelper* p_type = static_cast<MapLongInnerAliasArrayHelper*>(data);
+    const MapLongInnerAliasArrayHelper* p_type = static_cast<const MapLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14146,11 +14146,11 @@ MapLongInnerAliasSequenceHelperPubSubType::~MapLongInnerAliasSequenceHelperPubSu
 }
 
 bool MapLongInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasSequenceHelper* p_type = static_cast<MapLongInnerAliasSequenceHelper*>(data);
+    const MapLongInnerAliasSequenceHelper* p_type = static_cast<const MapLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14222,7 +14222,7 @@ bool MapLongInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14239,7 +14239,7 @@ std::function<uint32_t()> MapLongInnerAliasSequenceHelperPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14262,7 +14262,7 @@ void MapLongInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14271,7 +14271,7 @@ bool MapLongInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasSequenceHelper* p_type = static_cast<MapLongInnerAliasSequenceHelper*>(data);
+    const MapLongInnerAliasSequenceHelper* p_type = static_cast<const MapLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14339,11 +14339,11 @@ MapLongInnerAliasMapHelperPubSubType::~MapLongInnerAliasMapHelperPubSubType()
 }
 
 bool MapLongInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerAliasMapHelper* p_type = static_cast<MapLongInnerAliasMapHelper*>(data);
+    const MapLongInnerAliasMapHelper* p_type = static_cast<const MapLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14415,7 +14415,7 @@ bool MapLongInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14432,7 +14432,7 @@ std::function<uint32_t()> MapLongInnerAliasMapHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14455,7 +14455,7 @@ void MapLongInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14464,7 +14464,7 @@ bool MapLongInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerAliasMapHelper* p_type = static_cast<MapLongInnerAliasMapHelper*>(data);
+    const MapLongInnerAliasMapHelper* p_type = static_cast<const MapLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14532,11 +14532,11 @@ MapLongInnerUnionHelperPubSubType::~MapLongInnerUnionHelperPubSubType()
 }
 
 bool MapLongInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerUnionHelper* p_type = static_cast<MapLongInnerUnionHelper*>(data);
+    const MapLongInnerUnionHelper* p_type = static_cast<const MapLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14608,7 +14608,7 @@ bool MapLongInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14625,7 +14625,7 @@ std::function<uint32_t()> MapLongInnerUnionHelperPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14648,7 +14648,7 @@ void MapLongInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14657,7 +14657,7 @@ bool MapLongInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerUnionHelper* p_type = static_cast<MapLongInnerUnionHelper*>(data);
+    const MapLongInnerUnionHelper* p_type = static_cast<const MapLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14725,11 +14725,11 @@ MapLongInnerStructureHelperPubSubType::~MapLongInnerStructureHelperPubSubType()
 }
 
 bool MapLongInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerStructureHelper* p_type = static_cast<MapLongInnerStructureHelper*>(data);
+    const MapLongInnerStructureHelper* p_type = static_cast<const MapLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14801,7 +14801,7 @@ bool MapLongInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14818,7 +14818,7 @@ std::function<uint32_t()> MapLongInnerStructureHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14841,7 +14841,7 @@ void MapLongInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14850,7 +14850,7 @@ bool MapLongInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerStructureHelper* p_type = static_cast<MapLongInnerStructureHelper*>(data);
+    const MapLongInnerStructureHelper* p_type = static_cast<const MapLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14918,11 +14918,11 @@ MapLongInnerBitsetHelperPubSubType::~MapLongInnerBitsetHelperPubSubType()
 }
 
 bool MapLongInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongInnerBitsetHelper* p_type = static_cast<MapLongInnerBitsetHelper*>(data);
+    const MapLongInnerBitsetHelper* p_type = static_cast<const MapLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14994,7 +14994,7 @@ bool MapLongInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15011,7 +15011,7 @@ std::function<uint32_t()> MapLongInnerBitsetHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15034,7 +15034,7 @@ void MapLongInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapLongInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15043,7 +15043,7 @@ bool MapLongInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongInnerBitsetHelper* p_type = static_cast<MapLongInnerBitsetHelper*>(data);
+    const MapLongInnerBitsetHelper* p_type = static_cast<const MapLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15111,11 +15111,11 @@ MapULongShortPubSubType::~MapULongShortPubSubType()
 }
 
 bool MapULongShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongShort* p_type = static_cast<MapULongShort*>(data);
+    const MapULongShort* p_type = static_cast<const MapULongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15187,7 +15187,7 @@ bool MapULongShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15204,7 +15204,7 @@ std::function<uint32_t()> MapULongShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongShort*>(data), current_alignment)) +
+                               *static_cast<const MapULongShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15227,7 +15227,7 @@ void MapULongShortPubSubType::deleteData(
 }
 
 bool MapULongShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15236,7 +15236,7 @@ bool MapULongShortPubSubType::getKey(
         return false;
     }
 
-    MapULongShort* p_type = static_cast<MapULongShort*>(data);
+    const MapULongShort* p_type = static_cast<const MapULongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15304,11 +15304,11 @@ MapULongUShortPubSubType::~MapULongUShortPubSubType()
 }
 
 bool MapULongUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongUShort* p_type = static_cast<MapULongUShort*>(data);
+    const MapULongUShort* p_type = static_cast<const MapULongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15380,7 +15380,7 @@ bool MapULongUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15397,7 +15397,7 @@ std::function<uint32_t()> MapULongUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongUShort*>(data), current_alignment)) +
+                               *static_cast<const MapULongUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15420,7 +15420,7 @@ void MapULongUShortPubSubType::deleteData(
 }
 
 bool MapULongUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15429,7 +15429,7 @@ bool MapULongUShortPubSubType::getKey(
         return false;
     }
 
-    MapULongUShort* p_type = static_cast<MapULongUShort*>(data);
+    const MapULongUShort* p_type = static_cast<const MapULongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15497,11 +15497,11 @@ MapULongLongPubSubType::~MapULongLongPubSubType()
 }
 
 bool MapULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLong* p_type = static_cast<MapULongLong*>(data);
+    const MapULongLong* p_type = static_cast<const MapULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15573,7 +15573,7 @@ bool MapULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15590,7 +15590,7 @@ std::function<uint32_t()> MapULongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15613,7 +15613,7 @@ void MapULongLongPubSubType::deleteData(
 }
 
 bool MapULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15622,7 +15622,7 @@ bool MapULongLongPubSubType::getKey(
         return false;
     }
 
-    MapULongLong* p_type = static_cast<MapULongLong*>(data);
+    const MapULongLong* p_type = static_cast<const MapULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15690,11 +15690,11 @@ MapULongULongPubSubType::~MapULongULongPubSubType()
 }
 
 bool MapULongULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongULong* p_type = static_cast<MapULongULong*>(data);
+    const MapULongULong* p_type = static_cast<const MapULongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15766,7 +15766,7 @@ bool MapULongULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15783,7 +15783,7 @@ std::function<uint32_t()> MapULongULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongULong*>(data), current_alignment)) +
+                               *static_cast<const MapULongULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15806,7 +15806,7 @@ void MapULongULongPubSubType::deleteData(
 }
 
 bool MapULongULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15815,7 +15815,7 @@ bool MapULongULongPubSubType::getKey(
         return false;
     }
 
-    MapULongULong* p_type = static_cast<MapULongULong*>(data);
+    const MapULongULong* p_type = static_cast<const MapULongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15883,11 +15883,11 @@ MapKeyULongValueLongLongPubSubType::~MapKeyULongValueLongLongPubSubType()
 }
 
 bool MapKeyULongValueLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapKeyULongValueLongLong* p_type = static_cast<MapKeyULongValueLongLong*>(data);
+    const MapKeyULongValueLongLong* p_type = static_cast<const MapKeyULongValueLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15959,7 +15959,7 @@ bool MapKeyULongValueLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapKeyULongValueLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15976,7 +15976,7 @@ std::function<uint32_t()> MapKeyULongValueLongLongPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapKeyULongValueLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapKeyULongValueLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15999,7 +15999,7 @@ void MapKeyULongValueLongLongPubSubType::deleteData(
 }
 
 bool MapKeyULongValueLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16008,7 +16008,7 @@ bool MapKeyULongValueLongLongPubSubType::getKey(
         return false;
     }
 
-    MapKeyULongValueLongLong* p_type = static_cast<MapKeyULongValueLongLong*>(data);
+    const MapKeyULongValueLongLong* p_type = static_cast<const MapKeyULongValueLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16076,11 +16076,11 @@ MapULongULongLongPubSubType::~MapULongULongLongPubSubType()
 }
 
 bool MapULongULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongULongLong* p_type = static_cast<MapULongULongLong*>(data);
+    const MapULongULongLong* p_type = static_cast<const MapULongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16152,7 +16152,7 @@ bool MapULongULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16169,7 +16169,7 @@ std::function<uint32_t()> MapULongULongLongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapULongULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16192,7 +16192,7 @@ void MapULongULongLongPubSubType::deleteData(
 }
 
 bool MapULongULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16201,7 +16201,7 @@ bool MapULongULongLongPubSubType::getKey(
         return false;
     }
 
-    MapULongULongLong* p_type = static_cast<MapULongULongLong*>(data);
+    const MapULongULongLong* p_type = static_cast<const MapULongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16269,11 +16269,11 @@ MapULongFloatPubSubType::~MapULongFloatPubSubType()
 }
 
 bool MapULongFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongFloat* p_type = static_cast<MapULongFloat*>(data);
+    const MapULongFloat* p_type = static_cast<const MapULongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16345,7 +16345,7 @@ bool MapULongFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16362,7 +16362,7 @@ std::function<uint32_t()> MapULongFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongFloat*>(data), current_alignment)) +
+                               *static_cast<const MapULongFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16385,7 +16385,7 @@ void MapULongFloatPubSubType::deleteData(
 }
 
 bool MapULongFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16394,7 +16394,7 @@ bool MapULongFloatPubSubType::getKey(
         return false;
     }
 
-    MapULongFloat* p_type = static_cast<MapULongFloat*>(data);
+    const MapULongFloat* p_type = static_cast<const MapULongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16462,11 +16462,11 @@ MapULongDoublePubSubType::~MapULongDoublePubSubType()
 }
 
 bool MapULongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongDouble* p_type = static_cast<MapULongDouble*>(data);
+    const MapULongDouble* p_type = static_cast<const MapULongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16538,7 +16538,7 @@ bool MapULongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16555,7 +16555,7 @@ std::function<uint32_t()> MapULongDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapULongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16578,7 +16578,7 @@ void MapULongDoublePubSubType::deleteData(
 }
 
 bool MapULongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16587,7 +16587,7 @@ bool MapULongDoublePubSubType::getKey(
         return false;
     }
 
-    MapULongDouble* p_type = static_cast<MapULongDouble*>(data);
+    const MapULongDouble* p_type = static_cast<const MapULongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16655,11 +16655,11 @@ MapKeyULongValueLongDoublePubSubType::~MapKeyULongValueLongDoublePubSubType()
 }
 
 bool MapKeyULongValueLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapKeyULongValueLongDouble* p_type = static_cast<MapKeyULongValueLongDouble*>(data);
+    const MapKeyULongValueLongDouble* p_type = static_cast<const MapKeyULongValueLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16731,7 +16731,7 @@ bool MapKeyULongValueLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapKeyULongValueLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16748,7 +16748,7 @@ std::function<uint32_t()> MapKeyULongValueLongDoublePubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapKeyULongValueLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapKeyULongValueLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16771,7 +16771,7 @@ void MapKeyULongValueLongDoublePubSubType::deleteData(
 }
 
 bool MapKeyULongValueLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16780,7 +16780,7 @@ bool MapKeyULongValueLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapKeyULongValueLongDouble* p_type = static_cast<MapKeyULongValueLongDouble*>(data);
+    const MapKeyULongValueLongDouble* p_type = static_cast<const MapKeyULongValueLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -16848,11 +16848,11 @@ MapULongBooleanPubSubType::~MapULongBooleanPubSubType()
 }
 
 bool MapULongBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongBoolean* p_type = static_cast<MapULongBoolean*>(data);
+    const MapULongBoolean* p_type = static_cast<const MapULongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -16924,7 +16924,7 @@ bool MapULongBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -16941,7 +16941,7 @@ std::function<uint32_t()> MapULongBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapULongBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -16964,7 +16964,7 @@ void MapULongBooleanPubSubType::deleteData(
 }
 
 bool MapULongBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -16973,7 +16973,7 @@ bool MapULongBooleanPubSubType::getKey(
         return false;
     }
 
-    MapULongBoolean* p_type = static_cast<MapULongBoolean*>(data);
+    const MapULongBoolean* p_type = static_cast<const MapULongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17041,11 +17041,11 @@ MapULongOctetPubSubType::~MapULongOctetPubSubType()
 }
 
 bool MapULongOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongOctet* p_type = static_cast<MapULongOctet*>(data);
+    const MapULongOctet* p_type = static_cast<const MapULongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17117,7 +17117,7 @@ bool MapULongOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17134,7 +17134,7 @@ std::function<uint32_t()> MapULongOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongOctet*>(data), current_alignment)) +
+                               *static_cast<const MapULongOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17157,7 +17157,7 @@ void MapULongOctetPubSubType::deleteData(
 }
 
 bool MapULongOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17166,7 +17166,7 @@ bool MapULongOctetPubSubType::getKey(
         return false;
     }
 
-    MapULongOctet* p_type = static_cast<MapULongOctet*>(data);
+    const MapULongOctet* p_type = static_cast<const MapULongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17234,11 +17234,11 @@ MapULongCharPubSubType::~MapULongCharPubSubType()
 }
 
 bool MapULongCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongChar* p_type = static_cast<MapULongChar*>(data);
+    const MapULongChar* p_type = static_cast<const MapULongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17310,7 +17310,7 @@ bool MapULongCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17327,7 +17327,7 @@ std::function<uint32_t()> MapULongCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongChar*>(data), current_alignment)) +
+                               *static_cast<const MapULongChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17350,7 +17350,7 @@ void MapULongCharPubSubType::deleteData(
 }
 
 bool MapULongCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17359,7 +17359,7 @@ bool MapULongCharPubSubType::getKey(
         return false;
     }
 
-    MapULongChar* p_type = static_cast<MapULongChar*>(data);
+    const MapULongChar* p_type = static_cast<const MapULongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17427,11 +17427,11 @@ MapULongWCharPubSubType::~MapULongWCharPubSubType()
 }
 
 bool MapULongWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongWChar* p_type = static_cast<MapULongWChar*>(data);
+    const MapULongWChar* p_type = static_cast<const MapULongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17503,7 +17503,7 @@ bool MapULongWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17520,7 +17520,7 @@ std::function<uint32_t()> MapULongWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongWChar*>(data), current_alignment)) +
+                               *static_cast<const MapULongWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17543,7 +17543,7 @@ void MapULongWCharPubSubType::deleteData(
 }
 
 bool MapULongWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17552,7 +17552,7 @@ bool MapULongWCharPubSubType::getKey(
         return false;
     }
 
-    MapULongWChar* p_type = static_cast<MapULongWChar*>(data);
+    const MapULongWChar* p_type = static_cast<const MapULongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17620,11 +17620,11 @@ MapULongStringPubSubType::~MapULongStringPubSubType()
 }
 
 bool MapULongStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongString* p_type = static_cast<MapULongString*>(data);
+    const MapULongString* p_type = static_cast<const MapULongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17696,7 +17696,7 @@ bool MapULongStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17713,7 +17713,7 @@ std::function<uint32_t()> MapULongStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongString*>(data), current_alignment)) +
+                               *static_cast<const MapULongString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17736,7 +17736,7 @@ void MapULongStringPubSubType::deleteData(
 }
 
 bool MapULongStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17745,7 +17745,7 @@ bool MapULongStringPubSubType::getKey(
         return false;
     }
 
-    MapULongString* p_type = static_cast<MapULongString*>(data);
+    const MapULongString* p_type = static_cast<const MapULongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -17813,11 +17813,11 @@ MapULongWStringPubSubType::~MapULongWStringPubSubType()
 }
 
 bool MapULongWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongWString* p_type = static_cast<MapULongWString*>(data);
+    const MapULongWString* p_type = static_cast<const MapULongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -17889,7 +17889,7 @@ bool MapULongWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -17906,7 +17906,7 @@ std::function<uint32_t()> MapULongWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongWString*>(data), current_alignment)) +
+                               *static_cast<const MapULongWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -17929,7 +17929,7 @@ void MapULongWStringPubSubType::deleteData(
 }
 
 bool MapULongWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -17938,7 +17938,7 @@ bool MapULongWStringPubSubType::getKey(
         return false;
     }
 
-    MapULongWString* p_type = static_cast<MapULongWString*>(data);
+    const MapULongWString* p_type = static_cast<const MapULongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18006,11 +18006,11 @@ MapULongInnerAliasBoundedStringHelperPubSubType::~MapULongInnerAliasBoundedStrin
 }
 
 bool MapULongInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasBoundedStringHelper* p_type = static_cast<MapULongInnerAliasBoundedStringHelper*>(data);
+    const MapULongInnerAliasBoundedStringHelper* p_type = static_cast<const MapULongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18082,7 +18082,7 @@ bool MapULongInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18099,7 +18099,7 @@ std::function<uint32_t()> MapULongInnerAliasBoundedStringHelperPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18122,7 +18122,7 @@ void MapULongInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18131,7 +18131,7 @@ bool MapULongInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasBoundedStringHelper* p_type = static_cast<MapULongInnerAliasBoundedStringHelper*>(data);
+    const MapULongInnerAliasBoundedStringHelper* p_type = static_cast<const MapULongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18199,11 +18199,11 @@ MapULongInnerAliasBoundedWStringHelperPubSubType::~MapULongInnerAliasBoundedWStr
 }
 
 bool MapULongInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasBoundedWStringHelper* p_type = static_cast<MapULongInnerAliasBoundedWStringHelper*>(data);
+    const MapULongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapULongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18275,7 +18275,7 @@ bool MapULongInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18292,7 +18292,7 @@ std::function<uint32_t()> MapULongInnerAliasBoundedWStringHelperPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18315,7 +18315,7 @@ void MapULongInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18324,7 +18324,7 @@ bool MapULongInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasBoundedWStringHelper* p_type = static_cast<MapULongInnerAliasBoundedWStringHelper*>(data);
+    const MapULongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapULongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18392,11 +18392,11 @@ MapULongInnerEnumHelperPubSubType::~MapULongInnerEnumHelperPubSubType()
 }
 
 bool MapULongInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerEnumHelper* p_type = static_cast<MapULongInnerEnumHelper*>(data);
+    const MapULongInnerEnumHelper* p_type = static_cast<const MapULongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18468,7 +18468,7 @@ bool MapULongInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18485,7 +18485,7 @@ std::function<uint32_t()> MapULongInnerEnumHelperPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18508,7 +18508,7 @@ void MapULongInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18517,7 +18517,7 @@ bool MapULongInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerEnumHelper* p_type = static_cast<MapULongInnerEnumHelper*>(data);
+    const MapULongInnerEnumHelper* p_type = static_cast<const MapULongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18585,11 +18585,11 @@ MapULongInnerBitMaskHelperPubSubType::~MapULongInnerBitMaskHelperPubSubType()
 }
 
 bool MapULongInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerBitMaskHelper* p_type = static_cast<MapULongInnerBitMaskHelper*>(data);
+    const MapULongInnerBitMaskHelper* p_type = static_cast<const MapULongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18661,7 +18661,7 @@ bool MapULongInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18678,7 +18678,7 @@ std::function<uint32_t()> MapULongInnerBitMaskHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18701,7 +18701,7 @@ void MapULongInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18710,7 +18710,7 @@ bool MapULongInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerBitMaskHelper* p_type = static_cast<MapULongInnerBitMaskHelper*>(data);
+    const MapULongInnerBitMaskHelper* p_type = static_cast<const MapULongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18778,11 +18778,11 @@ MapULongInnerAliasHelperPubSubType::~MapULongInnerAliasHelperPubSubType()
 }
 
 bool MapULongInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasHelper* p_type = static_cast<MapULongInnerAliasHelper*>(data);
+    const MapULongInnerAliasHelper* p_type = static_cast<const MapULongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -18854,7 +18854,7 @@ bool MapULongInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -18871,7 +18871,7 @@ std::function<uint32_t()> MapULongInnerAliasHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -18894,7 +18894,7 @@ void MapULongInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -18903,7 +18903,7 @@ bool MapULongInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasHelper* p_type = static_cast<MapULongInnerAliasHelper*>(data);
+    const MapULongInnerAliasHelper* p_type = static_cast<const MapULongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -18971,11 +18971,11 @@ MapULongInnerAliasArrayHelperPubSubType::~MapULongInnerAliasArrayHelperPubSubTyp
 }
 
 bool MapULongInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasArrayHelper* p_type = static_cast<MapULongInnerAliasArrayHelper*>(data);
+    const MapULongInnerAliasArrayHelper* p_type = static_cast<const MapULongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19047,7 +19047,7 @@ bool MapULongInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19064,7 +19064,7 @@ std::function<uint32_t()> MapULongInnerAliasArrayHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19087,7 +19087,7 @@ void MapULongInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19096,7 +19096,7 @@ bool MapULongInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasArrayHelper* p_type = static_cast<MapULongInnerAliasArrayHelper*>(data);
+    const MapULongInnerAliasArrayHelper* p_type = static_cast<const MapULongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19164,11 +19164,11 @@ MapULongInnerAliasSequenceHelperPubSubType::~MapULongInnerAliasSequenceHelperPub
 }
 
 bool MapULongInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasSequenceHelper* p_type = static_cast<MapULongInnerAliasSequenceHelper*>(data);
+    const MapULongInnerAliasSequenceHelper* p_type = static_cast<const MapULongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19240,7 +19240,7 @@ bool MapULongInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19257,7 +19257,7 @@ std::function<uint32_t()> MapULongInnerAliasSequenceHelperPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19280,7 +19280,7 @@ void MapULongInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19289,7 +19289,7 @@ bool MapULongInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasSequenceHelper* p_type = static_cast<MapULongInnerAliasSequenceHelper*>(data);
+    const MapULongInnerAliasSequenceHelper* p_type = static_cast<const MapULongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19357,11 +19357,11 @@ MapULongInnerAliasMapHelperPubSubType::~MapULongInnerAliasMapHelperPubSubType()
 }
 
 bool MapULongInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerAliasMapHelper* p_type = static_cast<MapULongInnerAliasMapHelper*>(data);
+    const MapULongInnerAliasMapHelper* p_type = static_cast<const MapULongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19433,7 +19433,7 @@ bool MapULongInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19450,7 +19450,7 @@ std::function<uint32_t()> MapULongInnerAliasMapHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19473,7 +19473,7 @@ void MapULongInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19482,7 +19482,7 @@ bool MapULongInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerAliasMapHelper* p_type = static_cast<MapULongInnerAliasMapHelper*>(data);
+    const MapULongInnerAliasMapHelper* p_type = static_cast<const MapULongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19550,11 +19550,11 @@ MapULongInnerUnionHelperPubSubType::~MapULongInnerUnionHelperPubSubType()
 }
 
 bool MapULongInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerUnionHelper* p_type = static_cast<MapULongInnerUnionHelper*>(data);
+    const MapULongInnerUnionHelper* p_type = static_cast<const MapULongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19626,7 +19626,7 @@ bool MapULongInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19643,7 +19643,7 @@ std::function<uint32_t()> MapULongInnerUnionHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19666,7 +19666,7 @@ void MapULongInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19675,7 +19675,7 @@ bool MapULongInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerUnionHelper* p_type = static_cast<MapULongInnerUnionHelper*>(data);
+    const MapULongInnerUnionHelper* p_type = static_cast<const MapULongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19743,11 +19743,11 @@ MapULongInnerStructureHelperPubSubType::~MapULongInnerStructureHelperPubSubType(
 }
 
 bool MapULongInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerStructureHelper* p_type = static_cast<MapULongInnerStructureHelper*>(data);
+    const MapULongInnerStructureHelper* p_type = static_cast<const MapULongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -19819,7 +19819,7 @@ bool MapULongInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -19836,7 +19836,7 @@ std::function<uint32_t()> MapULongInnerStructureHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -19859,7 +19859,7 @@ void MapULongInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -19868,7 +19868,7 @@ bool MapULongInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerStructureHelper* p_type = static_cast<MapULongInnerStructureHelper*>(data);
+    const MapULongInnerStructureHelper* p_type = static_cast<const MapULongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -19936,11 +19936,11 @@ MapULongInnerBitsetHelperPubSubType::~MapULongInnerBitsetHelperPubSubType()
 }
 
 bool MapULongInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongInnerBitsetHelper* p_type = static_cast<MapULongInnerBitsetHelper*>(data);
+    const MapULongInnerBitsetHelper* p_type = static_cast<const MapULongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20012,7 +20012,7 @@ bool MapULongInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20029,7 +20029,7 @@ std::function<uint32_t()> MapULongInnerBitsetHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20052,7 +20052,7 @@ void MapULongInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapULongInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20061,7 +20061,7 @@ bool MapULongInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongInnerBitsetHelper* p_type = static_cast<MapULongInnerBitsetHelper*>(data);
+    const MapULongInnerBitsetHelper* p_type = static_cast<const MapULongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -20129,11 +20129,11 @@ MapLongLongShortPubSubType::~MapLongLongShortPubSubType()
 }
 
 bool MapLongLongShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongShort* p_type = static_cast<MapLongLongShort*>(data);
+    const MapLongLongShort* p_type = static_cast<const MapLongLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20205,7 +20205,7 @@ bool MapLongLongShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20222,7 +20222,7 @@ std::function<uint32_t()> MapLongLongShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongShort*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20245,7 +20245,7 @@ void MapLongLongShortPubSubType::deleteData(
 }
 
 bool MapLongLongShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20254,7 +20254,7 @@ bool MapLongLongShortPubSubType::getKey(
         return false;
     }
 
-    MapLongLongShort* p_type = static_cast<MapLongLongShort*>(data);
+    const MapLongLongShort* p_type = static_cast<const MapLongLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -20322,11 +20322,11 @@ MapLongLongUShortPubSubType::~MapLongLongUShortPubSubType()
 }
 
 bool MapLongLongUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongUShort* p_type = static_cast<MapLongLongUShort*>(data);
+    const MapLongLongUShort* p_type = static_cast<const MapLongLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20398,7 +20398,7 @@ bool MapLongLongUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20415,7 +20415,7 @@ std::function<uint32_t()> MapLongLongUShortPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongUShort*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20438,7 +20438,7 @@ void MapLongLongUShortPubSubType::deleteData(
 }
 
 bool MapLongLongUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20447,7 +20447,7 @@ bool MapLongLongUShortPubSubType::getKey(
         return false;
     }
 
-    MapLongLongUShort* p_type = static_cast<MapLongLongUShort*>(data);
+    const MapLongLongUShort* p_type = static_cast<const MapLongLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -20515,11 +20515,11 @@ MapLongLongKeyLongValuePubSubType::~MapLongLongKeyLongValuePubSubType()
 }
 
 bool MapLongLongKeyLongValuePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongKeyLongValue* p_type = static_cast<MapLongLongKeyLongValue*>(data);
+    const MapLongLongKeyLongValue* p_type = static_cast<const MapLongLongKeyLongValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20591,7 +20591,7 @@ bool MapLongLongKeyLongValuePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongKeyLongValuePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20608,7 +20608,7 @@ std::function<uint32_t()> MapLongLongKeyLongValuePubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongKeyLongValue*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongKeyLongValue*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20631,7 +20631,7 @@ void MapLongLongKeyLongValuePubSubType::deleteData(
 }
 
 bool MapLongLongKeyLongValuePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20640,7 +20640,7 @@ bool MapLongLongKeyLongValuePubSubType::getKey(
         return false;
     }
 
-    MapLongLongKeyLongValue* p_type = static_cast<MapLongLongKeyLongValue*>(data);
+    const MapLongLongKeyLongValue* p_type = static_cast<const MapLongLongKeyLongValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -20708,11 +20708,11 @@ MapLongLongULongPubSubType::~MapLongLongULongPubSubType()
 }
 
 bool MapLongLongULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongULong* p_type = static_cast<MapLongLongULong*>(data);
+    const MapLongLongULong* p_type = static_cast<const MapLongLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20784,7 +20784,7 @@ bool MapLongLongULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20801,7 +20801,7 @@ std::function<uint32_t()> MapLongLongULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongULong*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -20824,7 +20824,7 @@ void MapLongLongULongPubSubType::deleteData(
 }
 
 bool MapLongLongULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -20833,7 +20833,7 @@ bool MapLongLongULongPubSubType::getKey(
         return false;
     }
 
-    MapLongLongULong* p_type = static_cast<MapLongLongULong*>(data);
+    const MapLongLongULong* p_type = static_cast<const MapLongLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -20901,11 +20901,11 @@ MapLongLongLongLongPubSubType::~MapLongLongLongLongPubSubType()
 }
 
 bool MapLongLongLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongLongLong* p_type = static_cast<MapLongLongLongLong*>(data);
+    const MapLongLongLongLong* p_type = static_cast<const MapLongLongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -20977,7 +20977,7 @@ bool MapLongLongLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -20994,7 +20994,7 @@ std::function<uint32_t()> MapLongLongLongLongPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21017,7 +21017,7 @@ void MapLongLongLongLongPubSubType::deleteData(
 }
 
 bool MapLongLongLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21026,7 +21026,7 @@ bool MapLongLongLongLongPubSubType::getKey(
         return false;
     }
 
-    MapLongLongLongLong* p_type = static_cast<MapLongLongLongLong*>(data);
+    const MapLongLongLongLong* p_type = static_cast<const MapLongLongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -21094,11 +21094,11 @@ MapLongLongULongLongPubSubType::~MapLongLongULongLongPubSubType()
 }
 
 bool MapLongLongULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongULongLong* p_type = static_cast<MapLongLongULongLong*>(data);
+    const MapLongLongULongLong* p_type = static_cast<const MapLongLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -21170,7 +21170,7 @@ bool MapLongLongULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -21187,7 +21187,7 @@ std::function<uint32_t()> MapLongLongULongLongPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21210,7 +21210,7 @@ void MapLongLongULongLongPubSubType::deleteData(
 }
 
 bool MapLongLongULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21219,7 +21219,7 @@ bool MapLongLongULongLongPubSubType::getKey(
         return false;
     }
 
-    MapLongLongULongLong* p_type = static_cast<MapLongLongULongLong*>(data);
+    const MapLongLongULongLong* p_type = static_cast<const MapLongLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -21287,11 +21287,11 @@ MapLongLongFloatPubSubType::~MapLongLongFloatPubSubType()
 }
 
 bool MapLongLongFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongFloat* p_type = static_cast<MapLongLongFloat*>(data);
+    const MapLongLongFloat* p_type = static_cast<const MapLongLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -21363,7 +21363,7 @@ bool MapLongLongFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -21380,7 +21380,7 @@ std::function<uint32_t()> MapLongLongFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongFloat*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21403,7 +21403,7 @@ void MapLongLongFloatPubSubType::deleteData(
 }
 
 bool MapLongLongFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21412,7 +21412,7 @@ bool MapLongLongFloatPubSubType::getKey(
         return false;
     }
 
-    MapLongLongFloat* p_type = static_cast<MapLongLongFloat*>(data);
+    const MapLongLongFloat* p_type = static_cast<const MapLongLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -21480,11 +21480,11 @@ MapLongLongKeyDoubleValuePubSubType::~MapLongLongKeyDoubleValuePubSubType()
 }
 
 bool MapLongLongKeyDoubleValuePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongKeyDoubleValue* p_type = static_cast<MapLongLongKeyDoubleValue*>(data);
+    const MapLongLongKeyDoubleValue* p_type = static_cast<const MapLongLongKeyDoubleValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -21556,7 +21556,7 @@ bool MapLongLongKeyDoubleValuePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongKeyDoubleValuePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -21573,7 +21573,7 @@ std::function<uint32_t()> MapLongLongKeyDoubleValuePubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongKeyDoubleValue*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongKeyDoubleValue*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21596,7 +21596,7 @@ void MapLongLongKeyDoubleValuePubSubType::deleteData(
 }
 
 bool MapLongLongKeyDoubleValuePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21605,7 +21605,7 @@ bool MapLongLongKeyDoubleValuePubSubType::getKey(
         return false;
     }
 
-    MapLongLongKeyDoubleValue* p_type = static_cast<MapLongLongKeyDoubleValue*>(data);
+    const MapLongLongKeyDoubleValue* p_type = static_cast<const MapLongLongKeyDoubleValue*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -21673,11 +21673,11 @@ MapLongLongLongDoublePubSubType::~MapLongLongLongDoublePubSubType()
 }
 
 bool MapLongLongLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongLongDouble* p_type = static_cast<MapLongLongLongDouble*>(data);
+    const MapLongLongLongDouble* p_type = static_cast<const MapLongLongLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -21749,7 +21749,7 @@ bool MapLongLongLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -21766,7 +21766,7 @@ std::function<uint32_t()> MapLongLongLongDoublePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21789,7 +21789,7 @@ void MapLongLongLongDoublePubSubType::deleteData(
 }
 
 bool MapLongLongLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21798,7 +21798,7 @@ bool MapLongLongLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapLongLongLongDouble* p_type = static_cast<MapLongLongLongDouble*>(data);
+    const MapLongLongLongDouble* p_type = static_cast<const MapLongLongLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -21866,11 +21866,11 @@ MapLongLongBooleanPubSubType::~MapLongLongBooleanPubSubType()
 }
 
 bool MapLongLongBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongBoolean* p_type = static_cast<MapLongLongBoolean*>(data);
+    const MapLongLongBoolean* p_type = static_cast<const MapLongLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -21942,7 +21942,7 @@ bool MapLongLongBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -21959,7 +21959,7 @@ std::function<uint32_t()> MapLongLongBooleanPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -21982,7 +21982,7 @@ void MapLongLongBooleanPubSubType::deleteData(
 }
 
 bool MapLongLongBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -21991,7 +21991,7 @@ bool MapLongLongBooleanPubSubType::getKey(
         return false;
     }
 
-    MapLongLongBoolean* p_type = static_cast<MapLongLongBoolean*>(data);
+    const MapLongLongBoolean* p_type = static_cast<const MapLongLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -22059,11 +22059,11 @@ MapLongLongOctetPubSubType::~MapLongLongOctetPubSubType()
 }
 
 bool MapLongLongOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongOctet* p_type = static_cast<MapLongLongOctet*>(data);
+    const MapLongLongOctet* p_type = static_cast<const MapLongLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -22135,7 +22135,7 @@ bool MapLongLongOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -22152,7 +22152,7 @@ std::function<uint32_t()> MapLongLongOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongOctet*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -22175,7 +22175,7 @@ void MapLongLongOctetPubSubType::deleteData(
 }
 
 bool MapLongLongOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -22184,7 +22184,7 @@ bool MapLongLongOctetPubSubType::getKey(
         return false;
     }
 
-    MapLongLongOctet* p_type = static_cast<MapLongLongOctet*>(data);
+    const MapLongLongOctet* p_type = static_cast<const MapLongLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -22252,11 +22252,11 @@ MapLongLongCharPubSubType::~MapLongLongCharPubSubType()
 }
 
 bool MapLongLongCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongChar* p_type = static_cast<MapLongLongChar*>(data);
+    const MapLongLongChar* p_type = static_cast<const MapLongLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -22328,7 +22328,7 @@ bool MapLongLongCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -22345,7 +22345,7 @@ std::function<uint32_t()> MapLongLongCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongChar*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -22368,7 +22368,7 @@ void MapLongLongCharPubSubType::deleteData(
 }
 
 bool MapLongLongCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -22377,7 +22377,7 @@ bool MapLongLongCharPubSubType::getKey(
         return false;
     }
 
-    MapLongLongChar* p_type = static_cast<MapLongLongChar*>(data);
+    const MapLongLongChar* p_type = static_cast<const MapLongLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -22445,11 +22445,11 @@ MapLongLongWCharPubSubType::~MapLongLongWCharPubSubType()
 }
 
 bool MapLongLongWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongWChar* p_type = static_cast<MapLongLongWChar*>(data);
+    const MapLongLongWChar* p_type = static_cast<const MapLongLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -22521,7 +22521,7 @@ bool MapLongLongWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -22538,7 +22538,7 @@ std::function<uint32_t()> MapLongLongWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongWChar*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -22561,7 +22561,7 @@ void MapLongLongWCharPubSubType::deleteData(
 }
 
 bool MapLongLongWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -22570,7 +22570,7 @@ bool MapLongLongWCharPubSubType::getKey(
         return false;
     }
 
-    MapLongLongWChar* p_type = static_cast<MapLongLongWChar*>(data);
+    const MapLongLongWChar* p_type = static_cast<const MapLongLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -22638,11 +22638,11 @@ MapLongLongStringPubSubType::~MapLongLongStringPubSubType()
 }
 
 bool MapLongLongStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongString* p_type = static_cast<MapLongLongString*>(data);
+    const MapLongLongString* p_type = static_cast<const MapLongLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -22714,7 +22714,7 @@ bool MapLongLongStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -22731,7 +22731,7 @@ std::function<uint32_t()> MapLongLongStringPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongString*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -22754,7 +22754,7 @@ void MapLongLongStringPubSubType::deleteData(
 }
 
 bool MapLongLongStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -22763,7 +22763,7 @@ bool MapLongLongStringPubSubType::getKey(
         return false;
     }
 
-    MapLongLongString* p_type = static_cast<MapLongLongString*>(data);
+    const MapLongLongString* p_type = static_cast<const MapLongLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -22831,11 +22831,11 @@ MapLongLongWStringPubSubType::~MapLongLongWStringPubSubType()
 }
 
 bool MapLongLongWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongWString* p_type = static_cast<MapLongLongWString*>(data);
+    const MapLongLongWString* p_type = static_cast<const MapLongLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -22907,7 +22907,7 @@ bool MapLongLongWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -22924,7 +22924,7 @@ std::function<uint32_t()> MapLongLongWStringPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongWString*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -22947,7 +22947,7 @@ void MapLongLongWStringPubSubType::deleteData(
 }
 
 bool MapLongLongWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -22956,7 +22956,7 @@ bool MapLongLongWStringPubSubType::getKey(
         return false;
     }
 
-    MapLongLongWString* p_type = static_cast<MapLongLongWString*>(data);
+    const MapLongLongWString* p_type = static_cast<const MapLongLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23024,11 +23024,11 @@ MapLongLongInnerAliasBoundedStringHelperPubSubType::~MapLongLongInnerAliasBounde
 }
 
 bool MapLongLongInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasBoundedStringHelper* p_type = static_cast<MapLongLongInnerAliasBoundedStringHelper*>(data);
+    const MapLongLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapLongLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -23100,7 +23100,7 @@ bool MapLongLongInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -23117,7 +23117,7 @@ std::function<uint32_t()> MapLongLongInnerAliasBoundedStringHelperPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -23140,7 +23140,7 @@ void MapLongLongInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -23149,7 +23149,7 @@ bool MapLongLongInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasBoundedStringHelper* p_type = static_cast<MapLongLongInnerAliasBoundedStringHelper*>(data);
+    const MapLongLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapLongLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23217,11 +23217,11 @@ MapLongLongInnerAliasBoundedWStringHelperPubSubType::~MapLongLongInnerAliasBound
 }
 
 bool MapLongLongInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapLongLongInnerAliasBoundedWStringHelper*>(data);
+    const MapLongLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapLongLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -23293,7 +23293,7 @@ bool MapLongLongInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -23310,7 +23310,7 @@ std::function<uint32_t()> MapLongLongInnerAliasBoundedWStringHelperPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -23333,7 +23333,7 @@ void MapLongLongInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -23342,7 +23342,7 @@ bool MapLongLongInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapLongLongInnerAliasBoundedWStringHelper*>(data);
+    const MapLongLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapLongLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23410,11 +23410,11 @@ MapLongLongInnerEnumHelperPubSubType::~MapLongLongInnerEnumHelperPubSubType()
 }
 
 bool MapLongLongInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerEnumHelper* p_type = static_cast<MapLongLongInnerEnumHelper*>(data);
+    const MapLongLongInnerEnumHelper* p_type = static_cast<const MapLongLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -23486,7 +23486,7 @@ bool MapLongLongInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -23503,7 +23503,7 @@ std::function<uint32_t()> MapLongLongInnerEnumHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -23526,7 +23526,7 @@ void MapLongLongInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -23535,7 +23535,7 @@ bool MapLongLongInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerEnumHelper* p_type = static_cast<MapLongLongInnerEnumHelper*>(data);
+    const MapLongLongInnerEnumHelper* p_type = static_cast<const MapLongLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23603,11 +23603,11 @@ MapLongLongInnerBitMaskHelperPubSubType::~MapLongLongInnerBitMaskHelperPubSubTyp
 }
 
 bool MapLongLongInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerBitMaskHelper* p_type = static_cast<MapLongLongInnerBitMaskHelper*>(data);
+    const MapLongLongInnerBitMaskHelper* p_type = static_cast<const MapLongLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -23679,7 +23679,7 @@ bool MapLongLongInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -23696,7 +23696,7 @@ std::function<uint32_t()> MapLongLongInnerBitMaskHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -23719,7 +23719,7 @@ void MapLongLongInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -23728,7 +23728,7 @@ bool MapLongLongInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerBitMaskHelper* p_type = static_cast<MapLongLongInnerBitMaskHelper*>(data);
+    const MapLongLongInnerBitMaskHelper* p_type = static_cast<const MapLongLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23796,11 +23796,11 @@ MapLongLongInnerAliasHelperPubSubType::~MapLongLongInnerAliasHelperPubSubType()
 }
 
 bool MapLongLongInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasHelper* p_type = static_cast<MapLongLongInnerAliasHelper*>(data);
+    const MapLongLongInnerAliasHelper* p_type = static_cast<const MapLongLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -23872,7 +23872,7 @@ bool MapLongLongInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -23889,7 +23889,7 @@ std::function<uint32_t()> MapLongLongInnerAliasHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -23912,7 +23912,7 @@ void MapLongLongInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -23921,7 +23921,7 @@ bool MapLongLongInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasHelper* p_type = static_cast<MapLongLongInnerAliasHelper*>(data);
+    const MapLongLongInnerAliasHelper* p_type = static_cast<const MapLongLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -23989,11 +23989,11 @@ MapLongLongInnerAliasArrayHelperPubSubType::~MapLongLongInnerAliasArrayHelperPub
 }
 
 bool MapLongLongInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasArrayHelper* p_type = static_cast<MapLongLongInnerAliasArrayHelper*>(data);
+    const MapLongLongInnerAliasArrayHelper* p_type = static_cast<const MapLongLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -24065,7 +24065,7 @@ bool MapLongLongInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -24082,7 +24082,7 @@ std::function<uint32_t()> MapLongLongInnerAliasArrayHelperPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -24105,7 +24105,7 @@ void MapLongLongInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -24114,7 +24114,7 @@ bool MapLongLongInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasArrayHelper* p_type = static_cast<MapLongLongInnerAliasArrayHelper*>(data);
+    const MapLongLongInnerAliasArrayHelper* p_type = static_cast<const MapLongLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -24182,11 +24182,11 @@ MapLongLongInnerAliasSequenceHelperPubSubType::~MapLongLongInnerAliasSequenceHel
 }
 
 bool MapLongLongInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasSequenceHelper* p_type = static_cast<MapLongLongInnerAliasSequenceHelper*>(data);
+    const MapLongLongInnerAliasSequenceHelper* p_type = static_cast<const MapLongLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -24258,7 +24258,7 @@ bool MapLongLongInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -24275,7 +24275,7 @@ std::function<uint32_t()> MapLongLongInnerAliasSequenceHelperPubSubType::getSeri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -24298,7 +24298,7 @@ void MapLongLongInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -24307,7 +24307,7 @@ bool MapLongLongInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasSequenceHelper* p_type = static_cast<MapLongLongInnerAliasSequenceHelper*>(data);
+    const MapLongLongInnerAliasSequenceHelper* p_type = static_cast<const MapLongLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -24375,11 +24375,11 @@ MapLongLongInnerAliasMapHelperPubSubType::~MapLongLongInnerAliasMapHelperPubSubT
 }
 
 bool MapLongLongInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerAliasMapHelper* p_type = static_cast<MapLongLongInnerAliasMapHelper*>(data);
+    const MapLongLongInnerAliasMapHelper* p_type = static_cast<const MapLongLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -24451,7 +24451,7 @@ bool MapLongLongInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -24468,7 +24468,7 @@ std::function<uint32_t()> MapLongLongInnerAliasMapHelperPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -24491,7 +24491,7 @@ void MapLongLongInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -24500,7 +24500,7 @@ bool MapLongLongInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerAliasMapHelper* p_type = static_cast<MapLongLongInnerAliasMapHelper*>(data);
+    const MapLongLongInnerAliasMapHelper* p_type = static_cast<const MapLongLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -24568,11 +24568,11 @@ MapLongLongInnerUnionHelperPubSubType::~MapLongLongInnerUnionHelperPubSubType()
 }
 
 bool MapLongLongInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerUnionHelper* p_type = static_cast<MapLongLongInnerUnionHelper*>(data);
+    const MapLongLongInnerUnionHelper* p_type = static_cast<const MapLongLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -24644,7 +24644,7 @@ bool MapLongLongInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -24661,7 +24661,7 @@ std::function<uint32_t()> MapLongLongInnerUnionHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -24684,7 +24684,7 @@ void MapLongLongInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -24693,7 +24693,7 @@ bool MapLongLongInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerUnionHelper* p_type = static_cast<MapLongLongInnerUnionHelper*>(data);
+    const MapLongLongInnerUnionHelper* p_type = static_cast<const MapLongLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -24761,11 +24761,11 @@ MapLongLongInnerStructureHelperPubSubType::~MapLongLongInnerStructureHelperPubSu
 }
 
 bool MapLongLongInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerStructureHelper* p_type = static_cast<MapLongLongInnerStructureHelper*>(data);
+    const MapLongLongInnerStructureHelper* p_type = static_cast<const MapLongLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -24837,7 +24837,7 @@ bool MapLongLongInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -24854,7 +24854,7 @@ std::function<uint32_t()> MapLongLongInnerStructureHelperPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -24877,7 +24877,7 @@ void MapLongLongInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -24886,7 +24886,7 @@ bool MapLongLongInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerStructureHelper* p_type = static_cast<MapLongLongInnerStructureHelper*>(data);
+    const MapLongLongInnerStructureHelper* p_type = static_cast<const MapLongLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -24954,11 +24954,11 @@ MapLongLongInnerBitsetHelperPubSubType::~MapLongLongInnerBitsetHelperPubSubType(
 }
 
 bool MapLongLongInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapLongLongInnerBitsetHelper* p_type = static_cast<MapLongLongInnerBitsetHelper*>(data);
+    const MapLongLongInnerBitsetHelper* p_type = static_cast<const MapLongLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25030,7 +25030,7 @@ bool MapLongLongInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapLongLongInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -25047,7 +25047,7 @@ std::function<uint32_t()> MapLongLongInnerBitsetHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapLongLongInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapLongLongInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -25070,7 +25070,7 @@ void MapLongLongInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapLongLongInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -25079,7 +25079,7 @@ bool MapLongLongInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapLongLongInnerBitsetHelper* p_type = static_cast<MapLongLongInnerBitsetHelper*>(data);
+    const MapLongLongInnerBitsetHelper* p_type = static_cast<const MapLongLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -25147,11 +25147,11 @@ MapULongLongShortPubSubType::~MapULongLongShortPubSubType()
 }
 
 bool MapULongLongShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongShort* p_type = static_cast<MapULongLongShort*>(data);
+    const MapULongLongShort* p_type = static_cast<const MapULongLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25223,7 +25223,7 @@ bool MapULongLongShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -25240,7 +25240,7 @@ std::function<uint32_t()> MapULongLongShortPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongShort*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -25263,7 +25263,7 @@ void MapULongLongShortPubSubType::deleteData(
 }
 
 bool MapULongLongShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -25272,7 +25272,7 @@ bool MapULongLongShortPubSubType::getKey(
         return false;
     }
 
-    MapULongLongShort* p_type = static_cast<MapULongLongShort*>(data);
+    const MapULongLongShort* p_type = static_cast<const MapULongLongShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -25340,11 +25340,11 @@ MapULongLongUShortPubSubType::~MapULongLongUShortPubSubType()
 }
 
 bool MapULongLongUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongUShort* p_type = static_cast<MapULongLongUShort*>(data);
+    const MapULongLongUShort* p_type = static_cast<const MapULongLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25416,7 +25416,7 @@ bool MapULongLongUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -25433,7 +25433,7 @@ std::function<uint32_t()> MapULongLongUShortPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongUShort*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -25456,7 +25456,7 @@ void MapULongLongUShortPubSubType::deleteData(
 }
 
 bool MapULongLongUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -25465,7 +25465,7 @@ bool MapULongLongUShortPubSubType::getKey(
         return false;
     }
 
-    MapULongLongUShort* p_type = static_cast<MapULongLongUShort*>(data);
+    const MapULongLongUShort* p_type = static_cast<const MapULongLongUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -25533,11 +25533,11 @@ MapULongLongLongPubSubType::~MapULongLongLongPubSubType()
 }
 
 bool MapULongLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongLong* p_type = static_cast<MapULongLongLong*>(data);
+    const MapULongLongLong* p_type = static_cast<const MapULongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25609,7 +25609,7 @@ bool MapULongLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -25626,7 +25626,7 @@ std::function<uint32_t()> MapULongLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -25649,7 +25649,7 @@ void MapULongLongLongPubSubType::deleteData(
 }
 
 bool MapULongLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -25658,7 +25658,7 @@ bool MapULongLongLongPubSubType::getKey(
         return false;
     }
 
-    MapULongLongLong* p_type = static_cast<MapULongLongLong*>(data);
+    const MapULongLongLong* p_type = static_cast<const MapULongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -25726,11 +25726,11 @@ MapULongLongULongPubSubType::~MapULongLongULongPubSubType()
 }
 
 bool MapULongLongULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongULong* p_type = static_cast<MapULongLongULong*>(data);
+    const MapULongLongULong* p_type = static_cast<const MapULongLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25802,7 +25802,7 @@ bool MapULongLongULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -25819,7 +25819,7 @@ std::function<uint32_t()> MapULongLongULongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongULong*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -25842,7 +25842,7 @@ void MapULongLongULongPubSubType::deleteData(
 }
 
 bool MapULongLongULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -25851,7 +25851,7 @@ bool MapULongLongULongPubSubType::getKey(
         return false;
     }
 
-    MapULongLongULong* p_type = static_cast<MapULongLongULong*>(data);
+    const MapULongLongULong* p_type = static_cast<const MapULongLongULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -25919,11 +25919,11 @@ MapULongLongLongLongPubSubType::~MapULongLongLongLongPubSubType()
 }
 
 bool MapULongLongLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongLongLong* p_type = static_cast<MapULongLongLongLong*>(data);
+    const MapULongLongLongLong* p_type = static_cast<const MapULongLongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -25995,7 +25995,7 @@ bool MapULongLongLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26012,7 +26012,7 @@ std::function<uint32_t()> MapULongLongLongLongPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -26035,7 +26035,7 @@ void MapULongLongLongLongPubSubType::deleteData(
 }
 
 bool MapULongLongLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -26044,7 +26044,7 @@ bool MapULongLongLongLongPubSubType::getKey(
         return false;
     }
 
-    MapULongLongLongLong* p_type = static_cast<MapULongLongLongLong*>(data);
+    const MapULongLongLongLong* p_type = static_cast<const MapULongLongLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -26112,11 +26112,11 @@ MapULongLongULongLongPubSubType::~MapULongLongULongLongPubSubType()
 }
 
 bool MapULongLongULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongULongLong* p_type = static_cast<MapULongLongULongLong*>(data);
+    const MapULongLongULongLong* p_type = static_cast<const MapULongLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -26188,7 +26188,7 @@ bool MapULongLongULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26205,7 +26205,7 @@ std::function<uint32_t()> MapULongLongULongLongPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -26228,7 +26228,7 @@ void MapULongLongULongLongPubSubType::deleteData(
 }
 
 bool MapULongLongULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -26237,7 +26237,7 @@ bool MapULongLongULongLongPubSubType::getKey(
         return false;
     }
 
-    MapULongLongULongLong* p_type = static_cast<MapULongLongULongLong*>(data);
+    const MapULongLongULongLong* p_type = static_cast<const MapULongLongULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -26305,11 +26305,11 @@ MapULongLongFloatPubSubType::~MapULongLongFloatPubSubType()
 }
 
 bool MapULongLongFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongFloat* p_type = static_cast<MapULongLongFloat*>(data);
+    const MapULongLongFloat* p_type = static_cast<const MapULongLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -26381,7 +26381,7 @@ bool MapULongLongFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26398,7 +26398,7 @@ std::function<uint32_t()> MapULongLongFloatPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongFloat*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -26421,7 +26421,7 @@ void MapULongLongFloatPubSubType::deleteData(
 }
 
 bool MapULongLongFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -26430,7 +26430,7 @@ bool MapULongLongFloatPubSubType::getKey(
         return false;
     }
 
-    MapULongLongFloat* p_type = static_cast<MapULongLongFloat*>(data);
+    const MapULongLongFloat* p_type = static_cast<const MapULongLongFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -26498,11 +26498,11 @@ MapKeyULongLongValueDoublePubSubType::~MapKeyULongLongValueDoublePubSubType()
 }
 
 bool MapKeyULongLongValueDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapKeyULongLongValueDouble* p_type = static_cast<MapKeyULongLongValueDouble*>(data);
+    const MapKeyULongLongValueDouble* p_type = static_cast<const MapKeyULongLongValueDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -26574,7 +26574,7 @@ bool MapKeyULongLongValueDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapKeyULongLongValueDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26591,7 +26591,7 @@ std::function<uint32_t()> MapKeyULongLongValueDoublePubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapKeyULongLongValueDouble*>(data), current_alignment)) +
+                               *static_cast<const MapKeyULongLongValueDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -26614,7 +26614,7 @@ void MapKeyULongLongValueDoublePubSubType::deleteData(
 }
 
 bool MapKeyULongLongValueDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -26623,7 +26623,7 @@ bool MapKeyULongLongValueDoublePubSubType::getKey(
         return false;
     }
 
-    MapKeyULongLongValueDouble* p_type = static_cast<MapKeyULongLongValueDouble*>(data);
+    const MapKeyULongLongValueDouble* p_type = static_cast<const MapKeyULongLongValueDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -26691,11 +26691,11 @@ MapULongLongLongDoublePubSubType::~MapULongLongLongDoublePubSubType()
 }
 
 bool MapULongLongLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongLongDouble* p_type = static_cast<MapULongLongLongDouble*>(data);
+    const MapULongLongLongDouble* p_type = static_cast<const MapULongLongLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -26767,7 +26767,7 @@ bool MapULongLongLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26784,7 +26784,7 @@ std::function<uint32_t()> MapULongLongLongDoublePubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -26807,7 +26807,7 @@ void MapULongLongLongDoublePubSubType::deleteData(
 }
 
 bool MapULongLongLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -26816,7 +26816,7 @@ bool MapULongLongLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapULongLongLongDouble* p_type = static_cast<MapULongLongLongDouble*>(data);
+    const MapULongLongLongDouble* p_type = static_cast<const MapULongLongLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -26884,11 +26884,11 @@ MapULongLongBooleanPubSubType::~MapULongLongBooleanPubSubType()
 }
 
 bool MapULongLongBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongBoolean* p_type = static_cast<MapULongLongBoolean*>(data);
+    const MapULongLongBoolean* p_type = static_cast<const MapULongLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -26960,7 +26960,7 @@ bool MapULongLongBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -26977,7 +26977,7 @@ std::function<uint32_t()> MapULongLongBooleanPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27000,7 +27000,7 @@ void MapULongLongBooleanPubSubType::deleteData(
 }
 
 bool MapULongLongBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27009,7 +27009,7 @@ bool MapULongLongBooleanPubSubType::getKey(
         return false;
     }
 
-    MapULongLongBoolean* p_type = static_cast<MapULongLongBoolean*>(data);
+    const MapULongLongBoolean* p_type = static_cast<const MapULongLongBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -27077,11 +27077,11 @@ MapULongLongOctetPubSubType::~MapULongLongOctetPubSubType()
 }
 
 bool MapULongLongOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongOctet* p_type = static_cast<MapULongLongOctet*>(data);
+    const MapULongLongOctet* p_type = static_cast<const MapULongLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -27153,7 +27153,7 @@ bool MapULongLongOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -27170,7 +27170,7 @@ std::function<uint32_t()> MapULongLongOctetPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongOctet*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27193,7 +27193,7 @@ void MapULongLongOctetPubSubType::deleteData(
 }
 
 bool MapULongLongOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27202,7 +27202,7 @@ bool MapULongLongOctetPubSubType::getKey(
         return false;
     }
 
-    MapULongLongOctet* p_type = static_cast<MapULongLongOctet*>(data);
+    const MapULongLongOctet* p_type = static_cast<const MapULongLongOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -27270,11 +27270,11 @@ MapULongLongCharPubSubType::~MapULongLongCharPubSubType()
 }
 
 bool MapULongLongCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongChar* p_type = static_cast<MapULongLongChar*>(data);
+    const MapULongLongChar* p_type = static_cast<const MapULongLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -27346,7 +27346,7 @@ bool MapULongLongCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -27363,7 +27363,7 @@ std::function<uint32_t()> MapULongLongCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongChar*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27386,7 +27386,7 @@ void MapULongLongCharPubSubType::deleteData(
 }
 
 bool MapULongLongCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27395,7 +27395,7 @@ bool MapULongLongCharPubSubType::getKey(
         return false;
     }
 
-    MapULongLongChar* p_type = static_cast<MapULongLongChar*>(data);
+    const MapULongLongChar* p_type = static_cast<const MapULongLongChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -27463,11 +27463,11 @@ MapULongLongWCharPubSubType::~MapULongLongWCharPubSubType()
 }
 
 bool MapULongLongWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongWChar* p_type = static_cast<MapULongLongWChar*>(data);
+    const MapULongLongWChar* p_type = static_cast<const MapULongLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -27539,7 +27539,7 @@ bool MapULongLongWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -27556,7 +27556,7 @@ std::function<uint32_t()> MapULongLongWCharPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongWChar*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27579,7 +27579,7 @@ void MapULongLongWCharPubSubType::deleteData(
 }
 
 bool MapULongLongWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27588,7 +27588,7 @@ bool MapULongLongWCharPubSubType::getKey(
         return false;
     }
 
-    MapULongLongWChar* p_type = static_cast<MapULongLongWChar*>(data);
+    const MapULongLongWChar* p_type = static_cast<const MapULongLongWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -27656,11 +27656,11 @@ MapULongLongStringPubSubType::~MapULongLongStringPubSubType()
 }
 
 bool MapULongLongStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongString* p_type = static_cast<MapULongLongString*>(data);
+    const MapULongLongString* p_type = static_cast<const MapULongLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -27732,7 +27732,7 @@ bool MapULongLongStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -27749,7 +27749,7 @@ std::function<uint32_t()> MapULongLongStringPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongString*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27772,7 +27772,7 @@ void MapULongLongStringPubSubType::deleteData(
 }
 
 bool MapULongLongStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27781,7 +27781,7 @@ bool MapULongLongStringPubSubType::getKey(
         return false;
     }
 
-    MapULongLongString* p_type = static_cast<MapULongLongString*>(data);
+    const MapULongLongString* p_type = static_cast<const MapULongLongString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -27849,11 +27849,11 @@ MapULongLongWStringPubSubType::~MapULongLongWStringPubSubType()
 }
 
 bool MapULongLongWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongWString* p_type = static_cast<MapULongLongWString*>(data);
+    const MapULongLongWString* p_type = static_cast<const MapULongLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -27925,7 +27925,7 @@ bool MapULongLongWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -27942,7 +27942,7 @@ std::function<uint32_t()> MapULongLongWStringPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongWString*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -27965,7 +27965,7 @@ void MapULongLongWStringPubSubType::deleteData(
 }
 
 bool MapULongLongWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -27974,7 +27974,7 @@ bool MapULongLongWStringPubSubType::getKey(
         return false;
     }
 
-    MapULongLongWString* p_type = static_cast<MapULongLongWString*>(data);
+    const MapULongLongWString* p_type = static_cast<const MapULongLongWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -28042,11 +28042,11 @@ MapULongLongInnerAliasBoundedStringHelperPubSubType::~MapULongLongInnerAliasBoun
 }
 
 bool MapULongLongInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasBoundedStringHelper* p_type = static_cast<MapULongLongInnerAliasBoundedStringHelper*>(data);
+    const MapULongLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapULongLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -28118,7 +28118,7 @@ bool MapULongLongInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -28135,7 +28135,7 @@ std::function<uint32_t()> MapULongLongInnerAliasBoundedStringHelperPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -28158,7 +28158,7 @@ void MapULongLongInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -28167,7 +28167,7 @@ bool MapULongLongInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasBoundedStringHelper* p_type = static_cast<MapULongLongInnerAliasBoundedStringHelper*>(data);
+    const MapULongLongInnerAliasBoundedStringHelper* p_type = static_cast<const MapULongLongInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -28235,11 +28235,11 @@ MapULongLongInnerAliasBoundedWStringHelperPubSubType::~MapULongLongInnerAliasBou
 }
 
 bool MapULongLongInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapULongLongInnerAliasBoundedWStringHelper*>(data);
+    const MapULongLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapULongLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -28311,7 +28311,7 @@ bool MapULongLongInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -28328,7 +28328,7 @@ std::function<uint32_t()> MapULongLongInnerAliasBoundedWStringHelperPubSubType::
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -28351,7 +28351,7 @@ void MapULongLongInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -28360,7 +28360,7 @@ bool MapULongLongInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasBoundedWStringHelper* p_type = static_cast<MapULongLongInnerAliasBoundedWStringHelper*>(data);
+    const MapULongLongInnerAliasBoundedWStringHelper* p_type = static_cast<const MapULongLongInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -28428,11 +28428,11 @@ MapULongLongInnerEnumHelperPubSubType::~MapULongLongInnerEnumHelperPubSubType()
 }
 
 bool MapULongLongInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerEnumHelper* p_type = static_cast<MapULongLongInnerEnumHelper*>(data);
+    const MapULongLongInnerEnumHelper* p_type = static_cast<const MapULongLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -28504,7 +28504,7 @@ bool MapULongLongInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -28521,7 +28521,7 @@ std::function<uint32_t()> MapULongLongInnerEnumHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -28544,7 +28544,7 @@ void MapULongLongInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -28553,7 +28553,7 @@ bool MapULongLongInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerEnumHelper* p_type = static_cast<MapULongLongInnerEnumHelper*>(data);
+    const MapULongLongInnerEnumHelper* p_type = static_cast<const MapULongLongInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -28621,11 +28621,11 @@ MapULongLongInnerBitMaskHelperPubSubType::~MapULongLongInnerBitMaskHelperPubSubT
 }
 
 bool MapULongLongInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerBitMaskHelper* p_type = static_cast<MapULongLongInnerBitMaskHelper*>(data);
+    const MapULongLongInnerBitMaskHelper* p_type = static_cast<const MapULongLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -28697,7 +28697,7 @@ bool MapULongLongInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -28714,7 +28714,7 @@ std::function<uint32_t()> MapULongLongInnerBitMaskHelperPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -28737,7 +28737,7 @@ void MapULongLongInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -28746,7 +28746,7 @@ bool MapULongLongInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerBitMaskHelper* p_type = static_cast<MapULongLongInnerBitMaskHelper*>(data);
+    const MapULongLongInnerBitMaskHelper* p_type = static_cast<const MapULongLongInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -28814,11 +28814,11 @@ MapULongLongInnerAliasHelperPubSubType::~MapULongLongInnerAliasHelperPubSubType(
 }
 
 bool MapULongLongInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasHelper* p_type = static_cast<MapULongLongInnerAliasHelper*>(data);
+    const MapULongLongInnerAliasHelper* p_type = static_cast<const MapULongLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -28890,7 +28890,7 @@ bool MapULongLongInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -28907,7 +28907,7 @@ std::function<uint32_t()> MapULongLongInnerAliasHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -28930,7 +28930,7 @@ void MapULongLongInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -28939,7 +28939,7 @@ bool MapULongLongInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasHelper* p_type = static_cast<MapULongLongInnerAliasHelper*>(data);
+    const MapULongLongInnerAliasHelper* p_type = static_cast<const MapULongLongInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29007,11 +29007,11 @@ MapULongLongInnerAliasArrayHelperPubSubType::~MapULongLongInnerAliasArrayHelperP
 }
 
 bool MapULongLongInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasArrayHelper* p_type = static_cast<MapULongLongInnerAliasArrayHelper*>(data);
+    const MapULongLongInnerAliasArrayHelper* p_type = static_cast<const MapULongLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -29083,7 +29083,7 @@ bool MapULongLongInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -29100,7 +29100,7 @@ std::function<uint32_t()> MapULongLongInnerAliasArrayHelperPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -29123,7 +29123,7 @@ void MapULongLongInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -29132,7 +29132,7 @@ bool MapULongLongInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasArrayHelper* p_type = static_cast<MapULongLongInnerAliasArrayHelper*>(data);
+    const MapULongLongInnerAliasArrayHelper* p_type = static_cast<const MapULongLongInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29200,11 +29200,11 @@ MapULongLongInnerAliasSequenceHelperPubSubType::~MapULongLongInnerAliasSequenceH
 }
 
 bool MapULongLongInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasSequenceHelper* p_type = static_cast<MapULongLongInnerAliasSequenceHelper*>(data);
+    const MapULongLongInnerAliasSequenceHelper* p_type = static_cast<const MapULongLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -29276,7 +29276,7 @@ bool MapULongLongInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -29293,7 +29293,7 @@ std::function<uint32_t()> MapULongLongInnerAliasSequenceHelperPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -29316,7 +29316,7 @@ void MapULongLongInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -29325,7 +29325,7 @@ bool MapULongLongInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasSequenceHelper* p_type = static_cast<MapULongLongInnerAliasSequenceHelper*>(data);
+    const MapULongLongInnerAliasSequenceHelper* p_type = static_cast<const MapULongLongInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29393,11 +29393,11 @@ MapULongLongInnerAliasMapHelperPubSubType::~MapULongLongInnerAliasMapHelperPubSu
 }
 
 bool MapULongLongInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerAliasMapHelper* p_type = static_cast<MapULongLongInnerAliasMapHelper*>(data);
+    const MapULongLongInnerAliasMapHelper* p_type = static_cast<const MapULongLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -29469,7 +29469,7 @@ bool MapULongLongInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -29486,7 +29486,7 @@ std::function<uint32_t()> MapULongLongInnerAliasMapHelperPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -29509,7 +29509,7 @@ void MapULongLongInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -29518,7 +29518,7 @@ bool MapULongLongInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerAliasMapHelper* p_type = static_cast<MapULongLongInnerAliasMapHelper*>(data);
+    const MapULongLongInnerAliasMapHelper* p_type = static_cast<const MapULongLongInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29586,11 +29586,11 @@ MapULongLongInnerUnionHelperPubSubType::~MapULongLongInnerUnionHelperPubSubType(
 }
 
 bool MapULongLongInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerUnionHelper* p_type = static_cast<MapULongLongInnerUnionHelper*>(data);
+    const MapULongLongInnerUnionHelper* p_type = static_cast<const MapULongLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -29662,7 +29662,7 @@ bool MapULongLongInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -29679,7 +29679,7 @@ std::function<uint32_t()> MapULongLongInnerUnionHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -29702,7 +29702,7 @@ void MapULongLongInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -29711,7 +29711,7 @@ bool MapULongLongInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerUnionHelper* p_type = static_cast<MapULongLongInnerUnionHelper*>(data);
+    const MapULongLongInnerUnionHelper* p_type = static_cast<const MapULongLongInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29779,11 +29779,11 @@ MapULongLongInnerStructureHelperPubSubType::~MapULongLongInnerStructureHelperPub
 }
 
 bool MapULongLongInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerStructureHelper* p_type = static_cast<MapULongLongInnerStructureHelper*>(data);
+    const MapULongLongInnerStructureHelper* p_type = static_cast<const MapULongLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -29855,7 +29855,7 @@ bool MapULongLongInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -29872,7 +29872,7 @@ std::function<uint32_t()> MapULongLongInnerStructureHelperPubSubType::getSeriali
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -29895,7 +29895,7 @@ void MapULongLongInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -29904,7 +29904,7 @@ bool MapULongLongInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerStructureHelper* p_type = static_cast<MapULongLongInnerStructureHelper*>(data);
+    const MapULongLongInnerStructureHelper* p_type = static_cast<const MapULongLongInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -29972,11 +29972,11 @@ MapULongLongInnerBitsetHelperPubSubType::~MapULongLongInnerBitsetHelperPubSubTyp
 }
 
 bool MapULongLongInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapULongLongInnerBitsetHelper* p_type = static_cast<MapULongLongInnerBitsetHelper*>(data);
+    const MapULongLongInnerBitsetHelper* p_type = static_cast<const MapULongLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -30048,7 +30048,7 @@ bool MapULongLongInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapULongLongInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -30065,7 +30065,7 @@ std::function<uint32_t()> MapULongLongInnerBitsetHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapULongLongInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapULongLongInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -30088,7 +30088,7 @@ void MapULongLongInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapULongLongInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -30097,7 +30097,7 @@ bool MapULongLongInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapULongLongInnerBitsetHelper* p_type = static_cast<MapULongLongInnerBitsetHelper*>(data);
+    const MapULongLongInnerBitsetHelper* p_type = static_cast<const MapULongLongInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -30165,11 +30165,11 @@ MapStringShortPubSubType::~MapStringShortPubSubType()
 }
 
 bool MapStringShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringShort* p_type = static_cast<MapStringShort*>(data);
+    const MapStringShort* p_type = static_cast<const MapStringShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -30241,7 +30241,7 @@ bool MapStringShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -30258,7 +30258,7 @@ std::function<uint32_t()> MapStringShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringShort*>(data), current_alignment)) +
+                               *static_cast<const MapStringShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -30281,7 +30281,7 @@ void MapStringShortPubSubType::deleteData(
 }
 
 bool MapStringShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -30290,7 +30290,7 @@ bool MapStringShortPubSubType::getKey(
         return false;
     }
 
-    MapStringShort* p_type = static_cast<MapStringShort*>(data);
+    const MapStringShort* p_type = static_cast<const MapStringShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -30358,11 +30358,11 @@ MapStringUShortPubSubType::~MapStringUShortPubSubType()
 }
 
 bool MapStringUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringUShort* p_type = static_cast<MapStringUShort*>(data);
+    const MapStringUShort* p_type = static_cast<const MapStringUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -30434,7 +30434,7 @@ bool MapStringUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -30451,7 +30451,7 @@ std::function<uint32_t()> MapStringUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringUShort*>(data), current_alignment)) +
+                               *static_cast<const MapStringUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -30474,7 +30474,7 @@ void MapStringUShortPubSubType::deleteData(
 }
 
 bool MapStringUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -30483,7 +30483,7 @@ bool MapStringUShortPubSubType::getKey(
         return false;
     }
 
-    MapStringUShort* p_type = static_cast<MapStringUShort*>(data);
+    const MapStringUShort* p_type = static_cast<const MapStringUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -30551,11 +30551,11 @@ MapStringLongPubSubType::~MapStringLongPubSubType()
 }
 
 bool MapStringLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringLong* p_type = static_cast<MapStringLong*>(data);
+    const MapStringLong* p_type = static_cast<const MapStringLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -30627,7 +30627,7 @@ bool MapStringLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -30644,7 +30644,7 @@ std::function<uint32_t()> MapStringLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringLong*>(data), current_alignment)) +
+                               *static_cast<const MapStringLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -30667,7 +30667,7 @@ void MapStringLongPubSubType::deleteData(
 }
 
 bool MapStringLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -30676,7 +30676,7 @@ bool MapStringLongPubSubType::getKey(
         return false;
     }
 
-    MapStringLong* p_type = static_cast<MapStringLong*>(data);
+    const MapStringLong* p_type = static_cast<const MapStringLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -30744,11 +30744,11 @@ MapStringULongPubSubType::~MapStringULongPubSubType()
 }
 
 bool MapStringULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringULong* p_type = static_cast<MapStringULong*>(data);
+    const MapStringULong* p_type = static_cast<const MapStringULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -30820,7 +30820,7 @@ bool MapStringULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -30837,7 +30837,7 @@ std::function<uint32_t()> MapStringULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringULong*>(data), current_alignment)) +
+                               *static_cast<const MapStringULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -30860,7 +30860,7 @@ void MapStringULongPubSubType::deleteData(
 }
 
 bool MapStringULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -30869,7 +30869,7 @@ bool MapStringULongPubSubType::getKey(
         return false;
     }
 
-    MapStringULong* p_type = static_cast<MapStringULong*>(data);
+    const MapStringULong* p_type = static_cast<const MapStringULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -30937,11 +30937,11 @@ MapStringLongLongPubSubType::~MapStringLongLongPubSubType()
 }
 
 bool MapStringLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringLongLong* p_type = static_cast<MapStringLongLong*>(data);
+    const MapStringLongLong* p_type = static_cast<const MapStringLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31013,7 +31013,7 @@ bool MapStringLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31030,7 +31030,7 @@ std::function<uint32_t()> MapStringLongLongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapStringLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -31053,7 +31053,7 @@ void MapStringLongLongPubSubType::deleteData(
 }
 
 bool MapStringLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -31062,7 +31062,7 @@ bool MapStringLongLongPubSubType::getKey(
         return false;
     }
 
-    MapStringLongLong* p_type = static_cast<MapStringLongLong*>(data);
+    const MapStringLongLong* p_type = static_cast<const MapStringLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -31130,11 +31130,11 @@ MapStringULongLongPubSubType::~MapStringULongLongPubSubType()
 }
 
 bool MapStringULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringULongLong* p_type = static_cast<MapStringULongLong*>(data);
+    const MapStringULongLong* p_type = static_cast<const MapStringULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31206,7 +31206,7 @@ bool MapStringULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31223,7 +31223,7 @@ std::function<uint32_t()> MapStringULongLongPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapStringULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -31246,7 +31246,7 @@ void MapStringULongLongPubSubType::deleteData(
 }
 
 bool MapStringULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -31255,7 +31255,7 @@ bool MapStringULongLongPubSubType::getKey(
         return false;
     }
 
-    MapStringULongLong* p_type = static_cast<MapStringULongLong*>(data);
+    const MapStringULongLong* p_type = static_cast<const MapStringULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -31323,11 +31323,11 @@ MapStringFloatPubSubType::~MapStringFloatPubSubType()
 }
 
 bool MapStringFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringFloat* p_type = static_cast<MapStringFloat*>(data);
+    const MapStringFloat* p_type = static_cast<const MapStringFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31399,7 +31399,7 @@ bool MapStringFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31416,7 +31416,7 @@ std::function<uint32_t()> MapStringFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringFloat*>(data), current_alignment)) +
+                               *static_cast<const MapStringFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -31439,7 +31439,7 @@ void MapStringFloatPubSubType::deleteData(
 }
 
 bool MapStringFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -31448,7 +31448,7 @@ bool MapStringFloatPubSubType::getKey(
         return false;
     }
 
-    MapStringFloat* p_type = static_cast<MapStringFloat*>(data);
+    const MapStringFloat* p_type = static_cast<const MapStringFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -31516,11 +31516,11 @@ MapStringDoublePubSubType::~MapStringDoublePubSubType()
 }
 
 bool MapStringDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringDouble* p_type = static_cast<MapStringDouble*>(data);
+    const MapStringDouble* p_type = static_cast<const MapStringDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31592,7 +31592,7 @@ bool MapStringDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31609,7 +31609,7 @@ std::function<uint32_t()> MapStringDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringDouble*>(data), current_alignment)) +
+                               *static_cast<const MapStringDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -31632,7 +31632,7 @@ void MapStringDoublePubSubType::deleteData(
 }
 
 bool MapStringDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -31641,7 +31641,7 @@ bool MapStringDoublePubSubType::getKey(
         return false;
     }
 
-    MapStringDouble* p_type = static_cast<MapStringDouble*>(data);
+    const MapStringDouble* p_type = static_cast<const MapStringDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -31709,11 +31709,11 @@ MapStringLongDoublePubSubType::~MapStringLongDoublePubSubType()
 }
 
 bool MapStringLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringLongDouble* p_type = static_cast<MapStringLongDouble*>(data);
+    const MapStringLongDouble* p_type = static_cast<const MapStringLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31785,7 +31785,7 @@ bool MapStringLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31802,7 +31802,7 @@ std::function<uint32_t()> MapStringLongDoublePubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapStringLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -31825,7 +31825,7 @@ void MapStringLongDoublePubSubType::deleteData(
 }
 
 bool MapStringLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -31834,7 +31834,7 @@ bool MapStringLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapStringLongDouble* p_type = static_cast<MapStringLongDouble*>(data);
+    const MapStringLongDouble* p_type = static_cast<const MapStringLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -31902,11 +31902,11 @@ MapStringBooleanPubSubType::~MapStringBooleanPubSubType()
 }
 
 bool MapStringBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringBoolean* p_type = static_cast<MapStringBoolean*>(data);
+    const MapStringBoolean* p_type = static_cast<const MapStringBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -31978,7 +31978,7 @@ bool MapStringBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -31995,7 +31995,7 @@ std::function<uint32_t()> MapStringBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapStringBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32018,7 +32018,7 @@ void MapStringBooleanPubSubType::deleteData(
 }
 
 bool MapStringBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32027,7 +32027,7 @@ bool MapStringBooleanPubSubType::getKey(
         return false;
     }
 
-    MapStringBoolean* p_type = static_cast<MapStringBoolean*>(data);
+    const MapStringBoolean* p_type = static_cast<const MapStringBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -32095,11 +32095,11 @@ MapStringOctetPubSubType::~MapStringOctetPubSubType()
 }
 
 bool MapStringOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringOctet* p_type = static_cast<MapStringOctet*>(data);
+    const MapStringOctet* p_type = static_cast<const MapStringOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -32171,7 +32171,7 @@ bool MapStringOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -32188,7 +32188,7 @@ std::function<uint32_t()> MapStringOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringOctet*>(data), current_alignment)) +
+                               *static_cast<const MapStringOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32211,7 +32211,7 @@ void MapStringOctetPubSubType::deleteData(
 }
 
 bool MapStringOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32220,7 +32220,7 @@ bool MapStringOctetPubSubType::getKey(
         return false;
     }
 
-    MapStringOctet* p_type = static_cast<MapStringOctet*>(data);
+    const MapStringOctet* p_type = static_cast<const MapStringOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -32288,11 +32288,11 @@ MapStringCharPubSubType::~MapStringCharPubSubType()
 }
 
 bool MapStringCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringChar* p_type = static_cast<MapStringChar*>(data);
+    const MapStringChar* p_type = static_cast<const MapStringChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -32364,7 +32364,7 @@ bool MapStringCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -32381,7 +32381,7 @@ std::function<uint32_t()> MapStringCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringChar*>(data), current_alignment)) +
+                               *static_cast<const MapStringChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32404,7 +32404,7 @@ void MapStringCharPubSubType::deleteData(
 }
 
 bool MapStringCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32413,7 +32413,7 @@ bool MapStringCharPubSubType::getKey(
         return false;
     }
 
-    MapStringChar* p_type = static_cast<MapStringChar*>(data);
+    const MapStringChar* p_type = static_cast<const MapStringChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -32481,11 +32481,11 @@ MapStringWCharPubSubType::~MapStringWCharPubSubType()
 }
 
 bool MapStringWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringWChar* p_type = static_cast<MapStringWChar*>(data);
+    const MapStringWChar* p_type = static_cast<const MapStringWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -32557,7 +32557,7 @@ bool MapStringWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -32574,7 +32574,7 @@ std::function<uint32_t()> MapStringWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringWChar*>(data), current_alignment)) +
+                               *static_cast<const MapStringWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32597,7 +32597,7 @@ void MapStringWCharPubSubType::deleteData(
 }
 
 bool MapStringWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32606,7 +32606,7 @@ bool MapStringWCharPubSubType::getKey(
         return false;
     }
 
-    MapStringWChar* p_type = static_cast<MapStringWChar*>(data);
+    const MapStringWChar* p_type = static_cast<const MapStringWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -32674,11 +32674,11 @@ MapStringStringPubSubType::~MapStringStringPubSubType()
 }
 
 bool MapStringStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringString* p_type = static_cast<MapStringString*>(data);
+    const MapStringString* p_type = static_cast<const MapStringString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -32750,7 +32750,7 @@ bool MapStringStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -32767,7 +32767,7 @@ std::function<uint32_t()> MapStringStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringString*>(data), current_alignment)) +
+                               *static_cast<const MapStringString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32790,7 +32790,7 @@ void MapStringStringPubSubType::deleteData(
 }
 
 bool MapStringStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32799,7 +32799,7 @@ bool MapStringStringPubSubType::getKey(
         return false;
     }
 
-    MapStringString* p_type = static_cast<MapStringString*>(data);
+    const MapStringString* p_type = static_cast<const MapStringString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -32867,11 +32867,11 @@ MapStringWStringPubSubType::~MapStringWStringPubSubType()
 }
 
 bool MapStringWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringWString* p_type = static_cast<MapStringWString*>(data);
+    const MapStringWString* p_type = static_cast<const MapStringWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -32943,7 +32943,7 @@ bool MapStringWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -32960,7 +32960,7 @@ std::function<uint32_t()> MapStringWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringWString*>(data), current_alignment)) +
+                               *static_cast<const MapStringWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -32983,7 +32983,7 @@ void MapStringWStringPubSubType::deleteData(
 }
 
 bool MapStringWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -32992,7 +32992,7 @@ bool MapStringWStringPubSubType::getKey(
         return false;
     }
 
-    MapStringWString* p_type = static_cast<MapStringWString*>(data);
+    const MapStringWString* p_type = static_cast<const MapStringWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -33060,11 +33060,11 @@ MapStringInnerAliasBoundedStringHelperPubSubType::~MapStringInnerAliasBoundedStr
 }
 
 bool MapStringInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasBoundedStringHelper* p_type = static_cast<MapStringInnerAliasBoundedStringHelper*>(data);
+    const MapStringInnerAliasBoundedStringHelper* p_type = static_cast<const MapStringInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -33136,7 +33136,7 @@ bool MapStringInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -33153,7 +33153,7 @@ std::function<uint32_t()> MapStringInnerAliasBoundedStringHelperPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -33176,7 +33176,7 @@ void MapStringInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -33185,7 +33185,7 @@ bool MapStringInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasBoundedStringHelper* p_type = static_cast<MapStringInnerAliasBoundedStringHelper*>(data);
+    const MapStringInnerAliasBoundedStringHelper* p_type = static_cast<const MapStringInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -33253,11 +33253,11 @@ MapStringInnerAliasBoundedWStringHelperPubSubType::~MapStringInnerAliasBoundedWS
 }
 
 bool MapStringInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasBoundedWStringHelper* p_type = static_cast<MapStringInnerAliasBoundedWStringHelper*>(data);
+    const MapStringInnerAliasBoundedWStringHelper* p_type = static_cast<const MapStringInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -33329,7 +33329,7 @@ bool MapStringInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -33346,7 +33346,7 @@ std::function<uint32_t()> MapStringInnerAliasBoundedWStringHelperPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -33369,7 +33369,7 @@ void MapStringInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -33378,7 +33378,7 @@ bool MapStringInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasBoundedWStringHelper* p_type = static_cast<MapStringInnerAliasBoundedWStringHelper*>(data);
+    const MapStringInnerAliasBoundedWStringHelper* p_type = static_cast<const MapStringInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -33446,11 +33446,11 @@ MapStringInnerEnumHelperPubSubType::~MapStringInnerEnumHelperPubSubType()
 }
 
 bool MapStringInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerEnumHelper* p_type = static_cast<MapStringInnerEnumHelper*>(data);
+    const MapStringInnerEnumHelper* p_type = static_cast<const MapStringInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -33522,7 +33522,7 @@ bool MapStringInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -33539,7 +33539,7 @@ std::function<uint32_t()> MapStringInnerEnumHelperPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -33562,7 +33562,7 @@ void MapStringInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -33571,7 +33571,7 @@ bool MapStringInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerEnumHelper* p_type = static_cast<MapStringInnerEnumHelper*>(data);
+    const MapStringInnerEnumHelper* p_type = static_cast<const MapStringInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -33639,11 +33639,11 @@ MapStringInnerBitMaskHelperPubSubType::~MapStringInnerBitMaskHelperPubSubType()
 }
 
 bool MapStringInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerBitMaskHelper* p_type = static_cast<MapStringInnerBitMaskHelper*>(data);
+    const MapStringInnerBitMaskHelper* p_type = static_cast<const MapStringInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -33715,7 +33715,7 @@ bool MapStringInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -33732,7 +33732,7 @@ std::function<uint32_t()> MapStringInnerBitMaskHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -33755,7 +33755,7 @@ void MapStringInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -33764,7 +33764,7 @@ bool MapStringInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerBitMaskHelper* p_type = static_cast<MapStringInnerBitMaskHelper*>(data);
+    const MapStringInnerBitMaskHelper* p_type = static_cast<const MapStringInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -33832,11 +33832,11 @@ MapStringInnerAliasHelperPubSubType::~MapStringInnerAliasHelperPubSubType()
 }
 
 bool MapStringInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasHelper* p_type = static_cast<MapStringInnerAliasHelper*>(data);
+    const MapStringInnerAliasHelper* p_type = static_cast<const MapStringInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -33908,7 +33908,7 @@ bool MapStringInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -33925,7 +33925,7 @@ std::function<uint32_t()> MapStringInnerAliasHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -33948,7 +33948,7 @@ void MapStringInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -33957,7 +33957,7 @@ bool MapStringInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasHelper* p_type = static_cast<MapStringInnerAliasHelper*>(data);
+    const MapStringInnerAliasHelper* p_type = static_cast<const MapStringInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34025,11 +34025,11 @@ MapStringInnerAliasArrayHelperPubSubType::~MapStringInnerAliasArrayHelperPubSubT
 }
 
 bool MapStringInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasArrayHelper* p_type = static_cast<MapStringInnerAliasArrayHelper*>(data);
+    const MapStringInnerAliasArrayHelper* p_type = static_cast<const MapStringInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -34101,7 +34101,7 @@ bool MapStringInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -34118,7 +34118,7 @@ std::function<uint32_t()> MapStringInnerAliasArrayHelperPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -34141,7 +34141,7 @@ void MapStringInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -34150,7 +34150,7 @@ bool MapStringInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasArrayHelper* p_type = static_cast<MapStringInnerAliasArrayHelper*>(data);
+    const MapStringInnerAliasArrayHelper* p_type = static_cast<const MapStringInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34218,11 +34218,11 @@ MapStringInnerAliasSequenceHelperPubSubType::~MapStringInnerAliasSequenceHelperP
 }
 
 bool MapStringInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasSequenceHelper* p_type = static_cast<MapStringInnerAliasSequenceHelper*>(data);
+    const MapStringInnerAliasSequenceHelper* p_type = static_cast<const MapStringInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -34294,7 +34294,7 @@ bool MapStringInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -34311,7 +34311,7 @@ std::function<uint32_t()> MapStringInnerAliasSequenceHelperPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -34334,7 +34334,7 @@ void MapStringInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -34343,7 +34343,7 @@ bool MapStringInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasSequenceHelper* p_type = static_cast<MapStringInnerAliasSequenceHelper*>(data);
+    const MapStringInnerAliasSequenceHelper* p_type = static_cast<const MapStringInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34411,11 +34411,11 @@ MapStringInnerAliasMapHelperPubSubType::~MapStringInnerAliasMapHelperPubSubType(
 }
 
 bool MapStringInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerAliasMapHelper* p_type = static_cast<MapStringInnerAliasMapHelper*>(data);
+    const MapStringInnerAliasMapHelper* p_type = static_cast<const MapStringInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -34487,7 +34487,7 @@ bool MapStringInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -34504,7 +34504,7 @@ std::function<uint32_t()> MapStringInnerAliasMapHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -34527,7 +34527,7 @@ void MapStringInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -34536,7 +34536,7 @@ bool MapStringInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerAliasMapHelper* p_type = static_cast<MapStringInnerAliasMapHelper*>(data);
+    const MapStringInnerAliasMapHelper* p_type = static_cast<const MapStringInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34604,11 +34604,11 @@ MapStringInnerUnionHelperPubSubType::~MapStringInnerUnionHelperPubSubType()
 }
 
 bool MapStringInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerUnionHelper* p_type = static_cast<MapStringInnerUnionHelper*>(data);
+    const MapStringInnerUnionHelper* p_type = static_cast<const MapStringInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -34680,7 +34680,7 @@ bool MapStringInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -34697,7 +34697,7 @@ std::function<uint32_t()> MapStringInnerUnionHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -34720,7 +34720,7 @@ void MapStringInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -34729,7 +34729,7 @@ bool MapStringInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerUnionHelper* p_type = static_cast<MapStringInnerUnionHelper*>(data);
+    const MapStringInnerUnionHelper* p_type = static_cast<const MapStringInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34797,11 +34797,11 @@ MapStringInnerStructureHelperPubSubType::~MapStringInnerStructureHelperPubSubTyp
 }
 
 bool MapStringInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerStructureHelper* p_type = static_cast<MapStringInnerStructureHelper*>(data);
+    const MapStringInnerStructureHelper* p_type = static_cast<const MapStringInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -34873,7 +34873,7 @@ bool MapStringInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -34890,7 +34890,7 @@ std::function<uint32_t()> MapStringInnerStructureHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -34913,7 +34913,7 @@ void MapStringInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -34922,7 +34922,7 @@ bool MapStringInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerStructureHelper* p_type = static_cast<MapStringInnerStructureHelper*>(data);
+    const MapStringInnerStructureHelper* p_type = static_cast<const MapStringInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -34990,11 +34990,11 @@ MapStringInnerBitsetHelperPubSubType::~MapStringInnerBitsetHelperPubSubType()
 }
 
 bool MapStringInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapStringInnerBitsetHelper* p_type = static_cast<MapStringInnerBitsetHelper*>(data);
+    const MapStringInnerBitsetHelper* p_type = static_cast<const MapStringInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -35066,7 +35066,7 @@ bool MapStringInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapStringInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -35083,7 +35083,7 @@ std::function<uint32_t()> MapStringInnerBitsetHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapStringInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapStringInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -35106,7 +35106,7 @@ void MapStringInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapStringInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -35115,7 +35115,7 @@ bool MapStringInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapStringInnerBitsetHelper* p_type = static_cast<MapStringInnerBitsetHelper*>(data);
+    const MapStringInnerBitsetHelper* p_type = static_cast<const MapStringInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -35183,11 +35183,11 @@ MapWStringShortPubSubType::~MapWStringShortPubSubType()
 }
 
 bool MapWStringShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringShort* p_type = static_cast<MapWStringShort*>(data);
+    const MapWStringShort* p_type = static_cast<const MapWStringShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -35259,7 +35259,7 @@ bool MapWStringShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -35276,7 +35276,7 @@ std::function<uint32_t()> MapWStringShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringShort*>(data), current_alignment)) +
+                               *static_cast<const MapWStringShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -35299,7 +35299,7 @@ void MapWStringShortPubSubType::deleteData(
 }
 
 bool MapWStringShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -35308,7 +35308,7 @@ bool MapWStringShortPubSubType::getKey(
         return false;
     }
 
-    MapWStringShort* p_type = static_cast<MapWStringShort*>(data);
+    const MapWStringShort* p_type = static_cast<const MapWStringShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -35376,11 +35376,11 @@ MapWStringUShortPubSubType::~MapWStringUShortPubSubType()
 }
 
 bool MapWStringUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringUShort* p_type = static_cast<MapWStringUShort*>(data);
+    const MapWStringUShort* p_type = static_cast<const MapWStringUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -35452,7 +35452,7 @@ bool MapWStringUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -35469,7 +35469,7 @@ std::function<uint32_t()> MapWStringUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringUShort*>(data), current_alignment)) +
+                               *static_cast<const MapWStringUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -35492,7 +35492,7 @@ void MapWStringUShortPubSubType::deleteData(
 }
 
 bool MapWStringUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -35501,7 +35501,7 @@ bool MapWStringUShortPubSubType::getKey(
         return false;
     }
 
-    MapWStringUShort* p_type = static_cast<MapWStringUShort*>(data);
+    const MapWStringUShort* p_type = static_cast<const MapWStringUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -35569,11 +35569,11 @@ MapWStringLongPubSubType::~MapWStringLongPubSubType()
 }
 
 bool MapWStringLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringLong* p_type = static_cast<MapWStringLong*>(data);
+    const MapWStringLong* p_type = static_cast<const MapWStringLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -35645,7 +35645,7 @@ bool MapWStringLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -35662,7 +35662,7 @@ std::function<uint32_t()> MapWStringLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringLong*>(data), current_alignment)) +
+                               *static_cast<const MapWStringLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -35685,7 +35685,7 @@ void MapWStringLongPubSubType::deleteData(
 }
 
 bool MapWStringLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -35694,7 +35694,7 @@ bool MapWStringLongPubSubType::getKey(
         return false;
     }
 
-    MapWStringLong* p_type = static_cast<MapWStringLong*>(data);
+    const MapWStringLong* p_type = static_cast<const MapWStringLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -35762,11 +35762,11 @@ MapWStringULongPubSubType::~MapWStringULongPubSubType()
 }
 
 bool MapWStringULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringULong* p_type = static_cast<MapWStringULong*>(data);
+    const MapWStringULong* p_type = static_cast<const MapWStringULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -35838,7 +35838,7 @@ bool MapWStringULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -35855,7 +35855,7 @@ std::function<uint32_t()> MapWStringULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringULong*>(data), current_alignment)) +
+                               *static_cast<const MapWStringULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -35878,7 +35878,7 @@ void MapWStringULongPubSubType::deleteData(
 }
 
 bool MapWStringULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -35887,7 +35887,7 @@ bool MapWStringULongPubSubType::getKey(
         return false;
     }
 
-    MapWStringULong* p_type = static_cast<MapWStringULong*>(data);
+    const MapWStringULong* p_type = static_cast<const MapWStringULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -35955,11 +35955,11 @@ MapWStringLongLongPubSubType::~MapWStringLongLongPubSubType()
 }
 
 bool MapWStringLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringLongLong* p_type = static_cast<MapWStringLongLong*>(data);
+    const MapWStringLongLong* p_type = static_cast<const MapWStringLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36031,7 +36031,7 @@ bool MapWStringLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -36048,7 +36048,7 @@ std::function<uint32_t()> MapWStringLongLongPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapWStringLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -36071,7 +36071,7 @@ void MapWStringLongLongPubSubType::deleteData(
 }
 
 bool MapWStringLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -36080,7 +36080,7 @@ bool MapWStringLongLongPubSubType::getKey(
         return false;
     }
 
-    MapWStringLongLong* p_type = static_cast<MapWStringLongLong*>(data);
+    const MapWStringLongLong* p_type = static_cast<const MapWStringLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -36148,11 +36148,11 @@ MapWStringULongLongPubSubType::~MapWStringULongLongPubSubType()
 }
 
 bool MapWStringULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringULongLong* p_type = static_cast<MapWStringULongLong*>(data);
+    const MapWStringULongLong* p_type = static_cast<const MapWStringULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36224,7 +36224,7 @@ bool MapWStringULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -36241,7 +36241,7 @@ std::function<uint32_t()> MapWStringULongLongPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapWStringULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -36264,7 +36264,7 @@ void MapWStringULongLongPubSubType::deleteData(
 }
 
 bool MapWStringULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -36273,7 +36273,7 @@ bool MapWStringULongLongPubSubType::getKey(
         return false;
     }
 
-    MapWStringULongLong* p_type = static_cast<MapWStringULongLong*>(data);
+    const MapWStringULongLong* p_type = static_cast<const MapWStringULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -36341,11 +36341,11 @@ MapWStringFloatPubSubType::~MapWStringFloatPubSubType()
 }
 
 bool MapWStringFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringFloat* p_type = static_cast<MapWStringFloat*>(data);
+    const MapWStringFloat* p_type = static_cast<const MapWStringFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36417,7 +36417,7 @@ bool MapWStringFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -36434,7 +36434,7 @@ std::function<uint32_t()> MapWStringFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringFloat*>(data), current_alignment)) +
+                               *static_cast<const MapWStringFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -36457,7 +36457,7 @@ void MapWStringFloatPubSubType::deleteData(
 }
 
 bool MapWStringFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -36466,7 +36466,7 @@ bool MapWStringFloatPubSubType::getKey(
         return false;
     }
 
-    MapWStringFloat* p_type = static_cast<MapWStringFloat*>(data);
+    const MapWStringFloat* p_type = static_cast<const MapWStringFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -36534,11 +36534,11 @@ MapWStringDoublePubSubType::~MapWStringDoublePubSubType()
 }
 
 bool MapWStringDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringDouble* p_type = static_cast<MapWStringDouble*>(data);
+    const MapWStringDouble* p_type = static_cast<const MapWStringDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36610,7 +36610,7 @@ bool MapWStringDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -36627,7 +36627,7 @@ std::function<uint32_t()> MapWStringDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringDouble*>(data), current_alignment)) +
+                               *static_cast<const MapWStringDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -36650,7 +36650,7 @@ void MapWStringDoublePubSubType::deleteData(
 }
 
 bool MapWStringDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -36659,7 +36659,7 @@ bool MapWStringDoublePubSubType::getKey(
         return false;
     }
 
-    MapWStringDouble* p_type = static_cast<MapWStringDouble*>(data);
+    const MapWStringDouble* p_type = static_cast<const MapWStringDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -36727,11 +36727,11 @@ MapWStringLongDoublePubSubType::~MapWStringLongDoublePubSubType()
 }
 
 bool MapWStringLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringLongDouble* p_type = static_cast<MapWStringLongDouble*>(data);
+    const MapWStringLongDouble* p_type = static_cast<const MapWStringLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36803,7 +36803,7 @@ bool MapWStringLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -36820,7 +36820,7 @@ std::function<uint32_t()> MapWStringLongDoublePubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapWStringLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -36843,7 +36843,7 @@ void MapWStringLongDoublePubSubType::deleteData(
 }
 
 bool MapWStringLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -36852,7 +36852,7 @@ bool MapWStringLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapWStringLongDouble* p_type = static_cast<MapWStringLongDouble*>(data);
+    const MapWStringLongDouble* p_type = static_cast<const MapWStringLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -36920,11 +36920,11 @@ MapWStringBooleanPubSubType::~MapWStringBooleanPubSubType()
 }
 
 bool MapWStringBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringBoolean* p_type = static_cast<MapWStringBoolean*>(data);
+    const MapWStringBoolean* p_type = static_cast<const MapWStringBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -36996,7 +36996,7 @@ bool MapWStringBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37013,7 +37013,7 @@ std::function<uint32_t()> MapWStringBooleanPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapWStringBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -37036,7 +37036,7 @@ void MapWStringBooleanPubSubType::deleteData(
 }
 
 bool MapWStringBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -37045,7 +37045,7 @@ bool MapWStringBooleanPubSubType::getKey(
         return false;
     }
 
-    MapWStringBoolean* p_type = static_cast<MapWStringBoolean*>(data);
+    const MapWStringBoolean* p_type = static_cast<const MapWStringBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -37113,11 +37113,11 @@ MapWStringOctetPubSubType::~MapWStringOctetPubSubType()
 }
 
 bool MapWStringOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringOctet* p_type = static_cast<MapWStringOctet*>(data);
+    const MapWStringOctet* p_type = static_cast<const MapWStringOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -37189,7 +37189,7 @@ bool MapWStringOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37206,7 +37206,7 @@ std::function<uint32_t()> MapWStringOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringOctet*>(data), current_alignment)) +
+                               *static_cast<const MapWStringOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -37229,7 +37229,7 @@ void MapWStringOctetPubSubType::deleteData(
 }
 
 bool MapWStringOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -37238,7 +37238,7 @@ bool MapWStringOctetPubSubType::getKey(
         return false;
     }
 
-    MapWStringOctet* p_type = static_cast<MapWStringOctet*>(data);
+    const MapWStringOctet* p_type = static_cast<const MapWStringOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -37306,11 +37306,11 @@ MapWStringCharPubSubType::~MapWStringCharPubSubType()
 }
 
 bool MapWStringCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringChar* p_type = static_cast<MapWStringChar*>(data);
+    const MapWStringChar* p_type = static_cast<const MapWStringChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -37382,7 +37382,7 @@ bool MapWStringCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37399,7 +37399,7 @@ std::function<uint32_t()> MapWStringCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringChar*>(data), current_alignment)) +
+                               *static_cast<const MapWStringChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -37422,7 +37422,7 @@ void MapWStringCharPubSubType::deleteData(
 }
 
 bool MapWStringCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -37431,7 +37431,7 @@ bool MapWStringCharPubSubType::getKey(
         return false;
     }
 
-    MapWStringChar* p_type = static_cast<MapWStringChar*>(data);
+    const MapWStringChar* p_type = static_cast<const MapWStringChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -37499,11 +37499,11 @@ MapWStringWCharPubSubType::~MapWStringWCharPubSubType()
 }
 
 bool MapWStringWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringWChar* p_type = static_cast<MapWStringWChar*>(data);
+    const MapWStringWChar* p_type = static_cast<const MapWStringWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -37575,7 +37575,7 @@ bool MapWStringWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37592,7 +37592,7 @@ std::function<uint32_t()> MapWStringWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringWChar*>(data), current_alignment)) +
+                               *static_cast<const MapWStringWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -37615,7 +37615,7 @@ void MapWStringWCharPubSubType::deleteData(
 }
 
 bool MapWStringWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -37624,7 +37624,7 @@ bool MapWStringWCharPubSubType::getKey(
         return false;
     }
 
-    MapWStringWChar* p_type = static_cast<MapWStringWChar*>(data);
+    const MapWStringWChar* p_type = static_cast<const MapWStringWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -37692,11 +37692,11 @@ MapWStringStringPubSubType::~MapWStringStringPubSubType()
 }
 
 bool MapWStringStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringString* p_type = static_cast<MapWStringString*>(data);
+    const MapWStringString* p_type = static_cast<const MapWStringString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -37768,7 +37768,7 @@ bool MapWStringStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37785,7 +37785,7 @@ std::function<uint32_t()> MapWStringStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringString*>(data), current_alignment)) +
+                               *static_cast<const MapWStringString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -37808,7 +37808,7 @@ void MapWStringStringPubSubType::deleteData(
 }
 
 bool MapWStringStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -37817,7 +37817,7 @@ bool MapWStringStringPubSubType::getKey(
         return false;
     }
 
-    MapWStringString* p_type = static_cast<MapWStringString*>(data);
+    const MapWStringString* p_type = static_cast<const MapWStringString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -37885,11 +37885,11 @@ MapWStringWStringPubSubType::~MapWStringWStringPubSubType()
 }
 
 bool MapWStringWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringWString* p_type = static_cast<MapWStringWString*>(data);
+    const MapWStringWString* p_type = static_cast<const MapWStringWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -37961,7 +37961,7 @@ bool MapWStringWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -37978,7 +37978,7 @@ std::function<uint32_t()> MapWStringWStringPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringWString*>(data), current_alignment)) +
+                               *static_cast<const MapWStringWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38001,7 +38001,7 @@ void MapWStringWStringPubSubType::deleteData(
 }
 
 bool MapWStringWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38010,7 +38010,7 @@ bool MapWStringWStringPubSubType::getKey(
         return false;
     }
 
-    MapWStringWString* p_type = static_cast<MapWStringWString*>(data);
+    const MapWStringWString* p_type = static_cast<const MapWStringWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -38078,11 +38078,11 @@ MapWStringInnerAliasBoundedStringHelperPubSubType::~MapWStringInnerAliasBoundedS
 }
 
 bool MapWStringInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasBoundedStringHelper* p_type = static_cast<MapWStringInnerAliasBoundedStringHelper*>(data);
+    const MapWStringInnerAliasBoundedStringHelper* p_type = static_cast<const MapWStringInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -38154,7 +38154,7 @@ bool MapWStringInnerAliasBoundedStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -38171,7 +38171,7 @@ std::function<uint32_t()> MapWStringInnerAliasBoundedStringHelperPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38194,7 +38194,7 @@ void MapWStringInnerAliasBoundedStringHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38203,7 +38203,7 @@ bool MapWStringInnerAliasBoundedStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasBoundedStringHelper* p_type = static_cast<MapWStringInnerAliasBoundedStringHelper*>(data);
+    const MapWStringInnerAliasBoundedStringHelper* p_type = static_cast<const MapWStringInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -38271,11 +38271,11 @@ MapWStringInnerAliasBoundedWStringHelperPubSubType::~MapWStringInnerAliasBounded
 }
 
 bool MapWStringInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasBoundedWStringHelper* p_type = static_cast<MapWStringInnerAliasBoundedWStringHelper*>(data);
+    const MapWStringInnerAliasBoundedWStringHelper* p_type = static_cast<const MapWStringInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -38347,7 +38347,7 @@ bool MapWStringInnerAliasBoundedWStringHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -38364,7 +38364,7 @@ std::function<uint32_t()> MapWStringInnerAliasBoundedWStringHelperPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38387,7 +38387,7 @@ void MapWStringInnerAliasBoundedWStringHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38396,7 +38396,7 @@ bool MapWStringInnerAliasBoundedWStringHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasBoundedWStringHelper* p_type = static_cast<MapWStringInnerAliasBoundedWStringHelper*>(data);
+    const MapWStringInnerAliasBoundedWStringHelper* p_type = static_cast<const MapWStringInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -38464,11 +38464,11 @@ MapWStringInnerEnumHelperPubSubType::~MapWStringInnerEnumHelperPubSubType()
 }
 
 bool MapWStringInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerEnumHelper* p_type = static_cast<MapWStringInnerEnumHelper*>(data);
+    const MapWStringInnerEnumHelper* p_type = static_cast<const MapWStringInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -38540,7 +38540,7 @@ bool MapWStringInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -38557,7 +38557,7 @@ std::function<uint32_t()> MapWStringInnerEnumHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38580,7 +38580,7 @@ void MapWStringInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38589,7 +38589,7 @@ bool MapWStringInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerEnumHelper* p_type = static_cast<MapWStringInnerEnumHelper*>(data);
+    const MapWStringInnerEnumHelper* p_type = static_cast<const MapWStringInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -38657,11 +38657,11 @@ MapWStringInnerBitMaskHelperPubSubType::~MapWStringInnerBitMaskHelperPubSubType(
 }
 
 bool MapWStringInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerBitMaskHelper* p_type = static_cast<MapWStringInnerBitMaskHelper*>(data);
+    const MapWStringInnerBitMaskHelper* p_type = static_cast<const MapWStringInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -38733,7 +38733,7 @@ bool MapWStringInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -38750,7 +38750,7 @@ std::function<uint32_t()> MapWStringInnerBitMaskHelperPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38773,7 +38773,7 @@ void MapWStringInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38782,7 +38782,7 @@ bool MapWStringInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerBitMaskHelper* p_type = static_cast<MapWStringInnerBitMaskHelper*>(data);
+    const MapWStringInnerBitMaskHelper* p_type = static_cast<const MapWStringInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -38850,11 +38850,11 @@ MapWStringInnerAliasHelperPubSubType::~MapWStringInnerAliasHelperPubSubType()
 }
 
 bool MapWStringInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasHelper* p_type = static_cast<MapWStringInnerAliasHelper*>(data);
+    const MapWStringInnerAliasHelper* p_type = static_cast<const MapWStringInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -38926,7 +38926,7 @@ bool MapWStringInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -38943,7 +38943,7 @@ std::function<uint32_t()> MapWStringInnerAliasHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -38966,7 +38966,7 @@ void MapWStringInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -38975,7 +38975,7 @@ bool MapWStringInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasHelper* p_type = static_cast<MapWStringInnerAliasHelper*>(data);
+    const MapWStringInnerAliasHelper* p_type = static_cast<const MapWStringInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -39043,11 +39043,11 @@ MapWStringInnerAliasArrayHelperPubSubType::~MapWStringInnerAliasArrayHelperPubSu
 }
 
 bool MapWStringInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasArrayHelper* p_type = static_cast<MapWStringInnerAliasArrayHelper*>(data);
+    const MapWStringInnerAliasArrayHelper* p_type = static_cast<const MapWStringInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -39119,7 +39119,7 @@ bool MapWStringInnerAliasArrayHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -39136,7 +39136,7 @@ std::function<uint32_t()> MapWStringInnerAliasArrayHelperPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -39159,7 +39159,7 @@ void MapWStringInnerAliasArrayHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -39168,7 +39168,7 @@ bool MapWStringInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasArrayHelper* p_type = static_cast<MapWStringInnerAliasArrayHelper*>(data);
+    const MapWStringInnerAliasArrayHelper* p_type = static_cast<const MapWStringInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -39236,11 +39236,11 @@ MapWStringInnerAliasSequenceHelperPubSubType::~MapWStringInnerAliasSequenceHelpe
 }
 
 bool MapWStringInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasSequenceHelper* p_type = static_cast<MapWStringInnerAliasSequenceHelper*>(data);
+    const MapWStringInnerAliasSequenceHelper* p_type = static_cast<const MapWStringInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -39312,7 +39312,7 @@ bool MapWStringInnerAliasSequenceHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -39329,7 +39329,7 @@ std::function<uint32_t()> MapWStringInnerAliasSequenceHelperPubSubType::getSeria
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -39352,7 +39352,7 @@ void MapWStringInnerAliasSequenceHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -39361,7 +39361,7 @@ bool MapWStringInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasSequenceHelper* p_type = static_cast<MapWStringInnerAliasSequenceHelper*>(data);
+    const MapWStringInnerAliasSequenceHelper* p_type = static_cast<const MapWStringInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -39429,11 +39429,11 @@ MapWStringInnerAliasMapHelperPubSubType::~MapWStringInnerAliasMapHelperPubSubTyp
 }
 
 bool MapWStringInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerAliasMapHelper* p_type = static_cast<MapWStringInnerAliasMapHelper*>(data);
+    const MapWStringInnerAliasMapHelper* p_type = static_cast<const MapWStringInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -39505,7 +39505,7 @@ bool MapWStringInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -39522,7 +39522,7 @@ std::function<uint32_t()> MapWStringInnerAliasMapHelperPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -39545,7 +39545,7 @@ void MapWStringInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -39554,7 +39554,7 @@ bool MapWStringInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerAliasMapHelper* p_type = static_cast<MapWStringInnerAliasMapHelper*>(data);
+    const MapWStringInnerAliasMapHelper* p_type = static_cast<const MapWStringInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -39622,11 +39622,11 @@ MapWStringInnerUnionHelperPubSubType::~MapWStringInnerUnionHelperPubSubType()
 }
 
 bool MapWStringInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerUnionHelper* p_type = static_cast<MapWStringInnerUnionHelper*>(data);
+    const MapWStringInnerUnionHelper* p_type = static_cast<const MapWStringInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -39698,7 +39698,7 @@ bool MapWStringInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -39715,7 +39715,7 @@ std::function<uint32_t()> MapWStringInnerUnionHelperPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -39738,7 +39738,7 @@ void MapWStringInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -39747,7 +39747,7 @@ bool MapWStringInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerUnionHelper* p_type = static_cast<MapWStringInnerUnionHelper*>(data);
+    const MapWStringInnerUnionHelper* p_type = static_cast<const MapWStringInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -39815,11 +39815,11 @@ MapWStringInnerStructureHelperPubSubType::~MapWStringInnerStructureHelperPubSubT
 }
 
 bool MapWStringInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerStructureHelper* p_type = static_cast<MapWStringInnerStructureHelper*>(data);
+    const MapWStringInnerStructureHelper* p_type = static_cast<const MapWStringInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -39891,7 +39891,7 @@ bool MapWStringInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -39908,7 +39908,7 @@ std::function<uint32_t()> MapWStringInnerStructureHelperPubSubType::getSerialize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -39931,7 +39931,7 @@ void MapWStringInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -39940,7 +39940,7 @@ bool MapWStringInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerStructureHelper* p_type = static_cast<MapWStringInnerStructureHelper*>(data);
+    const MapWStringInnerStructureHelper* p_type = static_cast<const MapWStringInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40008,11 +40008,11 @@ MapWStringInnerBitsetHelperPubSubType::~MapWStringInnerBitsetHelperPubSubType()
 }
 
 bool MapWStringInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapWStringInnerBitsetHelper* p_type = static_cast<MapWStringInnerBitsetHelper*>(data);
+    const MapWStringInnerBitsetHelper* p_type = static_cast<const MapWStringInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -40084,7 +40084,7 @@ bool MapWStringInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapWStringInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -40101,7 +40101,7 @@ std::function<uint32_t()> MapWStringInnerBitsetHelperPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapWStringInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapWStringInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -40124,7 +40124,7 @@ void MapWStringInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapWStringInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -40133,7 +40133,7 @@ bool MapWStringInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapWStringInnerBitsetHelper* p_type = static_cast<MapWStringInnerBitsetHelper*>(data);
+    const MapWStringInnerBitsetHelper* p_type = static_cast<const MapWStringInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40201,11 +40201,11 @@ MapInnerAliasBoundedStringHelperShortPubSubType::~MapInnerAliasBoundedStringHelp
 }
 
 bool MapInnerAliasBoundedStringHelperShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperShort* p_type = static_cast<MapInnerAliasBoundedStringHelperShort*>(data);
+    const MapInnerAliasBoundedStringHelperShort* p_type = static_cast<const MapInnerAliasBoundedStringHelperShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -40277,7 +40277,7 @@ bool MapInnerAliasBoundedStringHelperShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -40294,7 +40294,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperShortPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperShort*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -40317,7 +40317,7 @@ void MapInnerAliasBoundedStringHelperShortPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -40326,7 +40326,7 @@ bool MapInnerAliasBoundedStringHelperShortPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperShort* p_type = static_cast<MapInnerAliasBoundedStringHelperShort*>(data);
+    const MapInnerAliasBoundedStringHelperShort* p_type = static_cast<const MapInnerAliasBoundedStringHelperShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40394,11 +40394,11 @@ MapInnerAliasBoundedStringHelperUShortPubSubType::~MapInnerAliasBoundedStringHel
 }
 
 bool MapInnerAliasBoundedStringHelperUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperUShort* p_type = static_cast<MapInnerAliasBoundedStringHelperUShort*>(data);
+    const MapInnerAliasBoundedStringHelperUShort* p_type = static_cast<const MapInnerAliasBoundedStringHelperUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -40470,7 +40470,7 @@ bool MapInnerAliasBoundedStringHelperUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -40487,7 +40487,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperUShortPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperUShort*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -40510,7 +40510,7 @@ void MapInnerAliasBoundedStringHelperUShortPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -40519,7 +40519,7 @@ bool MapInnerAliasBoundedStringHelperUShortPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperUShort* p_type = static_cast<MapInnerAliasBoundedStringHelperUShort*>(data);
+    const MapInnerAliasBoundedStringHelperUShort* p_type = static_cast<const MapInnerAliasBoundedStringHelperUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40587,11 +40587,11 @@ MapInnerAliasBoundedStringHelperLongPubSubType::~MapInnerAliasBoundedStringHelpe
 }
 
 bool MapInnerAliasBoundedStringHelperLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperLong* p_type = static_cast<MapInnerAliasBoundedStringHelperLong*>(data);
+    const MapInnerAliasBoundedStringHelperLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -40663,7 +40663,7 @@ bool MapInnerAliasBoundedStringHelperLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -40680,7 +40680,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -40703,7 +40703,7 @@ void MapInnerAliasBoundedStringHelperLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -40712,7 +40712,7 @@ bool MapInnerAliasBoundedStringHelperLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperLong* p_type = static_cast<MapInnerAliasBoundedStringHelperLong*>(data);
+    const MapInnerAliasBoundedStringHelperLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40780,11 +40780,11 @@ MapInnerAliasBoundedStringHelperULongPubSubType::~MapInnerAliasBoundedStringHelp
 }
 
 bool MapInnerAliasBoundedStringHelperULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperULong* p_type = static_cast<MapInnerAliasBoundedStringHelperULong*>(data);
+    const MapInnerAliasBoundedStringHelperULong* p_type = static_cast<const MapInnerAliasBoundedStringHelperULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -40856,7 +40856,7 @@ bool MapInnerAliasBoundedStringHelperULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -40873,7 +40873,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperULongPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperULong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -40896,7 +40896,7 @@ void MapInnerAliasBoundedStringHelperULongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -40905,7 +40905,7 @@ bool MapInnerAliasBoundedStringHelperULongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperULong* p_type = static_cast<MapInnerAliasBoundedStringHelperULong*>(data);
+    const MapInnerAliasBoundedStringHelperULong* p_type = static_cast<const MapInnerAliasBoundedStringHelperULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -40973,11 +40973,11 @@ MapInnerAliasBoundedStringHelperLongLongPubSubType::~MapInnerAliasBoundedStringH
 }
 
 bool MapInnerAliasBoundedStringHelperLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperLongLong* p_type = static_cast<MapInnerAliasBoundedStringHelperLongLong*>(data);
+    const MapInnerAliasBoundedStringHelperLongLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -41049,7 +41049,7 @@ bool MapInnerAliasBoundedStringHelperLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -41066,7 +41066,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongLongPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -41089,7 +41089,7 @@ void MapInnerAliasBoundedStringHelperLongLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -41098,7 +41098,7 @@ bool MapInnerAliasBoundedStringHelperLongLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperLongLong* p_type = static_cast<MapInnerAliasBoundedStringHelperLongLong*>(data);
+    const MapInnerAliasBoundedStringHelperLongLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -41166,11 +41166,11 @@ MapInnerAliasBoundedStringHelperULongLongPubSubType::~MapInnerAliasBoundedString
 }
 
 bool MapInnerAliasBoundedStringHelperULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperULongLong* p_type = static_cast<MapInnerAliasBoundedStringHelperULongLong*>(data);
+    const MapInnerAliasBoundedStringHelperULongLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -41242,7 +41242,7 @@ bool MapInnerAliasBoundedStringHelperULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -41259,7 +41259,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperULongLongPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -41282,7 +41282,7 @@ void MapInnerAliasBoundedStringHelperULongLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -41291,7 +41291,7 @@ bool MapInnerAliasBoundedStringHelperULongLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperULongLong* p_type = static_cast<MapInnerAliasBoundedStringHelperULongLong*>(data);
+    const MapInnerAliasBoundedStringHelperULongLong* p_type = static_cast<const MapInnerAliasBoundedStringHelperULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -41359,11 +41359,11 @@ MapInnerAliasBoundedStringHelperFloatPubSubType::~MapInnerAliasBoundedStringHelp
 }
 
 bool MapInnerAliasBoundedStringHelperFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperFloat* p_type = static_cast<MapInnerAliasBoundedStringHelperFloat*>(data);
+    const MapInnerAliasBoundedStringHelperFloat* p_type = static_cast<const MapInnerAliasBoundedStringHelperFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -41435,7 +41435,7 @@ bool MapInnerAliasBoundedStringHelperFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -41452,7 +41452,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperFloatPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperFloat*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -41475,7 +41475,7 @@ void MapInnerAliasBoundedStringHelperFloatPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -41484,7 +41484,7 @@ bool MapInnerAliasBoundedStringHelperFloatPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperFloat* p_type = static_cast<MapInnerAliasBoundedStringHelperFloat*>(data);
+    const MapInnerAliasBoundedStringHelperFloat* p_type = static_cast<const MapInnerAliasBoundedStringHelperFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -41552,11 +41552,11 @@ MapInnerAliasBoundedStringHelperDoublePubSubType::~MapInnerAliasBoundedStringHel
 }
 
 bool MapInnerAliasBoundedStringHelperDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperDouble* p_type = static_cast<MapInnerAliasBoundedStringHelperDouble*>(data);
+    const MapInnerAliasBoundedStringHelperDouble* p_type = static_cast<const MapInnerAliasBoundedStringHelperDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -41628,7 +41628,7 @@ bool MapInnerAliasBoundedStringHelperDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -41645,7 +41645,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperDoublePubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperDouble*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -41668,7 +41668,7 @@ void MapInnerAliasBoundedStringHelperDoublePubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -41677,7 +41677,7 @@ bool MapInnerAliasBoundedStringHelperDoublePubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperDouble* p_type = static_cast<MapInnerAliasBoundedStringHelperDouble*>(data);
+    const MapInnerAliasBoundedStringHelperDouble* p_type = static_cast<const MapInnerAliasBoundedStringHelperDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -41745,11 +41745,11 @@ MapInnerAliasBoundedStringHelperLongDoublePubSubType::~MapInnerAliasBoundedStrin
 }
 
 bool MapInnerAliasBoundedStringHelperLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperLongDouble* p_type = static_cast<MapInnerAliasBoundedStringHelperLongDouble*>(data);
+    const MapInnerAliasBoundedStringHelperLongDouble* p_type = static_cast<const MapInnerAliasBoundedStringHelperLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -41821,7 +41821,7 @@ bool MapInnerAliasBoundedStringHelperLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -41838,7 +41838,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperLongDoublePubSubType::
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -41861,7 +41861,7 @@ void MapInnerAliasBoundedStringHelperLongDoublePubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -41870,7 +41870,7 @@ bool MapInnerAliasBoundedStringHelperLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperLongDouble* p_type = static_cast<MapInnerAliasBoundedStringHelperLongDouble*>(data);
+    const MapInnerAliasBoundedStringHelperLongDouble* p_type = static_cast<const MapInnerAliasBoundedStringHelperLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -41938,11 +41938,11 @@ MapInnerAliasBoundedStringHelperBooleanPubSubType::~MapInnerAliasBoundedStringHe
 }
 
 bool MapInnerAliasBoundedStringHelperBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperBoolean* p_type = static_cast<MapInnerAliasBoundedStringHelperBoolean*>(data);
+    const MapInnerAliasBoundedStringHelperBoolean* p_type = static_cast<const MapInnerAliasBoundedStringHelperBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42014,7 +42014,7 @@ bool MapInnerAliasBoundedStringHelperBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42031,7 +42031,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperBooleanPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -42054,7 +42054,7 @@ void MapInnerAliasBoundedStringHelperBooleanPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -42063,7 +42063,7 @@ bool MapInnerAliasBoundedStringHelperBooleanPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperBoolean* p_type = static_cast<MapInnerAliasBoundedStringHelperBoolean*>(data);
+    const MapInnerAliasBoundedStringHelperBoolean* p_type = static_cast<const MapInnerAliasBoundedStringHelperBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -42131,11 +42131,11 @@ MapInnerAliasBoundedStringHelperOctetPubSubType::~MapInnerAliasBoundedStringHelp
 }
 
 bool MapInnerAliasBoundedStringHelperOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperOctet* p_type = static_cast<MapInnerAliasBoundedStringHelperOctet*>(data);
+    const MapInnerAliasBoundedStringHelperOctet* p_type = static_cast<const MapInnerAliasBoundedStringHelperOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42207,7 +42207,7 @@ bool MapInnerAliasBoundedStringHelperOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42224,7 +42224,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperOctetPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperOctet*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -42247,7 +42247,7 @@ void MapInnerAliasBoundedStringHelperOctetPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -42256,7 +42256,7 @@ bool MapInnerAliasBoundedStringHelperOctetPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperOctet* p_type = static_cast<MapInnerAliasBoundedStringHelperOctet*>(data);
+    const MapInnerAliasBoundedStringHelperOctet* p_type = static_cast<const MapInnerAliasBoundedStringHelperOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -42324,11 +42324,11 @@ MapInnerAliasBoundedStringHelperCharPubSubType::~MapInnerAliasBoundedStringHelpe
 }
 
 bool MapInnerAliasBoundedStringHelperCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperChar* p_type = static_cast<MapInnerAliasBoundedStringHelperChar*>(data);
+    const MapInnerAliasBoundedStringHelperChar* p_type = static_cast<const MapInnerAliasBoundedStringHelperChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42400,7 +42400,7 @@ bool MapInnerAliasBoundedStringHelperCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42417,7 +42417,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperCharPubSubType::getSer
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperChar*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -42440,7 +42440,7 @@ void MapInnerAliasBoundedStringHelperCharPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -42449,7 +42449,7 @@ bool MapInnerAliasBoundedStringHelperCharPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperChar* p_type = static_cast<MapInnerAliasBoundedStringHelperChar*>(data);
+    const MapInnerAliasBoundedStringHelperChar* p_type = static_cast<const MapInnerAliasBoundedStringHelperChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -42517,11 +42517,11 @@ MapInnerAliasBoundedStringHelperWCharPubSubType::~MapInnerAliasBoundedStringHelp
 }
 
 bool MapInnerAliasBoundedStringHelperWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperWChar* p_type = static_cast<MapInnerAliasBoundedStringHelperWChar*>(data);
+    const MapInnerAliasBoundedStringHelperWChar* p_type = static_cast<const MapInnerAliasBoundedStringHelperWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42593,7 +42593,7 @@ bool MapInnerAliasBoundedStringHelperWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42610,7 +42610,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperWCharPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperWChar*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -42633,7 +42633,7 @@ void MapInnerAliasBoundedStringHelperWCharPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -42642,7 +42642,7 @@ bool MapInnerAliasBoundedStringHelperWCharPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperWChar* p_type = static_cast<MapInnerAliasBoundedStringHelperWChar*>(data);
+    const MapInnerAliasBoundedStringHelperWChar* p_type = static_cast<const MapInnerAliasBoundedStringHelperWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -42710,11 +42710,11 @@ MapInnerAliasBoundedStringHelperStringPubSubType::~MapInnerAliasBoundedStringHel
 }
 
 bool MapInnerAliasBoundedStringHelperStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperString* p_type = static_cast<MapInnerAliasBoundedStringHelperString*>(data);
+    const MapInnerAliasBoundedStringHelperString* p_type = static_cast<const MapInnerAliasBoundedStringHelperString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42786,7 +42786,7 @@ bool MapInnerAliasBoundedStringHelperStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42803,7 +42803,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperStringPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperString*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -42826,7 +42826,7 @@ void MapInnerAliasBoundedStringHelperStringPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -42835,7 +42835,7 @@ bool MapInnerAliasBoundedStringHelperStringPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperString* p_type = static_cast<MapInnerAliasBoundedStringHelperString*>(data);
+    const MapInnerAliasBoundedStringHelperString* p_type = static_cast<const MapInnerAliasBoundedStringHelperString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -42903,11 +42903,11 @@ MapInnerAliasBoundedStringHelperWStringPubSubType::~MapInnerAliasBoundedStringHe
 }
 
 bool MapInnerAliasBoundedStringHelperWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperWString* p_type = static_cast<MapInnerAliasBoundedStringHelperWString*>(data);
+    const MapInnerAliasBoundedStringHelperWString* p_type = static_cast<const MapInnerAliasBoundedStringHelperWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -42979,7 +42979,7 @@ bool MapInnerAliasBoundedStringHelperWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -42996,7 +42996,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperWStringPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperWString*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43019,7 +43019,7 @@ void MapInnerAliasBoundedStringHelperWStringPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43028,7 +43028,7 @@ bool MapInnerAliasBoundedStringHelperWStringPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperWString* p_type = static_cast<MapInnerAliasBoundedStringHelperWString*>(data);
+    const MapInnerAliasBoundedStringHelperWString* p_type = static_cast<const MapInnerAliasBoundedStringHelperWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -43096,11 +43096,11 @@ MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::~MapInn
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -43172,7 +43172,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::de
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -43189,7 +43189,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasBoundedStrin
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43212,7 +43212,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::de
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43221,7 +43221,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::ge
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -43289,11 +43289,11 @@ MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::~MapIn
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -43365,7 +43365,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::d
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -43382,7 +43382,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasBoundedWStri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43405,7 +43405,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::d
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43414,7 +43414,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::g
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -43482,11 +43482,11 @@ MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::~MapInnerAliasBounded
 }
 
 bool MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerEnumHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerEnumHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -43558,7 +43558,7 @@ bool MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -43575,7 +43575,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubT
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43598,7 +43598,7 @@ void MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43607,7 +43607,7 @@ bool MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerEnumHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerEnumHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -43675,11 +43675,11 @@ MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::~MapInnerAliasBoun
 }
 
 bool MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerBitMaskHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerBitMaskHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -43751,7 +43751,7 @@ bool MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -43768,7 +43768,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43791,7 +43791,7 @@ void MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43800,7 +43800,7 @@ bool MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerBitMaskHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerBitMaskHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -43868,11 +43868,11 @@ MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::~MapInnerAliasBounde
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -43944,7 +43944,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -43961,7 +43961,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasHelperPubSub
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -43984,7 +43984,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -43993,7 +43993,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -44061,11 +44061,11 @@ MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::~MapInnerAliasB
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasArrayHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -44137,7 +44137,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::deserializ
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -44154,7 +44154,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasArrayHelperP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -44177,7 +44177,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::deleteData
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -44186,7 +44186,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasArrayHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -44254,11 +44254,11 @@ MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::~MapInnerAli
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -44330,7 +44330,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::deseria
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -44347,7 +44347,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasSequenceHelp
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -44370,7 +44370,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::deleteD
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -44379,7 +44379,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -44447,11 +44447,11 @@ MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::~MapInnerAliasBou
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerAliasMapHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasMapHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -44523,7 +44523,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -44540,7 +44540,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerAliasMapHelperPub
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -44563,7 +44563,7 @@ void MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -44572,7 +44572,7 @@ bool MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerAliasMapHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerAliasMapHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -44640,11 +44640,11 @@ MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::~MapInnerAliasBounde
 }
 
 bool MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerUnionHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerUnionHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -44716,7 +44716,7 @@ bool MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -44733,7 +44733,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerUnionHelperPubSub
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -44756,7 +44756,7 @@ void MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -44765,7 +44765,7 @@ bool MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerUnionHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerUnionHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -44833,11 +44833,11 @@ MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::~MapInnerAliasBo
 }
 
 bool MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerStructureHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerStructureHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -44909,7 +44909,7 @@ bool MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::deserialize
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -44926,7 +44926,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerStructureHelperPu
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -44949,7 +44949,7 @@ void MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -44958,7 +44958,7 @@ bool MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerStructureHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerStructureHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45026,11 +45026,11 @@ MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::~MapInnerAliasBound
 }
 
 bool MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedStringHelperInnerBitsetHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerBitsetHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -45102,7 +45102,7 @@ bool MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -45119,7 +45119,7 @@ std::function<uint32_t()> MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSu
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -45142,7 +45142,7 @@ void MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -45151,7 +45151,7 @@ bool MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedStringHelperInnerBitsetHelper* p_type = static_cast<MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data);
+    const MapInnerAliasBoundedStringHelperInnerBitsetHelper* p_type = static_cast<const MapInnerAliasBoundedStringHelperInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45219,11 +45219,11 @@ MapInnerAliasBoundedWStringHelperShortPubSubType::~MapInnerAliasBoundedWStringHe
 }
 
 bool MapInnerAliasBoundedWStringHelperShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperShort* p_type = static_cast<MapInnerAliasBoundedWStringHelperShort*>(data);
+    const MapInnerAliasBoundedWStringHelperShort* p_type = static_cast<const MapInnerAliasBoundedWStringHelperShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -45295,7 +45295,7 @@ bool MapInnerAliasBoundedWStringHelperShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -45312,7 +45312,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperShortPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperShort*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -45335,7 +45335,7 @@ void MapInnerAliasBoundedWStringHelperShortPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -45344,7 +45344,7 @@ bool MapInnerAliasBoundedWStringHelperShortPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperShort* p_type = static_cast<MapInnerAliasBoundedWStringHelperShort*>(data);
+    const MapInnerAliasBoundedWStringHelperShort* p_type = static_cast<const MapInnerAliasBoundedWStringHelperShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45412,11 +45412,11 @@ MapInnerAliasBoundedWStringHelperUShortPubSubType::~MapInnerAliasBoundedWStringH
 }
 
 bool MapInnerAliasBoundedWStringHelperUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperUShort* p_type = static_cast<MapInnerAliasBoundedWStringHelperUShort*>(data);
+    const MapInnerAliasBoundedWStringHelperUShort* p_type = static_cast<const MapInnerAliasBoundedWStringHelperUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -45488,7 +45488,7 @@ bool MapInnerAliasBoundedWStringHelperUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -45505,7 +45505,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperUShortPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperUShort*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -45528,7 +45528,7 @@ void MapInnerAliasBoundedWStringHelperUShortPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -45537,7 +45537,7 @@ bool MapInnerAliasBoundedWStringHelperUShortPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperUShort* p_type = static_cast<MapInnerAliasBoundedWStringHelperUShort*>(data);
+    const MapInnerAliasBoundedWStringHelperUShort* p_type = static_cast<const MapInnerAliasBoundedWStringHelperUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45605,11 +45605,11 @@ MapInnerAliasBoundedWStringHelperLongPubSubType::~MapInnerAliasBoundedWStringHel
 }
 
 bool MapInnerAliasBoundedWStringHelperLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperLong*>(data);
+    const MapInnerAliasBoundedWStringHelperLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -45681,7 +45681,7 @@ bool MapInnerAliasBoundedWStringHelperLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -45698,7 +45698,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -45721,7 +45721,7 @@ void MapInnerAliasBoundedWStringHelperLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -45730,7 +45730,7 @@ bool MapInnerAliasBoundedWStringHelperLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperLong*>(data);
+    const MapInnerAliasBoundedWStringHelperLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45798,11 +45798,11 @@ MapInnerAliasBoundedWStringHelperULongPubSubType::~MapInnerAliasBoundedWStringHe
 }
 
 bool MapInnerAliasBoundedWStringHelperULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperULong* p_type = static_cast<MapInnerAliasBoundedWStringHelperULong*>(data);
+    const MapInnerAliasBoundedWStringHelperULong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -45874,7 +45874,7 @@ bool MapInnerAliasBoundedWStringHelperULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -45891,7 +45891,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperULongPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperULong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -45914,7 +45914,7 @@ void MapInnerAliasBoundedWStringHelperULongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -45923,7 +45923,7 @@ bool MapInnerAliasBoundedWStringHelperULongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperULong* p_type = static_cast<MapInnerAliasBoundedWStringHelperULong*>(data);
+    const MapInnerAliasBoundedWStringHelperULong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -45991,11 +45991,11 @@ MapInnerAliasBoundedWStringHelperLongLongPubSubType::~MapInnerAliasBoundedWStrin
 }
 
 bool MapInnerAliasBoundedWStringHelperLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperLongLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperLongLong*>(data);
+    const MapInnerAliasBoundedWStringHelperLongLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -46067,7 +46067,7 @@ bool MapInnerAliasBoundedWStringHelperLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -46084,7 +46084,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongLongPubSubType::g
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperLongLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -46107,7 +46107,7 @@ void MapInnerAliasBoundedWStringHelperLongLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -46116,7 +46116,7 @@ bool MapInnerAliasBoundedWStringHelperLongLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperLongLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperLongLong*>(data);
+    const MapInnerAliasBoundedWStringHelperLongLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -46184,11 +46184,11 @@ MapInnerAliasBoundedWStringHelperULongLongPubSubType::~MapInnerAliasBoundedWStri
 }
 
 bool MapInnerAliasBoundedWStringHelperULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperULongLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperULongLong*>(data);
+    const MapInnerAliasBoundedWStringHelperULongLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -46260,7 +46260,7 @@ bool MapInnerAliasBoundedWStringHelperULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -46277,7 +46277,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperULongLongPubSubType::
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperULongLong*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -46300,7 +46300,7 @@ void MapInnerAliasBoundedWStringHelperULongLongPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -46309,7 +46309,7 @@ bool MapInnerAliasBoundedWStringHelperULongLongPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperULongLong* p_type = static_cast<MapInnerAliasBoundedWStringHelperULongLong*>(data);
+    const MapInnerAliasBoundedWStringHelperULongLong* p_type = static_cast<const MapInnerAliasBoundedWStringHelperULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -46377,11 +46377,11 @@ MapInnerAliasBoundedWStringHelperFloatPubSubType::~MapInnerAliasBoundedWStringHe
 }
 
 bool MapInnerAliasBoundedWStringHelperFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperFloat* p_type = static_cast<MapInnerAliasBoundedWStringHelperFloat*>(data);
+    const MapInnerAliasBoundedWStringHelperFloat* p_type = static_cast<const MapInnerAliasBoundedWStringHelperFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -46453,7 +46453,7 @@ bool MapInnerAliasBoundedWStringHelperFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -46470,7 +46470,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperFloatPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperFloat*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -46493,7 +46493,7 @@ void MapInnerAliasBoundedWStringHelperFloatPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -46502,7 +46502,7 @@ bool MapInnerAliasBoundedWStringHelperFloatPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperFloat* p_type = static_cast<MapInnerAliasBoundedWStringHelperFloat*>(data);
+    const MapInnerAliasBoundedWStringHelperFloat* p_type = static_cast<const MapInnerAliasBoundedWStringHelperFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -46570,11 +46570,11 @@ MapInnerAliasBoundedWStringHelperDoublePubSubType::~MapInnerAliasBoundedWStringH
 }
 
 bool MapInnerAliasBoundedWStringHelperDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperDouble* p_type = static_cast<MapInnerAliasBoundedWStringHelperDouble*>(data);
+    const MapInnerAliasBoundedWStringHelperDouble* p_type = static_cast<const MapInnerAliasBoundedWStringHelperDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -46646,7 +46646,7 @@ bool MapInnerAliasBoundedWStringHelperDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -46663,7 +46663,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperDoublePubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperDouble*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -46686,7 +46686,7 @@ void MapInnerAliasBoundedWStringHelperDoublePubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -46695,7 +46695,7 @@ bool MapInnerAliasBoundedWStringHelperDoublePubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperDouble* p_type = static_cast<MapInnerAliasBoundedWStringHelperDouble*>(data);
+    const MapInnerAliasBoundedWStringHelperDouble* p_type = static_cast<const MapInnerAliasBoundedWStringHelperDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -46763,11 +46763,11 @@ MapInnerAliasBoundedWStringHelperLongDoublePubSubType::~MapInnerAliasBoundedWStr
 }
 
 bool MapInnerAliasBoundedWStringHelperLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperLongDouble* p_type = static_cast<MapInnerAliasBoundedWStringHelperLongDouble*>(data);
+    const MapInnerAliasBoundedWStringHelperLongDouble* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -46839,7 +46839,7 @@ bool MapInnerAliasBoundedWStringHelperLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -46856,7 +46856,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperLongDoublePubSubType:
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperLongDouble*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -46879,7 +46879,7 @@ void MapInnerAliasBoundedWStringHelperLongDoublePubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -46888,7 +46888,7 @@ bool MapInnerAliasBoundedWStringHelperLongDoublePubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperLongDouble* p_type = static_cast<MapInnerAliasBoundedWStringHelperLongDouble*>(data);
+    const MapInnerAliasBoundedWStringHelperLongDouble* p_type = static_cast<const MapInnerAliasBoundedWStringHelperLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -46956,11 +46956,11 @@ MapInnerAliasBoundedWStringHelperBooleanPubSubType::~MapInnerAliasBoundedWString
 }
 
 bool MapInnerAliasBoundedWStringHelperBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperBoolean* p_type = static_cast<MapInnerAliasBoundedWStringHelperBoolean*>(data);
+    const MapInnerAliasBoundedWStringHelperBoolean* p_type = static_cast<const MapInnerAliasBoundedWStringHelperBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47032,7 +47032,7 @@ bool MapInnerAliasBoundedWStringHelperBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -47049,7 +47049,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperBooleanPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperBoolean*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -47072,7 +47072,7 @@ void MapInnerAliasBoundedWStringHelperBooleanPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -47081,7 +47081,7 @@ bool MapInnerAliasBoundedWStringHelperBooleanPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperBoolean* p_type = static_cast<MapInnerAliasBoundedWStringHelperBoolean*>(data);
+    const MapInnerAliasBoundedWStringHelperBoolean* p_type = static_cast<const MapInnerAliasBoundedWStringHelperBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -47149,11 +47149,11 @@ MapInnerAliasBoundedWStringHelperOctetPubSubType::~MapInnerAliasBoundedWStringHe
 }
 
 bool MapInnerAliasBoundedWStringHelperOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperOctet* p_type = static_cast<MapInnerAliasBoundedWStringHelperOctet*>(data);
+    const MapInnerAliasBoundedWStringHelperOctet* p_type = static_cast<const MapInnerAliasBoundedWStringHelperOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47225,7 +47225,7 @@ bool MapInnerAliasBoundedWStringHelperOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -47242,7 +47242,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperOctetPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperOctet*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -47265,7 +47265,7 @@ void MapInnerAliasBoundedWStringHelperOctetPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -47274,7 +47274,7 @@ bool MapInnerAliasBoundedWStringHelperOctetPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperOctet* p_type = static_cast<MapInnerAliasBoundedWStringHelperOctet*>(data);
+    const MapInnerAliasBoundedWStringHelperOctet* p_type = static_cast<const MapInnerAliasBoundedWStringHelperOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -47342,11 +47342,11 @@ MapInnerAliasBoundedWStringHelperCharPubSubType::~MapInnerAliasBoundedWStringHel
 }
 
 bool MapInnerAliasBoundedWStringHelperCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperChar* p_type = static_cast<MapInnerAliasBoundedWStringHelperChar*>(data);
+    const MapInnerAliasBoundedWStringHelperChar* p_type = static_cast<const MapInnerAliasBoundedWStringHelperChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47418,7 +47418,7 @@ bool MapInnerAliasBoundedWStringHelperCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -47435,7 +47435,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperCharPubSubType::getSe
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperChar*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -47458,7 +47458,7 @@ void MapInnerAliasBoundedWStringHelperCharPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -47467,7 +47467,7 @@ bool MapInnerAliasBoundedWStringHelperCharPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperChar* p_type = static_cast<MapInnerAliasBoundedWStringHelperChar*>(data);
+    const MapInnerAliasBoundedWStringHelperChar* p_type = static_cast<const MapInnerAliasBoundedWStringHelperChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -47535,11 +47535,11 @@ MapInnerAliasBoundedWStringHelperWCharPubSubType::~MapInnerAliasBoundedWStringHe
 }
 
 bool MapInnerAliasBoundedWStringHelperWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperWChar* p_type = static_cast<MapInnerAliasBoundedWStringHelperWChar*>(data);
+    const MapInnerAliasBoundedWStringHelperWChar* p_type = static_cast<const MapInnerAliasBoundedWStringHelperWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47611,7 +47611,7 @@ bool MapInnerAliasBoundedWStringHelperWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -47628,7 +47628,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperWCharPubSubType::getS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperWChar*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -47651,7 +47651,7 @@ void MapInnerAliasBoundedWStringHelperWCharPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -47660,7 +47660,7 @@ bool MapInnerAliasBoundedWStringHelperWCharPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperWChar* p_type = static_cast<MapInnerAliasBoundedWStringHelperWChar*>(data);
+    const MapInnerAliasBoundedWStringHelperWChar* p_type = static_cast<const MapInnerAliasBoundedWStringHelperWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -47728,11 +47728,11 @@ MapInnerAliasBoundedWStringHelperStringPubSubType::~MapInnerAliasBoundedWStringH
 }
 
 bool MapInnerAliasBoundedWStringHelperStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperString* p_type = static_cast<MapInnerAliasBoundedWStringHelperString*>(data);
+    const MapInnerAliasBoundedWStringHelperString* p_type = static_cast<const MapInnerAliasBoundedWStringHelperString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47804,7 +47804,7 @@ bool MapInnerAliasBoundedWStringHelperStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -47821,7 +47821,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperStringPubSubType::get
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperString*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -47844,7 +47844,7 @@ void MapInnerAliasBoundedWStringHelperStringPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -47853,7 +47853,7 @@ bool MapInnerAliasBoundedWStringHelperStringPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperString* p_type = static_cast<MapInnerAliasBoundedWStringHelperString*>(data);
+    const MapInnerAliasBoundedWStringHelperString* p_type = static_cast<const MapInnerAliasBoundedWStringHelperString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -47921,11 +47921,11 @@ MapInnerAliasBoundedWStringHelperWStringPubSubType::~MapInnerAliasBoundedWString
 }
 
 bool MapInnerAliasBoundedWStringHelperWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperWString* p_type = static_cast<MapInnerAliasBoundedWStringHelperWString*>(data);
+    const MapInnerAliasBoundedWStringHelperWString* p_type = static_cast<const MapInnerAliasBoundedWStringHelperWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -47997,7 +47997,7 @@ bool MapInnerAliasBoundedWStringHelperWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48014,7 +48014,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperWStringPubSubType::ge
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperWString*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -48037,7 +48037,7 @@ void MapInnerAliasBoundedWStringHelperWStringPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -48046,7 +48046,7 @@ bool MapInnerAliasBoundedWStringHelperWStringPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperWString* p_type = static_cast<MapInnerAliasBoundedWStringHelperWString*>(data);
+    const MapInnerAliasBoundedWStringHelperWString* p_type = static_cast<const MapInnerAliasBoundedWStringHelperWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -48114,11 +48114,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::~MapIn
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -48190,7 +48190,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::d
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48207,7 +48207,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasBoundedStri
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -48230,7 +48230,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::d
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -48239,7 +48239,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::g
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -48307,11 +48307,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::~MapI
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -48383,7 +48383,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48400,7 +48400,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -48423,7 +48423,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -48432,7 +48432,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -48500,11 +48500,11 @@ MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::~MapInnerAliasBounde
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerEnumHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerEnumHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -48576,7 +48576,7 @@ bool MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48593,7 +48593,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSub
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -48616,7 +48616,7 @@ void MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -48625,7 +48625,7 @@ bool MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerEnumHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerEnumHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -48693,11 +48693,11 @@ MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::~MapInnerAliasBou
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerBitMaskHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -48769,7 +48769,7 @@ bool MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48786,7 +48786,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPub
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -48809,7 +48809,7 @@ void MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -48818,7 +48818,7 @@ bool MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerBitMaskHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -48886,11 +48886,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::~MapInnerAliasBound
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -48962,7 +48962,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -48979,7 +48979,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSu
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49002,7 +49002,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49011,7 +49011,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -49079,11 +49079,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::~MapInnerAlias
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -49155,7 +49155,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::deseriali
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -49172,7 +49172,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49195,7 +49195,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::deleteDat
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49204,7 +49204,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -49272,11 +49272,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::~MapInnerAl
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -49348,7 +49348,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::deseri
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -49365,7 +49365,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasSequenceHel
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49388,7 +49388,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::delete
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49397,7 +49397,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::getKey
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -49465,11 +49465,11 @@ MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::~MapInnerAliasBo
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerAliasMapHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -49541,7 +49541,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::deserialize
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -49558,7 +49558,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPu
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49581,7 +49581,7 @@ void MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49590,7 +49590,7 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerAliasMapHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -49658,11 +49658,11 @@ MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::~MapInnerAliasBound
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerUnionHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerUnionHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -49734,7 +49734,7 @@ bool MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -49751,7 +49751,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSu
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49774,7 +49774,7 @@ void MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49783,7 +49783,7 @@ bool MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerUnionHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerUnionHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -49851,11 +49851,11 @@ MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::~MapInnerAliasB
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerStructureHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerStructureHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -49927,7 +49927,7 @@ bool MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::deserializ
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -49944,7 +49944,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerStructureHelperP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -49967,7 +49967,7 @@ void MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::deleteData
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -49976,7 +49976,7 @@ bool MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerStructureHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerStructureHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -50044,11 +50044,11 @@ MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::~MapInnerAliasBoun
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MapInnerAliasBoundedWStringHelperInnerBitsetHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerBitsetHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -50120,7 +50120,7 @@ bool MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -50137,7 +50137,7 @@ std::function<uint32_t()> MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -50160,7 +50160,7 @@ void MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -50169,7 +50169,7 @@ bool MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    MapInnerAliasBoundedWStringHelperInnerBitsetHelper* p_type = static_cast<MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data);
+    const MapInnerAliasBoundedWStringHelperInnerBitsetHelper* p_type = static_cast<const MapInnerAliasBoundedWStringHelperInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -50237,11 +50237,11 @@ BoundedSmallMapPubSubType::~BoundedSmallMapPubSubType()
 }
 
 bool BoundedSmallMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedSmallMap* p_type = static_cast<BoundedSmallMap*>(data);
+    const BoundedSmallMap* p_type = static_cast<const BoundedSmallMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -50313,7 +50313,7 @@ bool BoundedSmallMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedSmallMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -50330,7 +50330,7 @@ std::function<uint32_t()> BoundedSmallMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedSmallMap*>(data), current_alignment)) +
+                               *static_cast<const BoundedSmallMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -50353,7 +50353,7 @@ void BoundedSmallMapPubSubType::deleteData(
 }
 
 bool BoundedSmallMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -50362,7 +50362,7 @@ bool BoundedSmallMapPubSubType::getKey(
         return false;
     }
 
-    BoundedSmallMap* p_type = static_cast<BoundedSmallMap*>(data);
+    const BoundedSmallMap* p_type = static_cast<const BoundedSmallMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -50430,11 +50430,11 @@ BoundedLargeMapPubSubType::~BoundedLargeMapPubSubType()
 }
 
 bool BoundedLargeMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedLargeMap* p_type = static_cast<BoundedLargeMap*>(data);
+    const BoundedLargeMap* p_type = static_cast<const BoundedLargeMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -50506,7 +50506,7 @@ bool BoundedLargeMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedLargeMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -50523,7 +50523,7 @@ std::function<uint32_t()> BoundedLargeMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedLargeMap*>(data), current_alignment)) +
+                               *static_cast<const BoundedLargeMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -50546,7 +50546,7 @@ void BoundedLargeMapPubSubType::deleteData(
 }
 
 bool BoundedLargeMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -50555,7 +50555,7 @@ bool BoundedLargeMapPubSubType::getKey(
         return false;
     }
 
-    BoundedLargeMap* p_type = static_cast<BoundedLargeMap*>(data);
+    const BoundedLargeMap* p_type = static_cast<const BoundedLargeMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/mapsPubSubTypes.h
+++ b/test/dds-types-test/mapsPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~MapShortShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~MapShortUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~MapShortLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~MapShortULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~MapShortLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~MapShortULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~MapShortFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~MapShortDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~MapShortLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~MapShortBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~MapShortOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~MapShortCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~MapShortWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~MapShortStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~MapShortWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~MapShortInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~MapUShortShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~MapUShortUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2602,14 +2602,14 @@ public:
     eProsima_user_DllExport ~MapUShortLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2618,17 +2618,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2693,14 +2693,14 @@ public:
     eProsima_user_DllExport ~MapUShortULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2709,17 +2709,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2784,14 +2784,14 @@ public:
     eProsima_user_DllExport ~MapUShortLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2800,17 +2800,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2875,14 +2875,14 @@ public:
     eProsima_user_DllExport ~MapUShortULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2891,17 +2891,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2966,14 +2966,14 @@ public:
     eProsima_user_DllExport ~MapUShortFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2982,17 +2982,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3057,14 +3057,14 @@ public:
     eProsima_user_DllExport ~MapUShortDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3073,17 +3073,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3148,14 +3148,14 @@ public:
     eProsima_user_DllExport ~MapUShortLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3164,17 +3164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3239,14 +3239,14 @@ public:
     eProsima_user_DllExport ~MapUShortBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3255,17 +3255,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3330,14 +3330,14 @@ public:
     eProsima_user_DllExport ~MapUShortOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3346,17 +3346,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3421,14 +3421,14 @@ public:
     eProsima_user_DllExport ~MapUShortCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3437,17 +3437,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3512,14 +3512,14 @@ public:
     eProsima_user_DllExport ~MapUShortWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3528,17 +3528,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3603,14 +3603,14 @@ public:
     eProsima_user_DllExport ~MapUShortStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3619,17 +3619,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3694,14 +3694,14 @@ public:
     eProsima_user_DllExport ~MapUShortWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3710,17 +3710,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3785,14 +3785,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3801,17 +3801,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3876,14 +3876,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3892,17 +3892,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3967,14 +3967,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3983,17 +3983,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4058,14 +4058,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4074,17 +4074,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4149,14 +4149,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4165,17 +4165,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4240,14 +4240,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4256,17 +4256,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4331,14 +4331,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4347,17 +4347,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4422,14 +4422,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4438,17 +4438,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4513,14 +4513,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4529,17 +4529,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4604,14 +4604,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4620,17 +4620,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4695,14 +4695,14 @@ public:
     eProsima_user_DllExport ~MapUShortInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4711,17 +4711,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4786,14 +4786,14 @@ public:
     eProsima_user_DllExport ~MapLongShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4802,17 +4802,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4877,14 +4877,14 @@ public:
     eProsima_user_DllExport ~MapLongUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4893,17 +4893,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4968,14 +4968,14 @@ public:
     eProsima_user_DllExport ~MapLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4984,17 +4984,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5059,14 +5059,14 @@ public:
     eProsima_user_DllExport ~MapLongULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5075,17 +5075,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5150,14 +5150,14 @@ public:
     eProsima_user_DllExport ~MapLongKeyLongLongValuePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5166,17 +5166,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5241,14 +5241,14 @@ public:
     eProsima_user_DllExport ~MapLongULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5257,17 +5257,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5332,14 +5332,14 @@ public:
     eProsima_user_DllExport ~MapLongFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5348,17 +5348,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5423,14 +5423,14 @@ public:
     eProsima_user_DllExport ~MapLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5439,17 +5439,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5514,14 +5514,14 @@ public:
     eProsima_user_DllExport ~MapLongKeyLongDoubleValuePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5530,17 +5530,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5605,14 +5605,14 @@ public:
     eProsima_user_DllExport ~MapLongBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5621,17 +5621,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5696,14 +5696,14 @@ public:
     eProsima_user_DllExport ~MapLongOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5712,17 +5712,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5787,14 +5787,14 @@ public:
     eProsima_user_DllExport ~MapLongCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5803,17 +5803,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5878,14 +5878,14 @@ public:
     eProsima_user_DllExport ~MapLongWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5894,17 +5894,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5969,14 +5969,14 @@ public:
     eProsima_user_DllExport ~MapLongStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5985,17 +5985,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6060,14 +6060,14 @@ public:
     eProsima_user_DllExport ~MapLongWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6076,17 +6076,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6151,14 +6151,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6167,17 +6167,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6242,14 +6242,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6258,17 +6258,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6333,14 +6333,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6349,17 +6349,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6424,14 +6424,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6440,17 +6440,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6515,14 +6515,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6531,17 +6531,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6606,14 +6606,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6622,17 +6622,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6697,14 +6697,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6713,17 +6713,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6788,14 +6788,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6804,17 +6804,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6879,14 +6879,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6895,17 +6895,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6970,14 +6970,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6986,17 +6986,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7061,14 +7061,14 @@ public:
     eProsima_user_DllExport ~MapLongInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7077,17 +7077,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7152,14 +7152,14 @@ public:
     eProsima_user_DllExport ~MapULongShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7168,17 +7168,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7243,14 +7243,14 @@ public:
     eProsima_user_DllExport ~MapULongUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7259,17 +7259,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7334,14 +7334,14 @@ public:
     eProsima_user_DllExport ~MapULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7350,17 +7350,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7425,14 +7425,14 @@ public:
     eProsima_user_DllExport ~MapULongULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7441,17 +7441,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7516,14 +7516,14 @@ public:
     eProsima_user_DllExport ~MapKeyULongValueLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7532,17 +7532,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7607,14 +7607,14 @@ public:
     eProsima_user_DllExport ~MapULongULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7623,17 +7623,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7698,14 +7698,14 @@ public:
     eProsima_user_DllExport ~MapULongFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7714,17 +7714,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7789,14 +7789,14 @@ public:
     eProsima_user_DllExport ~MapULongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7805,17 +7805,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7880,14 +7880,14 @@ public:
     eProsima_user_DllExport ~MapKeyULongValueLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7896,17 +7896,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7971,14 +7971,14 @@ public:
     eProsima_user_DllExport ~MapULongBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7987,17 +7987,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8062,14 +8062,14 @@ public:
     eProsima_user_DllExport ~MapULongOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8078,17 +8078,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8153,14 +8153,14 @@ public:
     eProsima_user_DllExport ~MapULongCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8169,17 +8169,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8244,14 +8244,14 @@ public:
     eProsima_user_DllExport ~MapULongWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8260,17 +8260,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8335,14 +8335,14 @@ public:
     eProsima_user_DllExport ~MapULongStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8351,17 +8351,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8426,14 +8426,14 @@ public:
     eProsima_user_DllExport ~MapULongWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8442,17 +8442,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8517,14 +8517,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8533,17 +8533,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8608,14 +8608,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8624,17 +8624,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8699,14 +8699,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8715,17 +8715,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8790,14 +8790,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8806,17 +8806,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8881,14 +8881,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8897,17 +8897,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -8972,14 +8972,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -8988,17 +8988,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9063,14 +9063,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9079,17 +9079,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9154,14 +9154,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9170,17 +9170,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9245,14 +9245,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9261,17 +9261,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9336,14 +9336,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9352,17 +9352,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9427,14 +9427,14 @@ public:
     eProsima_user_DllExport ~MapULongInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9443,17 +9443,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9518,14 +9518,14 @@ public:
     eProsima_user_DllExport ~MapLongLongShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9534,17 +9534,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9609,14 +9609,14 @@ public:
     eProsima_user_DllExport ~MapLongLongUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9625,17 +9625,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9700,14 +9700,14 @@ public:
     eProsima_user_DllExport ~MapLongLongKeyLongValuePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9716,17 +9716,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9791,14 +9791,14 @@ public:
     eProsima_user_DllExport ~MapLongLongULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9807,17 +9807,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9882,14 +9882,14 @@ public:
     eProsima_user_DllExport ~MapLongLongLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9898,17 +9898,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -9973,14 +9973,14 @@ public:
     eProsima_user_DllExport ~MapLongLongULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -9989,17 +9989,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10064,14 +10064,14 @@ public:
     eProsima_user_DllExport ~MapLongLongFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10080,17 +10080,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10155,14 +10155,14 @@ public:
     eProsima_user_DllExport ~MapLongLongKeyDoubleValuePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10171,17 +10171,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10246,14 +10246,14 @@ public:
     eProsima_user_DllExport ~MapLongLongLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10262,17 +10262,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10337,14 +10337,14 @@ public:
     eProsima_user_DllExport ~MapLongLongBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10353,17 +10353,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10428,14 +10428,14 @@ public:
     eProsima_user_DllExport ~MapLongLongOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10444,17 +10444,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10519,14 +10519,14 @@ public:
     eProsima_user_DllExport ~MapLongLongCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10535,17 +10535,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10610,14 +10610,14 @@ public:
     eProsima_user_DllExport ~MapLongLongWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10626,17 +10626,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10701,14 +10701,14 @@ public:
     eProsima_user_DllExport ~MapLongLongStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10717,17 +10717,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10792,14 +10792,14 @@ public:
     eProsima_user_DllExport ~MapLongLongWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10808,17 +10808,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10883,14 +10883,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10899,17 +10899,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -10974,14 +10974,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -10990,17 +10990,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11065,14 +11065,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11081,17 +11081,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11156,14 +11156,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11172,17 +11172,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11247,14 +11247,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11263,17 +11263,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11338,14 +11338,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11354,17 +11354,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11429,14 +11429,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11445,17 +11445,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11520,14 +11520,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11536,17 +11536,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11611,14 +11611,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11627,17 +11627,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11702,14 +11702,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11718,17 +11718,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11793,14 +11793,14 @@ public:
     eProsima_user_DllExport ~MapLongLongInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11809,17 +11809,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11884,14 +11884,14 @@ public:
     eProsima_user_DllExport ~MapULongLongShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11900,17 +11900,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -11975,14 +11975,14 @@ public:
     eProsima_user_DllExport ~MapULongLongUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -11991,17 +11991,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12066,14 +12066,14 @@ public:
     eProsima_user_DllExport ~MapULongLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12082,17 +12082,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12157,14 +12157,14 @@ public:
     eProsima_user_DllExport ~MapULongLongULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12173,17 +12173,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12248,14 +12248,14 @@ public:
     eProsima_user_DllExport ~MapULongLongLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12264,17 +12264,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12339,14 +12339,14 @@ public:
     eProsima_user_DllExport ~MapULongLongULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12355,17 +12355,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12430,14 +12430,14 @@ public:
     eProsima_user_DllExport ~MapULongLongFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12446,17 +12446,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12521,14 +12521,14 @@ public:
     eProsima_user_DllExport ~MapKeyULongLongValueDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12537,17 +12537,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12612,14 +12612,14 @@ public:
     eProsima_user_DllExport ~MapULongLongLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12628,17 +12628,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12703,14 +12703,14 @@ public:
     eProsima_user_DllExport ~MapULongLongBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12719,17 +12719,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12794,14 +12794,14 @@ public:
     eProsima_user_DllExport ~MapULongLongOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12810,17 +12810,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12885,14 +12885,14 @@ public:
     eProsima_user_DllExport ~MapULongLongCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12901,17 +12901,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -12976,14 +12976,14 @@ public:
     eProsima_user_DllExport ~MapULongLongWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -12992,17 +12992,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13067,14 +13067,14 @@ public:
     eProsima_user_DllExport ~MapULongLongStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13083,17 +13083,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13158,14 +13158,14 @@ public:
     eProsima_user_DllExport ~MapULongLongWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13174,17 +13174,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13249,14 +13249,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13265,17 +13265,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13340,14 +13340,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13356,17 +13356,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13431,14 +13431,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13447,17 +13447,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13522,14 +13522,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13538,17 +13538,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13613,14 +13613,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13629,17 +13629,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13704,14 +13704,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13720,17 +13720,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13795,14 +13795,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13811,17 +13811,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13886,14 +13886,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13902,17 +13902,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -13977,14 +13977,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -13993,17 +13993,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14068,14 +14068,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14084,17 +14084,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14159,14 +14159,14 @@ public:
     eProsima_user_DllExport ~MapULongLongInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14175,17 +14175,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14250,14 +14250,14 @@ public:
     eProsima_user_DllExport ~MapStringShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14266,17 +14266,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14341,14 +14341,14 @@ public:
     eProsima_user_DllExport ~MapStringUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14357,17 +14357,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14432,14 +14432,14 @@ public:
     eProsima_user_DllExport ~MapStringLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14448,17 +14448,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14523,14 +14523,14 @@ public:
     eProsima_user_DllExport ~MapStringULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14539,17 +14539,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14614,14 +14614,14 @@ public:
     eProsima_user_DllExport ~MapStringLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14630,17 +14630,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14705,14 +14705,14 @@ public:
     eProsima_user_DllExport ~MapStringULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14721,17 +14721,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14796,14 +14796,14 @@ public:
     eProsima_user_DllExport ~MapStringFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14812,17 +14812,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14887,14 +14887,14 @@ public:
     eProsima_user_DllExport ~MapStringDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14903,17 +14903,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -14978,14 +14978,14 @@ public:
     eProsima_user_DllExport ~MapStringLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -14994,17 +14994,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15069,14 +15069,14 @@ public:
     eProsima_user_DllExport ~MapStringBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15085,17 +15085,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15160,14 +15160,14 @@ public:
     eProsima_user_DllExport ~MapStringOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15176,17 +15176,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15251,14 +15251,14 @@ public:
     eProsima_user_DllExport ~MapStringCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15267,17 +15267,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15342,14 +15342,14 @@ public:
     eProsima_user_DllExport ~MapStringWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15358,17 +15358,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15433,14 +15433,14 @@ public:
     eProsima_user_DllExport ~MapStringStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15449,17 +15449,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15524,14 +15524,14 @@ public:
     eProsima_user_DllExport ~MapStringWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15540,17 +15540,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15615,14 +15615,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15631,17 +15631,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15706,14 +15706,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15722,17 +15722,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15797,14 +15797,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15813,17 +15813,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15888,14 +15888,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15904,17 +15904,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -15979,14 +15979,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -15995,17 +15995,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16070,14 +16070,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16086,17 +16086,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16161,14 +16161,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16177,17 +16177,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16252,14 +16252,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16268,17 +16268,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16343,14 +16343,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16359,17 +16359,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16434,14 +16434,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16450,17 +16450,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16525,14 +16525,14 @@ public:
     eProsima_user_DllExport ~MapStringInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16541,17 +16541,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16616,14 +16616,14 @@ public:
     eProsima_user_DllExport ~MapWStringShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16632,17 +16632,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16707,14 +16707,14 @@ public:
     eProsima_user_DllExport ~MapWStringUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16723,17 +16723,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16798,14 +16798,14 @@ public:
     eProsima_user_DllExport ~MapWStringLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16814,17 +16814,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16889,14 +16889,14 @@ public:
     eProsima_user_DllExport ~MapWStringULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16905,17 +16905,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -16980,14 +16980,14 @@ public:
     eProsima_user_DllExport ~MapWStringLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -16996,17 +16996,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17071,14 +17071,14 @@ public:
     eProsima_user_DllExport ~MapWStringULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17087,17 +17087,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17162,14 +17162,14 @@ public:
     eProsima_user_DllExport ~MapWStringFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17178,17 +17178,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17253,14 +17253,14 @@ public:
     eProsima_user_DllExport ~MapWStringDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17269,17 +17269,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17344,14 +17344,14 @@ public:
     eProsima_user_DllExport ~MapWStringLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17360,17 +17360,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17435,14 +17435,14 @@ public:
     eProsima_user_DllExport ~MapWStringBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17451,17 +17451,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17526,14 +17526,14 @@ public:
     eProsima_user_DllExport ~MapWStringOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17542,17 +17542,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17617,14 +17617,14 @@ public:
     eProsima_user_DllExport ~MapWStringCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17633,17 +17633,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17708,14 +17708,14 @@ public:
     eProsima_user_DllExport ~MapWStringWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17724,17 +17724,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17799,14 +17799,14 @@ public:
     eProsima_user_DllExport ~MapWStringStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17815,17 +17815,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17890,14 +17890,14 @@ public:
     eProsima_user_DllExport ~MapWStringWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17906,17 +17906,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -17981,14 +17981,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -17997,17 +17997,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18072,14 +18072,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18088,17 +18088,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18163,14 +18163,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18179,17 +18179,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18254,14 +18254,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18270,17 +18270,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18345,14 +18345,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18361,17 +18361,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18436,14 +18436,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18452,17 +18452,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18527,14 +18527,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18543,17 +18543,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18618,14 +18618,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18634,17 +18634,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18709,14 +18709,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18725,17 +18725,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18800,14 +18800,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18816,17 +18816,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18891,14 +18891,14 @@ public:
     eProsima_user_DllExport ~MapWStringInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18907,17 +18907,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -18982,14 +18982,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -18998,17 +18998,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19073,14 +19073,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19089,17 +19089,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19164,14 +19164,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19180,17 +19180,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19255,14 +19255,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19271,17 +19271,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19346,14 +19346,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19362,17 +19362,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19437,14 +19437,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19453,17 +19453,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19528,14 +19528,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19544,17 +19544,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19619,14 +19619,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19635,17 +19635,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19710,14 +19710,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19726,17 +19726,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19801,14 +19801,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19817,17 +19817,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19892,14 +19892,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19908,17 +19908,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -19983,14 +19983,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -19999,17 +19999,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20074,14 +20074,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20090,17 +20090,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20165,14 +20165,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20181,17 +20181,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20256,14 +20256,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20272,17 +20272,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20347,14 +20347,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20363,17 +20363,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20438,14 +20438,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20454,17 +20454,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20529,14 +20529,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20545,17 +20545,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20620,14 +20620,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20636,17 +20636,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20711,14 +20711,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20727,17 +20727,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20802,14 +20802,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20818,17 +20818,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20893,14 +20893,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -20909,17 +20909,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -20984,14 +20984,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21000,17 +21000,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21075,14 +21075,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21091,17 +21091,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21166,14 +21166,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21182,17 +21182,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21257,14 +21257,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21273,17 +21273,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21348,14 +21348,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21364,17 +21364,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21439,14 +21439,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21455,17 +21455,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21530,14 +21530,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21546,17 +21546,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21621,14 +21621,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21637,17 +21637,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21712,14 +21712,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21728,17 +21728,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21803,14 +21803,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21819,17 +21819,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21894,14 +21894,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -21910,17 +21910,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -21985,14 +21985,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22001,17 +22001,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22076,14 +22076,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22092,17 +22092,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22167,14 +22167,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22183,17 +22183,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22258,14 +22258,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22274,17 +22274,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22349,14 +22349,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22365,17 +22365,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22440,14 +22440,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22456,17 +22456,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22531,14 +22531,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22547,17 +22547,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22622,14 +22622,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22638,17 +22638,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22713,14 +22713,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22729,17 +22729,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22804,14 +22804,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22820,17 +22820,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22895,14 +22895,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -22911,17 +22911,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -22986,14 +22986,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23002,17 +23002,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23077,14 +23077,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23093,17 +23093,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23168,14 +23168,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23184,17 +23184,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23259,14 +23259,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23275,17 +23275,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23350,14 +23350,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23366,17 +23366,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23441,14 +23441,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23457,17 +23457,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23532,14 +23532,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23548,17 +23548,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23623,14 +23623,14 @@ public:
     eProsima_user_DllExport ~MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23639,17 +23639,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23714,14 +23714,14 @@ public:
     eProsima_user_DllExport ~BoundedSmallMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23730,17 +23730,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -23805,14 +23805,14 @@ public:
     eProsima_user_DllExport ~BoundedLargeMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -23821,17 +23821,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/member_idPubSubTypes.cxx
+++ b/test/dds-types-test/member_idPubSubTypes.cxx
@@ -57,11 +57,11 @@ FixIdPubSubType::~FixIdPubSubType()
 }
 
 bool FixIdPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixId* p_type = static_cast<FixId*>(data);
+    const FixId* p_type = static_cast<const FixId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool FixIdPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixIdPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> FixIdPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixId*>(data), current_alignment)) +
+                               *static_cast<const FixId*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void FixIdPubSubType::deleteData(
 }
 
 bool FixIdPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool FixIdPubSubType::getKey(
         return false;
     }
 
-    FixId* p_type = static_cast<FixId*>(data);
+    const FixId* p_type = static_cast<const FixId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ FixHexIdPubSubType::~FixHexIdPubSubType()
 }
 
 bool FixHexIdPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixHexId* p_type = static_cast<FixHexId*>(data);
+    const FixHexId* p_type = static_cast<const FixHexId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool FixHexIdPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixHexIdPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> FixHexIdPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixHexId*>(data), current_alignment)) +
+                               *static_cast<const FixHexId*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void FixHexIdPubSubType::deleteData(
 }
 
 bool FixHexIdPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool FixHexIdPubSubType::getKey(
         return false;
     }
 
-    FixHexId* p_type = static_cast<FixHexId*>(data);
+    const FixHexId* p_type = static_cast<const FixHexId*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ FixHashidDefaultPubSubType::~FixHashidDefaultPubSubType()
 }
 
 bool FixHashidDefaultPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixHashidDefault* p_type = static_cast<FixHashidDefault*>(data);
+    const FixHashidDefault* p_type = static_cast<const FixHashidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool FixHashidDefaultPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixHashidDefaultPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> FixHashidDefaultPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixHashidDefault*>(data), current_alignment)) +
+                               *static_cast<const FixHashidDefault*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void FixHashidDefaultPubSubType::deleteData(
 }
 
 bool FixHashidDefaultPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool FixHashidDefaultPubSubType::getKey(
         return false;
     }
 
-    FixHashidDefault* p_type = static_cast<FixHashidDefault*>(data);
+    const FixHashidDefault* p_type = static_cast<const FixHashidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ FixHashidPubSubType::~FixHashidPubSubType()
 }
 
 bool FixHashidPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixHashid* p_type = static_cast<FixHashid*>(data);
+    const FixHashid* p_type = static_cast<const FixHashid*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool FixHashidPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixHashidPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> FixHashidPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixHashid*>(data), current_alignment)) +
+                               *static_cast<const FixHashid*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void FixHashidPubSubType::deleteData(
 }
 
 bool FixHashidPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool FixHashidPubSubType::getKey(
         return false;
     }
 
-    FixHashid* p_type = static_cast<FixHashid*>(data);
+    const FixHashid* p_type = static_cast<const FixHashid*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ FixMixPubSubType::~FixMixPubSubType()
 }
 
 bool FixMixPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FixMix* p_type = static_cast<FixMix*>(data);
+    const FixMix* p_type = static_cast<const FixMix*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool FixMixPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FixMixPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> FixMixPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FixMix*>(data), current_alignment)) +
+                               *static_cast<const FixMix*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void FixMixPubSubType::deleteData(
 }
 
 bool FixMixPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool FixMixPubSubType::getKey(
         return false;
     }
 
-    FixMix* p_type = static_cast<FixMix*>(data);
+    const FixMix* p_type = static_cast<const FixMix*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ AutoidDefaultPubSubType::~AutoidDefaultPubSubType()
 }
 
 bool AutoidDefaultPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AutoidDefault* p_type = static_cast<AutoidDefault*>(data);
+    const AutoidDefault* p_type = static_cast<const AutoidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool AutoidDefaultPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AutoidDefaultPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> AutoidDefaultPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AutoidDefault*>(data), current_alignment)) +
+                               *static_cast<const AutoidDefault*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void AutoidDefaultPubSubType::deleteData(
 }
 
 bool AutoidDefaultPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool AutoidDefaultPubSubType::getKey(
         return false;
     }
 
-    AutoidDefault* p_type = static_cast<AutoidDefault*>(data);
+    const AutoidDefault* p_type = static_cast<const AutoidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ AutoidSequentialPubSubType::~AutoidSequentialPubSubType()
 }
 
 bool AutoidSequentialPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AutoidSequential* p_type = static_cast<AutoidSequential*>(data);
+    const AutoidSequential* p_type = static_cast<const AutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool AutoidSequentialPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AutoidSequentialPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> AutoidSequentialPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AutoidSequential*>(data), current_alignment)) +
+                               *static_cast<const AutoidSequential*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void AutoidSequentialPubSubType::deleteData(
 }
 
 bool AutoidSequentialPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool AutoidSequentialPubSubType::getKey(
         return false;
     }
 
-    AutoidSequential* p_type = static_cast<AutoidSequential*>(data);
+    const AutoidSequential* p_type = static_cast<const AutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ AutoidHashPubSubType::~AutoidHashPubSubType()
 }
 
 bool AutoidHashPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AutoidHash* p_type = static_cast<AutoidHash*>(data);
+    const AutoidHash* p_type = static_cast<const AutoidHash*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool AutoidHashPubSubType::deserialize(
 }
 
 std::function<uint32_t()> AutoidHashPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> AutoidHashPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AutoidHash*>(data), current_alignment)) +
+                               *static_cast<const AutoidHash*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void AutoidHashPubSubType::deleteData(
 }
 
 bool AutoidHashPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool AutoidHashPubSubType::getKey(
         return false;
     }
 
-    AutoidHash* p_type = static_cast<AutoidHash*>(data);
+    const AutoidHash* p_type = static_cast<const AutoidHash*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ DerivedAutoidDefaultPubSubType::~DerivedAutoidDefaultPubSubType()
 }
 
 bool DerivedAutoidDefaultPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    DerivedAutoidDefault* p_type = static_cast<DerivedAutoidDefault*>(data);
+    const DerivedAutoidDefault* p_type = static_cast<const DerivedAutoidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool DerivedAutoidDefaultPubSubType::deserialize(
 }
 
 std::function<uint32_t()> DerivedAutoidDefaultPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> DerivedAutoidDefaultPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<DerivedAutoidDefault*>(data), current_alignment)) +
+                               *static_cast<const DerivedAutoidDefault*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void DerivedAutoidDefaultPubSubType::deleteData(
 }
 
 bool DerivedAutoidDefaultPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool DerivedAutoidDefaultPubSubType::getKey(
         return false;
     }
 
-    DerivedAutoidDefault* p_type = static_cast<DerivedAutoidDefault*>(data);
+    const DerivedAutoidDefault* p_type = static_cast<const DerivedAutoidDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ DerivedEmptyAutoidSequentialPubSubType::~DerivedEmptyAutoidSequentialPubSubType(
 }
 
 bool DerivedEmptyAutoidSequentialPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    DerivedEmptyAutoidSequential* p_type = static_cast<DerivedEmptyAutoidSequential*>(data);
+    const DerivedEmptyAutoidSequential* p_type = static_cast<const DerivedEmptyAutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool DerivedEmptyAutoidSequentialPubSubType::deserialize(
 }
 
 std::function<uint32_t()> DerivedEmptyAutoidSequentialPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> DerivedEmptyAutoidSequentialPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<DerivedEmptyAutoidSequential*>(data), current_alignment)) +
+                               *static_cast<const DerivedEmptyAutoidSequential*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void DerivedEmptyAutoidSequentialPubSubType::deleteData(
 }
 
 bool DerivedEmptyAutoidSequentialPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool DerivedEmptyAutoidSequentialPubSubType::getKey(
         return false;
     }
 
-    DerivedEmptyAutoidSequential* p_type = static_cast<DerivedEmptyAutoidSequential*>(data);
+    const DerivedEmptyAutoidSequential* p_type = static_cast<const DerivedEmptyAutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ DerivedAutoidSequentialPubSubType::~DerivedAutoidSequentialPubSubType()
 }
 
 bool DerivedAutoidSequentialPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    DerivedAutoidSequential* p_type = static_cast<DerivedAutoidSequential*>(data);
+    const DerivedAutoidSequential* p_type = static_cast<const DerivedAutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool DerivedAutoidSequentialPubSubType::deserialize(
 }
 
 std::function<uint32_t()> DerivedAutoidSequentialPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> DerivedAutoidSequentialPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<DerivedAutoidSequential*>(data), current_alignment)) +
+                               *static_cast<const DerivedAutoidSequential*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void DerivedAutoidSequentialPubSubType::deleteData(
 }
 
 bool DerivedAutoidSequentialPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool DerivedAutoidSequentialPubSubType::getKey(
         return false;
     }
 
-    DerivedAutoidSequential* p_type = static_cast<DerivedAutoidSequential*>(data);
+    const DerivedAutoidSequential* p_type = static_cast<const DerivedAutoidSequential*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ DerivedAutoidHashPubSubType::~DerivedAutoidHashPubSubType()
 }
 
 bool DerivedAutoidHashPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    DerivedAutoidHash* p_type = static_cast<DerivedAutoidHash*>(data);
+    const DerivedAutoidHash* p_type = static_cast<const DerivedAutoidHash*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool DerivedAutoidHashPubSubType::deserialize(
 }
 
 std::function<uint32_t()> DerivedAutoidHashPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> DerivedAutoidHashPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<DerivedAutoidHash*>(data), current_alignment)) +
+                               *static_cast<const DerivedAutoidHash*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void DerivedAutoidHashPubSubType::deleteData(
 }
 
 bool DerivedAutoidHashPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool DerivedAutoidHashPubSubType::getKey(
         return false;
     }
 
-    DerivedAutoidHash* p_type = static_cast<DerivedAutoidHash*>(data);
+    const DerivedAutoidHash* p_type = static_cast<const DerivedAutoidHash*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/member_idPubSubTypes.h
+++ b/test/dds-types-test/member_idPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~FixIdPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -144,14 +144,14 @@ public:
     eProsima_user_DllExport ~FixHexIdPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -160,17 +160,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -235,14 +235,14 @@ public:
     eProsima_user_DllExport ~FixHashidDefaultPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -251,17 +251,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -326,14 +326,14 @@ public:
     eProsima_user_DllExport ~FixHashidPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -342,17 +342,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -417,14 +417,14 @@ public:
     eProsima_user_DllExport ~FixMixPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -433,17 +433,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -508,14 +508,14 @@ public:
     eProsima_user_DllExport ~AutoidDefaultPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -524,17 +524,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -599,14 +599,14 @@ public:
     eProsima_user_DllExport ~AutoidSequentialPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -615,17 +615,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -690,14 +690,14 @@ public:
     eProsima_user_DllExport ~AutoidHashPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -706,17 +706,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -781,14 +781,14 @@ public:
     eProsima_user_DllExport ~DerivedAutoidDefaultPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -797,17 +797,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -872,14 +872,14 @@ public:
     eProsima_user_DllExport ~DerivedEmptyAutoidSequentialPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -888,17 +888,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -963,14 +963,14 @@ public:
     eProsima_user_DllExport ~DerivedAutoidSequentialPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -979,17 +979,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1054,14 +1054,14 @@ public:
     eProsima_user_DllExport ~DerivedAutoidHashPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1070,17 +1070,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/mutablePubSubTypes.cxx
+++ b/test/dds-types-test/mutablePubSubTypes.cxx
@@ -57,11 +57,11 @@ MutableShortStructPubSubType::~MutableShortStructPubSubType()
 }
 
 bool MutableShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableShortStruct* p_type = static_cast<MutableShortStruct*>(data);
+    const MutableShortStruct* p_type = static_cast<const MutableShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool MutableShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> MutableShortStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableShortStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void MutableShortStructPubSubType::deleteData(
 }
 
 bool MutableShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool MutableShortStructPubSubType::getKey(
         return false;
     }
 
-    MutableShortStruct* p_type = static_cast<MutableShortStruct*>(data);
+    const MutableShortStruct* p_type = static_cast<const MutableShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ MutableUShortStructPubSubType::~MutableUShortStructPubSubType()
 }
 
 bool MutableUShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableUShortStruct* p_type = static_cast<MutableUShortStruct*>(data);
+    const MutableUShortStruct* p_type = static_cast<const MutableUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool MutableUShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableUShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> MutableUShortStructPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableUShortStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableUShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void MutableUShortStructPubSubType::deleteData(
 }
 
 bool MutableUShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool MutableUShortStructPubSubType::getKey(
         return false;
     }
 
-    MutableUShortStruct* p_type = static_cast<MutableUShortStruct*>(data);
+    const MutableUShortStruct* p_type = static_cast<const MutableUShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ MutableLongStructPubSubType::~MutableLongStructPubSubType()
 }
 
 bool MutableLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableLongStruct* p_type = static_cast<MutableLongStruct*>(data);
+    const MutableLongStruct* p_type = static_cast<const MutableLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool MutableLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> MutableLongStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableLongStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void MutableLongStructPubSubType::deleteData(
 }
 
 bool MutableLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool MutableLongStructPubSubType::getKey(
         return false;
     }
 
-    MutableLongStruct* p_type = static_cast<MutableLongStruct*>(data);
+    const MutableLongStruct* p_type = static_cast<const MutableLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ MutableULongStructPubSubType::~MutableULongStructPubSubType()
 }
 
 bool MutableULongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableULongStruct* p_type = static_cast<MutableULongStruct*>(data);
+    const MutableULongStruct* p_type = static_cast<const MutableULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool MutableULongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableULongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> MutableULongStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableULongStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableULongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void MutableULongStructPubSubType::deleteData(
 }
 
 bool MutableULongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool MutableULongStructPubSubType::getKey(
         return false;
     }
 
-    MutableULongStruct* p_type = static_cast<MutableULongStruct*>(data);
+    const MutableULongStruct* p_type = static_cast<const MutableULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ MutableLongLongStructPubSubType::~MutableLongLongStructPubSubType()
 }
 
 bool MutableLongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableLongLongStruct* p_type = static_cast<MutableLongLongStruct*>(data);
+    const MutableLongLongStruct* p_type = static_cast<const MutableLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool MutableLongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableLongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> MutableLongLongStructPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableLongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableLongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void MutableLongLongStructPubSubType::deleteData(
 }
 
 bool MutableLongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool MutableLongLongStructPubSubType::getKey(
         return false;
     }
 
-    MutableLongLongStruct* p_type = static_cast<MutableLongLongStruct*>(data);
+    const MutableLongLongStruct* p_type = static_cast<const MutableLongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ MutableULongLongStructPubSubType::~MutableULongLongStructPubSubType()
 }
 
 bool MutableULongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableULongLongStruct* p_type = static_cast<MutableULongLongStruct*>(data);
+    const MutableULongLongStruct* p_type = static_cast<const MutableULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool MutableULongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableULongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> MutableULongLongStructPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableULongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableULongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void MutableULongLongStructPubSubType::deleteData(
 }
 
 bool MutableULongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool MutableULongLongStructPubSubType::getKey(
         return false;
     }
 
-    MutableULongLongStruct* p_type = static_cast<MutableULongLongStruct*>(data);
+    const MutableULongLongStruct* p_type = static_cast<const MutableULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ MutableFloatStructPubSubType::~MutableFloatStructPubSubType()
 }
 
 bool MutableFloatStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableFloatStruct* p_type = static_cast<MutableFloatStruct*>(data);
+    const MutableFloatStruct* p_type = static_cast<const MutableFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool MutableFloatStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableFloatStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> MutableFloatStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableFloatStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableFloatStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void MutableFloatStructPubSubType::deleteData(
 }
 
 bool MutableFloatStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool MutableFloatStructPubSubType::getKey(
         return false;
     }
 
-    MutableFloatStruct* p_type = static_cast<MutableFloatStruct*>(data);
+    const MutableFloatStruct* p_type = static_cast<const MutableFloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ MutableDoubleStructPubSubType::~MutableDoubleStructPubSubType()
 }
 
 bool MutableDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableDoubleStruct* p_type = static_cast<MutableDoubleStruct*>(data);
+    const MutableDoubleStruct* p_type = static_cast<const MutableDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool MutableDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> MutableDoubleStructPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void MutableDoubleStructPubSubType::deleteData(
 }
 
 bool MutableDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool MutableDoubleStructPubSubType::getKey(
         return false;
     }
 
-    MutableDoubleStruct* p_type = static_cast<MutableDoubleStruct*>(data);
+    const MutableDoubleStruct* p_type = static_cast<const MutableDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ MutableLongDoubleStructPubSubType::~MutableLongDoubleStructPubSubType()
 }
 
 bool MutableLongDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableLongDoubleStruct* p_type = static_cast<MutableLongDoubleStruct*>(data);
+    const MutableLongDoubleStruct* p_type = static_cast<const MutableLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool MutableLongDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableLongDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> MutableLongDoubleStructPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableLongDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableLongDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void MutableLongDoubleStructPubSubType::deleteData(
 }
 
 bool MutableLongDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool MutableLongDoubleStructPubSubType::getKey(
         return false;
     }
 
-    MutableLongDoubleStruct* p_type = static_cast<MutableLongDoubleStruct*>(data);
+    const MutableLongDoubleStruct* p_type = static_cast<const MutableLongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ MutableBooleanStructPubSubType::~MutableBooleanStructPubSubType()
 }
 
 bool MutableBooleanStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableBooleanStruct* p_type = static_cast<MutableBooleanStruct*>(data);
+    const MutableBooleanStruct* p_type = static_cast<const MutableBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool MutableBooleanStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableBooleanStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> MutableBooleanStructPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableBooleanStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableBooleanStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void MutableBooleanStructPubSubType::deleteData(
 }
 
 bool MutableBooleanStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool MutableBooleanStructPubSubType::getKey(
         return false;
     }
 
-    MutableBooleanStruct* p_type = static_cast<MutableBooleanStruct*>(data);
+    const MutableBooleanStruct* p_type = static_cast<const MutableBooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ MutableOctetStructPubSubType::~MutableOctetStructPubSubType()
 }
 
 bool MutableOctetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableOctetStruct* p_type = static_cast<MutableOctetStruct*>(data);
+    const MutableOctetStruct* p_type = static_cast<const MutableOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool MutableOctetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableOctetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> MutableOctetStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableOctetStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableOctetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void MutableOctetStructPubSubType::deleteData(
 }
 
 bool MutableOctetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool MutableOctetStructPubSubType::getKey(
         return false;
     }
 
-    MutableOctetStruct* p_type = static_cast<MutableOctetStruct*>(data);
+    const MutableOctetStruct* p_type = static_cast<const MutableOctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ MutableCharStructPubSubType::~MutableCharStructPubSubType()
 }
 
 bool MutableCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableCharStruct* p_type = static_cast<MutableCharStruct*>(data);
+    const MutableCharStruct* p_type = static_cast<const MutableCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool MutableCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> MutableCharStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableCharStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void MutableCharStructPubSubType::deleteData(
 }
 
 bool MutableCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool MutableCharStructPubSubType::getKey(
         return false;
     }
 
-    MutableCharStruct* p_type = static_cast<MutableCharStruct*>(data);
+    const MutableCharStruct* p_type = static_cast<const MutableCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ MutableWCharStructPubSubType::~MutableWCharStructPubSubType()
 }
 
 bool MutableWCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableWCharStruct* p_type = static_cast<MutableWCharStruct*>(data);
+    const MutableWCharStruct* p_type = static_cast<const MutableWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool MutableWCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableWCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> MutableWCharStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableWCharStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableWCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void MutableWCharStructPubSubType::deleteData(
 }
 
 bool MutableWCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool MutableWCharStructPubSubType::getKey(
         return false;
     }
 
-    MutableWCharStruct* p_type = static_cast<MutableWCharStruct*>(data);
+    const MutableWCharStruct* p_type = static_cast<const MutableWCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ MutableUnionStructPubSubType::~MutableUnionStructPubSubType()
 }
 
 bool MutableUnionStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableUnionStruct* p_type = static_cast<MutableUnionStruct*>(data);
+    const MutableUnionStruct* p_type = static_cast<const MutableUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool MutableUnionStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableUnionStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> MutableUnionStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableUnionStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableUnionStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void MutableUnionStructPubSubType::deleteData(
 }
 
 bool MutableUnionStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool MutableUnionStructPubSubType::getKey(
         return false;
     }
 
-    MutableUnionStruct* p_type = static_cast<MutableUnionStruct*>(data);
+    const MutableUnionStruct* p_type = static_cast<const MutableUnionStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ MutableEmptyStructPubSubType::~MutableEmptyStructPubSubType()
 }
 
 bool MutableEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableEmptyStruct* p_type = static_cast<MutableEmptyStruct*>(data);
+    const MutableEmptyStruct* p_type = static_cast<const MutableEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool MutableEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> MutableEmptyStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void MutableEmptyStructPubSubType::deleteData(
 }
 
 bool MutableEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool MutableEmptyStructPubSubType::getKey(
         return false;
     }
 
-    MutableEmptyStruct* p_type = static_cast<MutableEmptyStruct*>(data);
+    const MutableEmptyStruct* p_type = static_cast<const MutableEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ MutableEmptyInheritanceStructPubSubType::~MutableEmptyInheritanceStructPubSubTyp
 }
 
 bool MutableEmptyInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableEmptyInheritanceStruct* p_type = static_cast<MutableEmptyInheritanceStruct*>(data);
+    const MutableEmptyInheritanceStruct* p_type = static_cast<const MutableEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool MutableEmptyInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableEmptyInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> MutableEmptyInheritanceStructPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableEmptyInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableEmptyInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void MutableEmptyInheritanceStructPubSubType::deleteData(
 }
 
 bool MutableEmptyInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool MutableEmptyInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    MutableEmptyInheritanceStruct* p_type = static_cast<MutableEmptyInheritanceStruct*>(data);
+    const MutableEmptyInheritanceStruct* p_type = static_cast<const MutableEmptyInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ MutableInheritanceStructPubSubType::~MutableInheritanceStructPubSubType()
 }
 
 bool MutableInheritanceStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableInheritanceStruct* p_type = static_cast<MutableInheritanceStruct*>(data);
+    const MutableInheritanceStruct* p_type = static_cast<const MutableInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool MutableInheritanceStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableInheritanceStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> MutableInheritanceStructPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableInheritanceStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableInheritanceStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void MutableInheritanceStructPubSubType::deleteData(
 }
 
 bool MutableInheritanceStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool MutableInheritanceStructPubSubType::getKey(
         return false;
     }
 
-    MutableInheritanceStruct* p_type = static_cast<MutableInheritanceStruct*>(data);
+    const MutableInheritanceStruct* p_type = static_cast<const MutableInheritanceStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ MutableInheritanceEmptyStructPubSubType::~MutableInheritanceEmptyStructPubSubTyp
 }
 
 bool MutableInheritanceEmptyStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableInheritanceEmptyStruct* p_type = static_cast<MutableInheritanceEmptyStruct*>(data);
+    const MutableInheritanceEmptyStruct* p_type = static_cast<const MutableInheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool MutableInheritanceEmptyStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableInheritanceEmptyStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> MutableInheritanceEmptyStructPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableInheritanceEmptyStruct*>(data), current_alignment)) +
+                               *static_cast<const MutableInheritanceEmptyStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void MutableInheritanceEmptyStructPubSubType::deleteData(
 }
 
 bool MutableInheritanceEmptyStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool MutableInheritanceEmptyStructPubSubType::getKey(
         return false;
     }
 
-    MutableInheritanceEmptyStruct* p_type = static_cast<MutableInheritanceEmptyStruct*>(data);
+    const MutableInheritanceEmptyStruct* p_type = static_cast<const MutableInheritanceEmptyStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ MutableExtensibilityInheritancePubSubType::~MutableExtensibilityInheritancePubSu
 }
 
 bool MutableExtensibilityInheritancePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    MutableExtensibilityInheritance* p_type = static_cast<MutableExtensibilityInheritance*>(data);
+    const MutableExtensibilityInheritance* p_type = static_cast<const MutableExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool MutableExtensibilityInheritancePubSubType::deserialize(
 }
 
 std::function<uint32_t()> MutableExtensibilityInheritancePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> MutableExtensibilityInheritancePubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<MutableExtensibilityInheritance*>(data), current_alignment)) +
+                               *static_cast<const MutableExtensibilityInheritance*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void MutableExtensibilityInheritancePubSubType::deleteData(
 }
 
 bool MutableExtensibilityInheritancePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool MutableExtensibilityInheritancePubSubType::getKey(
         return false;
     }
 
-    MutableExtensibilityInheritance* p_type = static_cast<MutableExtensibilityInheritance*>(data);
+    const MutableExtensibilityInheritance* p_type = static_cast<const MutableExtensibilityInheritance*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/mutablePubSubTypes.h
+++ b/test/dds-types-test/mutablePubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~MutableShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~MutableUShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~MutableLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~MutableULongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~MutableLongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~MutableULongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~MutableFloatStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~MutableDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~MutableLongDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~MutableBooleanStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~MutableOctetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~MutableCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~MutableWCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~MutableUnionStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~MutableEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~MutableEmptyInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~MutableInheritanceStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~MutableInheritanceEmptyStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~MutableExtensibilityInheritancePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/optionalPubSubTypes.cxx
+++ b/test/dds-types-test/optionalPubSubTypes.cxx
@@ -57,11 +57,11 @@ short_optionalPubSubType::~short_optionalPubSubType()
 }
 
 bool short_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    short_optional* p_type = static_cast<short_optional*>(data);
+    const short_optional* p_type = static_cast<const short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool short_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> short_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> short_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<short_optional*>(data), current_alignment)) +
+                               *static_cast<const short_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void short_optionalPubSubType::deleteData(
 }
 
 bool short_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool short_optionalPubSubType::getKey(
         return false;
     }
 
-    short_optional* p_type = static_cast<short_optional*>(data);
+    const short_optional* p_type = static_cast<const short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ ushort_optionalPubSubType::~ushort_optionalPubSubType()
 }
 
 bool ushort_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ushort_optional* p_type = static_cast<ushort_optional*>(data);
+    const ushort_optional* p_type = static_cast<const ushort_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool ushort_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ushort_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> ushort_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ushort_optional*>(data), current_alignment)) +
+                               *static_cast<const ushort_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void ushort_optionalPubSubType::deleteData(
 }
 
 bool ushort_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool ushort_optionalPubSubType::getKey(
         return false;
     }
 
-    ushort_optional* p_type = static_cast<ushort_optional*>(data);
+    const ushort_optional* p_type = static_cast<const ushort_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ long_optionalPubSubType::~long_optionalPubSubType()
 }
 
 bool long_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    long_optional* p_type = static_cast<long_optional*>(data);
+    const long_optional* p_type = static_cast<const long_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool long_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> long_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> long_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<long_optional*>(data), current_alignment)) +
+                               *static_cast<const long_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void long_optionalPubSubType::deleteData(
 }
 
 bool long_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool long_optionalPubSubType::getKey(
         return false;
     }
 
-    long_optional* p_type = static_cast<long_optional*>(data);
+    const long_optional* p_type = static_cast<const long_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ ulong_optionalPubSubType::~ulong_optionalPubSubType()
 }
 
 bool ulong_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulong_optional* p_type = static_cast<ulong_optional*>(data);
+    const ulong_optional* p_type = static_cast<const ulong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool ulong_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulong_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> ulong_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulong_optional*>(data), current_alignment)) +
+                               *static_cast<const ulong_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void ulong_optionalPubSubType::deleteData(
 }
 
 bool ulong_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool ulong_optionalPubSubType::getKey(
         return false;
     }
 
-    ulong_optional* p_type = static_cast<ulong_optional*>(data);
+    const ulong_optional* p_type = static_cast<const ulong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ longlong_optionalPubSubType::~longlong_optionalPubSubType()
 }
 
 bool longlong_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longlong_optional* p_type = static_cast<longlong_optional*>(data);
+    const longlong_optional* p_type = static_cast<const longlong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool longlong_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longlong_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> longlong_optionalPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longlong_optional*>(data), current_alignment)) +
+                               *static_cast<const longlong_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void longlong_optionalPubSubType::deleteData(
 }
 
 bool longlong_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool longlong_optionalPubSubType::getKey(
         return false;
     }
 
-    longlong_optional* p_type = static_cast<longlong_optional*>(data);
+    const longlong_optional* p_type = static_cast<const longlong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ ulonglong_optionalPubSubType::~ulonglong_optionalPubSubType()
 }
 
 bool ulonglong_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulonglong_optional* p_type = static_cast<ulonglong_optional*>(data);
+    const ulonglong_optional* p_type = static_cast<const ulonglong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool ulonglong_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulonglong_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> ulonglong_optionalPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulonglong_optional*>(data), current_alignment)) +
+                               *static_cast<const ulonglong_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void ulonglong_optionalPubSubType::deleteData(
 }
 
 bool ulonglong_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool ulonglong_optionalPubSubType::getKey(
         return false;
     }
 
-    ulonglong_optional* p_type = static_cast<ulonglong_optional*>(data);
+    const ulonglong_optional* p_type = static_cast<const ulonglong_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ float_optionalPubSubType::~float_optionalPubSubType()
 }
 
 bool float_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    float_optional* p_type = static_cast<float_optional*>(data);
+    const float_optional* p_type = static_cast<const float_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool float_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> float_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> float_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<float_optional*>(data), current_alignment)) +
+                               *static_cast<const float_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void float_optionalPubSubType::deleteData(
 }
 
 bool float_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool float_optionalPubSubType::getKey(
         return false;
     }
 
-    float_optional* p_type = static_cast<float_optional*>(data);
+    const float_optional* p_type = static_cast<const float_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ double_optionalPubSubType::~double_optionalPubSubType()
 }
 
 bool double_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    double_optional* p_type = static_cast<double_optional*>(data);
+    const double_optional* p_type = static_cast<const double_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool double_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> double_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> double_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<double_optional*>(data), current_alignment)) +
+                               *static_cast<const double_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void double_optionalPubSubType::deleteData(
 }
 
 bool double_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool double_optionalPubSubType::getKey(
         return false;
     }
 
-    double_optional* p_type = static_cast<double_optional*>(data);
+    const double_optional* p_type = static_cast<const double_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ longdouble_optionalPubSubType::~longdouble_optionalPubSubType()
 }
 
 bool longdouble_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longdouble_optional* p_type = static_cast<longdouble_optional*>(data);
+    const longdouble_optional* p_type = static_cast<const longdouble_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool longdouble_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longdouble_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> longdouble_optionalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longdouble_optional*>(data), current_alignment)) +
+                               *static_cast<const longdouble_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void longdouble_optionalPubSubType::deleteData(
 }
 
 bool longdouble_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool longdouble_optionalPubSubType::getKey(
         return false;
     }
 
-    longdouble_optional* p_type = static_cast<longdouble_optional*>(data);
+    const longdouble_optional* p_type = static_cast<const longdouble_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ boolean_optionalPubSubType::~boolean_optionalPubSubType()
 }
 
 bool boolean_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    boolean_optional* p_type = static_cast<boolean_optional*>(data);
+    const boolean_optional* p_type = static_cast<const boolean_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool boolean_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> boolean_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> boolean_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<boolean_optional*>(data), current_alignment)) +
+                               *static_cast<const boolean_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void boolean_optionalPubSubType::deleteData(
 }
 
 bool boolean_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool boolean_optionalPubSubType::getKey(
         return false;
     }
 
-    boolean_optional* p_type = static_cast<boolean_optional*>(data);
+    const boolean_optional* p_type = static_cast<const boolean_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ octet_optionalPubSubType::~octet_optionalPubSubType()
 }
 
 bool octet_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    octet_optional* p_type = static_cast<octet_optional*>(data);
+    const octet_optional* p_type = static_cast<const octet_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool octet_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> octet_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> octet_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<octet_optional*>(data), current_alignment)) +
+                               *static_cast<const octet_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void octet_optionalPubSubType::deleteData(
 }
 
 bool octet_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool octet_optionalPubSubType::getKey(
         return false;
     }
 
-    octet_optional* p_type = static_cast<octet_optional*>(data);
+    const octet_optional* p_type = static_cast<const octet_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ char_optionalPubSubType::~char_optionalPubSubType()
 }
 
 bool char_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    char_optional* p_type = static_cast<char_optional*>(data);
+    const char_optional* p_type = static_cast<const char_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool char_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> char_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> char_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<char_optional*>(data), current_alignment)) +
+                               *static_cast<const char_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void char_optionalPubSubType::deleteData(
 }
 
 bool char_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool char_optionalPubSubType::getKey(
         return false;
     }
 
-    char_optional* p_type = static_cast<char_optional*>(data);
+    const char_optional* p_type = static_cast<const char_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ wchar_optionalPubSubType::~wchar_optionalPubSubType()
 }
 
 bool wchar_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    wchar_optional* p_type = static_cast<wchar_optional*>(data);
+    const wchar_optional* p_type = static_cast<const wchar_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool wchar_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> wchar_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> wchar_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<wchar_optional*>(data), current_alignment)) +
+                               *static_cast<const wchar_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void wchar_optionalPubSubType::deleteData(
 }
 
 bool wchar_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool wchar_optionalPubSubType::getKey(
         return false;
     }
 
-    wchar_optional* p_type = static_cast<wchar_optional*>(data);
+    const wchar_optional* p_type = static_cast<const wchar_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ short_align_1_optionalPubSubType::~short_align_1_optionalPubSubType()
 }
 
 bool short_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    short_align_1_optional* p_type = static_cast<short_align_1_optional*>(data);
+    const short_align_1_optional* p_type = static_cast<const short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool short_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> short_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> short_align_1_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<short_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const short_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void short_align_1_optionalPubSubType::deleteData(
 }
 
 bool short_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool short_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    short_align_1_optional* p_type = static_cast<short_align_1_optional*>(data);
+    const short_align_1_optional* p_type = static_cast<const short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ short_align_2_optionalPubSubType::~short_align_2_optionalPubSubType()
 }
 
 bool short_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    short_align_2_optional* p_type = static_cast<short_align_2_optional*>(data);
+    const short_align_2_optional* p_type = static_cast<const short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool short_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> short_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> short_align_2_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<short_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const short_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void short_align_2_optionalPubSubType::deleteData(
 }
 
 bool short_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool short_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    short_align_2_optional* p_type = static_cast<short_align_2_optional*>(data);
+    const short_align_2_optional* p_type = static_cast<const short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ short_align_4_optionalPubSubType::~short_align_4_optionalPubSubType()
 }
 
 bool short_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    short_align_4_optional* p_type = static_cast<short_align_4_optional*>(data);
+    const short_align_4_optional* p_type = static_cast<const short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool short_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> short_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> short_align_4_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<short_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const short_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void short_align_4_optionalPubSubType::deleteData(
 }
 
 bool short_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool short_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    short_align_4_optional* p_type = static_cast<short_align_4_optional*>(data);
+    const short_align_4_optional* p_type = static_cast<const short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ ushort_align_1_optionalPubSubType::~ushort_align_1_optionalPubSubType()
 }
 
 bool ushort_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ushort_align_1_optional* p_type = static_cast<ushort_align_1_optional*>(data);
+    const ushort_align_1_optional* p_type = static_cast<const ushort_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool ushort_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ushort_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> ushort_align_1_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ushort_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const ushort_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void ushort_align_1_optionalPubSubType::deleteData(
 }
 
 bool ushort_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool ushort_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    ushort_align_1_optional* p_type = static_cast<ushort_align_1_optional*>(data);
+    const ushort_align_1_optional* p_type = static_cast<const ushort_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ ushort_align_2_optionalPubSubType::~ushort_align_2_optionalPubSubType()
 }
 
 bool ushort_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ushort_align_2_optional* p_type = static_cast<ushort_align_2_optional*>(data);
+    const ushort_align_2_optional* p_type = static_cast<const ushort_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool ushort_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ushort_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> ushort_align_2_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ushort_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const ushort_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void ushort_align_2_optionalPubSubType::deleteData(
 }
 
 bool ushort_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool ushort_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    ushort_align_2_optional* p_type = static_cast<ushort_align_2_optional*>(data);
+    const ushort_align_2_optional* p_type = static_cast<const ushort_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ ushort_align_4_optionalPubSubType::~ushort_align_4_optionalPubSubType()
 }
 
 bool ushort_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ushort_align_4_optional* p_type = static_cast<ushort_align_4_optional*>(data);
+    const ushort_align_4_optional* p_type = static_cast<const ushort_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool ushort_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ushort_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> ushort_align_4_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ushort_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const ushort_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void ushort_align_4_optionalPubSubType::deleteData(
 }
 
 bool ushort_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool ushort_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    ushort_align_4_optional* p_type = static_cast<ushort_align_4_optional*>(data);
+    const ushort_align_4_optional* p_type = static_cast<const ushort_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ long_align_1_optionalPubSubType::~long_align_1_optionalPubSubType()
 }
 
 bool long_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    long_align_1_optional* p_type = static_cast<long_align_1_optional*>(data);
+    const long_align_1_optional* p_type = static_cast<const long_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool long_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> long_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> long_align_1_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<long_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const long_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void long_align_1_optionalPubSubType::deleteData(
 }
 
 bool long_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool long_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    long_align_1_optional* p_type = static_cast<long_align_1_optional*>(data);
+    const long_align_1_optional* p_type = static_cast<const long_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ long_align_2_optionalPubSubType::~long_align_2_optionalPubSubType()
 }
 
 bool long_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    long_align_2_optional* p_type = static_cast<long_align_2_optional*>(data);
+    const long_align_2_optional* p_type = static_cast<const long_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool long_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> long_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> long_align_2_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<long_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const long_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void long_align_2_optionalPubSubType::deleteData(
 }
 
 bool long_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool long_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    long_align_2_optional* p_type = static_cast<long_align_2_optional*>(data);
+    const long_align_2_optional* p_type = static_cast<const long_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ long_align_4_optionalPubSubType::~long_align_4_optionalPubSubType()
 }
 
 bool long_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    long_align_4_optional* p_type = static_cast<long_align_4_optional*>(data);
+    const long_align_4_optional* p_type = static_cast<const long_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool long_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> long_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> long_align_4_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<long_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const long_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void long_align_4_optionalPubSubType::deleteData(
 }
 
 bool long_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool long_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    long_align_4_optional* p_type = static_cast<long_align_4_optional*>(data);
+    const long_align_4_optional* p_type = static_cast<const long_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ ulong_align_1_optionalPubSubType::~ulong_align_1_optionalPubSubType()
 }
 
 bool ulong_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulong_align_1_optional* p_type = static_cast<ulong_align_1_optional*>(data);
+    const ulong_align_1_optional* p_type = static_cast<const ulong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool ulong_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulong_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> ulong_align_1_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulong_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const ulong_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void ulong_align_1_optionalPubSubType::deleteData(
 }
 
 bool ulong_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool ulong_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    ulong_align_1_optional* p_type = static_cast<ulong_align_1_optional*>(data);
+    const ulong_align_1_optional* p_type = static_cast<const ulong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ ulong_align_2_optionalPubSubType::~ulong_align_2_optionalPubSubType()
 }
 
 bool ulong_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulong_align_2_optional* p_type = static_cast<ulong_align_2_optional*>(data);
+    const ulong_align_2_optional* p_type = static_cast<const ulong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool ulong_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulong_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> ulong_align_2_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulong_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const ulong_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void ulong_align_2_optionalPubSubType::deleteData(
 }
 
 bool ulong_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool ulong_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    ulong_align_2_optional* p_type = static_cast<ulong_align_2_optional*>(data);
+    const ulong_align_2_optional* p_type = static_cast<const ulong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ ulong_align_4_optionalPubSubType::~ulong_align_4_optionalPubSubType()
 }
 
 bool ulong_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulong_align_4_optional* p_type = static_cast<ulong_align_4_optional*>(data);
+    const ulong_align_4_optional* p_type = static_cast<const ulong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool ulong_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulong_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> ulong_align_4_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulong_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const ulong_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void ulong_align_4_optionalPubSubType::deleteData(
 }
 
 bool ulong_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool ulong_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    ulong_align_4_optional* p_type = static_cast<ulong_align_4_optional*>(data);
+    const ulong_align_4_optional* p_type = static_cast<const ulong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ longlong_align_1_optionalPubSubType::~longlong_align_1_optionalPubSubType()
 }
 
 bool longlong_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longlong_align_1_optional* p_type = static_cast<longlong_align_1_optional*>(data);
+    const longlong_align_1_optional* p_type = static_cast<const longlong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool longlong_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longlong_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> longlong_align_1_optionalPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longlong_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const longlong_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void longlong_align_1_optionalPubSubType::deleteData(
 }
 
 bool longlong_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool longlong_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    longlong_align_1_optional* p_type = static_cast<longlong_align_1_optional*>(data);
+    const longlong_align_1_optional* p_type = static_cast<const longlong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ longlong_align_2_optionalPubSubType::~longlong_align_2_optionalPubSubType()
 }
 
 bool longlong_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longlong_align_2_optional* p_type = static_cast<longlong_align_2_optional*>(data);
+    const longlong_align_2_optional* p_type = static_cast<const longlong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool longlong_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longlong_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> longlong_align_2_optionalPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longlong_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const longlong_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void longlong_align_2_optionalPubSubType::deleteData(
 }
 
 bool longlong_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool longlong_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    longlong_align_2_optional* p_type = static_cast<longlong_align_2_optional*>(data);
+    const longlong_align_2_optional* p_type = static_cast<const longlong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ longlong_align_4_optionalPubSubType::~longlong_align_4_optionalPubSubType()
 }
 
 bool longlong_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longlong_align_4_optional* p_type = static_cast<longlong_align_4_optional*>(data);
+    const longlong_align_4_optional* p_type = static_cast<const longlong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool longlong_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longlong_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> longlong_align_4_optionalPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longlong_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const longlong_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void longlong_align_4_optionalPubSubType::deleteData(
 }
 
 bool longlong_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool longlong_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    longlong_align_4_optional* p_type = static_cast<longlong_align_4_optional*>(data);
+    const longlong_align_4_optional* p_type = static_cast<const longlong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5461,11 +5461,11 @@ ulonglong_align_1_optionalPubSubType::~ulonglong_align_1_optionalPubSubType()
 }
 
 bool ulonglong_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulonglong_align_1_optional* p_type = static_cast<ulonglong_align_1_optional*>(data);
+    const ulonglong_align_1_optional* p_type = static_cast<const ulonglong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5537,7 +5537,7 @@ bool ulonglong_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulonglong_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5554,7 +5554,7 @@ std::function<uint32_t()> ulonglong_align_1_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulonglong_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const ulonglong_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5577,7 +5577,7 @@ void ulonglong_align_1_optionalPubSubType::deleteData(
 }
 
 bool ulonglong_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5586,7 +5586,7 @@ bool ulonglong_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    ulonglong_align_1_optional* p_type = static_cast<ulonglong_align_1_optional*>(data);
+    const ulonglong_align_1_optional* p_type = static_cast<const ulonglong_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5654,11 +5654,11 @@ ulonglong_align_2_optionalPubSubType::~ulonglong_align_2_optionalPubSubType()
 }
 
 bool ulonglong_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulonglong_align_2_optional* p_type = static_cast<ulonglong_align_2_optional*>(data);
+    const ulonglong_align_2_optional* p_type = static_cast<const ulonglong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5730,7 +5730,7 @@ bool ulonglong_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulonglong_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5747,7 +5747,7 @@ std::function<uint32_t()> ulonglong_align_2_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulonglong_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const ulonglong_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5770,7 +5770,7 @@ void ulonglong_align_2_optionalPubSubType::deleteData(
 }
 
 bool ulonglong_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5779,7 +5779,7 @@ bool ulonglong_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    ulonglong_align_2_optional* p_type = static_cast<ulonglong_align_2_optional*>(data);
+    const ulonglong_align_2_optional* p_type = static_cast<const ulonglong_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5847,11 +5847,11 @@ ulonglong_align_4_optionalPubSubType::~ulonglong_align_4_optionalPubSubType()
 }
 
 bool ulonglong_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ulonglong_align_4_optional* p_type = static_cast<ulonglong_align_4_optional*>(data);
+    const ulonglong_align_4_optional* p_type = static_cast<const ulonglong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5923,7 +5923,7 @@ bool ulonglong_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ulonglong_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5940,7 +5940,7 @@ std::function<uint32_t()> ulonglong_align_4_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ulonglong_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const ulonglong_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5963,7 +5963,7 @@ void ulonglong_align_4_optionalPubSubType::deleteData(
 }
 
 bool ulonglong_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5972,7 +5972,7 @@ bool ulonglong_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    ulonglong_align_4_optional* p_type = static_cast<ulonglong_align_4_optional*>(data);
+    const ulonglong_align_4_optional* p_type = static_cast<const ulonglong_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6040,11 +6040,11 @@ float_align_1_optionalPubSubType::~float_align_1_optionalPubSubType()
 }
 
 bool float_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    float_align_1_optional* p_type = static_cast<float_align_1_optional*>(data);
+    const float_align_1_optional* p_type = static_cast<const float_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6116,7 +6116,7 @@ bool float_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> float_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6133,7 +6133,7 @@ std::function<uint32_t()> float_align_1_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<float_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const float_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6156,7 +6156,7 @@ void float_align_1_optionalPubSubType::deleteData(
 }
 
 bool float_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6165,7 +6165,7 @@ bool float_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    float_align_1_optional* p_type = static_cast<float_align_1_optional*>(data);
+    const float_align_1_optional* p_type = static_cast<const float_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6233,11 +6233,11 @@ float_align_2_optionalPubSubType::~float_align_2_optionalPubSubType()
 }
 
 bool float_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    float_align_2_optional* p_type = static_cast<float_align_2_optional*>(data);
+    const float_align_2_optional* p_type = static_cast<const float_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6309,7 +6309,7 @@ bool float_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> float_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6326,7 +6326,7 @@ std::function<uint32_t()> float_align_2_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<float_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const float_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6349,7 +6349,7 @@ void float_align_2_optionalPubSubType::deleteData(
 }
 
 bool float_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6358,7 +6358,7 @@ bool float_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    float_align_2_optional* p_type = static_cast<float_align_2_optional*>(data);
+    const float_align_2_optional* p_type = static_cast<const float_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6426,11 +6426,11 @@ float_align_4_optionalPubSubType::~float_align_4_optionalPubSubType()
 }
 
 bool float_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    float_align_4_optional* p_type = static_cast<float_align_4_optional*>(data);
+    const float_align_4_optional* p_type = static_cast<const float_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6502,7 +6502,7 @@ bool float_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> float_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6519,7 +6519,7 @@ std::function<uint32_t()> float_align_4_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<float_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const float_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6542,7 +6542,7 @@ void float_align_4_optionalPubSubType::deleteData(
 }
 
 bool float_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6551,7 +6551,7 @@ bool float_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    float_align_4_optional* p_type = static_cast<float_align_4_optional*>(data);
+    const float_align_4_optional* p_type = static_cast<const float_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6619,11 +6619,11 @@ double_align_1_optionalPubSubType::~double_align_1_optionalPubSubType()
 }
 
 bool double_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    double_align_1_optional* p_type = static_cast<double_align_1_optional*>(data);
+    const double_align_1_optional* p_type = static_cast<const double_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6695,7 +6695,7 @@ bool double_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> double_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6712,7 +6712,7 @@ std::function<uint32_t()> double_align_1_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<double_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const double_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6735,7 +6735,7 @@ void double_align_1_optionalPubSubType::deleteData(
 }
 
 bool double_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6744,7 +6744,7 @@ bool double_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    double_align_1_optional* p_type = static_cast<double_align_1_optional*>(data);
+    const double_align_1_optional* p_type = static_cast<const double_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6812,11 +6812,11 @@ double_align_2_optionalPubSubType::~double_align_2_optionalPubSubType()
 }
 
 bool double_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    double_align_2_optional* p_type = static_cast<double_align_2_optional*>(data);
+    const double_align_2_optional* p_type = static_cast<const double_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6888,7 +6888,7 @@ bool double_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> double_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6905,7 +6905,7 @@ std::function<uint32_t()> double_align_2_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<double_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const double_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6928,7 +6928,7 @@ void double_align_2_optionalPubSubType::deleteData(
 }
 
 bool double_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6937,7 +6937,7 @@ bool double_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    double_align_2_optional* p_type = static_cast<double_align_2_optional*>(data);
+    const double_align_2_optional* p_type = static_cast<const double_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7005,11 +7005,11 @@ double_align_4_optionalPubSubType::~double_align_4_optionalPubSubType()
 }
 
 bool double_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    double_align_4_optional* p_type = static_cast<double_align_4_optional*>(data);
+    const double_align_4_optional* p_type = static_cast<const double_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7081,7 +7081,7 @@ bool double_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> double_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7098,7 +7098,7 @@ std::function<uint32_t()> double_align_4_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<double_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const double_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7121,7 +7121,7 @@ void double_align_4_optionalPubSubType::deleteData(
 }
 
 bool double_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7130,7 +7130,7 @@ bool double_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    double_align_4_optional* p_type = static_cast<double_align_4_optional*>(data);
+    const double_align_4_optional* p_type = static_cast<const double_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7198,11 +7198,11 @@ longdouble_align_1_optionalPubSubType::~longdouble_align_1_optionalPubSubType()
 }
 
 bool longdouble_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longdouble_align_1_optional* p_type = static_cast<longdouble_align_1_optional*>(data);
+    const longdouble_align_1_optional* p_type = static_cast<const longdouble_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7274,7 +7274,7 @@ bool longdouble_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longdouble_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7291,7 +7291,7 @@ std::function<uint32_t()> longdouble_align_1_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longdouble_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const longdouble_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7314,7 +7314,7 @@ void longdouble_align_1_optionalPubSubType::deleteData(
 }
 
 bool longdouble_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7323,7 +7323,7 @@ bool longdouble_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    longdouble_align_1_optional* p_type = static_cast<longdouble_align_1_optional*>(data);
+    const longdouble_align_1_optional* p_type = static_cast<const longdouble_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7391,11 +7391,11 @@ longdouble_align_2_optionalPubSubType::~longdouble_align_2_optionalPubSubType()
 }
 
 bool longdouble_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longdouble_align_2_optional* p_type = static_cast<longdouble_align_2_optional*>(data);
+    const longdouble_align_2_optional* p_type = static_cast<const longdouble_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7467,7 +7467,7 @@ bool longdouble_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longdouble_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7484,7 +7484,7 @@ std::function<uint32_t()> longdouble_align_2_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longdouble_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const longdouble_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7507,7 +7507,7 @@ void longdouble_align_2_optionalPubSubType::deleteData(
 }
 
 bool longdouble_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7516,7 +7516,7 @@ bool longdouble_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    longdouble_align_2_optional* p_type = static_cast<longdouble_align_2_optional*>(data);
+    const longdouble_align_2_optional* p_type = static_cast<const longdouble_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7584,11 +7584,11 @@ longdouble_align_4_optionalPubSubType::~longdouble_align_4_optionalPubSubType()
 }
 
 bool longdouble_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    longdouble_align_4_optional* p_type = static_cast<longdouble_align_4_optional*>(data);
+    const longdouble_align_4_optional* p_type = static_cast<const longdouble_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7660,7 +7660,7 @@ bool longdouble_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> longdouble_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7677,7 +7677,7 @@ std::function<uint32_t()> longdouble_align_4_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<longdouble_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const longdouble_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7700,7 +7700,7 @@ void longdouble_align_4_optionalPubSubType::deleteData(
 }
 
 bool longdouble_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7709,7 +7709,7 @@ bool longdouble_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    longdouble_align_4_optional* p_type = static_cast<longdouble_align_4_optional*>(data);
+    const longdouble_align_4_optional* p_type = static_cast<const longdouble_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7777,11 +7777,11 @@ boolean_align_1_optionalPubSubType::~boolean_align_1_optionalPubSubType()
 }
 
 bool boolean_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    boolean_align_1_optional* p_type = static_cast<boolean_align_1_optional*>(data);
+    const boolean_align_1_optional* p_type = static_cast<const boolean_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7853,7 +7853,7 @@ bool boolean_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> boolean_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7870,7 +7870,7 @@ std::function<uint32_t()> boolean_align_1_optionalPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<boolean_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const boolean_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7893,7 +7893,7 @@ void boolean_align_1_optionalPubSubType::deleteData(
 }
 
 bool boolean_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7902,7 +7902,7 @@ bool boolean_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    boolean_align_1_optional* p_type = static_cast<boolean_align_1_optional*>(data);
+    const boolean_align_1_optional* p_type = static_cast<const boolean_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7970,11 +7970,11 @@ boolean_align_2_optionalPubSubType::~boolean_align_2_optionalPubSubType()
 }
 
 bool boolean_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    boolean_align_2_optional* p_type = static_cast<boolean_align_2_optional*>(data);
+    const boolean_align_2_optional* p_type = static_cast<const boolean_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8046,7 +8046,7 @@ bool boolean_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> boolean_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8063,7 +8063,7 @@ std::function<uint32_t()> boolean_align_2_optionalPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<boolean_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const boolean_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8086,7 +8086,7 @@ void boolean_align_2_optionalPubSubType::deleteData(
 }
 
 bool boolean_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8095,7 +8095,7 @@ bool boolean_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    boolean_align_2_optional* p_type = static_cast<boolean_align_2_optional*>(data);
+    const boolean_align_2_optional* p_type = static_cast<const boolean_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8163,11 +8163,11 @@ boolean_align_4_optionalPubSubType::~boolean_align_4_optionalPubSubType()
 }
 
 bool boolean_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    boolean_align_4_optional* p_type = static_cast<boolean_align_4_optional*>(data);
+    const boolean_align_4_optional* p_type = static_cast<const boolean_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8239,7 +8239,7 @@ bool boolean_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> boolean_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8256,7 +8256,7 @@ std::function<uint32_t()> boolean_align_4_optionalPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<boolean_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const boolean_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8279,7 +8279,7 @@ void boolean_align_4_optionalPubSubType::deleteData(
 }
 
 bool boolean_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8288,7 +8288,7 @@ bool boolean_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    boolean_align_4_optional* p_type = static_cast<boolean_align_4_optional*>(data);
+    const boolean_align_4_optional* p_type = static_cast<const boolean_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8356,11 +8356,11 @@ octet_align_1_optionalPubSubType::~octet_align_1_optionalPubSubType()
 }
 
 bool octet_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    octet_align_1_optional* p_type = static_cast<octet_align_1_optional*>(data);
+    const octet_align_1_optional* p_type = static_cast<const octet_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8432,7 +8432,7 @@ bool octet_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> octet_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8449,7 +8449,7 @@ std::function<uint32_t()> octet_align_1_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<octet_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const octet_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8472,7 +8472,7 @@ void octet_align_1_optionalPubSubType::deleteData(
 }
 
 bool octet_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8481,7 +8481,7 @@ bool octet_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    octet_align_1_optional* p_type = static_cast<octet_align_1_optional*>(data);
+    const octet_align_1_optional* p_type = static_cast<const octet_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8549,11 +8549,11 @@ octet_align_2_optionalPubSubType::~octet_align_2_optionalPubSubType()
 }
 
 bool octet_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    octet_align_2_optional* p_type = static_cast<octet_align_2_optional*>(data);
+    const octet_align_2_optional* p_type = static_cast<const octet_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8625,7 +8625,7 @@ bool octet_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> octet_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8642,7 +8642,7 @@ std::function<uint32_t()> octet_align_2_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<octet_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const octet_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8665,7 +8665,7 @@ void octet_align_2_optionalPubSubType::deleteData(
 }
 
 bool octet_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8674,7 +8674,7 @@ bool octet_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    octet_align_2_optional* p_type = static_cast<octet_align_2_optional*>(data);
+    const octet_align_2_optional* p_type = static_cast<const octet_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8742,11 +8742,11 @@ octet_align_4_optionalPubSubType::~octet_align_4_optionalPubSubType()
 }
 
 bool octet_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    octet_align_4_optional* p_type = static_cast<octet_align_4_optional*>(data);
+    const octet_align_4_optional* p_type = static_cast<const octet_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -8818,7 +8818,7 @@ bool octet_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> octet_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -8835,7 +8835,7 @@ std::function<uint32_t()> octet_align_4_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<octet_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const octet_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -8858,7 +8858,7 @@ void octet_align_4_optionalPubSubType::deleteData(
 }
 
 bool octet_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -8867,7 +8867,7 @@ bool octet_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    octet_align_4_optional* p_type = static_cast<octet_align_4_optional*>(data);
+    const octet_align_4_optional* p_type = static_cast<const octet_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -8935,11 +8935,11 @@ char_align_1_optionalPubSubType::~char_align_1_optionalPubSubType()
 }
 
 bool char_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    char_align_1_optional* p_type = static_cast<char_align_1_optional*>(data);
+    const char_align_1_optional* p_type = static_cast<const char_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9011,7 +9011,7 @@ bool char_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> char_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9028,7 +9028,7 @@ std::function<uint32_t()> char_align_1_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<char_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const char_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9051,7 +9051,7 @@ void char_align_1_optionalPubSubType::deleteData(
 }
 
 bool char_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9060,7 +9060,7 @@ bool char_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    char_align_1_optional* p_type = static_cast<char_align_1_optional*>(data);
+    const char_align_1_optional* p_type = static_cast<const char_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9128,11 +9128,11 @@ char_align_2_optionalPubSubType::~char_align_2_optionalPubSubType()
 }
 
 bool char_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    char_align_2_optional* p_type = static_cast<char_align_2_optional*>(data);
+    const char_align_2_optional* p_type = static_cast<const char_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9204,7 +9204,7 @@ bool char_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> char_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9221,7 +9221,7 @@ std::function<uint32_t()> char_align_2_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<char_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const char_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9244,7 +9244,7 @@ void char_align_2_optionalPubSubType::deleteData(
 }
 
 bool char_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9253,7 +9253,7 @@ bool char_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    char_align_2_optional* p_type = static_cast<char_align_2_optional*>(data);
+    const char_align_2_optional* p_type = static_cast<const char_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9321,11 +9321,11 @@ char_align_4_optionalPubSubType::~char_align_4_optionalPubSubType()
 }
 
 bool char_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    char_align_4_optional* p_type = static_cast<char_align_4_optional*>(data);
+    const char_align_4_optional* p_type = static_cast<const char_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9397,7 +9397,7 @@ bool char_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> char_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9414,7 +9414,7 @@ std::function<uint32_t()> char_align_4_optionalPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<char_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const char_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9437,7 +9437,7 @@ void char_align_4_optionalPubSubType::deleteData(
 }
 
 bool char_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9446,7 +9446,7 @@ bool char_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    char_align_4_optional* p_type = static_cast<char_align_4_optional*>(data);
+    const char_align_4_optional* p_type = static_cast<const char_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9514,11 +9514,11 @@ wchar_align_1_optionalPubSubType::~wchar_align_1_optionalPubSubType()
 }
 
 bool wchar_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    wchar_align_1_optional* p_type = static_cast<wchar_align_1_optional*>(data);
+    const wchar_align_1_optional* p_type = static_cast<const wchar_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9590,7 +9590,7 @@ bool wchar_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> wchar_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9607,7 +9607,7 @@ std::function<uint32_t()> wchar_align_1_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<wchar_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const wchar_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9630,7 +9630,7 @@ void wchar_align_1_optionalPubSubType::deleteData(
 }
 
 bool wchar_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9639,7 +9639,7 @@ bool wchar_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    wchar_align_1_optional* p_type = static_cast<wchar_align_1_optional*>(data);
+    const wchar_align_1_optional* p_type = static_cast<const wchar_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9707,11 +9707,11 @@ wchar_align_2_optionalPubSubType::~wchar_align_2_optionalPubSubType()
 }
 
 bool wchar_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    wchar_align_2_optional* p_type = static_cast<wchar_align_2_optional*>(data);
+    const wchar_align_2_optional* p_type = static_cast<const wchar_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9783,7 +9783,7 @@ bool wchar_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> wchar_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9800,7 +9800,7 @@ std::function<uint32_t()> wchar_align_2_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<wchar_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const wchar_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -9823,7 +9823,7 @@ void wchar_align_2_optionalPubSubType::deleteData(
 }
 
 bool wchar_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -9832,7 +9832,7 @@ bool wchar_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    wchar_align_2_optional* p_type = static_cast<wchar_align_2_optional*>(data);
+    const wchar_align_2_optional* p_type = static_cast<const wchar_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -9900,11 +9900,11 @@ wchar_align_4_optionalPubSubType::~wchar_align_4_optionalPubSubType()
 }
 
 bool wchar_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    wchar_align_4_optional* p_type = static_cast<wchar_align_4_optional*>(data);
+    const wchar_align_4_optional* p_type = static_cast<const wchar_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -9976,7 +9976,7 @@ bool wchar_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> wchar_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -9993,7 +9993,7 @@ std::function<uint32_t()> wchar_align_4_optionalPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<wchar_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const wchar_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10016,7 +10016,7 @@ void wchar_align_4_optionalPubSubType::deleteData(
 }
 
 bool wchar_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10025,7 +10025,7 @@ bool wchar_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    wchar_align_4_optional* p_type = static_cast<wchar_align_4_optional*>(data);
+    const wchar_align_4_optional* p_type = static_cast<const wchar_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10093,11 +10093,11 @@ sequence_short_optionalPubSubType::~sequence_short_optionalPubSubType()
 }
 
 bool sequence_short_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sequence_short_optional* p_type = static_cast<sequence_short_optional*>(data);
+    const sequence_short_optional* p_type = static_cast<const sequence_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10169,7 +10169,7 @@ bool sequence_short_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> sequence_short_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10186,7 +10186,7 @@ std::function<uint32_t()> sequence_short_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sequence_short_optional*>(data), current_alignment)) +
+                               *static_cast<const sequence_short_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10209,7 +10209,7 @@ void sequence_short_optionalPubSubType::deleteData(
 }
 
 bool sequence_short_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10218,7 +10218,7 @@ bool sequence_short_optionalPubSubType::getKey(
         return false;
     }
 
-    sequence_short_optional* p_type = static_cast<sequence_short_optional*>(data);
+    const sequence_short_optional* p_type = static_cast<const sequence_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10286,11 +10286,11 @@ sequence_short_align_1_optionalPubSubType::~sequence_short_align_1_optionalPubSu
 }
 
 bool sequence_short_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sequence_short_align_1_optional* p_type = static_cast<sequence_short_align_1_optional*>(data);
+    const sequence_short_align_1_optional* p_type = static_cast<const sequence_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10362,7 +10362,7 @@ bool sequence_short_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> sequence_short_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10379,7 +10379,7 @@ std::function<uint32_t()> sequence_short_align_1_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sequence_short_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const sequence_short_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10402,7 +10402,7 @@ void sequence_short_align_1_optionalPubSubType::deleteData(
 }
 
 bool sequence_short_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10411,7 +10411,7 @@ bool sequence_short_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    sequence_short_align_1_optional* p_type = static_cast<sequence_short_align_1_optional*>(data);
+    const sequence_short_align_1_optional* p_type = static_cast<const sequence_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10479,11 +10479,11 @@ sequence_short_align_2_optionalPubSubType::~sequence_short_align_2_optionalPubSu
 }
 
 bool sequence_short_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sequence_short_align_2_optional* p_type = static_cast<sequence_short_align_2_optional*>(data);
+    const sequence_short_align_2_optional* p_type = static_cast<const sequence_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10555,7 +10555,7 @@ bool sequence_short_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> sequence_short_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10572,7 +10572,7 @@ std::function<uint32_t()> sequence_short_align_2_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sequence_short_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const sequence_short_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10595,7 +10595,7 @@ void sequence_short_align_2_optionalPubSubType::deleteData(
 }
 
 bool sequence_short_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10604,7 +10604,7 @@ bool sequence_short_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    sequence_short_align_2_optional* p_type = static_cast<sequence_short_align_2_optional*>(data);
+    const sequence_short_align_2_optional* p_type = static_cast<const sequence_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10672,11 +10672,11 @@ sequence_short_align_4_optionalPubSubType::~sequence_short_align_4_optionalPubSu
 }
 
 bool sequence_short_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    sequence_short_align_4_optional* p_type = static_cast<sequence_short_align_4_optional*>(data);
+    const sequence_short_align_4_optional* p_type = static_cast<const sequence_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10748,7 +10748,7 @@ bool sequence_short_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> sequence_short_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10765,7 +10765,7 @@ std::function<uint32_t()> sequence_short_align_4_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<sequence_short_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const sequence_short_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10788,7 +10788,7 @@ void sequence_short_align_4_optionalPubSubType::deleteData(
 }
 
 bool sequence_short_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10797,7 +10797,7 @@ bool sequence_short_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    sequence_short_align_4_optional* p_type = static_cast<sequence_short_align_4_optional*>(data);
+    const sequence_short_align_4_optional* p_type = static_cast<const sequence_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -10865,11 +10865,11 @@ string_unbounded_optionalPubSubType::~string_unbounded_optionalPubSubType()
 }
 
 bool string_unbounded_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_unbounded_optional* p_type = static_cast<string_unbounded_optional*>(data);
+    const string_unbounded_optional* p_type = static_cast<const string_unbounded_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -10941,7 +10941,7 @@ bool string_unbounded_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_unbounded_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -10958,7 +10958,7 @@ std::function<uint32_t()> string_unbounded_optionalPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_unbounded_optional*>(data), current_alignment)) +
+                               *static_cast<const string_unbounded_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -10981,7 +10981,7 @@ void string_unbounded_optionalPubSubType::deleteData(
 }
 
 bool string_unbounded_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -10990,7 +10990,7 @@ bool string_unbounded_optionalPubSubType::getKey(
         return false;
     }
 
-    string_unbounded_optional* p_type = static_cast<string_unbounded_optional*>(data);
+    const string_unbounded_optional* p_type = static_cast<const string_unbounded_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11058,11 +11058,11 @@ string_unbounded_align_1_optionalPubSubType::~string_unbounded_align_1_optionalP
 }
 
 bool string_unbounded_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_unbounded_align_1_optional* p_type = static_cast<string_unbounded_align_1_optional*>(data);
+    const string_unbounded_align_1_optional* p_type = static_cast<const string_unbounded_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11134,7 +11134,7 @@ bool string_unbounded_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_unbounded_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11151,7 +11151,7 @@ std::function<uint32_t()> string_unbounded_align_1_optionalPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_unbounded_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const string_unbounded_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11174,7 +11174,7 @@ void string_unbounded_align_1_optionalPubSubType::deleteData(
 }
 
 bool string_unbounded_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11183,7 +11183,7 @@ bool string_unbounded_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    string_unbounded_align_1_optional* p_type = static_cast<string_unbounded_align_1_optional*>(data);
+    const string_unbounded_align_1_optional* p_type = static_cast<const string_unbounded_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11251,11 +11251,11 @@ string_unbounded_align_2_optionalPubSubType::~string_unbounded_align_2_optionalP
 }
 
 bool string_unbounded_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_unbounded_align_2_optional* p_type = static_cast<string_unbounded_align_2_optional*>(data);
+    const string_unbounded_align_2_optional* p_type = static_cast<const string_unbounded_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11327,7 +11327,7 @@ bool string_unbounded_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_unbounded_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11344,7 +11344,7 @@ std::function<uint32_t()> string_unbounded_align_2_optionalPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_unbounded_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const string_unbounded_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11367,7 +11367,7 @@ void string_unbounded_align_2_optionalPubSubType::deleteData(
 }
 
 bool string_unbounded_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11376,7 +11376,7 @@ bool string_unbounded_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    string_unbounded_align_2_optional* p_type = static_cast<string_unbounded_align_2_optional*>(data);
+    const string_unbounded_align_2_optional* p_type = static_cast<const string_unbounded_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11444,11 +11444,11 @@ string_unbounded_align_4_optionalPubSubType::~string_unbounded_align_4_optionalP
 }
 
 bool string_unbounded_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_unbounded_align_4_optional* p_type = static_cast<string_unbounded_align_4_optional*>(data);
+    const string_unbounded_align_4_optional* p_type = static_cast<const string_unbounded_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11520,7 +11520,7 @@ bool string_unbounded_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_unbounded_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11537,7 +11537,7 @@ std::function<uint32_t()> string_unbounded_align_4_optionalPubSubType::getSerial
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_unbounded_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const string_unbounded_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11560,7 +11560,7 @@ void string_unbounded_align_4_optionalPubSubType::deleteData(
 }
 
 bool string_unbounded_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11569,7 +11569,7 @@ bool string_unbounded_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    string_unbounded_align_4_optional* p_type = static_cast<string_unbounded_align_4_optional*>(data);
+    const string_unbounded_align_4_optional* p_type = static_cast<const string_unbounded_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11637,11 +11637,11 @@ string_bounded_optionalPubSubType::~string_bounded_optionalPubSubType()
 }
 
 bool string_bounded_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_bounded_optional* p_type = static_cast<string_bounded_optional*>(data);
+    const string_bounded_optional* p_type = static_cast<const string_bounded_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11713,7 +11713,7 @@ bool string_bounded_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_bounded_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11730,7 +11730,7 @@ std::function<uint32_t()> string_bounded_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_bounded_optional*>(data), current_alignment)) +
+                               *static_cast<const string_bounded_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11753,7 +11753,7 @@ void string_bounded_optionalPubSubType::deleteData(
 }
 
 bool string_bounded_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11762,7 +11762,7 @@ bool string_bounded_optionalPubSubType::getKey(
         return false;
     }
 
-    string_bounded_optional* p_type = static_cast<string_bounded_optional*>(data);
+    const string_bounded_optional* p_type = static_cast<const string_bounded_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -11830,11 +11830,11 @@ string_bounded_align_1_optionalPubSubType::~string_bounded_align_1_optionalPubSu
 }
 
 bool string_bounded_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_bounded_align_1_optional* p_type = static_cast<string_bounded_align_1_optional*>(data);
+    const string_bounded_align_1_optional* p_type = static_cast<const string_bounded_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -11906,7 +11906,7 @@ bool string_bounded_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_bounded_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -11923,7 +11923,7 @@ std::function<uint32_t()> string_bounded_align_1_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_bounded_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const string_bounded_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -11946,7 +11946,7 @@ void string_bounded_align_1_optionalPubSubType::deleteData(
 }
 
 bool string_bounded_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -11955,7 +11955,7 @@ bool string_bounded_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    string_bounded_align_1_optional* p_type = static_cast<string_bounded_align_1_optional*>(data);
+    const string_bounded_align_1_optional* p_type = static_cast<const string_bounded_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12023,11 +12023,11 @@ string_bounded_align_2_optionalPubSubType::~string_bounded_align_2_optionalPubSu
 }
 
 bool string_bounded_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_bounded_align_2_optional* p_type = static_cast<string_bounded_align_2_optional*>(data);
+    const string_bounded_align_2_optional* p_type = static_cast<const string_bounded_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12099,7 +12099,7 @@ bool string_bounded_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_bounded_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12116,7 +12116,7 @@ std::function<uint32_t()> string_bounded_align_2_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_bounded_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const string_bounded_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12139,7 +12139,7 @@ void string_bounded_align_2_optionalPubSubType::deleteData(
 }
 
 bool string_bounded_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12148,7 +12148,7 @@ bool string_bounded_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    string_bounded_align_2_optional* p_type = static_cast<string_bounded_align_2_optional*>(data);
+    const string_bounded_align_2_optional* p_type = static_cast<const string_bounded_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12216,11 +12216,11 @@ string_bounded_align_4_optionalPubSubType::~string_bounded_align_4_optionalPubSu
 }
 
 bool string_bounded_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    string_bounded_align_4_optional* p_type = static_cast<string_bounded_align_4_optional*>(data);
+    const string_bounded_align_4_optional* p_type = static_cast<const string_bounded_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12292,7 +12292,7 @@ bool string_bounded_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> string_bounded_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12309,7 +12309,7 @@ std::function<uint32_t()> string_bounded_align_4_optionalPubSubType::getSerializ
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<string_bounded_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const string_bounded_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12332,7 +12332,7 @@ void string_bounded_align_4_optionalPubSubType::deleteData(
 }
 
 bool string_bounded_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12341,7 +12341,7 @@ bool string_bounded_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    string_bounded_align_4_optional* p_type = static_cast<string_bounded_align_4_optional*>(data);
+    const string_bounded_align_4_optional* p_type = static_cast<const string_bounded_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12409,11 +12409,11 @@ map_short_optionalPubSubType::~map_short_optionalPubSubType()
 }
 
 bool map_short_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    map_short_optional* p_type = static_cast<map_short_optional*>(data);
+    const map_short_optional* p_type = static_cast<const map_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12485,7 +12485,7 @@ bool map_short_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> map_short_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12502,7 +12502,7 @@ std::function<uint32_t()> map_short_optionalPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<map_short_optional*>(data), current_alignment)) +
+                               *static_cast<const map_short_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12525,7 +12525,7 @@ void map_short_optionalPubSubType::deleteData(
 }
 
 bool map_short_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12534,7 +12534,7 @@ bool map_short_optionalPubSubType::getKey(
         return false;
     }
 
-    map_short_optional* p_type = static_cast<map_short_optional*>(data);
+    const map_short_optional* p_type = static_cast<const map_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12602,11 +12602,11 @@ map_short_align_1_optionalPubSubType::~map_short_align_1_optionalPubSubType()
 }
 
 bool map_short_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    map_short_align_1_optional* p_type = static_cast<map_short_align_1_optional*>(data);
+    const map_short_align_1_optional* p_type = static_cast<const map_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12678,7 +12678,7 @@ bool map_short_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> map_short_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12695,7 +12695,7 @@ std::function<uint32_t()> map_short_align_1_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<map_short_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const map_short_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12718,7 +12718,7 @@ void map_short_align_1_optionalPubSubType::deleteData(
 }
 
 bool map_short_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12727,7 +12727,7 @@ bool map_short_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    map_short_align_1_optional* p_type = static_cast<map_short_align_1_optional*>(data);
+    const map_short_align_1_optional* p_type = static_cast<const map_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12795,11 +12795,11 @@ map_short_align_2_optionalPubSubType::~map_short_align_2_optionalPubSubType()
 }
 
 bool map_short_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    map_short_align_2_optional* p_type = static_cast<map_short_align_2_optional*>(data);
+    const map_short_align_2_optional* p_type = static_cast<const map_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -12871,7 +12871,7 @@ bool map_short_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> map_short_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -12888,7 +12888,7 @@ std::function<uint32_t()> map_short_align_2_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<map_short_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const map_short_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -12911,7 +12911,7 @@ void map_short_align_2_optionalPubSubType::deleteData(
 }
 
 bool map_short_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -12920,7 +12920,7 @@ bool map_short_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    map_short_align_2_optional* p_type = static_cast<map_short_align_2_optional*>(data);
+    const map_short_align_2_optional* p_type = static_cast<const map_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -12988,11 +12988,11 @@ map_short_align_4_optionalPubSubType::~map_short_align_4_optionalPubSubType()
 }
 
 bool map_short_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    map_short_align_4_optional* p_type = static_cast<map_short_align_4_optional*>(data);
+    const map_short_align_4_optional* p_type = static_cast<const map_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13064,7 +13064,7 @@ bool map_short_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> map_short_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13081,7 +13081,7 @@ std::function<uint32_t()> map_short_align_4_optionalPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<map_short_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const map_short_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13104,7 +13104,7 @@ void map_short_align_4_optionalPubSubType::deleteData(
 }
 
 bool map_short_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13113,7 +13113,7 @@ bool map_short_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    map_short_align_4_optional* p_type = static_cast<map_short_align_4_optional*>(data);
+    const map_short_align_4_optional* p_type = static_cast<const map_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13181,11 +13181,11 @@ array_short_optionalPubSubType::~array_short_optionalPubSubType()
 }
 
 bool array_short_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    array_short_optional* p_type = static_cast<array_short_optional*>(data);
+    const array_short_optional* p_type = static_cast<const array_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13257,7 +13257,7 @@ bool array_short_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> array_short_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13274,7 +13274,7 @@ std::function<uint32_t()> array_short_optionalPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<array_short_optional*>(data), current_alignment)) +
+                               *static_cast<const array_short_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13297,7 +13297,7 @@ void array_short_optionalPubSubType::deleteData(
 }
 
 bool array_short_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13306,7 +13306,7 @@ bool array_short_optionalPubSubType::getKey(
         return false;
     }
 
-    array_short_optional* p_type = static_cast<array_short_optional*>(data);
+    const array_short_optional* p_type = static_cast<const array_short_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13374,11 +13374,11 @@ array_short_align_1_optionalPubSubType::~array_short_align_1_optionalPubSubType(
 }
 
 bool array_short_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    array_short_align_1_optional* p_type = static_cast<array_short_align_1_optional*>(data);
+    const array_short_align_1_optional* p_type = static_cast<const array_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13450,7 +13450,7 @@ bool array_short_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> array_short_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13467,7 +13467,7 @@ std::function<uint32_t()> array_short_align_1_optionalPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<array_short_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const array_short_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13490,7 +13490,7 @@ void array_short_align_1_optionalPubSubType::deleteData(
 }
 
 bool array_short_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13499,7 +13499,7 @@ bool array_short_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    array_short_align_1_optional* p_type = static_cast<array_short_align_1_optional*>(data);
+    const array_short_align_1_optional* p_type = static_cast<const array_short_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13567,11 +13567,11 @@ array_short_align_2_optionalPubSubType::~array_short_align_2_optionalPubSubType(
 }
 
 bool array_short_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    array_short_align_2_optional* p_type = static_cast<array_short_align_2_optional*>(data);
+    const array_short_align_2_optional* p_type = static_cast<const array_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13643,7 +13643,7 @@ bool array_short_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> array_short_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13660,7 +13660,7 @@ std::function<uint32_t()> array_short_align_2_optionalPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<array_short_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const array_short_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13683,7 +13683,7 @@ void array_short_align_2_optionalPubSubType::deleteData(
 }
 
 bool array_short_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13692,7 +13692,7 @@ bool array_short_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    array_short_align_2_optional* p_type = static_cast<array_short_align_2_optional*>(data);
+    const array_short_align_2_optional* p_type = static_cast<const array_short_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13760,11 +13760,11 @@ array_short_align_4_optionalPubSubType::~array_short_align_4_optionalPubSubType(
 }
 
 bool array_short_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    array_short_align_4_optional* p_type = static_cast<array_short_align_4_optional*>(data);
+    const array_short_align_4_optional* p_type = static_cast<const array_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -13836,7 +13836,7 @@ bool array_short_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> array_short_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -13853,7 +13853,7 @@ std::function<uint32_t()> array_short_align_4_optionalPubSubType::getSerializedS
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<array_short_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const array_short_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -13876,7 +13876,7 @@ void array_short_align_4_optionalPubSubType::deleteData(
 }
 
 bool array_short_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -13885,7 +13885,7 @@ bool array_short_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    array_short_align_4_optional* p_type = static_cast<array_short_align_4_optional*>(data);
+    const array_short_align_4_optional* p_type = static_cast<const array_short_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -13953,11 +13953,11 @@ struct_optionalPubSubType::~struct_optionalPubSubType()
 }
 
 bool struct_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_optional* p_type = static_cast<struct_optional*>(data);
+    const struct_optional* p_type = static_cast<const struct_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14029,7 +14029,7 @@ bool struct_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14046,7 +14046,7 @@ std::function<uint32_t()> struct_optionalPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_optional*>(data), current_alignment)) +
+                               *static_cast<const struct_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14069,7 +14069,7 @@ void struct_optionalPubSubType::deleteData(
 }
 
 bool struct_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14078,7 +14078,7 @@ bool struct_optionalPubSubType::getKey(
         return false;
     }
 
-    struct_optional* p_type = static_cast<struct_optional*>(data);
+    const struct_optional* p_type = static_cast<const struct_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14146,11 +14146,11 @@ struct_align_1_optionalPubSubType::~struct_align_1_optionalPubSubType()
 }
 
 bool struct_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_align_1_optional* p_type = static_cast<struct_align_1_optional*>(data);
+    const struct_align_1_optional* p_type = static_cast<const struct_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14222,7 +14222,7 @@ bool struct_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14239,7 +14239,7 @@ std::function<uint32_t()> struct_align_1_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const struct_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14262,7 +14262,7 @@ void struct_align_1_optionalPubSubType::deleteData(
 }
 
 bool struct_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14271,7 +14271,7 @@ bool struct_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    struct_align_1_optional* p_type = static_cast<struct_align_1_optional*>(data);
+    const struct_align_1_optional* p_type = static_cast<const struct_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14339,11 +14339,11 @@ struct_align_2_optionalPubSubType::~struct_align_2_optionalPubSubType()
 }
 
 bool struct_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_align_2_optional* p_type = static_cast<struct_align_2_optional*>(data);
+    const struct_align_2_optional* p_type = static_cast<const struct_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14415,7 +14415,7 @@ bool struct_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14432,7 +14432,7 @@ std::function<uint32_t()> struct_align_2_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const struct_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14455,7 +14455,7 @@ void struct_align_2_optionalPubSubType::deleteData(
 }
 
 bool struct_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14464,7 +14464,7 @@ bool struct_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    struct_align_2_optional* p_type = static_cast<struct_align_2_optional*>(data);
+    const struct_align_2_optional* p_type = static_cast<const struct_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14532,11 +14532,11 @@ struct_align_4_optionalPubSubType::~struct_align_4_optionalPubSubType()
 }
 
 bool struct_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    struct_align_4_optional* p_type = static_cast<struct_align_4_optional*>(data);
+    const struct_align_4_optional* p_type = static_cast<const struct_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14608,7 +14608,7 @@ bool struct_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> struct_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14625,7 +14625,7 @@ std::function<uint32_t()> struct_align_4_optionalPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<struct_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const struct_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14648,7 +14648,7 @@ void struct_align_4_optionalPubSubType::deleteData(
 }
 
 bool struct_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14657,7 +14657,7 @@ bool struct_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    struct_align_4_optional* p_type = static_cast<struct_align_4_optional*>(data);
+    const struct_align_4_optional* p_type = static_cast<const struct_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14725,11 +14725,11 @@ InnerStructOptionalPubSubType::~InnerStructOptionalPubSubType()
 }
 
 bool InnerStructOptionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    InnerStructOptional* p_type = static_cast<InnerStructOptional*>(data);
+    const InnerStructOptional* p_type = static_cast<const InnerStructOptional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14801,7 +14801,7 @@ bool InnerStructOptionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> InnerStructOptionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -14818,7 +14818,7 @@ std::function<uint32_t()> InnerStructOptionalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<InnerStructOptional*>(data), current_alignment)) +
+                               *static_cast<const InnerStructOptional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -14841,7 +14841,7 @@ void InnerStructOptionalPubSubType::deleteData(
 }
 
 bool InnerStructOptionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -14850,7 +14850,7 @@ bool InnerStructOptionalPubSubType::getKey(
         return false;
     }
 
-    InnerStructOptional* p_type = static_cast<InnerStructOptional*>(data);
+    const InnerStructOptional* p_type = static_cast<const InnerStructOptional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -14918,11 +14918,11 @@ opt_struct_optionalPubSubType::~opt_struct_optionalPubSubType()
 }
 
 bool opt_struct_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    opt_struct_optional* p_type = static_cast<opt_struct_optional*>(data);
+    const opt_struct_optional* p_type = static_cast<const opt_struct_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -14994,7 +14994,7 @@ bool opt_struct_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> opt_struct_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15011,7 +15011,7 @@ std::function<uint32_t()> opt_struct_optionalPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<opt_struct_optional*>(data), current_alignment)) +
+                               *static_cast<const opt_struct_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15034,7 +15034,7 @@ void opt_struct_optionalPubSubType::deleteData(
 }
 
 bool opt_struct_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15043,7 +15043,7 @@ bool opt_struct_optionalPubSubType::getKey(
         return false;
     }
 
-    opt_struct_optional* p_type = static_cast<opt_struct_optional*>(data);
+    const opt_struct_optional* p_type = static_cast<const opt_struct_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15111,11 +15111,11 @@ opt_struct_align_1_optionalPubSubType::~opt_struct_align_1_optionalPubSubType()
 }
 
 bool opt_struct_align_1_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    opt_struct_align_1_optional* p_type = static_cast<opt_struct_align_1_optional*>(data);
+    const opt_struct_align_1_optional* p_type = static_cast<const opt_struct_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15187,7 +15187,7 @@ bool opt_struct_align_1_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> opt_struct_align_1_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15204,7 +15204,7 @@ std::function<uint32_t()> opt_struct_align_1_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<opt_struct_align_1_optional*>(data), current_alignment)) +
+                               *static_cast<const opt_struct_align_1_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15227,7 +15227,7 @@ void opt_struct_align_1_optionalPubSubType::deleteData(
 }
 
 bool opt_struct_align_1_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15236,7 +15236,7 @@ bool opt_struct_align_1_optionalPubSubType::getKey(
         return false;
     }
 
-    opt_struct_align_1_optional* p_type = static_cast<opt_struct_align_1_optional*>(data);
+    const opt_struct_align_1_optional* p_type = static_cast<const opt_struct_align_1_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15304,11 +15304,11 @@ opt_struct_align_2_optionalPubSubType::~opt_struct_align_2_optionalPubSubType()
 }
 
 bool opt_struct_align_2_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    opt_struct_align_2_optional* p_type = static_cast<opt_struct_align_2_optional*>(data);
+    const opt_struct_align_2_optional* p_type = static_cast<const opt_struct_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15380,7 +15380,7 @@ bool opt_struct_align_2_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> opt_struct_align_2_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15397,7 +15397,7 @@ std::function<uint32_t()> opt_struct_align_2_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<opt_struct_align_2_optional*>(data), current_alignment)) +
+                               *static_cast<const opt_struct_align_2_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15420,7 +15420,7 @@ void opt_struct_align_2_optionalPubSubType::deleteData(
 }
 
 bool opt_struct_align_2_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15429,7 +15429,7 @@ bool opt_struct_align_2_optionalPubSubType::getKey(
         return false;
     }
 
-    opt_struct_align_2_optional* p_type = static_cast<opt_struct_align_2_optional*>(data);
+    const opt_struct_align_2_optional* p_type = static_cast<const opt_struct_align_2_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -15497,11 +15497,11 @@ opt_struct_align_4_optionalPubSubType::~opt_struct_align_4_optionalPubSubType()
 }
 
 bool opt_struct_align_4_optionalPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    opt_struct_align_4_optional* p_type = static_cast<opt_struct_align_4_optional*>(data);
+    const opt_struct_align_4_optional* p_type = static_cast<const opt_struct_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -15573,7 +15573,7 @@ bool opt_struct_align_4_optionalPubSubType::deserialize(
 }
 
 std::function<uint32_t()> opt_struct_align_4_optionalPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -15590,7 +15590,7 @@ std::function<uint32_t()> opt_struct_align_4_optionalPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<opt_struct_align_4_optional*>(data), current_alignment)) +
+                               *static_cast<const opt_struct_align_4_optional*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -15613,7 +15613,7 @@ void opt_struct_align_4_optionalPubSubType::deleteData(
 }
 
 bool opt_struct_align_4_optionalPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -15622,7 +15622,7 @@ bool opt_struct_align_4_optionalPubSubType::getKey(
         return false;
     }
 
-    opt_struct_align_4_optional* p_type = static_cast<opt_struct_align_4_optional*>(data);
+    const opt_struct_align_4_optional* p_type = static_cast<const opt_struct_align_4_optional*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/optionalPubSubTypes.h
+++ b/test/dds-types-test/optionalPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~short_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~ushort_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~long_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~ulong_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~longlong_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~ulonglong_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~float_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~double_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~longdouble_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~boolean_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~octet_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~char_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~wchar_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~short_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~short_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~short_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~ushort_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~ushort_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~ushort_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~long_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~long_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~long_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~ulong_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~ulong_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~ulong_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~longlong_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~longlong_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~longlong_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2602,14 +2602,14 @@ public:
     eProsima_user_DllExport ~ulonglong_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2618,17 +2618,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2693,14 +2693,14 @@ public:
     eProsima_user_DllExport ~ulonglong_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2709,17 +2709,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2784,14 +2784,14 @@ public:
     eProsima_user_DllExport ~ulonglong_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2800,17 +2800,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2875,14 +2875,14 @@ public:
     eProsima_user_DllExport ~float_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2891,17 +2891,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2966,14 +2966,14 @@ public:
     eProsima_user_DllExport ~float_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2982,17 +2982,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3057,14 +3057,14 @@ public:
     eProsima_user_DllExport ~float_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3073,17 +3073,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3148,14 +3148,14 @@ public:
     eProsima_user_DllExport ~double_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3164,17 +3164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3239,14 +3239,14 @@ public:
     eProsima_user_DllExport ~double_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3255,17 +3255,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3330,14 +3330,14 @@ public:
     eProsima_user_DllExport ~double_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3346,17 +3346,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3421,14 +3421,14 @@ public:
     eProsima_user_DllExport ~longdouble_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3437,17 +3437,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3512,14 +3512,14 @@ public:
     eProsima_user_DllExport ~longdouble_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3528,17 +3528,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3603,14 +3603,14 @@ public:
     eProsima_user_DllExport ~longdouble_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3619,17 +3619,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3694,14 +3694,14 @@ public:
     eProsima_user_DllExport ~boolean_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3710,17 +3710,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3785,14 +3785,14 @@ public:
     eProsima_user_DllExport ~boolean_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3801,17 +3801,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3876,14 +3876,14 @@ public:
     eProsima_user_DllExport ~boolean_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3892,17 +3892,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3967,14 +3967,14 @@ public:
     eProsima_user_DllExport ~octet_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3983,17 +3983,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4058,14 +4058,14 @@ public:
     eProsima_user_DllExport ~octet_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4074,17 +4074,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4149,14 +4149,14 @@ public:
     eProsima_user_DllExport ~octet_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4165,17 +4165,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4240,14 +4240,14 @@ public:
     eProsima_user_DllExport ~char_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4256,17 +4256,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4331,14 +4331,14 @@ public:
     eProsima_user_DllExport ~char_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4347,17 +4347,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4422,14 +4422,14 @@ public:
     eProsima_user_DllExport ~char_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4438,17 +4438,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4513,14 +4513,14 @@ public:
     eProsima_user_DllExport ~wchar_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4529,17 +4529,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4604,14 +4604,14 @@ public:
     eProsima_user_DllExport ~wchar_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4620,17 +4620,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4695,14 +4695,14 @@ public:
     eProsima_user_DllExport ~wchar_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4711,17 +4711,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4786,14 +4786,14 @@ public:
     eProsima_user_DllExport ~sequence_short_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4802,17 +4802,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4877,14 +4877,14 @@ public:
     eProsima_user_DllExport ~sequence_short_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4893,17 +4893,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -4968,14 +4968,14 @@ public:
     eProsima_user_DllExport ~sequence_short_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -4984,17 +4984,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5059,14 +5059,14 @@ public:
     eProsima_user_DllExport ~sequence_short_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5075,17 +5075,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5150,14 +5150,14 @@ public:
     eProsima_user_DllExport ~string_unbounded_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5166,17 +5166,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5241,14 +5241,14 @@ public:
     eProsima_user_DllExport ~string_unbounded_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5257,17 +5257,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5332,14 +5332,14 @@ public:
     eProsima_user_DllExport ~string_unbounded_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5348,17 +5348,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5423,14 +5423,14 @@ public:
     eProsima_user_DllExport ~string_unbounded_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5439,17 +5439,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5514,14 +5514,14 @@ public:
     eProsima_user_DllExport ~string_bounded_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5530,17 +5530,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5605,14 +5605,14 @@ public:
     eProsima_user_DllExport ~string_bounded_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5621,17 +5621,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5696,14 +5696,14 @@ public:
     eProsima_user_DllExport ~string_bounded_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5712,17 +5712,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5787,14 +5787,14 @@ public:
     eProsima_user_DllExport ~string_bounded_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5803,17 +5803,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5878,14 +5878,14 @@ public:
     eProsima_user_DllExport ~map_short_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5894,17 +5894,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -5969,14 +5969,14 @@ public:
     eProsima_user_DllExport ~map_short_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -5985,17 +5985,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6060,14 +6060,14 @@ public:
     eProsima_user_DllExport ~map_short_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6076,17 +6076,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6151,14 +6151,14 @@ public:
     eProsima_user_DllExport ~map_short_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6167,17 +6167,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6242,14 +6242,14 @@ public:
     eProsima_user_DllExport ~array_short_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6258,17 +6258,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6333,14 +6333,14 @@ public:
     eProsima_user_DllExport ~array_short_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6349,17 +6349,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6424,14 +6424,14 @@ public:
     eProsima_user_DllExport ~array_short_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6440,17 +6440,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6515,14 +6515,14 @@ public:
     eProsima_user_DllExport ~array_short_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6531,17 +6531,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6606,14 +6606,14 @@ public:
     eProsima_user_DllExport ~struct_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6622,17 +6622,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6697,14 +6697,14 @@ public:
     eProsima_user_DllExport ~struct_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6713,17 +6713,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6788,14 +6788,14 @@ public:
     eProsima_user_DllExport ~struct_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6804,17 +6804,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6879,14 +6879,14 @@ public:
     eProsima_user_DllExport ~struct_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6895,17 +6895,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -6970,14 +6970,14 @@ public:
     eProsima_user_DllExport ~InnerStructOptionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -6986,17 +6986,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7061,14 +7061,14 @@ public:
     eProsima_user_DllExport ~opt_struct_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7077,17 +7077,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7152,14 +7152,14 @@ public:
     eProsima_user_DllExport ~opt_struct_align_1_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7168,17 +7168,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7243,14 +7243,14 @@ public:
     eProsima_user_DllExport ~opt_struct_align_2_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7259,17 +7259,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -7334,14 +7334,14 @@ public:
     eProsima_user_DllExport ~opt_struct_align_4_optionalPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -7350,17 +7350,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/primitivesPubSubTypes.cxx
+++ b/test/dds-types-test/primitivesPubSubTypes.cxx
@@ -57,11 +57,11 @@ ShortStructPubSubType::~ShortStructPubSubType()
 }
 
 bool ShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ShortStruct* p_type = static_cast<ShortStruct*>(data);
+    const ShortStruct* p_type = static_cast<const ShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool ShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> ShortStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ShortStruct*>(data), current_alignment)) +
+                               *static_cast<const ShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void ShortStructPubSubType::deleteData(
 }
 
 bool ShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool ShortStructPubSubType::getKey(
         return false;
     }
 
-    ShortStruct* p_type = static_cast<ShortStruct*>(data);
+    const ShortStruct* p_type = static_cast<const ShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ UShortStructPubSubType::~UShortStructPubSubType()
 }
 
 bool UShortStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UShortStruct* p_type = static_cast<UShortStruct*>(data);
+    const UShortStruct* p_type = static_cast<const UShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool UShortStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UShortStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> UShortStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UShortStruct*>(data), current_alignment)) +
+                               *static_cast<const UShortStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void UShortStructPubSubType::deleteData(
 }
 
 bool UShortStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool UShortStructPubSubType::getKey(
         return false;
     }
 
-    UShortStruct* p_type = static_cast<UShortStruct*>(data);
+    const UShortStruct* p_type = static_cast<const UShortStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ LongStructPubSubType::~LongStructPubSubType()
 }
 
 bool LongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LongStruct* p_type = static_cast<LongStruct*>(data);
+    const LongStruct* p_type = static_cast<const LongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool LongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> LongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LongStruct*>(data), current_alignment)) +
+                               *static_cast<const LongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void LongStructPubSubType::deleteData(
 }
 
 bool LongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool LongStructPubSubType::getKey(
         return false;
     }
 
-    LongStruct* p_type = static_cast<LongStruct*>(data);
+    const LongStruct* p_type = static_cast<const LongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ ULongStructPubSubType::~ULongStructPubSubType()
 }
 
 bool ULongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ULongStruct* p_type = static_cast<ULongStruct*>(data);
+    const ULongStruct* p_type = static_cast<const ULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool ULongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ULongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> ULongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ULongStruct*>(data), current_alignment)) +
+                               *static_cast<const ULongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void ULongStructPubSubType::deleteData(
 }
 
 bool ULongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool ULongStructPubSubType::getKey(
         return false;
     }
 
-    ULongStruct* p_type = static_cast<ULongStruct*>(data);
+    const ULongStruct* p_type = static_cast<const ULongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ LongLongStructPubSubType::~LongLongStructPubSubType()
 }
 
 bool LongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LongLongStruct* p_type = static_cast<LongLongStruct*>(data);
+    const LongLongStruct* p_type = static_cast<const LongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool LongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> LongLongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const LongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void LongLongStructPubSubType::deleteData(
 }
 
 bool LongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool LongLongStructPubSubType::getKey(
         return false;
     }
 
-    LongLongStruct* p_type = static_cast<LongLongStruct*>(data);
+    const LongLongStruct* p_type = static_cast<const LongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ ULongLongStructPubSubType::~ULongLongStructPubSubType()
 }
 
 bool ULongLongStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ULongLongStruct* p_type = static_cast<ULongLongStruct*>(data);
+    const ULongLongStruct* p_type = static_cast<const ULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool ULongLongStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> ULongLongStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> ULongLongStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ULongLongStruct*>(data), current_alignment)) +
+                               *static_cast<const ULongLongStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void ULongLongStructPubSubType::deleteData(
 }
 
 bool ULongLongStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool ULongLongStructPubSubType::getKey(
         return false;
     }
 
-    ULongLongStruct* p_type = static_cast<ULongLongStruct*>(data);
+    const ULongLongStruct* p_type = static_cast<const ULongLongStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ FloatStructPubSubType::~FloatStructPubSubType()
 }
 
 bool FloatStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    FloatStruct* p_type = static_cast<FloatStruct*>(data);
+    const FloatStruct* p_type = static_cast<const FloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool FloatStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> FloatStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> FloatStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<FloatStruct*>(data), current_alignment)) +
+                               *static_cast<const FloatStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void FloatStructPubSubType::deleteData(
 }
 
 bool FloatStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool FloatStructPubSubType::getKey(
         return false;
     }
 
-    FloatStruct* p_type = static_cast<FloatStruct*>(data);
+    const FloatStruct* p_type = static_cast<const FloatStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ DoubleStructPubSubType::~DoubleStructPubSubType()
 }
 
 bool DoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    DoubleStruct* p_type = static_cast<DoubleStruct*>(data);
+    const DoubleStruct* p_type = static_cast<const DoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool DoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> DoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> DoubleStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<DoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const DoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void DoubleStructPubSubType::deleteData(
 }
 
 bool DoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool DoubleStructPubSubType::getKey(
         return false;
     }
 
-    DoubleStruct* p_type = static_cast<DoubleStruct*>(data);
+    const DoubleStruct* p_type = static_cast<const DoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ LongDoubleStructPubSubType::~LongDoubleStructPubSubType()
 }
 
 bool LongDoubleStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LongDoubleStruct* p_type = static_cast<LongDoubleStruct*>(data);
+    const LongDoubleStruct* p_type = static_cast<const LongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool LongDoubleStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LongDoubleStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> LongDoubleStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LongDoubleStruct*>(data), current_alignment)) +
+                               *static_cast<const LongDoubleStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void LongDoubleStructPubSubType::deleteData(
 }
 
 bool LongDoubleStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool LongDoubleStructPubSubType::getKey(
         return false;
     }
 
-    LongDoubleStruct* p_type = static_cast<LongDoubleStruct*>(data);
+    const LongDoubleStruct* p_type = static_cast<const LongDoubleStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ BooleanStructPubSubType::~BooleanStructPubSubType()
 }
 
 bool BooleanStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BooleanStruct* p_type = static_cast<BooleanStruct*>(data);
+    const BooleanStruct* p_type = static_cast<const BooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool BooleanStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BooleanStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> BooleanStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BooleanStruct*>(data), current_alignment)) +
+                               *static_cast<const BooleanStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void BooleanStructPubSubType::deleteData(
 }
 
 bool BooleanStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool BooleanStructPubSubType::getKey(
         return false;
     }
 
-    BooleanStruct* p_type = static_cast<BooleanStruct*>(data);
+    const BooleanStruct* p_type = static_cast<const BooleanStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ OctetStructPubSubType::~OctetStructPubSubType()
 }
 
 bool OctetStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    OctetStruct* p_type = static_cast<OctetStruct*>(data);
+    const OctetStruct* p_type = static_cast<const OctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool OctetStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> OctetStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> OctetStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<OctetStruct*>(data), current_alignment)) +
+                               *static_cast<const OctetStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void OctetStructPubSubType::deleteData(
 }
 
 bool OctetStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool OctetStructPubSubType::getKey(
         return false;
     }
 
-    OctetStruct* p_type = static_cast<OctetStruct*>(data);
+    const OctetStruct* p_type = static_cast<const OctetStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ CharStructPubSubType::~CharStructPubSubType()
 }
 
 bool CharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    CharStruct* p_type = static_cast<CharStruct*>(data);
+    const CharStruct* p_type = static_cast<const CharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool CharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> CharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> CharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<CharStruct*>(data), current_alignment)) +
+                               *static_cast<const CharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void CharStructPubSubType::deleteData(
 }
 
 bool CharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool CharStructPubSubType::getKey(
         return false;
     }
 
-    CharStruct* p_type = static_cast<CharStruct*>(data);
+    const CharStruct* p_type = static_cast<const CharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ WCharStructPubSubType::~WCharStructPubSubType()
 }
 
 bool WCharStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    WCharStruct* p_type = static_cast<WCharStruct*>(data);
+    const WCharStruct* p_type = static_cast<const WCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool WCharStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> WCharStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> WCharStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<WCharStruct*>(data), current_alignment)) +
+                               *static_cast<const WCharStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void WCharStructPubSubType::deleteData(
 }
 
 bool WCharStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool WCharStructPubSubType::getKey(
         return false;
     }
 
-    WCharStruct* p_type = static_cast<WCharStruct*>(data);
+    const WCharStruct* p_type = static_cast<const WCharStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ Int8StructPubSubType::~Int8StructPubSubType()
 }
 
 bool Int8StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Int8Struct* p_type = static_cast<Int8Struct*>(data);
+    const Int8Struct* p_type = static_cast<const Int8Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool Int8StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Int8StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> Int8StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Int8Struct*>(data), current_alignment)) +
+                               *static_cast<const Int8Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void Int8StructPubSubType::deleteData(
 }
 
 bool Int8StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool Int8StructPubSubType::getKey(
         return false;
     }
 
-    Int8Struct* p_type = static_cast<Int8Struct*>(data);
+    const Int8Struct* p_type = static_cast<const Int8Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ Uint8StructPubSubType::~Uint8StructPubSubType()
 }
 
 bool Uint8StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Uint8Struct* p_type = static_cast<Uint8Struct*>(data);
+    const Uint8Struct* p_type = static_cast<const Uint8Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool Uint8StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Uint8StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> Uint8StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Uint8Struct*>(data), current_alignment)) +
+                               *static_cast<const Uint8Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void Uint8StructPubSubType::deleteData(
 }
 
 bool Uint8StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool Uint8StructPubSubType::getKey(
         return false;
     }
 
-    Uint8Struct* p_type = static_cast<Uint8Struct*>(data);
+    const Uint8Struct* p_type = static_cast<const Uint8Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ Int16StructPubSubType::~Int16StructPubSubType()
 }
 
 bool Int16StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Int16Struct* p_type = static_cast<Int16Struct*>(data);
+    const Int16Struct* p_type = static_cast<const Int16Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool Int16StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Int16StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> Int16StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Int16Struct*>(data), current_alignment)) +
+                               *static_cast<const Int16Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void Int16StructPubSubType::deleteData(
 }
 
 bool Int16StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool Int16StructPubSubType::getKey(
         return false;
     }
 
-    Int16Struct* p_type = static_cast<Int16Struct*>(data);
+    const Int16Struct* p_type = static_cast<const Int16Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ Uint16StructPubSubType::~Uint16StructPubSubType()
 }
 
 bool Uint16StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Uint16Struct* p_type = static_cast<Uint16Struct*>(data);
+    const Uint16Struct* p_type = static_cast<const Uint16Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool Uint16StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Uint16StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> Uint16StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Uint16Struct*>(data), current_alignment)) +
+                               *static_cast<const Uint16Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void Uint16StructPubSubType::deleteData(
 }
 
 bool Uint16StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool Uint16StructPubSubType::getKey(
         return false;
     }
 
-    Uint16Struct* p_type = static_cast<Uint16Struct*>(data);
+    const Uint16Struct* p_type = static_cast<const Uint16Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ Int32StructPubSubType::~Int32StructPubSubType()
 }
 
 bool Int32StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Int32Struct* p_type = static_cast<Int32Struct*>(data);
+    const Int32Struct* p_type = static_cast<const Int32Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool Int32StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Int32StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> Int32StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Int32Struct*>(data), current_alignment)) +
+                               *static_cast<const Int32Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void Int32StructPubSubType::deleteData(
 }
 
 bool Int32StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool Int32StructPubSubType::getKey(
         return false;
     }
 
-    Int32Struct* p_type = static_cast<Int32Struct*>(data);
+    const Int32Struct* p_type = static_cast<const Int32Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ Uint32StructPubSubType::~Uint32StructPubSubType()
 }
 
 bool Uint32StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Uint32Struct* p_type = static_cast<Uint32Struct*>(data);
+    const Uint32Struct* p_type = static_cast<const Uint32Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool Uint32StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Uint32StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> Uint32StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Uint32Struct*>(data), current_alignment)) +
+                               *static_cast<const Uint32Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void Uint32StructPubSubType::deleteData(
 }
 
 bool Uint32StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool Uint32StructPubSubType::getKey(
         return false;
     }
 
-    Uint32Struct* p_type = static_cast<Uint32Struct*>(data);
+    const Uint32Struct* p_type = static_cast<const Uint32Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ Int64StructPubSubType::~Int64StructPubSubType()
 }
 
 bool Int64StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Int64Struct* p_type = static_cast<Int64Struct*>(data);
+    const Int64Struct* p_type = static_cast<const Int64Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool Int64StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Int64StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> Int64StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Int64Struct*>(data), current_alignment)) +
+                               *static_cast<const Int64Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void Int64StructPubSubType::deleteData(
 }
 
 bool Int64StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool Int64StructPubSubType::getKey(
         return false;
     }
 
-    Int64Struct* p_type = static_cast<Int64Struct*>(data);
+    const Int64Struct* p_type = static_cast<const Int64Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ Uint64StructPubSubType::~Uint64StructPubSubType()
 }
 
 bool Uint64StructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Uint64Struct* p_type = static_cast<Uint64Struct*>(data);
+    const Uint64Struct* p_type = static_cast<const Uint64Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool Uint64StructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> Uint64StructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> Uint64StructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Uint64Struct*>(data), current_alignment)) +
+                               *static_cast<const Uint64Struct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void Uint64StructPubSubType::deleteData(
 }
 
 bool Uint64StructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool Uint64StructPubSubType::getKey(
         return false;
     }
 
-    Uint64Struct* p_type = static_cast<Uint64Struct*>(data);
+    const Uint64Struct* p_type = static_cast<const Uint64Struct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/primitivesPubSubTypes.h
+++ b/test/dds-types-test/primitivesPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~ShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -144,14 +144,14 @@ public:
     eProsima_user_DllExport ~UShortStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -160,17 +160,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -235,14 +235,14 @@ public:
     eProsima_user_DllExport ~LongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -251,17 +251,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -326,14 +326,14 @@ public:
     eProsima_user_DllExport ~ULongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -342,17 +342,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -417,14 +417,14 @@ public:
     eProsima_user_DllExport ~LongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -433,17 +433,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -508,14 +508,14 @@ public:
     eProsima_user_DllExport ~ULongLongStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -524,17 +524,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -599,14 +599,14 @@ public:
     eProsima_user_DllExport ~FloatStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -615,17 +615,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -690,14 +690,14 @@ public:
     eProsima_user_DllExport ~DoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -706,17 +706,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -781,14 +781,14 @@ public:
     eProsima_user_DllExport ~LongDoubleStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -797,17 +797,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -872,14 +872,14 @@ public:
     eProsima_user_DllExport ~BooleanStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -888,17 +888,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -963,14 +963,14 @@ public:
     eProsima_user_DllExport ~OctetStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -979,17 +979,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1054,14 +1054,14 @@ public:
     eProsima_user_DllExport ~CharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1070,17 +1070,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1145,14 +1145,14 @@ public:
     eProsima_user_DllExport ~WCharStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1161,17 +1161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1236,14 +1236,14 @@ public:
     eProsima_user_DllExport ~Int8StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1252,17 +1252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1327,14 +1327,14 @@ public:
     eProsima_user_DllExport ~Uint8StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1343,17 +1343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1418,14 +1418,14 @@ public:
     eProsima_user_DllExport ~Int16StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1434,17 +1434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1509,14 +1509,14 @@ public:
     eProsima_user_DllExport ~Uint16StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1525,17 +1525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1600,14 +1600,14 @@ public:
     eProsima_user_DllExport ~Int32StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1616,17 +1616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1691,14 +1691,14 @@ public:
     eProsima_user_DllExport ~Uint32StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1707,17 +1707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1782,14 +1782,14 @@ public:
     eProsima_user_DllExport ~Int64StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1798,17 +1798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1873,14 +1873,14 @@ public:
     eProsima_user_DllExport ~Uint64StructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1889,17 +1889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/relative_path_includePubSubTypes.cxx
+++ b/test/dds-types-test/relative_path_includePubSubTypes.cxx
@@ -57,11 +57,11 @@ RelativePathIncludeStructPubSubType::~RelativePathIncludeStructPubSubType()
 }
 
 bool RelativePathIncludeStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    RelativePathIncludeStruct* p_type = static_cast<RelativePathIncludeStruct*>(data);
+    const RelativePathIncludeStruct* p_type = static_cast<const RelativePathIncludeStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool RelativePathIncludeStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> RelativePathIncludeStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> RelativePathIncludeStructPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<RelativePathIncludeStruct*>(data), current_alignment)) +
+                               *static_cast<const RelativePathIncludeStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void RelativePathIncludeStructPubSubType::deleteData(
 }
 
 bool RelativePathIncludeStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool RelativePathIncludeStructPubSubType::getKey(
         return false;
     }
 
-    RelativePathIncludeStruct* p_type = static_cast<RelativePathIncludeStruct*>(data);
+    const RelativePathIncludeStruct* p_type = static_cast<const RelativePathIncludeStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/relative_path_includePubSubTypes.h
+++ b/test/dds-types-test/relative_path_includePubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~RelativePathIncludeStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/sequencesPubSubTypes.cxx
+++ b/test/dds-types-test/sequencesPubSubTypes.cxx
@@ -57,11 +57,11 @@ SequenceShortPubSubType::~SequenceShortPubSubType()
 }
 
 bool SequenceShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceShort* p_type = static_cast<SequenceShort*>(data);
+    const SequenceShort* p_type = static_cast<const SequenceShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool SequenceShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> SequenceShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceShort*>(data), current_alignment)) +
+                               *static_cast<const SequenceShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void SequenceShortPubSubType::deleteData(
 }
 
 bool SequenceShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool SequenceShortPubSubType::getKey(
         return false;
     }
 
-    SequenceShort* p_type = static_cast<SequenceShort*>(data);
+    const SequenceShort* p_type = static_cast<const SequenceShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ SequenceUShortPubSubType::~SequenceUShortPubSubType()
 }
 
 bool SequenceUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceUShort* p_type = static_cast<SequenceUShort*>(data);
+    const SequenceUShort* p_type = static_cast<const SequenceUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool SequenceUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> SequenceUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceUShort*>(data), current_alignment)) +
+                               *static_cast<const SequenceUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void SequenceUShortPubSubType::deleteData(
 }
 
 bool SequenceUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool SequenceUShortPubSubType::getKey(
         return false;
     }
 
-    SequenceUShort* p_type = static_cast<SequenceUShort*>(data);
+    const SequenceUShort* p_type = static_cast<const SequenceUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ SequenceLongPubSubType::~SequenceLongPubSubType()
 }
 
 bool SequenceLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceLong* p_type = static_cast<SequenceLong*>(data);
+    const SequenceLong* p_type = static_cast<const SequenceLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool SequenceLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> SequenceLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceLong*>(data), current_alignment)) +
+                               *static_cast<const SequenceLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void SequenceLongPubSubType::deleteData(
 }
 
 bool SequenceLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool SequenceLongPubSubType::getKey(
         return false;
     }
 
-    SequenceLong* p_type = static_cast<SequenceLong*>(data);
+    const SequenceLong* p_type = static_cast<const SequenceLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ SequenceULongPubSubType::~SequenceULongPubSubType()
 }
 
 bool SequenceULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceULong* p_type = static_cast<SequenceULong*>(data);
+    const SequenceULong* p_type = static_cast<const SequenceULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool SequenceULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> SequenceULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceULong*>(data), current_alignment)) +
+                               *static_cast<const SequenceULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void SequenceULongPubSubType::deleteData(
 }
 
 bool SequenceULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool SequenceULongPubSubType::getKey(
         return false;
     }
 
-    SequenceULong* p_type = static_cast<SequenceULong*>(data);
+    const SequenceULong* p_type = static_cast<const SequenceULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ SequenceLongLongPubSubType::~SequenceLongLongPubSubType()
 }
 
 bool SequenceLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceLongLong* p_type = static_cast<SequenceLongLong*>(data);
+    const SequenceLongLong* p_type = static_cast<const SequenceLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool SequenceLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> SequenceLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceLongLong*>(data), current_alignment)) +
+                               *static_cast<const SequenceLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void SequenceLongLongPubSubType::deleteData(
 }
 
 bool SequenceLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool SequenceLongLongPubSubType::getKey(
         return false;
     }
 
-    SequenceLongLong* p_type = static_cast<SequenceLongLong*>(data);
+    const SequenceLongLong* p_type = static_cast<const SequenceLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ SequenceULongLongPubSubType::~SequenceULongLongPubSubType()
 }
 
 bool SequenceULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceULongLong* p_type = static_cast<SequenceULongLong*>(data);
+    const SequenceULongLong* p_type = static_cast<const SequenceULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool SequenceULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> SequenceULongLongPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceULongLong*>(data), current_alignment)) +
+                               *static_cast<const SequenceULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void SequenceULongLongPubSubType::deleteData(
 }
 
 bool SequenceULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool SequenceULongLongPubSubType::getKey(
         return false;
     }
 
-    SequenceULongLong* p_type = static_cast<SequenceULongLong*>(data);
+    const SequenceULongLong* p_type = static_cast<const SequenceULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ SequenceFloatPubSubType::~SequenceFloatPubSubType()
 }
 
 bool SequenceFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceFloat* p_type = static_cast<SequenceFloat*>(data);
+    const SequenceFloat* p_type = static_cast<const SequenceFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool SequenceFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> SequenceFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceFloat*>(data), current_alignment)) +
+                               *static_cast<const SequenceFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void SequenceFloatPubSubType::deleteData(
 }
 
 bool SequenceFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool SequenceFloatPubSubType::getKey(
         return false;
     }
 
-    SequenceFloat* p_type = static_cast<SequenceFloat*>(data);
+    const SequenceFloat* p_type = static_cast<const SequenceFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ SequenceDoublePubSubType::~SequenceDoublePubSubType()
 }
 
 bool SequenceDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceDouble* p_type = static_cast<SequenceDouble*>(data);
+    const SequenceDouble* p_type = static_cast<const SequenceDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool SequenceDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> SequenceDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceDouble*>(data), current_alignment)) +
+                               *static_cast<const SequenceDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void SequenceDoublePubSubType::deleteData(
 }
 
 bool SequenceDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool SequenceDoublePubSubType::getKey(
         return false;
     }
 
-    SequenceDouble* p_type = static_cast<SequenceDouble*>(data);
+    const SequenceDouble* p_type = static_cast<const SequenceDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ SequenceLongDoublePubSubType::~SequenceLongDoublePubSubType()
 }
 
 bool SequenceLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceLongDouble* p_type = static_cast<SequenceLongDouble*>(data);
+    const SequenceLongDouble* p_type = static_cast<const SequenceLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool SequenceLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> SequenceLongDoublePubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceLongDouble*>(data), current_alignment)) +
+                               *static_cast<const SequenceLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void SequenceLongDoublePubSubType::deleteData(
 }
 
 bool SequenceLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool SequenceLongDoublePubSubType::getKey(
         return false;
     }
 
-    SequenceLongDouble* p_type = static_cast<SequenceLongDouble*>(data);
+    const SequenceLongDouble* p_type = static_cast<const SequenceLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ SequenceBooleanPubSubType::~SequenceBooleanPubSubType()
 }
 
 bool SequenceBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceBoolean* p_type = static_cast<SequenceBoolean*>(data);
+    const SequenceBoolean* p_type = static_cast<const SequenceBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool SequenceBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> SequenceBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceBoolean*>(data), current_alignment)) +
+                               *static_cast<const SequenceBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void SequenceBooleanPubSubType::deleteData(
 }
 
 bool SequenceBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool SequenceBooleanPubSubType::getKey(
         return false;
     }
 
-    SequenceBoolean* p_type = static_cast<SequenceBoolean*>(data);
+    const SequenceBoolean* p_type = static_cast<const SequenceBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ SequenceOctetPubSubType::~SequenceOctetPubSubType()
 }
 
 bool SequenceOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceOctet* p_type = static_cast<SequenceOctet*>(data);
+    const SequenceOctet* p_type = static_cast<const SequenceOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool SequenceOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> SequenceOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceOctet*>(data), current_alignment)) +
+                               *static_cast<const SequenceOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void SequenceOctetPubSubType::deleteData(
 }
 
 bool SequenceOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool SequenceOctetPubSubType::getKey(
         return false;
     }
 
-    SequenceOctet* p_type = static_cast<SequenceOctet*>(data);
+    const SequenceOctet* p_type = static_cast<const SequenceOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ SequenceCharPubSubType::~SequenceCharPubSubType()
 }
 
 bool SequenceCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceChar* p_type = static_cast<SequenceChar*>(data);
+    const SequenceChar* p_type = static_cast<const SequenceChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool SequenceCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> SequenceCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceChar*>(data), current_alignment)) +
+                               *static_cast<const SequenceChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void SequenceCharPubSubType::deleteData(
 }
 
 bool SequenceCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool SequenceCharPubSubType::getKey(
         return false;
     }
 
-    SequenceChar* p_type = static_cast<SequenceChar*>(data);
+    const SequenceChar* p_type = static_cast<const SequenceChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ SequenceWCharPubSubType::~SequenceWCharPubSubType()
 }
 
 bool SequenceWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceWChar* p_type = static_cast<SequenceWChar*>(data);
+    const SequenceWChar* p_type = static_cast<const SequenceWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool SequenceWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> SequenceWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceWChar*>(data), current_alignment)) +
+                               *static_cast<const SequenceWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void SequenceWCharPubSubType::deleteData(
 }
 
 bool SequenceWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool SequenceWCharPubSubType::getKey(
         return false;
     }
 
-    SequenceWChar* p_type = static_cast<SequenceWChar*>(data);
+    const SequenceWChar* p_type = static_cast<const SequenceWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ SequenceStringPubSubType::~SequenceStringPubSubType()
 }
 
 bool SequenceStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceString* p_type = static_cast<SequenceString*>(data);
+    const SequenceString* p_type = static_cast<const SequenceString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool SequenceStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> SequenceStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceString*>(data), current_alignment)) +
+                               *static_cast<const SequenceString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void SequenceStringPubSubType::deleteData(
 }
 
 bool SequenceStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool SequenceStringPubSubType::getKey(
         return false;
     }
 
-    SequenceString* p_type = static_cast<SequenceString*>(data);
+    const SequenceString* p_type = static_cast<const SequenceString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ SequenceWStringPubSubType::~SequenceWStringPubSubType()
 }
 
 bool SequenceWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceWString* p_type = static_cast<SequenceWString*>(data);
+    const SequenceWString* p_type = static_cast<const SequenceWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool SequenceWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> SequenceWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceWString*>(data), current_alignment)) +
+                               *static_cast<const SequenceWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void SequenceWStringPubSubType::deleteData(
 }
 
 bool SequenceWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool SequenceWStringPubSubType::getKey(
         return false;
     }
 
-    SequenceWString* p_type = static_cast<SequenceWString*>(data);
+    const SequenceWString* p_type = static_cast<const SequenceWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ SequenceStringBoundedPubSubType::~SequenceStringBoundedPubSubType()
 }
 
 bool SequenceStringBoundedPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceStringBounded* p_type = static_cast<SequenceStringBounded*>(data);
+    const SequenceStringBounded* p_type = static_cast<const SequenceStringBounded*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool SequenceStringBoundedPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceStringBoundedPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> SequenceStringBoundedPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceStringBounded*>(data), current_alignment)) +
+                               *static_cast<const SequenceStringBounded*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void SequenceStringBoundedPubSubType::deleteData(
 }
 
 bool SequenceStringBoundedPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool SequenceStringBoundedPubSubType::getKey(
         return false;
     }
 
-    SequenceStringBounded* p_type = static_cast<SequenceStringBounded*>(data);
+    const SequenceStringBounded* p_type = static_cast<const SequenceStringBounded*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ SequenceWStringBoundedPubSubType::~SequenceWStringBoundedPubSubType()
 }
 
 bool SequenceWStringBoundedPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceWStringBounded* p_type = static_cast<SequenceWStringBounded*>(data);
+    const SequenceWStringBounded* p_type = static_cast<const SequenceWStringBounded*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool SequenceWStringBoundedPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceWStringBoundedPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> SequenceWStringBoundedPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceWStringBounded*>(data), current_alignment)) +
+                               *static_cast<const SequenceWStringBounded*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void SequenceWStringBoundedPubSubType::deleteData(
 }
 
 bool SequenceWStringBoundedPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool SequenceWStringBoundedPubSubType::getKey(
         return false;
     }
 
-    SequenceWStringBounded* p_type = static_cast<SequenceWStringBounded*>(data);
+    const SequenceWStringBounded* p_type = static_cast<const SequenceWStringBounded*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ SequenceEnumPubSubType::~SequenceEnumPubSubType()
 }
 
 bool SequenceEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceEnum* p_type = static_cast<SequenceEnum*>(data);
+    const SequenceEnum* p_type = static_cast<const SequenceEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool SequenceEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> SequenceEnumPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceEnum*>(data), current_alignment)) +
+                               *static_cast<const SequenceEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void SequenceEnumPubSubType::deleteData(
 }
 
 bool SequenceEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool SequenceEnumPubSubType::getKey(
         return false;
     }
 
-    SequenceEnum* p_type = static_cast<SequenceEnum*>(data);
+    const SequenceEnum* p_type = static_cast<const SequenceEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ SequenceBitMaskPubSubType::~SequenceBitMaskPubSubType()
 }
 
 bool SequenceBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceBitMask* p_type = static_cast<SequenceBitMask*>(data);
+    const SequenceBitMask* p_type = static_cast<const SequenceBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool SequenceBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> SequenceBitMaskPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceBitMask*>(data), current_alignment)) +
+                               *static_cast<const SequenceBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void SequenceBitMaskPubSubType::deleteData(
 }
 
 bool SequenceBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool SequenceBitMaskPubSubType::getKey(
         return false;
     }
 
-    SequenceBitMask* p_type = static_cast<SequenceBitMask*>(data);
+    const SequenceBitMask* p_type = static_cast<const SequenceBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ SequenceAliasPubSubType::~SequenceAliasPubSubType()
 }
 
 bool SequenceAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceAlias* p_type = static_cast<SequenceAlias*>(data);
+    const SequenceAlias* p_type = static_cast<const SequenceAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool SequenceAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> SequenceAliasPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceAlias*>(data), current_alignment)) +
+                               *static_cast<const SequenceAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void SequenceAliasPubSubType::deleteData(
 }
 
 bool SequenceAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool SequenceAliasPubSubType::getKey(
         return false;
     }
 
-    SequenceAlias* p_type = static_cast<SequenceAlias*>(data);
+    const SequenceAlias* p_type = static_cast<const SequenceAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ SequenceShortArrayPubSubType::~SequenceShortArrayPubSubType()
 }
 
 bool SequenceShortArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceShortArray* p_type = static_cast<SequenceShortArray*>(data);
+    const SequenceShortArray* p_type = static_cast<const SequenceShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool SequenceShortArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceShortArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> SequenceShortArrayPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceShortArray*>(data), current_alignment)) +
+                               *static_cast<const SequenceShortArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void SequenceShortArrayPubSubType::deleteData(
 }
 
 bool SequenceShortArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool SequenceShortArrayPubSubType::getKey(
         return false;
     }
 
-    SequenceShortArray* p_type = static_cast<SequenceShortArray*>(data);
+    const SequenceShortArray* p_type = static_cast<const SequenceShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ SequenceSequencePubSubType::~SequenceSequencePubSubType()
 }
 
 bool SequenceSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceSequence* p_type = static_cast<SequenceSequence*>(data);
+    const SequenceSequence* p_type = static_cast<const SequenceSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool SequenceSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> SequenceSequencePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceSequence*>(data), current_alignment)) +
+                               *static_cast<const SequenceSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void SequenceSequencePubSubType::deleteData(
 }
 
 bool SequenceSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool SequenceSequencePubSubType::getKey(
         return false;
     }
 
-    SequenceSequence* p_type = static_cast<SequenceSequence*>(data);
+    const SequenceSequence* p_type = static_cast<const SequenceSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ SequenceMapPubSubType::~SequenceMapPubSubType()
 }
 
 bool SequenceMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceMap* p_type = static_cast<SequenceMap*>(data);
+    const SequenceMap* p_type = static_cast<const SequenceMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool SequenceMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> SequenceMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceMap*>(data), current_alignment)) +
+                               *static_cast<const SequenceMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void SequenceMapPubSubType::deleteData(
 }
 
 bool SequenceMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool SequenceMapPubSubType::getKey(
         return false;
     }
 
-    SequenceMap* p_type = static_cast<SequenceMap*>(data);
+    const SequenceMap* p_type = static_cast<const SequenceMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ SequenceUnionPubSubType::~SequenceUnionPubSubType()
 }
 
 bool SequenceUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceUnion* p_type = static_cast<SequenceUnion*>(data);
+    const SequenceUnion* p_type = static_cast<const SequenceUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool SequenceUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> SequenceUnionPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceUnion*>(data), current_alignment)) +
+                               *static_cast<const SequenceUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void SequenceUnionPubSubType::deleteData(
 }
 
 bool SequenceUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool SequenceUnionPubSubType::getKey(
         return false;
     }
 
-    SequenceUnion* p_type = static_cast<SequenceUnion*>(data);
+    const SequenceUnion* p_type = static_cast<const SequenceUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ SequenceStructurePubSubType::~SequenceStructurePubSubType()
 }
 
 bool SequenceStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceStructure* p_type = static_cast<SequenceStructure*>(data);
+    const SequenceStructure* p_type = static_cast<const SequenceStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool SequenceStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> SequenceStructurePubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceStructure*>(data), current_alignment)) +
+                               *static_cast<const SequenceStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void SequenceStructurePubSubType::deleteData(
 }
 
 bool SequenceStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool SequenceStructurePubSubType::getKey(
         return false;
     }
 
-    SequenceStructure* p_type = static_cast<SequenceStructure*>(data);
+    const SequenceStructure* p_type = static_cast<const SequenceStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ SequenceBitsetPubSubType::~SequenceBitsetPubSubType()
 }
 
 bool SequenceBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SequenceBitset* p_type = static_cast<SequenceBitset*>(data);
+    const SequenceBitset* p_type = static_cast<const SequenceBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool SequenceBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SequenceBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> SequenceBitsetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SequenceBitset*>(data), current_alignment)) +
+                               *static_cast<const SequenceBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void SequenceBitsetPubSubType::deleteData(
 }
 
 bool SequenceBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool SequenceBitsetPubSubType::getKey(
         return false;
     }
 
-    SequenceBitset* p_type = static_cast<SequenceBitset*>(data);
+    const SequenceBitset* p_type = static_cast<const SequenceBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ BoundedSmallSequencesPubSubType::~BoundedSmallSequencesPubSubType()
 }
 
 bool BoundedSmallSequencesPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedSmallSequences* p_type = static_cast<BoundedSmallSequences*>(data);
+    const BoundedSmallSequences* p_type = static_cast<const BoundedSmallSequences*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool BoundedSmallSequencesPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedSmallSequencesPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> BoundedSmallSequencesPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedSmallSequences*>(data), current_alignment)) +
+                               *static_cast<const BoundedSmallSequences*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void BoundedSmallSequencesPubSubType::deleteData(
 }
 
 bool BoundedSmallSequencesPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool BoundedSmallSequencesPubSubType::getKey(
         return false;
     }
 
-    BoundedSmallSequences* p_type = static_cast<BoundedSmallSequences*>(data);
+    const BoundedSmallSequences* p_type = static_cast<const BoundedSmallSequences*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ BoundedBigSequencesPubSubType::~BoundedBigSequencesPubSubType()
 }
 
 bool BoundedBigSequencesPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    BoundedBigSequences* p_type = static_cast<BoundedBigSequences*>(data);
+    const BoundedBigSequences* p_type = static_cast<const BoundedBigSequences*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool BoundedBigSequencesPubSubType::deserialize(
 }
 
 std::function<uint32_t()> BoundedBigSequencesPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> BoundedBigSequencesPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<BoundedBigSequences*>(data), current_alignment)) +
+                               *static_cast<const BoundedBigSequences*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void BoundedBigSequencesPubSubType::deleteData(
 }
 
 bool BoundedBigSequencesPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool BoundedBigSequencesPubSubType::getKey(
         return false;
     }
 
-    BoundedBigSequences* p_type = static_cast<BoundedBigSequences*>(data);
+    const BoundedBigSequences* p_type = static_cast<const BoundedBigSequences*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/sequencesPubSubTypes.h
+++ b/test/dds-types-test/sequencesPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~SequenceShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~SequenceUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~SequenceLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~SequenceULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~SequenceLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~SequenceULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~SequenceFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~SequenceDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~SequenceLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~SequenceBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~SequenceOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~SequenceCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~SequenceWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~SequenceStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~SequenceWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~SequenceStringBoundedPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~SequenceWStringBoundedPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~SequenceEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~SequenceBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~SequenceAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~SequenceShortArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~SequenceSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~SequenceMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~SequenceUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~SequenceStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~SequenceBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~BoundedSmallSequencesPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~BoundedBigSequencesPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/stringsPubSubTypes.cxx
+++ b/test/dds-types-test/stringsPubSubTypes.cxx
@@ -57,11 +57,11 @@ StringStructPubSubType::~StringStructPubSubType()
 }
 
 bool StringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StringStruct* p_type = static_cast<StringStruct*>(data);
+    const StringStruct* p_type = static_cast<const StringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool StringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> StringStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StringStruct*>(data), current_alignment)) +
+                               *static_cast<const StringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void StringStructPubSubType::deleteData(
 }
 
 bool StringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool StringStructPubSubType::getKey(
         return false;
     }
 
-    StringStruct* p_type = static_cast<StringStruct*>(data);
+    const StringStruct* p_type = static_cast<const StringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ WStringStructPubSubType::~WStringStructPubSubType()
 }
 
 bool WStringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    WStringStruct* p_type = static_cast<WStringStruct*>(data);
+    const WStringStruct* p_type = static_cast<const WStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool WStringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> WStringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> WStringStructPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<WStringStruct*>(data), current_alignment)) +
+                               *static_cast<const WStringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void WStringStructPubSubType::deleteData(
 }
 
 bool WStringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool WStringStructPubSubType::getKey(
         return false;
     }
 
-    WStringStruct* p_type = static_cast<WStringStruct*>(data);
+    const WStringStruct* p_type = static_cast<const WStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ SmallStringStructPubSubType::~SmallStringStructPubSubType()
 }
 
 bool SmallStringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SmallStringStruct* p_type = static_cast<SmallStringStruct*>(data);
+    const SmallStringStruct* p_type = static_cast<const SmallStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool SmallStringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SmallStringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> SmallStringStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SmallStringStruct*>(data), current_alignment)) +
+                               *static_cast<const SmallStringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void SmallStringStructPubSubType::deleteData(
 }
 
 bool SmallStringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool SmallStringStructPubSubType::getKey(
         return false;
     }
 
-    SmallStringStruct* p_type = static_cast<SmallStringStruct*>(data);
+    const SmallStringStruct* p_type = static_cast<const SmallStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ SmallWStringStructPubSubType::~SmallWStringStructPubSubType()
 }
 
 bool SmallWStringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    SmallWStringStruct* p_type = static_cast<SmallWStringStruct*>(data);
+    const SmallWStringStruct* p_type = static_cast<const SmallWStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool SmallWStringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> SmallWStringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> SmallWStringStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<SmallWStringStruct*>(data), current_alignment)) +
+                               *static_cast<const SmallWStringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void SmallWStringStructPubSubType::deleteData(
 }
 
 bool SmallWStringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool SmallWStringStructPubSubType::getKey(
         return false;
     }
 
-    SmallWStringStruct* p_type = static_cast<SmallWStringStruct*>(data);
+    const SmallWStringStruct* p_type = static_cast<const SmallWStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ LargeStringStructPubSubType::~LargeStringStructPubSubType()
 }
 
 bool LargeStringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LargeStringStruct* p_type = static_cast<LargeStringStruct*>(data);
+    const LargeStringStruct* p_type = static_cast<const LargeStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool LargeStringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LargeStringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> LargeStringStructPubSubType::getSerializedSizeProvider
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LargeStringStruct*>(data), current_alignment)) +
+                               *static_cast<const LargeStringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void LargeStringStructPubSubType::deleteData(
 }
 
 bool LargeStringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool LargeStringStructPubSubType::getKey(
         return false;
     }
 
-    LargeStringStruct* p_type = static_cast<LargeStringStruct*>(data);
+    const LargeStringStruct* p_type = static_cast<const LargeStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ LargeWStringStructPubSubType::~LargeWStringStructPubSubType()
 }
 
 bool LargeWStringStructPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    LargeWStringStruct* p_type = static_cast<LargeWStringStruct*>(data);
+    const LargeWStringStruct* p_type = static_cast<const LargeWStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool LargeWStringStructPubSubType::deserialize(
 }
 
 std::function<uint32_t()> LargeWStringStructPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> LargeWStringStructPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<LargeWStringStruct*>(data), current_alignment)) +
+                               *static_cast<const LargeWStringStruct*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void LargeWStringStructPubSubType::deleteData(
 }
 
 bool LargeWStringStructPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool LargeWStringStructPubSubType::getKey(
         return false;
     }
 
-    LargeWStringStruct* p_type = static_cast<LargeWStringStruct*>(data);
+    const LargeWStringStruct* p_type = static_cast<const LargeWStringStruct*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/stringsPubSubTypes.h
+++ b/test/dds-types-test/stringsPubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~StringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -144,14 +144,14 @@ public:
     eProsima_user_DllExport ~WStringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -160,17 +160,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -235,14 +235,14 @@ public:
     eProsima_user_DllExport ~SmallStringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -251,17 +251,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -326,14 +326,14 @@ public:
     eProsima_user_DllExport ~SmallWStringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -342,17 +342,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -417,14 +417,14 @@ public:
     eProsima_user_DllExport ~LargeStringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -433,17 +433,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -508,14 +508,14 @@ public:
     eProsima_user_DllExport ~LargeWStringStructPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -524,17 +524,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/structuresPubSubTypes.cxx
+++ b/test/dds-types-test/structuresPubSubTypes.cxx
@@ -57,11 +57,11 @@ StructShortPubSubType::~StructShortPubSubType()
 }
 
 bool StructShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructShort* p_type = static_cast<StructShort*>(data);
+    const StructShort* p_type = static_cast<const StructShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool StructShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> StructShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructShort*>(data), current_alignment)) +
+                               *static_cast<const StructShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void StructShortPubSubType::deleteData(
 }
 
 bool StructShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool StructShortPubSubType::getKey(
         return false;
     }
 
-    StructShort* p_type = static_cast<StructShort*>(data);
+    const StructShort* p_type = static_cast<const StructShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ StructUnsignedShortPubSubType::~StructUnsignedShortPubSubType()
 }
 
 bool StructUnsignedShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructUnsignedShort* p_type = static_cast<StructUnsignedShort*>(data);
+    const StructUnsignedShort* p_type = static_cast<const StructUnsignedShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool StructUnsignedShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructUnsignedShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> StructUnsignedShortPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructUnsignedShort*>(data), current_alignment)) +
+                               *static_cast<const StructUnsignedShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void StructUnsignedShortPubSubType::deleteData(
 }
 
 bool StructUnsignedShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool StructUnsignedShortPubSubType::getKey(
         return false;
     }
 
-    StructUnsignedShort* p_type = static_cast<StructUnsignedShort*>(data);
+    const StructUnsignedShort* p_type = static_cast<const StructUnsignedShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ StructLongPubSubType::~StructLongPubSubType()
 }
 
 bool StructLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructLong* p_type = static_cast<StructLong*>(data);
+    const StructLong* p_type = static_cast<const StructLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool StructLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> StructLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructLong*>(data), current_alignment)) +
+                               *static_cast<const StructLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void StructLongPubSubType::deleteData(
 }
 
 bool StructLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool StructLongPubSubType::getKey(
         return false;
     }
 
-    StructLong* p_type = static_cast<StructLong*>(data);
+    const StructLong* p_type = static_cast<const StructLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ StructUnsignedLongPubSubType::~StructUnsignedLongPubSubType()
 }
 
 bool StructUnsignedLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructUnsignedLong* p_type = static_cast<StructUnsignedLong*>(data);
+    const StructUnsignedLong* p_type = static_cast<const StructUnsignedLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool StructUnsignedLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructUnsignedLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> StructUnsignedLongPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructUnsignedLong*>(data), current_alignment)) +
+                               *static_cast<const StructUnsignedLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void StructUnsignedLongPubSubType::deleteData(
 }
 
 bool StructUnsignedLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool StructUnsignedLongPubSubType::getKey(
         return false;
     }
 
-    StructUnsignedLong* p_type = static_cast<StructUnsignedLong*>(data);
+    const StructUnsignedLong* p_type = static_cast<const StructUnsignedLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ StructLongLongPubSubType::~StructLongLongPubSubType()
 }
 
 bool StructLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructLongLong* p_type = static_cast<StructLongLong*>(data);
+    const StructLongLong* p_type = static_cast<const StructLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool StructLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> StructLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructLongLong*>(data), current_alignment)) +
+                               *static_cast<const StructLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void StructLongLongPubSubType::deleteData(
 }
 
 bool StructLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool StructLongLongPubSubType::getKey(
         return false;
     }
 
-    StructLongLong* p_type = static_cast<StructLongLong*>(data);
+    const StructLongLong* p_type = static_cast<const StructLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ StructUnsignedLongLongPubSubType::~StructUnsignedLongLongPubSubType()
 }
 
 bool StructUnsignedLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructUnsignedLongLong* p_type = static_cast<StructUnsignedLongLong*>(data);
+    const StructUnsignedLongLong* p_type = static_cast<const StructUnsignedLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool StructUnsignedLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructUnsignedLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> StructUnsignedLongLongPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructUnsignedLongLong*>(data), current_alignment)) +
+                               *static_cast<const StructUnsignedLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void StructUnsignedLongLongPubSubType::deleteData(
 }
 
 bool StructUnsignedLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool StructUnsignedLongLongPubSubType::getKey(
         return false;
     }
 
-    StructUnsignedLongLong* p_type = static_cast<StructUnsignedLongLong*>(data);
+    const StructUnsignedLongLong* p_type = static_cast<const StructUnsignedLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ StructFloatPubSubType::~StructFloatPubSubType()
 }
 
 bool StructFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructFloat* p_type = static_cast<StructFloat*>(data);
+    const StructFloat* p_type = static_cast<const StructFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool StructFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> StructFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructFloat*>(data), current_alignment)) +
+                               *static_cast<const StructFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void StructFloatPubSubType::deleteData(
 }
 
 bool StructFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool StructFloatPubSubType::getKey(
         return false;
     }
 
-    StructFloat* p_type = static_cast<StructFloat*>(data);
+    const StructFloat* p_type = static_cast<const StructFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ StructDoublePubSubType::~StructDoublePubSubType()
 }
 
 bool StructDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructDouble* p_type = static_cast<StructDouble*>(data);
+    const StructDouble* p_type = static_cast<const StructDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool StructDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> StructDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructDouble*>(data), current_alignment)) +
+                               *static_cast<const StructDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void StructDoublePubSubType::deleteData(
 }
 
 bool StructDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool StructDoublePubSubType::getKey(
         return false;
     }
 
-    StructDouble* p_type = static_cast<StructDouble*>(data);
+    const StructDouble* p_type = static_cast<const StructDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ StructLongDoublePubSubType::~StructLongDoublePubSubType()
 }
 
 bool StructLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructLongDouble* p_type = static_cast<StructLongDouble*>(data);
+    const StructLongDouble* p_type = static_cast<const StructLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool StructLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> StructLongDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructLongDouble*>(data), current_alignment)) +
+                               *static_cast<const StructLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void StructLongDoublePubSubType::deleteData(
 }
 
 bool StructLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool StructLongDoublePubSubType::getKey(
         return false;
     }
 
-    StructLongDouble* p_type = static_cast<StructLongDouble*>(data);
+    const StructLongDouble* p_type = static_cast<const StructLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ StructBooleanPubSubType::~StructBooleanPubSubType()
 }
 
 bool StructBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructBoolean* p_type = static_cast<StructBoolean*>(data);
+    const StructBoolean* p_type = static_cast<const StructBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool StructBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> StructBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructBoolean*>(data), current_alignment)) +
+                               *static_cast<const StructBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void StructBooleanPubSubType::deleteData(
 }
 
 bool StructBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool StructBooleanPubSubType::getKey(
         return false;
     }
 
-    StructBoolean* p_type = static_cast<StructBoolean*>(data);
+    const StructBoolean* p_type = static_cast<const StructBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ StructOctetPubSubType::~StructOctetPubSubType()
 }
 
 bool StructOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructOctet* p_type = static_cast<StructOctet*>(data);
+    const StructOctet* p_type = static_cast<const StructOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool StructOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> StructOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructOctet*>(data), current_alignment)) +
+                               *static_cast<const StructOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void StructOctetPubSubType::deleteData(
 }
 
 bool StructOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool StructOctetPubSubType::getKey(
         return false;
     }
 
-    StructOctet* p_type = static_cast<StructOctet*>(data);
+    const StructOctet* p_type = static_cast<const StructOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ StructChar8PubSubType::~StructChar8PubSubType()
 }
 
 bool StructChar8PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructChar8* p_type = static_cast<StructChar8*>(data);
+    const StructChar8* p_type = static_cast<const StructChar8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool StructChar8PubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructChar8PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> StructChar8PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructChar8*>(data), current_alignment)) +
+                               *static_cast<const StructChar8*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void StructChar8PubSubType::deleteData(
 }
 
 bool StructChar8PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool StructChar8PubSubType::getKey(
         return false;
     }
 
-    StructChar8* p_type = static_cast<StructChar8*>(data);
+    const StructChar8* p_type = static_cast<const StructChar8*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ StructChar16PubSubType::~StructChar16PubSubType()
 }
 
 bool StructChar16PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructChar16* p_type = static_cast<StructChar16*>(data);
+    const StructChar16* p_type = static_cast<const StructChar16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool StructChar16PubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructChar16PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> StructChar16PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructChar16*>(data), current_alignment)) +
+                               *static_cast<const StructChar16*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void StructChar16PubSubType::deleteData(
 }
 
 bool StructChar16PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool StructChar16PubSubType::getKey(
         return false;
     }
 
-    StructChar16* p_type = static_cast<StructChar16*>(data);
+    const StructChar16* p_type = static_cast<const StructChar16*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ StructStringPubSubType::~StructStringPubSubType()
 }
 
 bool StructStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructString* p_type = static_cast<StructString*>(data);
+    const StructString* p_type = static_cast<const StructString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool StructStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> StructStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructString*>(data), current_alignment)) +
+                               *static_cast<const StructString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void StructStringPubSubType::deleteData(
 }
 
 bool StructStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool StructStringPubSubType::getKey(
         return false;
     }
 
-    StructString* p_type = static_cast<StructString*>(data);
+    const StructString* p_type = static_cast<const StructString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ StructWStringPubSubType::~StructWStringPubSubType()
 }
 
 bool StructWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructWString* p_type = static_cast<StructWString*>(data);
+    const StructWString* p_type = static_cast<const StructWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool StructWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> StructWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructWString*>(data), current_alignment)) +
+                               *static_cast<const StructWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void StructWStringPubSubType::deleteData(
 }
 
 bool StructWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool StructWStringPubSubType::getKey(
         return false;
     }
 
-    StructWString* p_type = static_cast<StructWString*>(data);
+    const StructWString* p_type = static_cast<const StructWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ StructBoundedStringPubSubType::~StructBoundedStringPubSubType()
 }
 
 bool StructBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructBoundedString* p_type = static_cast<StructBoundedString*>(data);
+    const StructBoundedString* p_type = static_cast<const StructBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool StructBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> StructBoundedStringPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructBoundedString*>(data), current_alignment)) +
+                               *static_cast<const StructBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void StructBoundedStringPubSubType::deleteData(
 }
 
 bool StructBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool StructBoundedStringPubSubType::getKey(
         return false;
     }
 
-    StructBoundedString* p_type = static_cast<StructBoundedString*>(data);
+    const StructBoundedString* p_type = static_cast<const StructBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ StructBoundedWStringPubSubType::~StructBoundedWStringPubSubType()
 }
 
 bool StructBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructBoundedWString* p_type = static_cast<StructBoundedWString*>(data);
+    const StructBoundedWString* p_type = static_cast<const StructBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool StructBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> StructBoundedWStringPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const StructBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void StructBoundedWStringPubSubType::deleteData(
 }
 
 bool StructBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool StructBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    StructBoundedWString* p_type = static_cast<StructBoundedWString*>(data);
+    const StructBoundedWString* p_type = static_cast<const StructBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ StructEnumPubSubType::~StructEnumPubSubType()
 }
 
 bool StructEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructEnum* p_type = static_cast<StructEnum*>(data);
+    const StructEnum* p_type = static_cast<const StructEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool StructEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> StructEnumPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructEnum*>(data), current_alignment)) +
+                               *static_cast<const StructEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void StructEnumPubSubType::deleteData(
 }
 
 bool StructEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool StructEnumPubSubType::getKey(
         return false;
     }
 
-    StructEnum* p_type = static_cast<StructEnum*>(data);
+    const StructEnum* p_type = static_cast<const StructEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ StructBitMaskPubSubType::~StructBitMaskPubSubType()
 }
 
 bool StructBitMaskPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructBitMask* p_type = static_cast<StructBitMask*>(data);
+    const StructBitMask* p_type = static_cast<const StructBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool StructBitMaskPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructBitMaskPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> StructBitMaskPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructBitMask*>(data), current_alignment)) +
+                               *static_cast<const StructBitMask*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void StructBitMaskPubSubType::deleteData(
 }
 
 bool StructBitMaskPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool StructBitMaskPubSubType::getKey(
         return false;
     }
 
-    StructBitMask* p_type = static_cast<StructBitMask*>(data);
+    const StructBitMask* p_type = static_cast<const StructBitMask*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ StructAliasPubSubType::~StructAliasPubSubType()
 }
 
 bool StructAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructAlias* p_type = static_cast<StructAlias*>(data);
+    const StructAlias* p_type = static_cast<const StructAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool StructAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> StructAliasPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructAlias*>(data), current_alignment)) +
+                               *static_cast<const StructAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void StructAliasPubSubType::deleteData(
 }
 
 bool StructAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool StructAliasPubSubType::getKey(
         return false;
     }
 
-    StructAlias* p_type = static_cast<StructAlias*>(data);
+    const StructAlias* p_type = static_cast<const StructAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ StructShortArrayPubSubType::~StructShortArrayPubSubType()
 }
 
 bool StructShortArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructShortArray* p_type = static_cast<StructShortArray*>(data);
+    const StructShortArray* p_type = static_cast<const StructShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool StructShortArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructShortArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> StructShortArrayPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructShortArray*>(data), current_alignment)) +
+                               *static_cast<const StructShortArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void StructShortArrayPubSubType::deleteData(
 }
 
 bool StructShortArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool StructShortArrayPubSubType::getKey(
         return false;
     }
 
-    StructShortArray* p_type = static_cast<StructShortArray*>(data);
+    const StructShortArray* p_type = static_cast<const StructShortArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ StructSequencePubSubType::~StructSequencePubSubType()
 }
 
 bool StructSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructSequence* p_type = static_cast<StructSequence*>(data);
+    const StructSequence* p_type = static_cast<const StructSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool StructSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> StructSequencePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructSequence*>(data), current_alignment)) +
+                               *static_cast<const StructSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void StructSequencePubSubType::deleteData(
 }
 
 bool StructSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool StructSequencePubSubType::getKey(
         return false;
     }
 
-    StructSequence* p_type = static_cast<StructSequence*>(data);
+    const StructSequence* p_type = static_cast<const StructSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ StructMapPubSubType::~StructMapPubSubType()
 }
 
 bool StructMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructMap* p_type = static_cast<StructMap*>(data);
+    const StructMap* p_type = static_cast<const StructMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool StructMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> StructMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructMap*>(data), current_alignment)) +
+                               *static_cast<const StructMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void StructMapPubSubType::deleteData(
 }
 
 bool StructMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool StructMapPubSubType::getKey(
         return false;
     }
 
-    StructMap* p_type = static_cast<StructMap*>(data);
+    const StructMap* p_type = static_cast<const StructMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ StructUnionPubSubType::~StructUnionPubSubType()
 }
 
 bool StructUnionPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructUnion* p_type = static_cast<StructUnion*>(data);
+    const StructUnion* p_type = static_cast<const StructUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool StructUnionPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructUnionPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> StructUnionPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructUnion*>(data), current_alignment)) +
+                               *static_cast<const StructUnion*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void StructUnionPubSubType::deleteData(
 }
 
 bool StructUnionPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool StructUnionPubSubType::getKey(
         return false;
     }
 
-    StructUnion* p_type = static_cast<StructUnion*>(data);
+    const StructUnion* p_type = static_cast<const StructUnion*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ StructStructurePubSubType::~StructStructurePubSubType()
 }
 
 bool StructStructurePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructStructure* p_type = static_cast<StructStructure*>(data);
+    const StructStructure* p_type = static_cast<const StructStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool StructStructurePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructStructurePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> StructStructurePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructStructure*>(data), current_alignment)) +
+                               *static_cast<const StructStructure*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void StructStructurePubSubType::deleteData(
 }
 
 bool StructStructurePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool StructStructurePubSubType::getKey(
         return false;
     }
 
-    StructStructure* p_type = static_cast<StructStructure*>(data);
+    const StructStructure* p_type = static_cast<const StructStructure*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ StructBitsetPubSubType::~StructBitsetPubSubType()
 }
 
 bool StructBitsetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructBitset* p_type = static_cast<StructBitset*>(data);
+    const StructBitset* p_type = static_cast<const StructBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool StructBitsetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructBitsetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> StructBitsetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructBitset*>(data), current_alignment)) +
+                               *static_cast<const StructBitset*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void StructBitsetPubSubType::deleteData(
 }
 
 bool StructBitsetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool StructBitsetPubSubType::getKey(
         return false;
     }
 
-    StructBitset* p_type = static_cast<StructBitset*>(data);
+    const StructBitset* p_type = static_cast<const StructBitset*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ StructEmptyPubSubType::~StructEmptyPubSubType()
 }
 
 bool StructEmptyPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructEmpty* p_type = static_cast<StructEmpty*>(data);
+    const StructEmpty* p_type = static_cast<const StructEmpty*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool StructEmptyPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructEmptyPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> StructEmptyPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructEmpty*>(data), current_alignment)) +
+                               *static_cast<const StructEmpty*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void StructEmptyPubSubType::deleteData(
 }
 
 bool StructEmptyPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool StructEmptyPubSubType::getKey(
         return false;
     }
 
-    StructEmpty* p_type = static_cast<StructEmpty*>(data);
+    const StructEmpty* p_type = static_cast<const StructEmpty*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ StructuresPubSubType::~StructuresPubSubType()
 }
 
 bool StructuresPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    Structures* p_type = static_cast<Structures*>(data);
+    const Structures* p_type = static_cast<const Structures*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool StructuresPubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructuresPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> StructuresPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<Structures*>(data), current_alignment)) +
+                               *static_cast<const Structures*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void StructuresPubSubType::deleteData(
 }
 
 bool StructuresPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool StructuresPubSubType::getKey(
         return false;
     }
 
-    Structures* p_type = static_cast<Structures*>(data);
+    const Structures* p_type = static_cast<const Structures*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5462,11 +5462,11 @@ namespace testing_1 {
     }
 
     bool fooPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        foo* p_type = static_cast<foo*>(data);
+        const foo* p_type = static_cast<const foo*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5538,7 +5538,7 @@ namespace testing_1 {
     }
 
     std::function<uint32_t()> fooPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -5555,7 +5555,7 @@ namespace testing_1 {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<foo*>(data), current_alignment)) +
+                                   *static_cast<const foo*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5578,7 +5578,7 @@ namespace testing_1 {
     }
 
     bool fooPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -5587,7 +5587,7 @@ namespace testing_1 {
             return false;
         }
 
-        foo* p_type = static_cast<foo*>(data);
+        const foo* p_type = static_cast<const foo*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5658,11 +5658,11 @@ namespace testing_2 {
     }
 
     bool fooPubSubType::serialize(
-            void* data,
+            const void* const data,
             SerializedPayload_t* payload,
             DataRepresentationId_t data_representation)
     {
-        foo* p_type = static_cast<foo*>(data);
+        const foo* p_type = static_cast<const foo*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5734,7 +5734,7 @@ namespace testing_2 {
     }
 
     std::function<uint32_t()> fooPubSubType::getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t data_representation)
     {
         return [data, data_representation]() -> uint32_t
@@ -5751,7 +5751,7 @@ namespace testing_2 {
                            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                        size_t current_alignment {0};
                        return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                                   *static_cast<foo*>(data), current_alignment)) +
+                                   *static_cast<const foo*>(data), current_alignment)) +
                                4u /*encapsulation*/;
                    }
                    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5774,7 +5774,7 @@ namespace testing_2 {
     }
 
     bool fooPubSubType::getKey(
-            void* data,
+            const void* const data,
             InstanceHandle_t* handle,
             bool force_md5)
     {
@@ -5783,7 +5783,7 @@ namespace testing_2 {
             return false;
         }
 
-        foo* p_type = static_cast<foo*>(data);
+        const foo* p_type = static_cast<const foo*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5853,11 +5853,11 @@ barPubSubType::~barPubSubType()
 }
 
 bool barPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    bar* p_type = static_cast<bar*>(data);
+    const bar* p_type = static_cast<const bar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5929,7 +5929,7 @@ bool barPubSubType::deserialize(
 }
 
 std::function<uint32_t()> barPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5946,7 +5946,7 @@ std::function<uint32_t()> barPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<bar*>(data), current_alignment)) +
+                               *static_cast<const bar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5969,7 +5969,7 @@ void barPubSubType::deleteData(
 }
 
 bool barPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5978,7 +5978,7 @@ bool barPubSubType::getKey(
         return false;
     }
 
-    bar* p_type = static_cast<bar*>(data);
+    const bar* p_type = static_cast<const bar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6046,11 +6046,11 @@ root1PubSubType::~root1PubSubType()
 }
 
 bool root1PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    root1* p_type = static_cast<root1*>(data);
+    const root1* p_type = static_cast<const root1*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6122,7 +6122,7 @@ bool root1PubSubType::deserialize(
 }
 
 std::function<uint32_t()> root1PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6139,7 +6139,7 @@ std::function<uint32_t()> root1PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<root1*>(data), current_alignment)) +
+                               *static_cast<const root1*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6162,7 +6162,7 @@ void root1PubSubType::deleteData(
 }
 
 bool root1PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6171,7 +6171,7 @@ bool root1PubSubType::getKey(
         return false;
     }
 
-    root1* p_type = static_cast<root1*>(data);
+    const root1* p_type = static_cast<const root1*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6239,11 +6239,11 @@ root2PubSubType::~root2PubSubType()
 }
 
 bool root2PubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    root2* p_type = static_cast<root2*>(data);
+    const root2* p_type = static_cast<const root2*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6315,7 +6315,7 @@ bool root2PubSubType::deserialize(
 }
 
 std::function<uint32_t()> root2PubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6332,7 +6332,7 @@ std::function<uint32_t()> root2PubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<root2*>(data), current_alignment)) +
+                               *static_cast<const root2*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6355,7 +6355,7 @@ void root2PubSubType::deleteData(
 }
 
 bool root2PubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6364,7 +6364,7 @@ bool root2PubSubType::getKey(
         return false;
     }
 
-    root2* p_type = static_cast<root2*>(data);
+    const root2* p_type = static_cast<const root2*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6432,11 +6432,11 @@ rootPubSubType::~rootPubSubType()
 }
 
 bool rootPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    root* p_type = static_cast<root*>(data);
+    const root* p_type = static_cast<const root*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6508,7 +6508,7 @@ bool rootPubSubType::deserialize(
 }
 
 std::function<uint32_t()> rootPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6525,7 +6525,7 @@ std::function<uint32_t()> rootPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<root*>(data), current_alignment)) +
+                               *static_cast<const root*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6548,7 +6548,7 @@ void rootPubSubType::deleteData(
 }
 
 bool rootPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6557,7 +6557,7 @@ bool rootPubSubType::getKey(
         return false;
     }
 
-    root* p_type = static_cast<root*>(data);
+    const root* p_type = static_cast<const root*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/structuresPubSubTypes.h
+++ b/test/dds-types-test/structuresPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~StructShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~StructUnsignedShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~StructLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~StructUnsignedLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~StructLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~StructUnsignedLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~StructFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~StructDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~StructLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~StructBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~StructOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~StructChar8PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~StructChar16PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~StructStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~StructWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~StructBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~StructBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~StructEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~StructBitMaskPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~StructAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~StructShortArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~StructSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~StructMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~StructUnionPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~StructStructurePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~StructBitsetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~StructEmptyPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~StructuresPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2604,14 +2604,14 @@ namespace testing_1
         eProsima_user_DllExport ~fooPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2620,17 +2620,17 @@ namespace testing_1
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -2698,14 +2698,14 @@ namespace testing_2
         eProsima_user_DllExport ~fooPubSubType() override;
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload) override
         {
             return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport bool serialize(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2714,17 +2714,17 @@ namespace testing_2
                 void* data) override;
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data) override
+                const void* const data) override
         {
             return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
         }
 
         eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
         eProsima_user_DllExport bool getKey(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
                 bool force_md5 = false) override;
 
@@ -2790,14 +2790,14 @@ public:
     eProsima_user_DllExport ~barPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2806,17 +2806,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2881,14 +2881,14 @@ public:
     eProsima_user_DllExport ~root1PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2897,17 +2897,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2972,14 +2972,14 @@ public:
     eProsima_user_DllExport ~root2PubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2988,17 +2988,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3063,14 +3063,14 @@ public:
     eProsima_user_DllExport ~rootPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3079,17 +3079,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/dds-types-test/unionsPubSubTypes.cxx
+++ b/test/dds-types-test/unionsPubSubTypes.cxx
@@ -57,11 +57,11 @@ UnionShortPubSubType::~UnionShortPubSubType()
 }
 
 bool UnionShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionShort* p_type = static_cast<UnionShort*>(data);
+    const UnionShort* p_type = static_cast<const UnionShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool UnionShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> UnionShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionShort*>(data), current_alignment)) +
+                               *static_cast<const UnionShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void UnionShortPubSubType::deleteData(
 }
 
 bool UnionShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool UnionShortPubSubType::getKey(
         return false;
     }
 
-    UnionShort* p_type = static_cast<UnionShort*>(data);
+    const UnionShort* p_type = static_cast<const UnionShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -250,11 +250,11 @@ UnionUShortPubSubType::~UnionUShortPubSubType()
 }
 
 bool UnionUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionUShort* p_type = static_cast<UnionUShort*>(data);
+    const UnionUShort* p_type = static_cast<const UnionUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -326,7 +326,7 @@ bool UnionUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -343,7 +343,7 @@ std::function<uint32_t()> UnionUShortPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionUShort*>(data), current_alignment)) +
+                               *static_cast<const UnionUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -366,7 +366,7 @@ void UnionUShortPubSubType::deleteData(
 }
 
 bool UnionUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -375,7 +375,7 @@ bool UnionUShortPubSubType::getKey(
         return false;
     }
 
-    UnionUShort* p_type = static_cast<UnionUShort*>(data);
+    const UnionUShort* p_type = static_cast<const UnionUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -443,11 +443,11 @@ UnionLongPubSubType::~UnionLongPubSubType()
 }
 
 bool UnionLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionLong* p_type = static_cast<UnionLong*>(data);
+    const UnionLong* p_type = static_cast<const UnionLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -519,7 +519,7 @@ bool UnionLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -536,7 +536,7 @@ std::function<uint32_t()> UnionLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionLong*>(data), current_alignment)) +
+                               *static_cast<const UnionLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -559,7 +559,7 @@ void UnionLongPubSubType::deleteData(
 }
 
 bool UnionLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -568,7 +568,7 @@ bool UnionLongPubSubType::getKey(
         return false;
     }
 
-    UnionLong* p_type = static_cast<UnionLong*>(data);
+    const UnionLong* p_type = static_cast<const UnionLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -636,11 +636,11 @@ UnionULongPubSubType::~UnionULongPubSubType()
 }
 
 bool UnionULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionULong* p_type = static_cast<UnionULong*>(data);
+    const UnionULong* p_type = static_cast<const UnionULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -712,7 +712,7 @@ bool UnionULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -729,7 +729,7 @@ std::function<uint32_t()> UnionULongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionULong*>(data), current_alignment)) +
+                               *static_cast<const UnionULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -752,7 +752,7 @@ void UnionULongPubSubType::deleteData(
 }
 
 bool UnionULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -761,7 +761,7 @@ bool UnionULongPubSubType::getKey(
         return false;
     }
 
-    UnionULong* p_type = static_cast<UnionULong*>(data);
+    const UnionULong* p_type = static_cast<const UnionULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -829,11 +829,11 @@ UnionLongLongPubSubType::~UnionLongLongPubSubType()
 }
 
 bool UnionLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionLongLong* p_type = static_cast<UnionLongLong*>(data);
+    const UnionLongLong* p_type = static_cast<const UnionLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -905,7 +905,7 @@ bool UnionLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -922,7 +922,7 @@ std::function<uint32_t()> UnionLongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionLongLong*>(data), current_alignment)) +
+                               *static_cast<const UnionLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -945,7 +945,7 @@ void UnionLongLongPubSubType::deleteData(
 }
 
 bool UnionLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -954,7 +954,7 @@ bool UnionLongLongPubSubType::getKey(
         return false;
     }
 
-    UnionLongLong* p_type = static_cast<UnionLongLong*>(data);
+    const UnionLongLong* p_type = static_cast<const UnionLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1022,11 +1022,11 @@ UnionULongLongPubSubType::~UnionULongLongPubSubType()
 }
 
 bool UnionULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionULongLong* p_type = static_cast<UnionULongLong*>(data);
+    const UnionULongLong* p_type = static_cast<const UnionULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1098,7 +1098,7 @@ bool UnionULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1115,7 +1115,7 @@ std::function<uint32_t()> UnionULongLongPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionULongLong*>(data), current_alignment)) +
+                               *static_cast<const UnionULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1138,7 +1138,7 @@ void UnionULongLongPubSubType::deleteData(
 }
 
 bool UnionULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1147,7 +1147,7 @@ bool UnionULongLongPubSubType::getKey(
         return false;
     }
 
-    UnionULongLong* p_type = static_cast<UnionULongLong*>(data);
+    const UnionULongLong* p_type = static_cast<const UnionULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1215,11 +1215,11 @@ UnionFloatPubSubType::~UnionFloatPubSubType()
 }
 
 bool UnionFloatPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionFloat* p_type = static_cast<UnionFloat*>(data);
+    const UnionFloat* p_type = static_cast<const UnionFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1291,7 +1291,7 @@ bool UnionFloatPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionFloatPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1308,7 +1308,7 @@ std::function<uint32_t()> UnionFloatPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionFloat*>(data), current_alignment)) +
+                               *static_cast<const UnionFloat*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1331,7 +1331,7 @@ void UnionFloatPubSubType::deleteData(
 }
 
 bool UnionFloatPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1340,7 +1340,7 @@ bool UnionFloatPubSubType::getKey(
         return false;
     }
 
-    UnionFloat* p_type = static_cast<UnionFloat*>(data);
+    const UnionFloat* p_type = static_cast<const UnionFloat*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1408,11 +1408,11 @@ UnionDoublePubSubType::~UnionDoublePubSubType()
 }
 
 bool UnionDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDouble* p_type = static_cast<UnionDouble*>(data);
+    const UnionDouble* p_type = static_cast<const UnionDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1484,7 +1484,7 @@ bool UnionDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1501,7 +1501,7 @@ std::function<uint32_t()> UnionDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDouble*>(data), current_alignment)) +
+                               *static_cast<const UnionDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1524,7 +1524,7 @@ void UnionDoublePubSubType::deleteData(
 }
 
 bool UnionDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1533,7 +1533,7 @@ bool UnionDoublePubSubType::getKey(
         return false;
     }
 
-    UnionDouble* p_type = static_cast<UnionDouble*>(data);
+    const UnionDouble* p_type = static_cast<const UnionDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1601,11 +1601,11 @@ UnionLongDoublePubSubType::~UnionLongDoublePubSubType()
 }
 
 bool UnionLongDoublePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionLongDouble* p_type = static_cast<UnionLongDouble*>(data);
+    const UnionLongDouble* p_type = static_cast<const UnionLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1677,7 +1677,7 @@ bool UnionLongDoublePubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionLongDoublePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1694,7 +1694,7 @@ std::function<uint32_t()> UnionLongDoublePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionLongDouble*>(data), current_alignment)) +
+                               *static_cast<const UnionLongDouble*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1717,7 +1717,7 @@ void UnionLongDoublePubSubType::deleteData(
 }
 
 bool UnionLongDoublePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1726,7 +1726,7 @@ bool UnionLongDoublePubSubType::getKey(
         return false;
     }
 
-    UnionLongDouble* p_type = static_cast<UnionLongDouble*>(data);
+    const UnionLongDouble* p_type = static_cast<const UnionLongDouble*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1794,11 +1794,11 @@ UnionBooleanPubSubType::~UnionBooleanPubSubType()
 }
 
 bool UnionBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionBoolean* p_type = static_cast<UnionBoolean*>(data);
+    const UnionBoolean* p_type = static_cast<const UnionBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -1870,7 +1870,7 @@ bool UnionBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -1887,7 +1887,7 @@ std::function<uint32_t()> UnionBooleanPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionBoolean*>(data), current_alignment)) +
+                               *static_cast<const UnionBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -1910,7 +1910,7 @@ void UnionBooleanPubSubType::deleteData(
 }
 
 bool UnionBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -1919,7 +1919,7 @@ bool UnionBooleanPubSubType::getKey(
         return false;
     }
 
-    UnionBoolean* p_type = static_cast<UnionBoolean*>(data);
+    const UnionBoolean* p_type = static_cast<const UnionBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -1987,11 +1987,11 @@ UnionOctetPubSubType::~UnionOctetPubSubType()
 }
 
 bool UnionOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionOctet* p_type = static_cast<UnionOctet*>(data);
+    const UnionOctet* p_type = static_cast<const UnionOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2063,7 +2063,7 @@ bool UnionOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2080,7 +2080,7 @@ std::function<uint32_t()> UnionOctetPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionOctet*>(data), current_alignment)) +
+                               *static_cast<const UnionOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2103,7 +2103,7 @@ void UnionOctetPubSubType::deleteData(
 }
 
 bool UnionOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2112,7 +2112,7 @@ bool UnionOctetPubSubType::getKey(
         return false;
     }
 
-    UnionOctet* p_type = static_cast<UnionOctet*>(data);
+    const UnionOctet* p_type = static_cast<const UnionOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2180,11 +2180,11 @@ UnionCharPubSubType::~UnionCharPubSubType()
 }
 
 bool UnionCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionChar* p_type = static_cast<UnionChar*>(data);
+    const UnionChar* p_type = static_cast<const UnionChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2256,7 +2256,7 @@ bool UnionCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2273,7 +2273,7 @@ std::function<uint32_t()> UnionCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionChar*>(data), current_alignment)) +
+                               *static_cast<const UnionChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2296,7 +2296,7 @@ void UnionCharPubSubType::deleteData(
 }
 
 bool UnionCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2305,7 +2305,7 @@ bool UnionCharPubSubType::getKey(
         return false;
     }
 
-    UnionChar* p_type = static_cast<UnionChar*>(data);
+    const UnionChar* p_type = static_cast<const UnionChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2373,11 +2373,11 @@ UnionWCharPubSubType::~UnionWCharPubSubType()
 }
 
 bool UnionWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionWChar* p_type = static_cast<UnionWChar*>(data);
+    const UnionWChar* p_type = static_cast<const UnionWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2449,7 +2449,7 @@ bool UnionWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2466,7 +2466,7 @@ std::function<uint32_t()> UnionWCharPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionWChar*>(data), current_alignment)) +
+                               *static_cast<const UnionWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2489,7 +2489,7 @@ void UnionWCharPubSubType::deleteData(
 }
 
 bool UnionWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2498,7 +2498,7 @@ bool UnionWCharPubSubType::getKey(
         return false;
     }
 
-    UnionWChar* p_type = static_cast<UnionWChar*>(data);
+    const UnionWChar* p_type = static_cast<const UnionWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2566,11 +2566,11 @@ UnionStringPubSubType::~UnionStringPubSubType()
 }
 
 bool UnionStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionString* p_type = static_cast<UnionString*>(data);
+    const UnionString* p_type = static_cast<const UnionString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2642,7 +2642,7 @@ bool UnionStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2659,7 +2659,7 @@ std::function<uint32_t()> UnionStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionString*>(data), current_alignment)) +
+                               *static_cast<const UnionString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2682,7 +2682,7 @@ void UnionStringPubSubType::deleteData(
 }
 
 bool UnionStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2691,7 +2691,7 @@ bool UnionStringPubSubType::getKey(
         return false;
     }
 
-    UnionString* p_type = static_cast<UnionString*>(data);
+    const UnionString* p_type = static_cast<const UnionString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2759,11 +2759,11 @@ UnionWStringPubSubType::~UnionWStringPubSubType()
 }
 
 bool UnionWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionWString* p_type = static_cast<UnionWString*>(data);
+    const UnionWString* p_type = static_cast<const UnionWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -2835,7 +2835,7 @@ bool UnionWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -2852,7 +2852,7 @@ std::function<uint32_t()> UnionWStringPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionWString*>(data), current_alignment)) +
+                               *static_cast<const UnionWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -2875,7 +2875,7 @@ void UnionWStringPubSubType::deleteData(
 }
 
 bool UnionWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -2884,7 +2884,7 @@ bool UnionWStringPubSubType::getKey(
         return false;
     }
 
-    UnionWString* p_type = static_cast<UnionWString*>(data);
+    const UnionWString* p_type = static_cast<const UnionWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -2952,11 +2952,11 @@ UnionBoundedStringPubSubType::~UnionBoundedStringPubSubType()
 }
 
 bool UnionBoundedStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionBoundedString* p_type = static_cast<UnionBoundedString*>(data);
+    const UnionBoundedString* p_type = static_cast<const UnionBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3028,7 +3028,7 @@ bool UnionBoundedStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionBoundedStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3045,7 +3045,7 @@ std::function<uint32_t()> UnionBoundedStringPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionBoundedString*>(data), current_alignment)) +
+                               *static_cast<const UnionBoundedString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3068,7 +3068,7 @@ void UnionBoundedStringPubSubType::deleteData(
 }
 
 bool UnionBoundedStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3077,7 +3077,7 @@ bool UnionBoundedStringPubSubType::getKey(
         return false;
     }
 
-    UnionBoundedString* p_type = static_cast<UnionBoundedString*>(data);
+    const UnionBoundedString* p_type = static_cast<const UnionBoundedString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3145,11 +3145,11 @@ UnionBoundedWStringPubSubType::~UnionBoundedWStringPubSubType()
 }
 
 bool UnionBoundedWStringPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionBoundedWString* p_type = static_cast<UnionBoundedWString*>(data);
+    const UnionBoundedWString* p_type = static_cast<const UnionBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3221,7 +3221,7 @@ bool UnionBoundedWStringPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionBoundedWStringPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3238,7 +3238,7 @@ std::function<uint32_t()> UnionBoundedWStringPubSubType::getSerializedSizeProvid
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionBoundedWString*>(data), current_alignment)) +
+                               *static_cast<const UnionBoundedWString*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3261,7 +3261,7 @@ void UnionBoundedWStringPubSubType::deleteData(
 }
 
 bool UnionBoundedWStringPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3270,7 +3270,7 @@ bool UnionBoundedWStringPubSubType::getKey(
         return false;
     }
 
-    UnionBoundedWString* p_type = static_cast<UnionBoundedWString*>(data);
+    const UnionBoundedWString* p_type = static_cast<const UnionBoundedWString*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3338,11 +3338,11 @@ UnionInnerEnumHelperPubSubType::~UnionInnerEnumHelperPubSubType()
 }
 
 bool UnionInnerEnumHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerEnumHelper* p_type = static_cast<UnionInnerEnumHelper*>(data);
+    const UnionInnerEnumHelper* p_type = static_cast<const UnionInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3414,7 +3414,7 @@ bool UnionInnerEnumHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerEnumHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3431,7 +3431,7 @@ std::function<uint32_t()> UnionInnerEnumHelperPubSubType::getSerializedSizeProvi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerEnumHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerEnumHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3454,7 +3454,7 @@ void UnionInnerEnumHelperPubSubType::deleteData(
 }
 
 bool UnionInnerEnumHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3463,7 +3463,7 @@ bool UnionInnerEnumHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerEnumHelper* p_type = static_cast<UnionInnerEnumHelper*>(data);
+    const UnionInnerEnumHelper* p_type = static_cast<const UnionInnerEnumHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3531,11 +3531,11 @@ UnionInnerBitMaskHelperPubSubType::~UnionInnerBitMaskHelperPubSubType()
 }
 
 bool UnionInnerBitMaskHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerBitMaskHelper* p_type = static_cast<UnionInnerBitMaskHelper*>(data);
+    const UnionInnerBitMaskHelper* p_type = static_cast<const UnionInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3607,7 +3607,7 @@ bool UnionInnerBitMaskHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerBitMaskHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3624,7 +3624,7 @@ std::function<uint32_t()> UnionInnerBitMaskHelperPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerBitMaskHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerBitMaskHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3647,7 +3647,7 @@ void UnionInnerBitMaskHelperPubSubType::deleteData(
 }
 
 bool UnionInnerBitMaskHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3656,7 +3656,7 @@ bool UnionInnerBitMaskHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerBitMaskHelper* p_type = static_cast<UnionInnerBitMaskHelper*>(data);
+    const UnionInnerBitMaskHelper* p_type = static_cast<const UnionInnerBitMaskHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3724,11 +3724,11 @@ UnionInnerAliasHelperPubSubType::~UnionInnerAliasHelperPubSubType()
 }
 
 bool UnionInnerAliasHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerAliasHelper* p_type = static_cast<UnionInnerAliasHelper*>(data);
+    const UnionInnerAliasHelper* p_type = static_cast<const UnionInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3800,7 +3800,7 @@ bool UnionInnerAliasHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerAliasHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -3817,7 +3817,7 @@ std::function<uint32_t()> UnionInnerAliasHelperPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerAliasHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerAliasHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -3840,7 +3840,7 @@ void UnionInnerAliasHelperPubSubType::deleteData(
 }
 
 bool UnionInnerAliasHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -3849,7 +3849,7 @@ bool UnionInnerAliasHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerAliasHelper* p_type = static_cast<UnionInnerAliasHelper*>(data);
+    const UnionInnerAliasHelper* p_type = static_cast<const UnionInnerAliasHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -3917,11 +3917,11 @@ UnionArrayPubSubType::~UnionArrayPubSubType()
 }
 
 bool UnionArrayPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionArray* p_type = static_cast<UnionArray*>(data);
+    const UnionArray* p_type = static_cast<const UnionArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -3993,7 +3993,7 @@ bool UnionArrayPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionArrayPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4010,7 +4010,7 @@ std::function<uint32_t()> UnionArrayPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionArray*>(data), current_alignment)) +
+                               *static_cast<const UnionArray*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4033,7 +4033,7 @@ void UnionArrayPubSubType::deleteData(
 }
 
 bool UnionArrayPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4042,7 +4042,7 @@ bool UnionArrayPubSubType::getKey(
         return false;
     }
 
-    UnionArray* p_type = static_cast<UnionArray*>(data);
+    const UnionArray* p_type = static_cast<const UnionArray*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4110,11 +4110,11 @@ UnionSequencePubSubType::~UnionSequencePubSubType()
 }
 
 bool UnionSequencePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionSequence* p_type = static_cast<UnionSequence*>(data);
+    const UnionSequence* p_type = static_cast<const UnionSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4186,7 +4186,7 @@ bool UnionSequencePubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionSequencePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4203,7 +4203,7 @@ std::function<uint32_t()> UnionSequencePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionSequence*>(data), current_alignment)) +
+                               *static_cast<const UnionSequence*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4226,7 +4226,7 @@ void UnionSequencePubSubType::deleteData(
 }
 
 bool UnionSequencePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4235,7 +4235,7 @@ bool UnionSequencePubSubType::getKey(
         return false;
     }
 
-    UnionSequence* p_type = static_cast<UnionSequence*>(data);
+    const UnionSequence* p_type = static_cast<const UnionSequence*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4303,11 +4303,11 @@ UnionMapPubSubType::~UnionMapPubSubType()
 }
 
 bool UnionMapPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionMap* p_type = static_cast<UnionMap*>(data);
+    const UnionMap* p_type = static_cast<const UnionMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4379,7 +4379,7 @@ bool UnionMapPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionMapPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4396,7 +4396,7 @@ std::function<uint32_t()> UnionMapPubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionMap*>(data), current_alignment)) +
+                               *static_cast<const UnionMap*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4419,7 +4419,7 @@ void UnionMapPubSubType::deleteData(
 }
 
 bool UnionMapPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4428,7 +4428,7 @@ bool UnionMapPubSubType::getKey(
         return false;
     }
 
-    UnionMap* p_type = static_cast<UnionMap*>(data);
+    const UnionMap* p_type = static_cast<const UnionMap*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4496,11 +4496,11 @@ UnionInnerUnionHelperPubSubType::~UnionInnerUnionHelperPubSubType()
 }
 
 bool UnionInnerUnionHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerUnionHelper* p_type = static_cast<UnionInnerUnionHelper*>(data);
+    const UnionInnerUnionHelper* p_type = static_cast<const UnionInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4572,7 +4572,7 @@ bool UnionInnerUnionHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerUnionHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4589,7 +4589,7 @@ std::function<uint32_t()> UnionInnerUnionHelperPubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerUnionHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerUnionHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4612,7 +4612,7 @@ void UnionInnerUnionHelperPubSubType::deleteData(
 }
 
 bool UnionInnerUnionHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4621,7 +4621,7 @@ bool UnionInnerUnionHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerUnionHelper* p_type = static_cast<UnionInnerUnionHelper*>(data);
+    const UnionInnerUnionHelper* p_type = static_cast<const UnionInnerUnionHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4689,11 +4689,11 @@ UnionInnerStructureHelperPubSubType::~UnionInnerStructureHelperPubSubType()
 }
 
 bool UnionInnerStructureHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerStructureHelper* p_type = static_cast<UnionInnerStructureHelper*>(data);
+    const UnionInnerStructureHelper* p_type = static_cast<const UnionInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4765,7 +4765,7 @@ bool UnionInnerStructureHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerStructureHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4782,7 +4782,7 @@ std::function<uint32_t()> UnionInnerStructureHelperPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerStructureHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerStructureHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4805,7 +4805,7 @@ void UnionInnerStructureHelperPubSubType::deleteData(
 }
 
 bool UnionInnerStructureHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -4814,7 +4814,7 @@ bool UnionInnerStructureHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerStructureHelper* p_type = static_cast<UnionInnerStructureHelper*>(data);
+    const UnionInnerStructureHelper* p_type = static_cast<const UnionInnerStructureHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -4882,11 +4882,11 @@ UnionInnerBitsetHelperPubSubType::~UnionInnerBitsetHelperPubSubType()
 }
 
 bool UnionInnerBitsetHelperPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionInnerBitsetHelper* p_type = static_cast<UnionInnerBitsetHelper*>(data);
+    const UnionInnerBitsetHelper* p_type = static_cast<const UnionInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -4958,7 +4958,7 @@ bool UnionInnerBitsetHelperPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionInnerBitsetHelperPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -4975,7 +4975,7 @@ std::function<uint32_t()> UnionInnerBitsetHelperPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionInnerBitsetHelper*>(data), current_alignment)) +
+                               *static_cast<const UnionInnerBitsetHelper*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -4998,7 +4998,7 @@ void UnionInnerBitsetHelperPubSubType::deleteData(
 }
 
 bool UnionInnerBitsetHelperPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5007,7 +5007,7 @@ bool UnionInnerBitsetHelperPubSubType::getKey(
         return false;
     }
 
-    UnionInnerBitsetHelper* p_type = static_cast<UnionInnerBitsetHelper*>(data);
+    const UnionInnerBitsetHelper* p_type = static_cast<const UnionInnerBitsetHelper*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5075,11 +5075,11 @@ UnionDiscriminatorShortPubSubType::~UnionDiscriminatorShortPubSubType()
 }
 
 bool UnionDiscriminatorShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorShort* p_type = static_cast<UnionDiscriminatorShort*>(data);
+    const UnionDiscriminatorShort* p_type = static_cast<const UnionDiscriminatorShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5151,7 +5151,7 @@ bool UnionDiscriminatorShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5168,7 +5168,7 @@ std::function<uint32_t()> UnionDiscriminatorShortPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorShort*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5191,7 +5191,7 @@ void UnionDiscriminatorShortPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5200,7 +5200,7 @@ bool UnionDiscriminatorShortPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorShort* p_type = static_cast<UnionDiscriminatorShort*>(data);
+    const UnionDiscriminatorShort* p_type = static_cast<const UnionDiscriminatorShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5268,11 +5268,11 @@ UnionDiscriminatorUShortPubSubType::~UnionDiscriminatorUShortPubSubType()
 }
 
 bool UnionDiscriminatorUShortPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorUShort* p_type = static_cast<UnionDiscriminatorUShort*>(data);
+    const UnionDiscriminatorUShort* p_type = static_cast<const UnionDiscriminatorUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5344,7 +5344,7 @@ bool UnionDiscriminatorUShortPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorUShortPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5361,7 +5361,7 @@ std::function<uint32_t()> UnionDiscriminatorUShortPubSubType::getSerializedSizeP
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorUShort*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorUShort*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5384,7 +5384,7 @@ void UnionDiscriminatorUShortPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorUShortPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5393,7 +5393,7 @@ bool UnionDiscriminatorUShortPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorUShort* p_type = static_cast<UnionDiscriminatorUShort*>(data);
+    const UnionDiscriminatorUShort* p_type = static_cast<const UnionDiscriminatorUShort*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5461,11 +5461,11 @@ UnionDiscriminatorLongPubSubType::~UnionDiscriminatorLongPubSubType()
 }
 
 bool UnionDiscriminatorLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorLong* p_type = static_cast<UnionDiscriminatorLong*>(data);
+    const UnionDiscriminatorLong* p_type = static_cast<const UnionDiscriminatorLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5537,7 +5537,7 @@ bool UnionDiscriminatorLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5554,7 +5554,7 @@ std::function<uint32_t()> UnionDiscriminatorLongPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorLong*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5577,7 +5577,7 @@ void UnionDiscriminatorLongPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5586,7 +5586,7 @@ bool UnionDiscriminatorLongPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorLong* p_type = static_cast<UnionDiscriminatorLong*>(data);
+    const UnionDiscriminatorLong* p_type = static_cast<const UnionDiscriminatorLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5654,11 +5654,11 @@ UnionDiscriminatorULongPubSubType::~UnionDiscriminatorULongPubSubType()
 }
 
 bool UnionDiscriminatorULongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorULong* p_type = static_cast<UnionDiscriminatorULong*>(data);
+    const UnionDiscriminatorULong* p_type = static_cast<const UnionDiscriminatorULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5730,7 +5730,7 @@ bool UnionDiscriminatorULongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorULongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5747,7 +5747,7 @@ std::function<uint32_t()> UnionDiscriminatorULongPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorULong*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorULong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5770,7 +5770,7 @@ void UnionDiscriminatorULongPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorULongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5779,7 +5779,7 @@ bool UnionDiscriminatorULongPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorULong* p_type = static_cast<UnionDiscriminatorULong*>(data);
+    const UnionDiscriminatorULong* p_type = static_cast<const UnionDiscriminatorULong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -5847,11 +5847,11 @@ UnionDiscriminatorLongLongPubSubType::~UnionDiscriminatorLongLongPubSubType()
 }
 
 bool UnionDiscriminatorLongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorLongLong* p_type = static_cast<UnionDiscriminatorLongLong*>(data);
+    const UnionDiscriminatorLongLong* p_type = static_cast<const UnionDiscriminatorLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -5923,7 +5923,7 @@ bool UnionDiscriminatorLongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorLongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -5940,7 +5940,7 @@ std::function<uint32_t()> UnionDiscriminatorLongLongPubSubType::getSerializedSiz
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorLongLong*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorLongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -5963,7 +5963,7 @@ void UnionDiscriminatorLongLongPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorLongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -5972,7 +5972,7 @@ bool UnionDiscriminatorLongLongPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorLongLong* p_type = static_cast<UnionDiscriminatorLongLong*>(data);
+    const UnionDiscriminatorLongLong* p_type = static_cast<const UnionDiscriminatorLongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6040,11 +6040,11 @@ UnionDiscriminatorULongLongPubSubType::~UnionDiscriminatorULongLongPubSubType()
 }
 
 bool UnionDiscriminatorULongLongPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorULongLong* p_type = static_cast<UnionDiscriminatorULongLong*>(data);
+    const UnionDiscriminatorULongLong* p_type = static_cast<const UnionDiscriminatorULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6116,7 +6116,7 @@ bool UnionDiscriminatorULongLongPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorULongLongPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6133,7 +6133,7 @@ std::function<uint32_t()> UnionDiscriminatorULongLongPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorULongLong*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorULongLong*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6156,7 +6156,7 @@ void UnionDiscriminatorULongLongPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorULongLongPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6165,7 +6165,7 @@ bool UnionDiscriminatorULongLongPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorULongLong* p_type = static_cast<UnionDiscriminatorULongLong*>(data);
+    const UnionDiscriminatorULongLong* p_type = static_cast<const UnionDiscriminatorULongLong*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6233,11 +6233,11 @@ UnionDiscriminatorBooleanPubSubType::~UnionDiscriminatorBooleanPubSubType()
 }
 
 bool UnionDiscriminatorBooleanPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorBoolean* p_type = static_cast<UnionDiscriminatorBoolean*>(data);
+    const UnionDiscriminatorBoolean* p_type = static_cast<const UnionDiscriminatorBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6309,7 +6309,7 @@ bool UnionDiscriminatorBooleanPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorBooleanPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6326,7 +6326,7 @@ std::function<uint32_t()> UnionDiscriminatorBooleanPubSubType::getSerializedSize
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorBoolean*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorBoolean*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6349,7 +6349,7 @@ void UnionDiscriminatorBooleanPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorBooleanPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6358,7 +6358,7 @@ bool UnionDiscriminatorBooleanPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorBoolean* p_type = static_cast<UnionDiscriminatorBoolean*>(data);
+    const UnionDiscriminatorBoolean* p_type = static_cast<const UnionDiscriminatorBoolean*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6426,11 +6426,11 @@ UnionDiscriminatorOctetPubSubType::~UnionDiscriminatorOctetPubSubType()
 }
 
 bool UnionDiscriminatorOctetPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorOctet* p_type = static_cast<UnionDiscriminatorOctet*>(data);
+    const UnionDiscriminatorOctet* p_type = static_cast<const UnionDiscriminatorOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6502,7 +6502,7 @@ bool UnionDiscriminatorOctetPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorOctetPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6519,7 +6519,7 @@ std::function<uint32_t()> UnionDiscriminatorOctetPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorOctet*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorOctet*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6542,7 +6542,7 @@ void UnionDiscriminatorOctetPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorOctetPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6551,7 +6551,7 @@ bool UnionDiscriminatorOctetPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorOctet* p_type = static_cast<UnionDiscriminatorOctet*>(data);
+    const UnionDiscriminatorOctet* p_type = static_cast<const UnionDiscriminatorOctet*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6619,11 +6619,11 @@ UnionDiscriminatorCharPubSubType::~UnionDiscriminatorCharPubSubType()
 }
 
 bool UnionDiscriminatorCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorChar* p_type = static_cast<UnionDiscriminatorChar*>(data);
+    const UnionDiscriminatorChar* p_type = static_cast<const UnionDiscriminatorChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6695,7 +6695,7 @@ bool UnionDiscriminatorCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6712,7 +6712,7 @@ std::function<uint32_t()> UnionDiscriminatorCharPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorChar*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6735,7 +6735,7 @@ void UnionDiscriminatorCharPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6744,7 +6744,7 @@ bool UnionDiscriminatorCharPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorChar* p_type = static_cast<UnionDiscriminatorChar*>(data);
+    const UnionDiscriminatorChar* p_type = static_cast<const UnionDiscriminatorChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -6812,11 +6812,11 @@ UnionDiscriminatorWCharPubSubType::~UnionDiscriminatorWCharPubSubType()
 }
 
 bool UnionDiscriminatorWCharPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorWChar* p_type = static_cast<UnionDiscriminatorWChar*>(data);
+    const UnionDiscriminatorWChar* p_type = static_cast<const UnionDiscriminatorWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -6888,7 +6888,7 @@ bool UnionDiscriminatorWCharPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorWCharPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -6905,7 +6905,7 @@ std::function<uint32_t()> UnionDiscriminatorWCharPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorWChar*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorWChar*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -6928,7 +6928,7 @@ void UnionDiscriminatorWCharPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorWCharPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -6937,7 +6937,7 @@ bool UnionDiscriminatorWCharPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorWChar* p_type = static_cast<UnionDiscriminatorWChar*>(data);
+    const UnionDiscriminatorWChar* p_type = static_cast<const UnionDiscriminatorWChar*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7005,11 +7005,11 @@ UnionDiscriminatorEnumPubSubType::~UnionDiscriminatorEnumPubSubType()
 }
 
 bool UnionDiscriminatorEnumPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorEnum* p_type = static_cast<UnionDiscriminatorEnum*>(data);
+    const UnionDiscriminatorEnum* p_type = static_cast<const UnionDiscriminatorEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7081,7 +7081,7 @@ bool UnionDiscriminatorEnumPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorEnumPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7098,7 +7098,7 @@ std::function<uint32_t()> UnionDiscriminatorEnumPubSubType::getSerializedSizePro
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorEnum*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorEnum*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7121,7 +7121,7 @@ void UnionDiscriminatorEnumPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorEnumPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7130,7 +7130,7 @@ bool UnionDiscriminatorEnumPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorEnum* p_type = static_cast<UnionDiscriminatorEnum*>(data);
+    const UnionDiscriminatorEnum* p_type = static_cast<const UnionDiscriminatorEnum*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7198,11 +7198,11 @@ UnionDiscriminatorEnumLabelPubSubType::~UnionDiscriminatorEnumLabelPubSubType()
 }
 
 bool UnionDiscriminatorEnumLabelPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorEnumLabel* p_type = static_cast<UnionDiscriminatorEnumLabel*>(data);
+    const UnionDiscriminatorEnumLabel* p_type = static_cast<const UnionDiscriminatorEnumLabel*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7274,7 +7274,7 @@ bool UnionDiscriminatorEnumLabelPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorEnumLabelPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7291,7 +7291,7 @@ std::function<uint32_t()> UnionDiscriminatorEnumLabelPubSubType::getSerializedSi
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorEnumLabel*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorEnumLabel*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7314,7 +7314,7 @@ void UnionDiscriminatorEnumLabelPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorEnumLabelPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7323,7 +7323,7 @@ bool UnionDiscriminatorEnumLabelPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorEnumLabel* p_type = static_cast<UnionDiscriminatorEnumLabel*>(data);
+    const UnionDiscriminatorEnumLabel* p_type = static_cast<const UnionDiscriminatorEnumLabel*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7391,11 +7391,11 @@ UnionDiscriminatorAliasPubSubType::~UnionDiscriminatorAliasPubSubType()
 }
 
 bool UnionDiscriminatorAliasPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionDiscriminatorAlias* p_type = static_cast<UnionDiscriminatorAlias*>(data);
+    const UnionDiscriminatorAlias* p_type = static_cast<const UnionDiscriminatorAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7467,7 +7467,7 @@ bool UnionDiscriminatorAliasPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionDiscriminatorAliasPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7484,7 +7484,7 @@ std::function<uint32_t()> UnionDiscriminatorAliasPubSubType::getSerializedSizePr
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionDiscriminatorAlias*>(data), current_alignment)) +
+                               *static_cast<const UnionDiscriminatorAlias*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7507,7 +7507,7 @@ void UnionDiscriminatorAliasPubSubType::deleteData(
 }
 
 bool UnionDiscriminatorAliasPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7516,7 +7516,7 @@ bool UnionDiscriminatorAliasPubSubType::getKey(
         return false;
     }
 
-    UnionDiscriminatorAlias* p_type = static_cast<UnionDiscriminatorAlias*>(data);
+    const UnionDiscriminatorAlias* p_type = static_cast<const UnionDiscriminatorAlias*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7584,11 +7584,11 @@ UnionSeveralFieldsPubSubType::~UnionSeveralFieldsPubSubType()
 }
 
 bool UnionSeveralFieldsPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionSeveralFields* p_type = static_cast<UnionSeveralFields*>(data);
+    const UnionSeveralFields* p_type = static_cast<const UnionSeveralFields*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7660,7 +7660,7 @@ bool UnionSeveralFieldsPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionSeveralFieldsPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7677,7 +7677,7 @@ std::function<uint32_t()> UnionSeveralFieldsPubSubType::getSerializedSizeProvide
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionSeveralFields*>(data), current_alignment)) +
+                               *static_cast<const UnionSeveralFields*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7700,7 +7700,7 @@ void UnionSeveralFieldsPubSubType::deleteData(
 }
 
 bool UnionSeveralFieldsPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7709,7 +7709,7 @@ bool UnionSeveralFieldsPubSubType::getKey(
         return false;
     }
 
-    UnionSeveralFields* p_type = static_cast<UnionSeveralFields*>(data);
+    const UnionSeveralFields* p_type = static_cast<const UnionSeveralFields*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -7777,11 +7777,11 @@ UnionSeveralFieldsWithDefaultPubSubType::~UnionSeveralFieldsWithDefaultPubSubTyp
 }
 
 bool UnionSeveralFieldsWithDefaultPubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    UnionSeveralFieldsWithDefault* p_type = static_cast<UnionSeveralFieldsWithDefault*>(data);
+    const UnionSeveralFieldsWithDefault* p_type = static_cast<const UnionSeveralFieldsWithDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -7853,7 +7853,7 @@ bool UnionSeveralFieldsWithDefaultPubSubType::deserialize(
 }
 
 std::function<uint32_t()> UnionSeveralFieldsWithDefaultPubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -7870,7 +7870,7 @@ std::function<uint32_t()> UnionSeveralFieldsWithDefaultPubSubType::getSerialized
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<UnionSeveralFieldsWithDefault*>(data), current_alignment)) +
+                               *static_cast<const UnionSeveralFieldsWithDefault*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -7893,7 +7893,7 @@ void UnionSeveralFieldsWithDefaultPubSubType::deleteData(
 }
 
 bool UnionSeveralFieldsWithDefaultPubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -7902,7 +7902,7 @@ bool UnionSeveralFieldsWithDefaultPubSubType::getKey(
         return false;
     }
 
-    UnionSeveralFieldsWithDefault* p_type = static_cast<UnionSeveralFieldsWithDefault*>(data);
+    const UnionSeveralFieldsWithDefault* p_type = static_cast<const UnionSeveralFieldsWithDefault*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/dds-types-test/unionsPubSubTypes.h
+++ b/test/dds-types-test/unionsPubSubTypes.h
@@ -54,14 +54,14 @@ public:
     eProsima_user_DllExport ~UnionShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -70,17 +70,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -145,14 +145,14 @@ public:
     eProsima_user_DllExport ~UnionUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -161,17 +161,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -236,14 +236,14 @@ public:
     eProsima_user_DllExport ~UnionLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -252,17 +252,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -327,14 +327,14 @@ public:
     eProsima_user_DllExport ~UnionULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -343,17 +343,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -418,14 +418,14 @@ public:
     eProsima_user_DllExport ~UnionLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -434,17 +434,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -509,14 +509,14 @@ public:
     eProsima_user_DllExport ~UnionULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -525,17 +525,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -600,14 +600,14 @@ public:
     eProsima_user_DllExport ~UnionFloatPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -616,17 +616,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -691,14 +691,14 @@ public:
     eProsima_user_DllExport ~UnionDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -707,17 +707,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -782,14 +782,14 @@ public:
     eProsima_user_DllExport ~UnionLongDoublePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -798,17 +798,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -873,14 +873,14 @@ public:
     eProsima_user_DllExport ~UnionBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -889,17 +889,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -964,14 +964,14 @@ public:
     eProsima_user_DllExport ~UnionOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -980,17 +980,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1055,14 +1055,14 @@ public:
     eProsima_user_DllExport ~UnionCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1071,17 +1071,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1146,14 +1146,14 @@ public:
     eProsima_user_DllExport ~UnionWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1162,17 +1162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1237,14 +1237,14 @@ public:
     eProsima_user_DllExport ~UnionStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1253,17 +1253,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1328,14 +1328,14 @@ public:
     eProsima_user_DllExport ~UnionWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1344,17 +1344,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1419,14 +1419,14 @@ public:
     eProsima_user_DllExport ~UnionBoundedStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1435,17 +1435,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1510,14 +1510,14 @@ public:
     eProsima_user_DllExport ~UnionBoundedWStringPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1526,17 +1526,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1601,14 +1601,14 @@ public:
     eProsima_user_DllExport ~UnionInnerEnumHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1617,17 +1617,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1692,14 +1692,14 @@ public:
     eProsima_user_DllExport ~UnionInnerBitMaskHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1708,17 +1708,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1783,14 +1783,14 @@ public:
     eProsima_user_DllExport ~UnionInnerAliasHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1799,17 +1799,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1874,14 +1874,14 @@ public:
     eProsima_user_DllExport ~UnionArrayPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1890,17 +1890,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -1965,14 +1965,14 @@ public:
     eProsima_user_DllExport ~UnionSequencePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -1981,17 +1981,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2056,14 +2056,14 @@ public:
     eProsima_user_DllExport ~UnionMapPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2072,17 +2072,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2147,14 +2147,14 @@ public:
     eProsima_user_DllExport ~UnionInnerUnionHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2163,17 +2163,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2238,14 +2238,14 @@ public:
     eProsima_user_DllExport ~UnionInnerStructureHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2254,17 +2254,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2329,14 +2329,14 @@ public:
     eProsima_user_DllExport ~UnionInnerBitsetHelperPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2345,17 +2345,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2420,14 +2420,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2436,17 +2436,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2511,14 +2511,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorUShortPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2527,17 +2527,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2602,14 +2602,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2618,17 +2618,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2693,14 +2693,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorULongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2709,17 +2709,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2784,14 +2784,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorLongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2800,17 +2800,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2875,14 +2875,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorULongLongPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2891,17 +2891,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -2966,14 +2966,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorBooleanPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -2982,17 +2982,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3057,14 +3057,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorOctetPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3073,17 +3073,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3148,14 +3148,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3164,17 +3164,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3239,14 +3239,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorWCharPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3255,17 +3255,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3330,14 +3330,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorEnumPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3346,17 +3346,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3421,14 +3421,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorEnumLabelPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3437,17 +3437,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3512,14 +3512,14 @@ public:
     eProsima_user_DllExport ~UnionDiscriminatorAliasPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3528,17 +3528,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3603,14 +3603,14 @@ public:
     eProsima_user_DllExport ~UnionSeveralFieldsPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3619,17 +3619,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -3694,14 +3694,14 @@ public:
     eProsima_user_DllExport ~UnionSeveralFieldsWithDefaultPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -3710,17 +3710,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/performance/latency/LatencyTestTypes.cpp
+++ b/test/performance/latency/LatencyTestTypes.cpp
@@ -54,7 +54,7 @@ void LatencyDataType::copy_data(
 }
 
 bool LatencyDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -89,7 +89,7 @@ bool LatencyDataType::deserialize(
 }
 
 std::function<uint32_t()> LatencyDataType::getSerializedSizeProvider(
-        void*,
+        const void* const,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     uint32_t size = m_typeSize;
@@ -111,7 +111,7 @@ void LatencyDataType::deleteData(
 }
 
 bool TestCommandDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -134,7 +134,7 @@ bool TestCommandDataType::deserialize(
 }
 
 std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
-        void*,
+        const void* const,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return []() -> uint32_t

--- a/test/performance/latency/LatencyTestTypes.hpp
+++ b/test/performance/latency/LatencyTestTypes.hpp
@@ -105,33 +105,33 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     bool deserialize(
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     void* createData() override;
     void deleteData(
             void* data) override;
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {
@@ -209,33 +209,33 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     bool deserialize(
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     void* createData() override;
     void deleteData(
             void* data) override;
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {

--- a/test/performance/throughput/ThroughputTypes.cpp
+++ b/test/performance/throughput/ThroughputTypes.cpp
@@ -42,7 +42,7 @@ bool ThroughputDataType::compare_data(
 
 // Serialization and deserialization functions
 bool ThroughputDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -76,7 +76,7 @@ bool ThroughputDataType::deserialize(
 }
 
 std::function<uint32_t()> ThroughputDataType::getSerializedSizeProvider(
-        void*,
+        const void* const,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     // uint32_t seqnum + uint32_t buffer_size_ + actual data
@@ -99,7 +99,7 @@ void ThroughputDataType::deleteData(
 }
 
 bool ThroughputCommandDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* p,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -149,7 +149,7 @@ bool ThroughputCommandDataType::deserialize(
 }
 
 std::function<uint32_t()> ThroughputCommandDataType::getSerializedSizeProvider(
-        void*,
+        const void* const,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return []() -> uint32_t

--- a/test/performance/throughput/ThroughputTypes.hpp
+++ b/test/performance/throughput/ThroughputTypes.hpp
@@ -137,14 +137,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -153,13 +153,13 @@ public:
             void* data) override;
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     void* createData() override;
@@ -168,7 +168,7 @@ public:
             void* data) override;
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {
@@ -267,14 +267,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -283,13 +283,13 @@ public:
             void* data) override;
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     void* createData() override;
@@ -298,7 +298,7 @@ public:
             void* data) override;
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {

--- a/test/profiling/MemoryTestTypes.cpp
+++ b/test/profiling/MemoryTestTypes.cpp
@@ -32,7 +32,6 @@ bool MemoryDataType::serialize(
     *(uint32_t*)payload->data = lt->seqnum;
     *(uint32_t*)(payload->data + 4) = (uint32_t)lt->data.size();
 
-    //std::copy(lt->data.begin(),lt->data.end(),payload->data+8);
     memcpy(payload->data + 8, lt->data.data(), lt->data.size());
     payload->length = static_cast<uint32_t>(8 + lt->data.size());
     return true;
@@ -114,10 +113,7 @@ bool TestCommandDataType::deserialize(
         void* data)
 {
     TestCommandType* t = static_cast<TestCommandType*>(data);
-    // cout << "PAYLOAD LENGTH: "<<payload->length << endl;
-    // cout << "PAYLOAD FIRST BYTE: "<< (int)payload->data[0] << endl;
     t->m_command = static_cast<TESTCOMMAND>(*(payload->data));
-    // cout << "COMMAND: "<<t->m_command<< endl;
     return true;
 }
 

--- a/test/profiling/MemoryTestTypes.cpp
+++ b/test/profiling/MemoryTestTypes.cpp
@@ -23,10 +23,10 @@ using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
 bool MemoryDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload)
 {
-    MemoryType* lt = (MemoryType*)data;
+    const MemoryType* lt = static_cast<const MemoryType*>(data);
 
 
     *(uint32_t*)payload->data = lt->seqnum;
@@ -34,12 +34,12 @@ bool MemoryDataType::serialize(
 
     //std::copy(lt->data.begin(),lt->data.end(),payload->data+8);
     memcpy(payload->data + 8, lt->data.data(), lt->data.size());
-    payload->length = (uint32_t)(8 + lt->data.size());
+    payload->length = static_cast<uint32_t>(8 + lt->data.size());
     return true;
 }
 
 bool MemoryDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -50,29 +50,29 @@ bool MemoryDataType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
-    MemoryType* lt = (MemoryType*)data;
-    lt->seqnum = *(uint32_t*)payload->data;
-    uint32_t siz = *(uint32_t*)(payload->data + 4);
+    MemoryType* lt = static_cast<MemoryType*>(data);
+    lt->seqnum = static_cast<uint32_t>(*(payload->data));
+    uint32_t siz = static_cast<uint32_t>(*(payload->data + 4));
     std::copy(payload->data + 8, payload->data + 8 + siz, lt->data.begin());
     return true;
 }
 
 std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(
-        void* data)
+        const void* const data)
 {
     return [data]() -> uint32_t
            {
-               MemoryType* tdata = static_cast<MemoryType*>(data);
+               const MemoryType* tdata = static_cast<const MemoryType*>(data);
                uint32_t size = 0;
 
-               size = (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + tdata->data.size());
+               size = static_cast<uint32_t>(sizeof(uint32_t) + sizeof(uint32_t) + tdata->data.size());
 
                return size;
            };
 }
 
 std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return getSerializedSizeProvider(data);
@@ -81,28 +81,28 @@ std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(
 void* MemoryDataType::createData()
 {
 
-    return (void*)new MemoryType();
+    return static_cast<void*>(new MemoryType());
 }
 
 void MemoryDataType::deleteData(
         void* data)
 {
 
-    delete((MemoryType*)data);
+    delete(static_cast<MemoryType*>(data));
 }
 
 bool TestCommandDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload)
 {
-    TestCommandType* t = (TestCommandType*)data;
+    const TestCommandType* t = static_cast<const TestCommandType*>(data);
     *(TESTCOMMAND*)payload->data = t->m_command;
     payload->length = 4;
     return true;
 }
 
 bool TestCommandDataType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
@@ -113,29 +113,29 @@ bool TestCommandDataType::deserialize(
         SerializedPayload_t* payload,
         void* data)
 {
-    TestCommandType* t = (TestCommandType*)data;
-    //	cout << "PAYLOAD LENGTH: "<<payload->length << endl;
-    //	cout << "PAYLOAD FIRST BYTE: "<< (int)payload->data[0] << endl;
-    t->m_command = *(TESTCOMMAND*)payload->data;
-    //	cout << "COMMAND: "<<t->m_command<< endl;
+    TestCommandType* t = static_cast<TestCommandType*>(data);
+    // cout << "PAYLOAD LENGTH: "<<payload->length << endl;
+    // cout << "PAYLOAD FIRST BYTE: "<< (int)payload->data[0] << endl;
+    t->m_command = static_cast<TESTCOMMAND>(*(payload->data));
+    // cout << "COMMAND: "<<t->m_command<< endl;
     return true;
 }
 
 std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
-        void*)
+        const void* const)
 {
     return []() -> uint32_t
            {
                uint32_t size = 0;
 
-               size = (uint32_t)sizeof(uint32_t);
+               size = static_cast<uint32_t>(sizeof(uint32_t));
 
                return size;
            };
 }
 
 std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return getSerializedSizeProvider(data);
@@ -144,12 +144,12 @@ std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
 void* TestCommandDataType::createData()
 {
 
-    return (void*)new TestCommandType();
+    return static_cast<void*>(new TestCommandType());
 }
 
 void TestCommandDataType::deleteData(
         void* data)
 {
 
-    delete((TestCommandType*)data);
+    delete(static_cast<TestCommandType*>(data));
 }

--- a/test/profiling/MemoryTestTypes.h
+++ b/test/profiling/MemoryTestTypes.h
@@ -90,25 +90,25 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override;
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     bool deserialize(
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override;
+            const void* const data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     void* createData();
     void deleteData(
             void* data);
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {
@@ -159,25 +159,25 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override;
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     bool deserialize(
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             void* data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override;
+            const void* const data) override;
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
     void* createData();
     void deleteData(
             void* data);
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool force_md5 = false) override
     {

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
@@ -57,11 +57,11 @@ AllocTestTypePubSubType::~AllocTestTypePubSubType()
 }
 
 bool AllocTestTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    AllocTestType* p_type = static_cast<AllocTestType*>(data);
+    const AllocTestType* p_type = static_cast<const AllocTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool AllocTestTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> AllocTestTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> AllocTestTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<AllocTestType*>(data), current_alignment)) +
+                               *static_cast<const AllocTestType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void AllocTestTypePubSubType::deleteData(
 }
 
 bool AllocTestTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool AllocTestTypePubSubType::getKey(
         return false;
     }
 
-    AllocTestType* p_type = static_cast<AllocTestType*>(data);
+    const AllocTestType* p_type = static_cast<const AllocTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.h
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~AllocTestTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/profiling/allocations/README.md
+++ b/test/profiling/allocations/README.md
@@ -1,6 +1,6 @@
 ## Requisites
 
-This test uses [OSRF testing tools](https://github.com/osrf/osrf_testing_tools_cpp) memory_tools package.
+This test uses [OSRF testing tools v1.4.0](https://github.com/osrf/osrf_testing_tools_cpp/tree/1.4.0) memory_tools package.
 OSRF testing tools should be installed before building this test.
 
 ## Usage

--- a/test/realtime/UserThreadNonBlockedTest.cpp
+++ b/test/realtime/UserThreadNonBlockedTest.cpp
@@ -51,10 +51,10 @@ public:
     virtual ~DummyType() = default;
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload)
     {
-        DummyType* sample = reinterpret_cast<DummyType*>(data);
+        const DummyType* sample = static_cast<const DummyType*>(data);
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fastbuffer((char*)payload->data, payload->max_size);
         // Object that serializes the data.
@@ -91,7 +91,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void*)
+            const void* const)
     {
         return []() -> uint32_t
                {
@@ -100,7 +100,7 @@ public:
     }
 
     bool getKey(
-            void*,
+            const void* const,
             eprosima::fastdds::rtps::InstanceHandle_t*,
             bool)
     {

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -96,14 +96,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -118,13 +118,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -144,7 +144,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {
@@ -170,14 +170,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -192,13 +192,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -234,7 +234,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -94,14 +94,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -116,13 +116,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -142,7 +142,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {
@@ -199,14 +199,14 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -221,7 +221,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return []()->uint32_t
                {
@@ -230,7 +230,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -250,7 +250,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* ihandle,
             bool /*force_md5*/) override
     {
@@ -274,14 +274,14 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -296,13 +296,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return std::function<uint32_t()>();
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return std::function<uint32_t()>();
@@ -319,7 +319,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {
@@ -1328,14 +1328,14 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -1350,7 +1350,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return [this]()
                {
@@ -1359,7 +1359,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return [this]()
@@ -1379,7 +1379,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -45,14 +45,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -67,13 +67,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -93,7 +93,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {
@@ -114,14 +114,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -136,13 +136,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return std::function<uint32_t()>();
@@ -175,7 +175,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -496,7 +496,7 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
@@ -510,7 +510,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return []()->uint32_t
                {
@@ -529,7 +529,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
@@ -17,34 +17,41 @@ class TestType : public TopicDataType
 {
 public:
 
-    MOCK_METHOD2(serialize, bool(
+    MOCK_METHOD(bool, serialize, (
                 const void* const data,
-                eprosima::fastdds::rtps::SerializedPayload_t* payload));
+                eprosima::fastdds::rtps::SerializedPayload_t* payload),
+                (override));
 
-    MOCK_METHOD3(serialize, bool(
+    MOCK_METHOD(bool, serialize, (
                 const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
-                DataRepresentationId_t data_representation));
+                DataRepresentationId_t data_representation),
+                (override));
 
-    MOCK_METHOD2(deserialize, bool(
+    MOCK_METHOD(bool, deserialize, (
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
-                void* data));
+                void* data),
+                (override));
 
-    MOCK_METHOD2(getSerializedSizeProvider, std::function<uint32_t()> (
-                const void* const data, DataRepresentationId_t data_representation));
+    MOCK_METHOD(std::function<uint32_t()>, getSerializedSizeProvider, (
+                const void* const data, DataRepresentationId_t data_representation),
+                (override));
 
-    MOCK_METHOD1(getSerializedSizeProvider, std::function<uint32_t()> (
-                const void* const data));
+    MOCK_METHOD(std::function<uint32_t()>, getSerializedSizeProvider, (
+                const void* const data),
+                (override));
 
-    MOCK_METHOD0(createData, void* ());
+    MOCK_METHOD(void*, createData, (), (override));
 
-    MOCK_METHOD1(deleteData, void(
-                void* data));
+    MOCK_METHOD(void, deleteData, (
+                void* data),
+                (override));
 
-    MOCK_METHOD3(getKey, bool(
+    MOCK_METHOD(bool, getKey, (
                 const void* const data,
                 eprosima::fastdds::dds::InstanceHandle_t* ihandle,
-                bool));
+                bool),
+                (override));
 };
 
 /*!

--- a/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
@@ -18,11 +18,11 @@ class TestType : public TopicDataType
 public:
 
     MOCK_METHOD2(serialize, bool(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload));
 
     MOCK_METHOD3(serialize, bool(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::rtps::SerializedPayload_t* payload,
                 DataRepresentationId_t data_representation));
 
@@ -31,10 +31,10 @@ public:
                 void* data));
 
     MOCK_METHOD2(getSerializedSizeProvider, std::function<uint32_t()> (
-                void* data, DataRepresentationId_t data_representation));
+                const void* const data, DataRepresentationId_t data_representation));
 
     MOCK_METHOD1(getSerializedSizeProvider, std::function<uint32_t()> (
-                void* data));
+                const void* const data));
 
     MOCK_METHOD0(createData, void* ());
 
@@ -42,7 +42,7 @@ public:
                 void* data));
 
     MOCK_METHOD3(getKey, bool(
-                void* data,
+                const void* const data,
                 eprosima::fastdds::dds::InstanceHandle_t* ihandle,
                 bool));
 };

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3769,14 +3769,14 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -3791,7 +3791,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return [this]()
                {
@@ -3800,7 +3800,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return [this]()
@@ -3820,7 +3820,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooBoundedTypeSupport.hpp
@@ -40,18 +40,18 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload,
             DataRepresentationId_t data_representation) override
     {
-        type* p_type = static_cast<type*>(data);
+        const type* p_type = static_cast<const type*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -125,18 +125,18 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             DataRepresentationId_t /*data_representation*/) override
     {
         return [data]() -> uint32_t
                {
-                   return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<type*>(data))) +
+                   return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<const type*>(data))) +
                           4u /*encapsulation*/;
                };
     }
@@ -154,7 +154,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*handle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/subscriber/FooTypeSupport.hpp
+++ b/test/unittest/dds/subscriber/FooTypeSupport.hpp
@@ -38,18 +38,18 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             fastdds::rtps::SerializedPayload_t* payload,
             DataRepresentationId_t data_representation) override
     {
-        FooType* p_type = static_cast<FooType*>(data);
+        const FooType* p_type = static_cast<const FooType*>(data);
 
         // Object that manages the raw buffer.
         eprosima::fastcdr::FastBuffer fb(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -123,13 +123,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return [this]
@@ -151,11 +151,11 @@ public:
     }
 
     bool getKey(
-            void* data,
+            const void* const data,
             fastdds::rtps::InstanceHandle_t* handle,
             bool force_md5) override
     {
-        FooType* p_type = static_cast<FooType*>(data);
+        const FooType* p_type = static_cast<const FooType*>(data);
         char key_buf[16]{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
         // Object that manages the raw buffer.

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -154,14 +154,14 @@ public:
     }
 
     bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/,
             DataRepresentationId_t /*data_representation*/) override
     {
@@ -176,13 +176,13 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/,
+            const void* const /*data*/,
             DataRepresentationId_t /*data_representation*/) override
     {
         return []()->uint32_t
@@ -202,7 +202,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
@@ -57,11 +57,11 @@ StructTypePubSubType::~StructTypePubSubType()
 }
 
 bool StructTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    StructType* p_type = static_cast<StructType*>(data);
+    const StructType* p_type = static_cast<const StructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -133,7 +133,7 @@ bool StructTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -150,7 +150,7 @@ std::function<uint32_t()> StructTypePubSubType::getSerializedSizeProvider(
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<StructType*>(data), current_alignment)) +
+                               *static_cast<const StructType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -173,7 +173,7 @@ void StructTypePubSubType::deleteData(
 }
 
 bool StructTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -182,7 +182,7 @@ bool StructTypePubSubType::getKey(
         return false;
     }
 
-    StructType* p_type = static_cast<StructType*>(data);
+    const StructType* p_type = static_cast<const StructType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
@@ -252,11 +252,11 @@ ContentFilterTestTypePubSubType::~ContentFilterTestTypePubSubType()
 }
 
 bool ContentFilterTestTypePubSubType::serialize(
-        void* data,
+        const void* const data,
         SerializedPayload_t* payload,
         DataRepresentationId_t data_representation)
 {
-    ContentFilterTestType* p_type = static_cast<ContentFilterTestType*>(data);
+    const ContentFilterTestType* p_type = static_cast<const ContentFilterTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
@@ -328,7 +328,7 @@ bool ContentFilterTestTypePubSubType::deserialize(
 }
 
 std::function<uint32_t()> ContentFilterTestTypePubSubType::getSerializedSizeProvider(
-        void* data,
+        const void* const data,
         DataRepresentationId_t data_representation)
 {
     return [data, data_representation]() -> uint32_t
@@ -345,7 +345,7 @@ std::function<uint32_t()> ContentFilterTestTypePubSubType::getSerializedSizeProv
                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
                    size_t current_alignment {0};
                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                               *static_cast<ContentFilterTestType*>(data), current_alignment)) +
+                               *static_cast<const ContentFilterTestType*>(data), current_alignment)) +
                            4u /*encapsulation*/;
                }
                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -368,7 +368,7 @@ void ContentFilterTestTypePubSubType::deleteData(
 }
 
 bool ContentFilterTestTypePubSubType::getKey(
-        void* data,
+        const void* const data,
         InstanceHandle_t* handle,
         bool force_md5)
 {
@@ -377,7 +377,7 @@ bool ContentFilterTestTypePubSubType::getKey(
         return false;
     }
 
-    ContentFilterTestType* p_type = static_cast<ContentFilterTestType*>(data);
+    const ContentFilterTestType* p_type = static_cast<const ContentFilterTestType*>(data);
 
     // Object that manages the raw buffer.
     eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.h
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.h
@@ -53,14 +53,14 @@ public:
     eProsima_user_DllExport ~StructTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -69,17 +69,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 
@@ -146,14 +146,14 @@ public:
     eProsima_user_DllExport ~ContentFilterTestTypePubSubType() override;
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload) override
     {
         return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport bool serialize(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
@@ -162,17 +162,17 @@ public:
             void* data) override;
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data) override
+            const void* const data) override
     {
         return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
     }
 
     eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
-            void* data,
+            const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
 
     eProsima_user_DllExport bool getKey(
-            void* data,
+            const void* const data,
             eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
             bool force_md5 = false) override;
 

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -73,7 +73,7 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
@@ -87,7 +87,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return []()->uint32_t
                {
@@ -106,7 +106,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests.cpp
@@ -42,7 +42,7 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
@@ -56,7 +56,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return []()->uint32_t
                {
@@ -75,7 +75,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             eprosima::fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -161,27 +161,27 @@ public:
     }
 
     bool write(
-            void* )
+            const void* const )
     {
         return true;
     }
 
     bool write(
-            void*,
+            const void* const,
             fastdds::rtps::WriteParams& )
     {
         return true;
     }
 
     ReturnCode_t write(
-            void*,
+            const void* const,
             const InstanceHandle_t& )
     {
         return RETCODE_OK;
     }
 
     ReturnCode_t write_w_timestamp(
-            void*,
+            const void* const,
             const InstanceHandle_t&,
             const fastdds::Time_t& )
     {
@@ -189,20 +189,20 @@ public:
     }
 
     InstanceHandle_t register_instance(
-            void* )
+            const void* const )
     {
         return InstanceHandle_t();
     }
 
     InstanceHandle_t register_instance_w_timestamp(
-            void*,
+            const void* const,
             const fastdds::Time_t& )
     {
         return InstanceHandle_t();
     }
 
     ReturnCode_t unregister_instance(
-            void*,
+            const void* const,
             const InstanceHandle_t&,
             bool = false)
     {
@@ -210,7 +210,7 @@ public:
     }
 
     ReturnCode_t unregister_instance_w_timestamp(
-            void*,
+            const void* const,
             const InstanceHandle_t&,
             const fastdds::Time_t&,
             bool  = false)
@@ -249,7 +249,7 @@ public:
     }
 
     ReturnCode_t wait_for_acknowledgments(
-            void*,
+            const void* const,
             const InstanceHandle_t&,
             const fastdds::Duration_t& )
     {

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantTests.cpp
@@ -87,7 +87,7 @@ public:
     }
 
     bool serialize(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::SerializedPayload_t* /*payload*/) override
     {
         return true;
@@ -101,7 +101,7 @@ public:
     }
 
     std::function<uint32_t()> getSerializedSizeProvider(
-            void* /*data*/) override
+            const void* const /*data*/) override
     {
         return []()->uint32_t
                {
@@ -120,7 +120,7 @@ public:
     }
 
     bool getKey(
-            void* /*data*/,
+            const void* const /*data*/,
             fastdds::rtps::InstanceHandle_t* /*ihandle*/,
             bool /*force_md5*/) override
     {

--- a/versions.md
+++ b/versions.md
@@ -59,6 +59,7 @@ Forthcoming
   * `SenderResource` and Transport APIs now receive a collection of `NetworkBuffer` on their `send` method.
 * Migrate fastrtps namespace to fastdds
 * Migrate fastrtps `ResourceManagement` API from `rtps/resources` to `rtps/attributes`.
+* `const` qualify all data related inputs in DataWriter APIs
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR qualifies all the data related inputs from `DataWriter` API as `const`.

Related PRs:

* eProsima/Fast-DDS-Gen#357
* eProsima/Fast-DDS-python#142
* eProsima/Fast-DDS-docs#817
* eProsima/ShapesDemo#147
* eProsima/Discovery-Server#88

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
