### PR TITLE
[21130] Migrate ResourceManagement to rtps attributes API

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -35,7 +35,7 @@
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/flowcontrol/FlowControllerConsts.hpp>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/rtps/transport/network/NetmaskFilterKind.hpp>
 
 #include <fastdds/utils/collections/ResourceLimitedVector.hpp>

--- a/include/fastdds/rtps/attributes/HistoryAttributes.h
+++ b/include/fastdds/rtps/attributes/HistoryAttributes.h
@@ -20,7 +20,7 @@
 #ifndef _FASTDDS_HISTORYATTRIBUTES_H_
 #define _FASTDDS_HISTORYATTRIBUTES_H_
 
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/fastdds_dll.hpp>
 
 #include <cstdint>

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -35,7 +35,7 @@
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/rtps/transport/network/NetmaskFilterKind.hpp>
 #include <fastdds/rtps/transport/TransportInterface.h>
 #include <fastdds/fastdds_dll.hpp>

--- a/include/fastdds/rtps/attributes/ResourceManagement.hpp
+++ b/include/fastdds/rtps/attributes/ResourceManagement.hpp
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 /**
- * @file ResourceManagement.h
+ * @file ResourceManagement.hpp
  *
  */
 
-#ifndef _FASTDDS_RTPS_RESOURCE_MANAGEMENT_H_
-#define _FASTDDS_RTPS_RESOURCE_MANAGEMENT_H_
+#ifndef FASTDDS_RTPS_ATTRIBUTES__RESOURCEMANAGEMENT_HPP
+#define FASTDDS_RTPS_ATTRIBUTES__RESOURCEMANAGEMENT_HPP
 
 
 namespace eprosima {
@@ -38,8 +38,8 @@ typedef enum MemoryManagementPolicy
 }MemoryManagementPolicy_t;
 
 
-} // end namespaces
+} // namespace rtps
 } // namespace fastdds
 } // namespace eprosima
 
-#endif /* _FASTDDS_RTPS_RESOURCE_MANAGEMENT_H_ */
+#endif // FASTDDS_RTPS_ATTRIBUTES__RESOURCEMANAGEMENT_HPP

--- a/src/cpp/fastdds/publisher/DataWriterHistory.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.hpp
@@ -27,7 +27,7 @@
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 #include <fastdds/publisher/history/DataWriterInstance.hpp>
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -40,7 +40,7 @@
 #include <fastdds/rtps/common/InstanceHandle.h>
 #include <fastdds/rtps/common/SequenceNumber.h>
 #include <fastdds/rtps/history/ReaderHistory.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 #include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
 

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -20,7 +20,7 @@
 #define RTPS_DATASHARING_READERPOOL_HPP
 
 #include <fastdds/rtps/common/CacheChange.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/DataSharing/DataSharingPayloadPool.hpp>
 

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -21,7 +21,7 @@
 
 #include <fastdds/rtps/common/CacheChange.h>
 #include <fastdds/rtps/writer/RTPSWriter.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/DataSharing/DataSharingPayloadPool.hpp>
 #include <utils/collections/FixedSizeQueue.hpp>

--- a/src/cpp/rtps/history/CacheChangePool.h
+++ b/src/cpp/rtps/history/CacheChangePool.h
@@ -21,7 +21,7 @@
 
 #include <fastdds/rtps/common/CacheChange.h>
 #include <fastdds/rtps/history/IChangePool.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 #include <rtps/history/PoolConfig.h>
 

--- a/src/cpp/rtps/history/PoolConfig.h
+++ b/src/cpp/rtps/history/PoolConfig.h
@@ -20,7 +20,7 @@
 #define RTPS_HISTORY_POOLCONFIG_H_
 
 #include <fastdds/rtps/attributes/HistoryAttributes.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/history/TopicPayloadPool.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.hpp
@@ -21,7 +21,7 @@
 
 #include <fastdds/rtps/common/SerializedPayload.h>
 #include <fastdds/rtps/history/IPayloadPool.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <rtps/history/PoolConfig.h>
 #include <rtps/history/ITopicPayloadPool.h>

--- a/src/cpp/statistics/fastdds/subscriber/qos/DataReaderQos.cpp
+++ b/src/cpp/statistics/fastdds/subscriber/qos/DataReaderQos.cpp
@@ -19,7 +19,7 @@
 #include <fastdds/statistics/dds/subscriber/qos/DataReaderQos.hpp>
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
@@ -19,7 +19,7 @@
 #ifndef _FASTDDS_PUBLISHERATTRIBUTES_H_
 #define _FASTDDS_PUBLISHERATTRIBUTES_H_
 
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/attributes/ExternalLocators.hpp>

--- a/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
@@ -26,7 +26,7 @@
 #include <fastdds/rtps/attributes/TopicAttributes.h>
 #include <fastdds/rtps/common/Locator.h>
 #include <fastdds/rtps/common/Time_t.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -29,7 +29,7 @@
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/utils/TimedMutex.hpp>
 
 #include <fastdds/publisher/history/DataWriterInstance.hpp>

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.h
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.h
@@ -35,7 +35,7 @@
 #include <fastdds/rtps/common/Time_t.h>
 #include <fastdds/rtps/common/Types.h>
 #include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/rtps/transport/network/NetmaskFilterKind.hpp>
 #include <fastdds/rtps/transport/TransportInterface.h>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>

--- a/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
@@ -22,7 +22,7 @@
 #include <gmock/gmock.h>
 
 #include <fastdds/rtps/history/WriterHistory.h>
-#include <fastdds/rtps/resources/ResourceManagement.h>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/utils/TimedMutex.hpp>
 
 namespace eprosima {

--- a/versions.md
+++ b/versions.md
@@ -58,6 +58,7 @@ Forthcoming
   * New attribute in `SendBuffersAllocationAttributes` to configure allocation of `NetworkBuffer` vector.
   * `SenderResource` and Transport APIs now receive a collection of `NetworkBuffer` on their `send` method.
 * Migrate fastrtps namespace to fastdds
+* Migrate fastrtps `ResourceManagement` API from `rtps/resources` to `rtps/attributes`.
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR migrates the ResouceManagement file from `include/fastdds/rtps/resources/` to `include/fastdds/rtps/attributes/`.
This is part of a set of migrations and refactors related to the new mayor version v3.0.0.

Related python PR:
- eProsima/Fast-DDS-python/pull/144
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
