### PR TITLE
[21198] Add product version on Participant Discovery information

### DIFF
--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -30,6 +30,7 @@
 #include <fastdds/dds/core/Types.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
 #include <fastdds/rtps/common/Locator.hpp>
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/SampleIdentity.hpp>
 #include <fastdds/rtps/common/SerializedPayload.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
@@ -165,11 +166,12 @@ enum ParameterId_t : uint16_t
     PID_RELATED_SAMPLE_IDENTITY             = 0x0083,
 
     /* eProsima Fast DDS extensions */
+    PID_PRODUCT_VERSION                     = 0x8000,
     PID_PERSISTENCE_GUID                    = 0x8002,
-    PID_CUSTOM_RELATED_SAMPLE_IDENTITY      = 0x800f,
     PID_DISABLE_POSITIVE_ACKS               = 0x8005,
     PID_DATASHARING                         = 0x8006,
     PID_NETWORK_CONFIGURATION_SET           = 0x8007,
+    PID_CUSTOM_RELATED_SAMPLE_IDENTITY      = 0x800f,
 };
 
 /*!
@@ -631,6 +633,39 @@ public:
 };
 
 #define PARAMETER_VENDOR_LENGTH 4
+
+/**
+ * @ingroup PARAMETER_MODULE
+ */
+class ParameterProductVersion_t : public Parameter_t
+{
+public:
+
+    rtps::ProductVersion_t version;
+
+    /**
+     * @brief Constructor without parameters
+     */
+    ParameterProductVersion_t()
+    {
+    }
+
+    /**
+     * Constructor using a parameter PID and the parameter length
+     *
+     * @param pid Pid of the parameter
+     * @param in_length Its associated length
+     */
+    ParameterProductVersion_t(
+            ParameterId_t pid,
+            uint16_t in_length)
+        : Parameter_t(pid, in_length)
+    {
+    }
+
+};
+
+#define PARAMETER_PRODUCT_VERSION_LENGTH 4
 
 /**
  * @ingroup PARAMETER_MODULE
@@ -1883,6 +1918,7 @@ using ParameterGuid_t = fastdds::dds::ParameterGuid_t;
 using ParameterDomainId_t = fastdds::dds::ParameterDomainId_t;
 using ParameterProtocolVersion_t = fastdds::dds::ParameterProtocolVersion_t;
 using ParameterVendorId_t = fastdds::dds::ParameterVendorId_t;
+using ParameterProductVersion_t = fastdds::dds::ParameterProductVersion_t;
 using ParameterIP4Address_t = fastdds::dds::ParameterIP4Address_t;
 using ParameterBool_t = fastdds::dds::ParameterBool_t;
 using ParameterStatusInfo_t = fastdds::dds::ParameterStatusInfo_t;

--- a/include/fastdds/rtps/builtin/data/ParticipantBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/ParticipantBuiltinTopicData.hpp
@@ -22,6 +22,7 @@
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/builtin/data/BuiltinTopicKey.hpp>
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 
 namespace eprosima {
@@ -56,6 +57,9 @@ struct ParticipantBuiltinTopicData
 
     /// Vendor id
     VendorId_t vendor_id;
+
+    /// Product version
+    ProductVersion_t product_version;
 
     /// Participant domain id
     dds::DomainId_t domain_id;

--- a/include/fastdds/rtps/common/ProductVersion_t.hpp
+++ b/include/fastdds/rtps/common/ProductVersion_t.hpp
@@ -1,0 +1,59 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ProductVersion_t.hpp
+ */
+
+#ifndef _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_
+#define _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+struct ProductVersion_t
+{
+    uint8_t major {0};
+    uint8_t minor {0};
+    uint8_t patch {0};
+    uint8_t tweak {0};
+};
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+/**
+ * @brief ostream operator<< for VendorId_t
+ *
+ * @param output: the output stream
+ * @param vendor_id: the vendor id to append to the output stream
+ */
+inline std::ostream& operator <<(
+        std::ostream& output,
+        eprosima::fastdds::rtps::ProductVersion_t product_version)
+{
+    output << static_cast<uint32_t>(product_version.major)
+           << "." << static_cast<uint32_t>(product_version.minor)
+           << "." << static_cast<uint32_t>(product_version.patch)
+           << "." << static_cast<uint32_t>(product_version.tweak);
+    return output;
+}
+
+#endif /* _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_ */

--- a/include/fastdds/rtps/common/ProductVersion_t.hpp
+++ b/include/fastdds/rtps/common/ProductVersion_t.hpp
@@ -16,8 +16,8 @@
  * @file ProductVersion_t.hpp
  */
 
-#ifndef _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_
-#define _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_
+#ifndef FASTDDS_RTPS_COMMON__PRODUCTVERSION_T_HPP
+#define FASTDDS_RTPS_COMMON__PRODUCTVERSION_T_HPP
 
 #include <cstdint>
 #include <iomanip>
@@ -40,10 +40,10 @@ struct ProductVersion_t
 } // namespace eprosima
 
 /**
- * @brief ostream operator<< for VendorId_t
+ * @brief ostream operator<< for ProductVersion_t
  *
  * @param output: the output stream
- * @param vendor_id: the vendor id to append to the output stream
+ * @param product_version: the product version to append to the output stream
  */
 inline std::ostream& operator <<(
         std::ostream& output,
@@ -56,4 +56,4 @@ inline std::ostream& operator <<(
     return output;
 }
 
-#endif /* _FASTDDS_RTPS_COMMON_PRODUCTVERSIONT_HPP_ */
+#endif /* FASTDDS_RTPS_COMMON__PRODUCTVERSION_T_HPP */

--- a/include/fastdds/rtps/common/Types.hpp
+++ b/include/fastdds/rtps/common/Types.hpp
@@ -26,6 +26,7 @@
 
 #include <fastdds/fastdds_dll.hpp>
 
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
 
 namespace eprosima {

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -434,6 +434,36 @@ inline bool ParameterSerializer<ParameterVendorId_t>::read_content_from_cdr_mess
 }
 
 template<>
+inline bool ParameterSerializer<ParameterProductVersion_t>::add_content_to_cdr_message(
+        const ParameterProductVersion_t& parameter,
+        rtps::CDRMessage_t* cdr_message)
+{
+    bool valid = rtps::CDRMessage::addOctet(cdr_message, parameter.version.major);
+    valid &= rtps::CDRMessage::addOctet(cdr_message, parameter.version.minor);
+    valid &= rtps::CDRMessage::addOctet(cdr_message, parameter.version.patch);
+    valid &= rtps::CDRMessage::addOctet(cdr_message, parameter.version.tweak);
+    return valid;
+}
+
+template<>
+inline bool ParameterSerializer<ParameterProductVersion_t>::read_content_from_cdr_message(
+        ParameterProductVersion_t& parameter,
+        rtps::CDRMessage_t* cdr_message,
+        const uint16_t parameter_length)
+{
+    if (parameter_length != PARAMETER_PRODUCT_VERSION_LENGTH)
+    {
+        return false;
+    }
+    parameter.length = parameter_length;
+    bool valid = rtps::CDRMessage::readOctet(cdr_message, &parameter.version.major);
+    valid &= rtps::CDRMessage::readOctet(cdr_message, &parameter.version.minor);
+    valid &= rtps::CDRMessage::readOctet(cdr_message, &parameter.version.patch);
+    valid &= rtps::CDRMessage::readOctet(cdr_message, &parameter.version.tweak);
+    return valid;
+}
+
+template<>
 inline bool ParameterSerializer<ParameterDomainId_t>::add_content_to_cdr_message(
         const ParameterDomainId_t& parameter,
         fastdds::rtps::CDRMessage_t* cdr_message)

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -78,6 +78,7 @@ ParticipantProxyData::ParticipantProxyData(
     : m_protocolVersion(pdata.m_protocolVersion)
     , m_guid(pdata.m_guid)
     , m_VendorId(pdata.m_VendorId)
+    , product_version(pdata.product_version)
     , m_domain_id(pdata.m_domain_id)
     , m_expectsInlineQos(pdata.m_expectsInlineQos)
     , m_availableBuiltinEndpoints(pdata.m_availableBuiltinEndpoints)
@@ -147,10 +148,13 @@ uint32_t ParticipantProxyData::get_serialized_size(
     uint32_t ret_val = include_encapsulation ? 4 : 0;
 
     // PID_PROTOCOL_VERSION
-    ret_val += 4 + 4;
+    ret_val += 4 + PARAMETER_PROTOCOL_LENGTH;
 
     // PID_VENDORID
-    ret_val += 4 + 4;
+    ret_val += 4 + PARAMETER_VENDOR_LENGTH;
+
+    // PID_PRODUCT_VERSION
+    ret_val += 4 + PARAMETER_PRODUCT_VERSION_LENGTH;
 
     // PID_DOMAIN_ID
     ret_val += 4 + PARAMETER_DOMAINID_LENGTH;
@@ -240,7 +244,7 @@ bool ParticipantProxyData::writeToCDRMessage(
     }
 
     {
-        ParameterProtocolVersion_t p(fastdds::dds::PID_PROTOCOL_VERSION, 4);
+        ParameterProtocolVersion_t p(fastdds::dds::PID_PROTOCOL_VERSION, PARAMETER_PROTOCOL_LENGTH);
         p.protocolVersion = this->m_protocolVersion;
         if (!fastdds::dds::ParameterSerializer<ParameterProtocolVersion_t>::add_to_cdr_message(p, msg))
         {
@@ -248,10 +252,21 @@ bool ParticipantProxyData::writeToCDRMessage(
         }
     }
     {
-        ParameterVendorId_t p(fastdds::dds::PID_VENDORID, 4);
+        ParameterVendorId_t p(fastdds::dds::PID_VENDORID, PARAMETER_VENDOR_LENGTH);
         p.vendorId[0] = this->m_VendorId[0];
         p.vendorId[1] = this->m_VendorId[1];
         if (!fastdds::dds::ParameterSerializer<ParameterVendorId_t>::add_to_cdr_message(p, msg))
+        {
+            return false;
+        }
+    }
+    {
+        ParameterProductVersion_t p(fastdds::dds::PID_PRODUCT_VERSION, PARAMETER_PRODUCT_VERSION_LENGTH);
+        p.version.major = this->product_version.major;
+        p.version.minor = this->product_version.minor;
+        p.version.patch = this->product_version.patch;
+        p.version.tweak = this->product_version.tweak;
+        if (!fastdds::dds::ParameterSerializer<ParameterProductVersion_t>::add_to_cdr_message(p, msg))
         {
             return false;
         }
@@ -453,6 +468,32 @@ bool ParticipantProxyData::readFromCDRMessage(
                         m_VendorId[0] = p.vendorId[0];
                         m_VendorId[1] = p.vendorId[1];
                         is_shm_transport_available &= (m_VendorId == c_VendorId_eProsima);
+                        break;
+                    }
+                    case fastdds::dds::PID_PRODUCT_VERSION:
+                    {
+                        VendorId_t local_vendor_id = source_vendor_id;
+                        if (c_VendorId_Unknown == local_vendor_id)
+                        {
+                            local_vendor_id = ((c_VendorId_Unknown == m_VendorId) ? c_VendorId_eProsima : m_VendorId);
+                        }
+
+                        // Ignore custom PID when coming from other vendors
+                        if (c_VendorId_eProsima != local_vendor_id)
+                        {
+                            EPROSIMA_LOG_INFO(RTPS_PROXY_DATA,
+                                    "Ignoring custom PID" << pid << " from vendor " << local_vendor_id);
+                            return true;
+                        }
+
+                        ParameterProductVersion_t p(pid, plength);
+                        if (!fastdds::dds::ParameterSerializer<ParameterProductVersion_t>::read_from_cdr_message(p,
+                                msg, plength))
+                        {
+                            return false;
+                        }
+
+                        product_version = p.version;
                         break;
                     }
                     case fastdds::dds::PID_DOMAIN_ID:
@@ -765,6 +806,7 @@ void ParticipantProxyData::clear()
     m_guid = GUID_t();
     //set_VendorId_Unknown(m_VendorId);
     m_VendorId = c_VendorId_Unknown;
+    product_version = {};
     m_domain_id = fastdds::dds::DOMAIN_ID_UNKNOWN;
     m_expectsInlineQos = false;
     m_availableBuiltinEndpoints = 0;
@@ -797,6 +839,7 @@ void ParticipantProxyData::copy(
     m_guid = pdata.m_guid;
     m_VendorId[0] = pdata.m_VendorId[0];
     m_VendorId[1] = pdata.m_VendorId[1];
+    product_version = pdata.product_version;
     m_domain_id = pdata.m_domain_id;
     m_availableBuiltinEndpoints = pdata.m_availableBuiltinEndpoints;
     m_networkConfiguration = pdata.m_networkConfiguration;

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -25,6 +25,7 @@
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/core/policy/QosPoliciesSerializer.hpp>
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
 
 #include <rtps/builtin/BuiltinProtocols.h>
@@ -472,11 +473,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_PRODUCT_VERSION:
                     {
-                        VendorId_t local_vendor_id = source_vendor_id;
-                        if (c_VendorId_Unknown == local_vendor_id)
-                        {
-                            local_vendor_id = ((c_VendorId_Unknown == m_VendorId) ? c_VendorId_eProsima : m_VendorId);
-                        }
+                        VendorId_t local_vendor_id {select_vendor_id(source_vendor_id)};
 
                         // Ignore custom PID when coming from other vendors
                         if (c_VendorId_eProsima != local_vendor_id)
@@ -533,11 +530,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_NETWORK_CONFIGURATION_SET:
                     {
-                        VendorId_t local_vendor_id = source_vendor_id;
-                        if (c_VendorId_Unknown == local_vendor_id)
-                        {
-                            local_vendor_id = ((c_VendorId_Unknown == m_VendorId) ? c_VendorId_eProsima : m_VendorId);
-                        }
+                        VendorId_t local_vendor_id {select_vendor_id(source_vendor_id)};
 
                         // Ignore custom PID when coming from other vendors
                         if (c_VendorId_eProsima != local_vendor_id)
@@ -990,6 +983,17 @@ GUID_t ParticipantProxyData::get_backup_stamp() const
 void ParticipantProxyData::assert_liveliness()
 {
     last_received_message_tm_ = std::chrono::steady_clock::now();
+}
+
+VendorId_t ParticipantProxyData::select_vendor_id(
+        const VendorId_t source_vendor_id)
+{
+    VendorId_t ret_vendor_id {source_vendor_id};
+    if (c_VendorId_Unknown == ret_vendor_id)
+    {
+        ret_vendor_id = ((c_VendorId_Unknown == m_VendorId) ? c_VendorId_eProsima : m_VendorId);
+    }
+    return ret_vendor_id;
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -56,9 +56,11 @@ ParticipantProxyData::ParticipantProxyData(
     , m_expectsInlineQos(false)
     , m_availableBuiltinEndpoints(0)
     , m_networkConfiguration(0)
-    , metatraffic_locators(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators)
-    , default_locators(allocation.locators.max_unicast_locators, allocation.locators.max_multicast_locators)
-    , m_manualLivelinessCount ()
+    , metatraffic_locators(allocation.locators.max_unicast_locators,
+            allocation.locators.max_multicast_locators)
+    , default_locators(allocation.locators.max_unicast_locators,
+            allocation.locators.max_multicast_locators)
+    , m_manualLivelinessCount()
 #if HAVE_SECURITY
     , security_attributes_(0UL)
     , plugin_security_attributes_(0UL)
@@ -86,7 +88,7 @@ ParticipantProxyData::ParticipantProxyData(
     , m_networkConfiguration(pdata.m_networkConfiguration)
     , metatraffic_locators(pdata.metatraffic_locators)
     , default_locators(pdata.default_locators)
-    , m_manualLivelinessCount ()
+    , m_manualLivelinessCount()
     , m_participantName(pdata.m_participantName)
     , m_key(pdata.m_key)
     , m_leaseDuration(pdata.m_leaseDuration)
@@ -173,16 +175,22 @@ uint32_t ParticipantProxyData::get_serialized_size(
     ret_val += 4 + PARAMETER_NETWORKCONFIGSET_LENGTH;
 
     // PID_METATRAFFIC_MULTICAST_LOCATOR
-    ret_val += static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * metatraffic_locators.multicast.size());
+    ret_val +=
+            static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) *
+            metatraffic_locators.multicast.size());
 
     // PID_METATRAFFIC_UNICAST_LOCATOR
-    ret_val += static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * metatraffic_locators.unicast.size());
+    ret_val +=
+            static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) *
+            metatraffic_locators.unicast.size());
 
     // PID_DEFAULT_UNICAST_LOCATOR
-    ret_val += static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * default_locators.unicast.size());
+    ret_val +=
+            static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * default_locators.unicast.size());
 
     // PID_DEFAULT_MULTICAST_LOCATOR
-    ret_val += static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * default_locators.multicast.size());
+    ret_val +=
+            static_cast<uint32_t>((4 + PARAMETER_LOCATOR_LENGTH) * default_locators.multicast.size());
 
     // PID_PARTICIPANT_LEASE_DURATION
     ret_val += 4 + PARAMETER_TIME_LENGTH;
@@ -193,19 +201,22 @@ uint32_t ParticipantProxyData::get_serialized_size(
     if (m_participantName.size() > 0)
     {
         // PID_ENTITY_NAME
-        ret_val += fastdds::dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(m_participantName);
+        ret_val +=
+                fastdds::dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(m_participantName);
     }
 
     if (m_userData.size() > 0)
     {
         // PID_USER_DATA
-        ret_val += fastdds::dds::QosPoliciesSerializer<dds::UserDataQosPolicy>::cdr_serialized_size(m_userData);
+        ret_val += fastdds::dds::QosPoliciesSerializer<dds::UserDataQosPolicy>::cdr_serialized_size(
+            m_userData);
     }
 
     if (m_properties.size() > 0)
     {
         // PID_PROPERTY_LIST
-        ret_val += fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::cdr_serialized_size(m_properties);
+        ret_val += fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::cdr_serialized_size(
+            m_properties);
     }
 
 #if HAVE_SECURITY
@@ -218,7 +229,8 @@ uint32_t ParticipantProxyData::get_serialized_size(
     if (!permissions_token_.class_id().empty())
     {
         // PID_PERMISSIONS_TOKEN
-        ret_val += fastdds::dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(permissions_token_);
+        ret_val += fastdds::dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(
+            permissions_token_);
     }
 
     if ((security_attributes_ != 0UL) || (plugin_security_attributes_ != 0UL))
@@ -247,7 +259,9 @@ bool ParticipantProxyData::writeToCDRMessage(
     {
         ParameterProtocolVersion_t p(fastdds::dds::PID_PROTOCOL_VERSION, PARAMETER_PROTOCOL_LENGTH);
         p.protocolVersion = this->m_protocolVersion;
-        if (!fastdds::dds::ParameterSerializer<ParameterProtocolVersion_t>::add_to_cdr_message(p, msg))
+        if (!fastdds::dds::ParameterSerializer<ParameterProtocolVersion_t>::add_to_cdr_message(
+                    p,
+                    msg))
         {
             return false;
         }
@@ -262,7 +276,8 @@ bool ParticipantProxyData::writeToCDRMessage(
         }
     }
     {
-        ParameterProductVersion_t p(fastdds::dds::PID_PRODUCT_VERSION, PARAMETER_PRODUCT_VERSION_LENGTH);
+        ParameterProductVersion_t p(fastdds::dds::PID_PRODUCT_VERSION,
+                PARAMETER_PRODUCT_VERSION_LENGTH);
         p.version.major = this->product_version.major;
         p.version.minor = this->product_version.minor;
         p.version.patch = this->product_version.patch;
@@ -282,7 +297,8 @@ bool ParticipantProxyData::writeToCDRMessage(
     }
     if (this->m_expectsInlineQos)
     {
-        ParameterBool_t p(fastdds::dds::PID_EXPECTS_INLINE_QOS, PARAMETER_BOOL_LENGTH, m_expectsInlineQos);
+        ParameterBool_t p(fastdds::dds::PID_EXPECTS_INLINE_QOS, PARAMETER_BOOL_LENGTH,
+                m_expectsInlineQos);
         if (!fastdds::dds::ParameterSerializer<ParameterBool_t>::add_to_cdr_message(p, msg))
         {
             return false;
@@ -296,16 +312,20 @@ bool ParticipantProxyData::writeToCDRMessage(
         }
     }
     {
-        ParameterNetworkConfigSet_t p(fastdds::dds::PID_NETWORK_CONFIGURATION_SET, PARAMETER_NETWORKCONFIGSET_LENGTH);
+        ParameterNetworkConfigSet_t p(fastdds::dds::PID_NETWORK_CONFIGURATION_SET,
+                PARAMETER_NETWORKCONFIGSET_LENGTH);
         p.netconfigSet = m_networkConfiguration;
-        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::add_to_cdr_message(p, msg))
+        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::add_to_cdr_message(
+                    p,
+                    msg))
         {
             return false;
         }
     }
     for (const Locator_t& it : metatraffic_locators.multicast)
     {
-        ParameterLocator_t p(fastdds::dds::PID_METATRAFFIC_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
+        ParameterLocator_t p(fastdds::dds::PID_METATRAFFIC_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH,
+                it);
         if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::add_to_cdr_message(p, msg))
         {
             return false;
@@ -313,7 +333,8 @@ bool ParticipantProxyData::writeToCDRMessage(
     }
     for (const Locator_t& it : metatraffic_locators.unicast)
     {
-        ParameterLocator_t p(fastdds::dds::PID_METATRAFFIC_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH, it);
+        ParameterLocator_t p(fastdds::dds::PID_METATRAFFIC_UNICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH,
+                it);
         if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::add_to_cdr_message(p, msg))
         {
             return false;
@@ -344,9 +365,12 @@ bool ParticipantProxyData::writeToCDRMessage(
         }
     }
     {
-        ParameterBuiltinEndpointSet_t p(fastdds::dds::PID_BUILTIN_ENDPOINT_SET, PARAMETER_BUILTINENDPOINTSET_LENGTH);
+        ParameterBuiltinEndpointSet_t p(fastdds::dds::PID_BUILTIN_ENDPOINT_SET,
+                PARAMETER_BUILTINENDPOINTSET_LENGTH);
         p.endpointSet = m_availableBuiltinEndpoints;
-        if (!fastdds::dds::ParameterSerializer<ParameterBuiltinEndpointSet_t>::add_to_cdr_message(p, msg))
+        if (!fastdds::dds::ParameterSerializer<ParameterBuiltinEndpointSet_t>::add_to_cdr_message(
+                    p,
+                    msg))
         {
             return false;
         }
@@ -363,8 +387,9 @@ bool ParticipantProxyData::writeToCDRMessage(
 
     if (m_userData.size() > 0)
     {
-        if (!fastdds::dds::QosPoliciesSerializer<dds::UserDataQosPolicy>::add_to_cdr_message(m_userData,
-                msg))
+        if (!fastdds::dds::QosPoliciesSerializer<dds::UserDataQosPolicy>::add_to_cdr_message(
+                    m_userData,
+                    msg))
         {
             return false;
         }
@@ -372,7 +397,9 @@ bool ParticipantProxyData::writeToCDRMessage(
 
     if (m_properties.size() > 0)
     {
-        if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::add_to_cdr_message(m_properties, msg))
+        if (!fastdds::dds::ParameterSerializer<ParameterPropertyList_t>::add_to_cdr_message(
+                    m_properties,
+                    msg))
         {
             return false;
         }
@@ -404,7 +431,9 @@ bool ParticipantProxyData::writeToCDRMessage(
         ParameterParticipantSecurityInfo_t p;
         p.security_attributes = security_attributes_;
         p.plugin_security_attributes = plugin_security_attributes_;
-        if (!fastdds::dds::ParameterSerializer<ParameterParticipantSecurityInfo_t>::add_to_cdr_message(p, msg))
+        if (!fastdds::dds::ParameterSerializer<ParameterParticipantSecurityInfo_t>::add_to_cdr_message(
+                    p,
+                    msg))
         {
             return false;
         }
@@ -422,15 +451,18 @@ bool ParticipantProxyData::readFromCDRMessage(
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
-    auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
+    auto param_process =
+            [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
-                switch (pid)
-                {
+                static_cast<void>(source_vendor_id);
+                switch (pid){
                     case fastdds::dds::PID_KEY_HASH:
                     {
                         ParameterKey_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterKey_t>::read_from_cdr_message(p, msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterKey_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -444,8 +476,10 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_PROTOCOL_VERSION:
                     {
                         ParameterProtocolVersion_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterProtocolVersion_t>::read_from_cdr_message(p,
-                                msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterProtocolVersion_t>::
+                                read_from_cdr_message(
+                                    p,
+                                    msg, plength))
                         {
                             return false;
                         }
@@ -460,8 +494,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_VENDORID:
                     {
                         ParameterVendorId_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterVendorId_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterVendorId_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -473,19 +508,19 @@ bool ParticipantProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_PRODUCT_VERSION:
                     {
-                        VendorId_t local_vendor_id {select_vendor_id(source_vendor_id)};
-
                         // Ignore custom PID when coming from other vendors
-                        if (c_VendorId_eProsima != local_vendor_id)
+                        if (c_VendorId_eProsima != m_VendorId)
                         {
-                            EPROSIMA_LOG_INFO(RTPS_PROXY_DATA,
-                                    "Ignoring custom PID" << pid << " from vendor " << local_vendor_id);
+                            EPROSIMA_LOG_INFO(
+                                RTPS_PROXY_DATA,
+                                "Ignoring custom PID" << pid << " from vendor " << source_vendor_id);
                             return true;
                         }
 
                         ParameterProductVersion_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterProductVersion_t>::read_from_cdr_message(p,
-                                msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterProductVersion_t>::read_from_cdr_message(
+                                    p,
+                                    msg, plength))
                         {
                             return false;
                         }
@@ -496,8 +531,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_DOMAIN_ID:
                     {
                         ParameterDomainId_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterDomainId_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterDomainId_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -508,7 +544,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_EXPECTS_INLINE_QOS:
                     {
                         ParameterBool_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterBool_t>::read_from_cdr_message(p, msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterBool_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -519,7 +557,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_PARTICIPANT_GUID:
                     {
                         ParameterGuid_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(p, msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterGuid_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -530,19 +570,20 @@ bool ParticipantProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_NETWORK_CONFIGURATION_SET:
                     {
-                        VendorId_t local_vendor_id {select_vendor_id(source_vendor_id)};
-
                         // Ignore custom PID when coming from other vendors
-                        if (c_VendorId_eProsima != local_vendor_id)
+                        if (c_VendorId_eProsima != m_VendorId)
                         {
-                            EPROSIMA_LOG_INFO(RTPS_PROXY_DATA,
-                                    "Ignoring custom PID" << pid << " from vendor " << local_vendor_id);
+                            EPROSIMA_LOG_INFO(
+                                RTPS_PROXY_DATA,
+                                "Ignoring custom PID" << pid << " from vendor " << source_vendor_id);
                             return true;
                         }
 
                         ParameterNetworkConfigSet_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::read_from_cdr_message(p,
-                                msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::
+                                read_from_cdr_message(
+                                    p,
+                                    msg, plength))
                         {
                             return false;
                         }
@@ -553,8 +594,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_METATRAFFIC_MULTICAST_LOCATOR:
                     {
                         ParameterLocator_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -566,8 +608,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                         else
                         {
                             Locator_t temp_locator;
-                            if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration,
-                                    m_guid.is_from_this_host()))
+                            if (network.transform_remote_locator(
+                                        p.locator, temp_locator, m_networkConfiguration,
+                                        m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
                                     is_shm_transport_available,
@@ -581,8 +624,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_METATRAFFIC_UNICAST_LOCATOR:
                     {
                         ParameterLocator_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -594,8 +638,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                         else
                         {
                             Locator_t temp_locator;
-                            if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration,
-                                    m_guid.is_from_this_host()))
+                            if (network.transform_remote_locator(
+                                        p.locator, temp_locator, m_networkConfiguration,
+                                        m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
                                     is_shm_transport_available,
@@ -609,8 +654,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_DEFAULT_UNICAST_LOCATOR:
                     {
                         ParameterLocator_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -622,8 +668,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                         else
                         {
                             Locator_t temp_locator;
-                            if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration,
-                                    m_guid.is_from_this_host()))
+                            if (network.transform_remote_locator(
+                                        p.locator, temp_locator, m_networkConfiguration,
+                                        m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
                                     is_shm_transport_available,
@@ -637,8 +684,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_DEFAULT_MULTICAST_LOCATOR:
                     {
                         ParameterLocator_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterLocator_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -650,8 +698,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                         else
                         {
                             Locator_t temp_locator;
-                            if (network.transform_remote_locator(p.locator, temp_locator, m_networkConfiguration,
-                                    m_guid.is_from_this_host()))
+                            if (network.transform_remote_locator(
+                                        p.locator, temp_locator, m_networkConfiguration,
+                                        m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
                                     is_shm_transport_available,
@@ -665,22 +714,27 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_PARTICIPANT_LEASE_DURATION:
                     {
                         ParameterTime_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterTime_t>::read_from_cdr_message(p, msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterTime_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
 
                         m_leaseDuration = p.time.to_duration_t();
                         lease_duration_ =
-                                std::chrono::microseconds(fastdds::rtps::TimeConv::Duration_t2MicroSecondsInt64(
-                                            m_leaseDuration));
+                                std::chrono::microseconds(
+                            fastdds::rtps::TimeConv::Duration_t2MicroSecondsInt64(
+                                m_leaseDuration));
                         break;
                     }
                     case fastdds::dds::PID_BUILTIN_ENDPOINT_SET:
                     {
                         ParameterBuiltinEndpointSet_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterBuiltinEndpointSet_t>::read_from_cdr_message(p,
-                                msg, plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterBuiltinEndpointSet_t>::
+                                read_from_cdr_message(
+                                    p,
+                                    msg, plength))
                         {
                             return false;
                         }
@@ -691,8 +745,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                     case fastdds::dds::PID_ENTITY_NAME:
                     {
                         ParameterString_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterString_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterString_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
@@ -723,15 +778,18 @@ bool ParticipantProxyData::readFromCDRMessage(
                     {
 #if HAVE_SECURITY
                         ParameterToken_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterToken_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterToken_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
 
                         identity_token_ = std::move(p.token);
 #else
-                        EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT, "Received PID_IDENTITY_TOKEN but security is disabled");
+                        EPROSIMA_LOG_WARNING(
+                            RTPS_PARTICIPANT,
+                            "Received PID_IDENTITY_TOKEN but security is disabled");
 #endif // if HAVE_SECURITY
                         break;
                     }
@@ -739,16 +797,18 @@ bool ParticipantProxyData::readFromCDRMessage(
                     {
 #if HAVE_SECURITY
                         ParameterToken_t p(pid, plength);
-                        if (!fastdds::dds::ParameterSerializer<ParameterToken_t>::read_from_cdr_message(p, msg,
-                                plength))
+                        if (!fastdds::dds::ParameterSerializer<ParameterToken_t>::read_from_cdr_message(
+                                    p, msg,
+                                    plength))
                         {
                             return false;
                         }
 
                         permissions_token_ = std::move(p.token);
 #else
-                        EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT,
-                                "Received PID_PERMISSIONS_TOKEN but security is disabled");
+                        EPROSIMA_LOG_WARNING(
+                            RTPS_PARTICIPANT,
+                            "Received PID_PERMISSIONS_TOKEN but security is disabled");
 #endif // if HAVE_SECURITY
                         break;
                     }
@@ -766,8 +826,9 @@ bool ParticipantProxyData::readFromCDRMessage(
                         security_attributes_ = p.security_attributes;
                         plugin_security_attributes_ = p.plugin_security_attributes;
 #else
-                        EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT,
-                                "Received PID_PARTICIPANT_SECURITY_INFO but security is disabled");
+                        EPROSIMA_LOG_WARNING(
+                            RTPS_PARTICIPANT,
+                            "Received PID_PARTICIPANT_SECURITY_INFO but security is disabled");
 #endif // if HAVE_SECURITY
                         break;
                     }
@@ -784,7 +845,9 @@ bool ParticipantProxyData::readFromCDRMessage(
     clear();
     try
     {
-        return ParameterList::readParameterListfromCDRMsg(*msg, param_process, use_encapsulation, qos_size);
+        return ParameterList::readParameterListfromCDRMsg(
+            *msg, param_process, use_encapsulation,
+            qos_size);
     }
     catch (std::bad_alloc& ba)
     {
@@ -841,8 +904,9 @@ void ParticipantProxyData::copy(
     m_participantName = pdata.m_participantName;
     m_leaseDuration = pdata.m_leaseDuration;
     lease_duration_ =
-            std::chrono::microseconds(fastdds::rtps::TimeConv::Duration_t2MicroSecondsInt64(
-                        pdata.m_leaseDuration));
+            std::chrono::microseconds(
+        fastdds::rtps::TimeConv::Duration_t2MicroSecondsInt64(
+            pdata.m_leaseDuration));
     m_key = pdata.m_key;
     isAlive = pdata.isAlive;
     m_userData = pdata.m_userData;
@@ -925,7 +989,8 @@ void ParticipantProxyData::set_persistence_guid(
     {
         if (!it->modify(persistent_guid))
         {
-            EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Failed to change property <"
+            EPROSIMA_LOG_ERROR(
+                RTPS_PARTICIPANT, "Failed to change property <"
                     << it->first() << " | " << it->second() << "> to <"
                     << persistent_guid.first << " | " << persistent_guid.second << ">");
         }
@@ -983,17 +1048,6 @@ GUID_t ParticipantProxyData::get_backup_stamp() const
 void ParticipantProxyData::assert_liveliness()
 {
     last_received_message_tm_ = std::chrono::steady_clock::now();
-}
-
-VendorId_t ParticipantProxyData::select_vendor_id(
-        const VendorId_t source_vendor_id)
-{
-    VendorId_t ret_vendor_id {source_vendor_id};
-    if (c_VendorId_Unknown == ret_vendor_id)
-    {
-        ret_vendor_id = ((c_VendorId_Unknown == m_VendorId) ? c_VendorId_eProsima : m_VendorId);
-    }
-    return ret_vendor_id;
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -76,6 +76,8 @@ public:
     GUID_t m_guid;
     //!Vendor ID
     fastdds::rtps::VendorId_t m_VendorId;
+    //! Product version
+    fastdds::rtps::ProductVersion_t product_version;
     //!Domain ID
     fastdds::dds::DomainId_t m_domain_id;
     //!Expects Inline QOS.

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -30,6 +30,7 @@
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/rtps/common/Token.hpp>
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -223,6 +223,9 @@ public:
         return lease_duration_;
     }
 
+    VendorId_t select_vendor_id(
+            const VendorId_t source_vendor_id);
+
 private:
 
     //! Store the last timestamp it was received a RTPS message from the remote participant.

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -223,9 +223,6 @@ public:
         return lease_duration_;
     }
 
-    VendorId_t select_vendor_id(
-            const VendorId_t source_vendor_id);
-
 private:
 
     //! Store the last timestamp it was received a RTPS message from the remote participant.

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -113,6 +113,7 @@ void from_proxy_to_builtin(
     builtin_data.properties = proxy_data.m_properties;
     builtin_data.lease_duration = proxy_data.m_leaseDuration;
     builtin_data.vendor_id = proxy_data.m_VendorId;
+    builtin_data.product_version = proxy_data.product_version;
     builtin_data.domain_id = proxy_data.m_domain_id;
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <chrono>
 
+#include <fastdds/config.h>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/log/Log.hpp>
@@ -306,6 +307,9 @@ void PDP::initializeParticipantProxyData(
     participant_data->m_leaseDuration = attributes.builtin.discovery_config.leaseDuration;
     //set_VendorId_eProsima(participant_data->m_VendorId);
     participant_data->m_VendorId = c_VendorId_eProsima;
+    participant_data->product_version.major = FASTDDS_VERSION_MAJOR;
+    participant_data->product_version.minor = FASTDDS_VERSION_MINOR;
+    participant_data->product_version.patch = FASTDDS_VERSION_MICRO;
 
     // TODO: participant_data->m_availableBuiltinEndpoints |= mp_builtin->available_builtin_endpoints();
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -22,7 +22,7 @@
 #include <mutex>
 #include <chrono>
 
-#include <fastdds/config.h>
+#include <fastdds/config.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/log/Log.hpp>

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -170,11 +170,14 @@ TEST(BuiltinDataSerializationTests, msg_with_product_version)
         {
             // Encapsulation
             0x00, 0x03, 0x00, 0x00,
+            // PID_VENDORID
+            0x16, 0x00, 0x04, 0x00,
+            0x01, 0x0f, 0x00, 0x00,
             // PID_PRODUCT_VERSION
-            0x00, 0x80, 4, 0,
+            0x00, 0x80, 0x04, 0x00,
             FASTDDS_VERSION_MAJOR, FASTDDS_VERSION_MINOR, FASTDDS_VERSION_MICRO, 0,
             // PID_SENTINEL
-            0x01, 0, 0, 0
+            0x01, 0x00, 0x00, 0x00
         };
 
         uint32_t buffer_length = static_cast<uint32_t>(sizeof(data_buffer));

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <fastdds/config.h>
+#include <fastdds/config.hpp>
 #include <fastdds/core/policy/ParameterList.hpp>
 #include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>

--- a/versions.md
+++ b/versions.md
@@ -102,6 +102,7 @@ Forthcoming
 * Added new DynamicType to IDL serializer (`idl_serialize`).
 * DDS implementation of `eprosima::fastdds::Time_t` moved to `eprosima::fastdds::dds::Time_t`.
 * `TopicDataType::auto_fill_type_information` has been removed in favor of `fastdds.type_propagation` participant property.
+* Add new custom pid PID_PRODUCT_VERSION.
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR introduces a new custom pid PID_PRODUCT_VERSION (0x8000) used to send the Fast DDS version.

Depends on:
- #4930
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

