### PR TITLE
Only signed integers are permited in Dynamic Language Binding enumerations [21201]

### DIFF
--- a/examples/cpp/dds/RequestReplyExample/Calculator.hpp
+++ b/examples/cpp/dds/RequestReplyExample/Calculator.hpp
@@ -53,7 +53,7 @@
  * @brief This class represents the enumeration OperationType defined by the user in the IDL file.
  * @ingroup Calculator
  */
-enum class OperationType : uint32_t
+enum class OperationType : int32_t
 {
     ADDITION,
     SUBTRACTION,

--- a/include/fastdds/dds/xtypes/dynamic_types/detail/dynamic_language_binding.hpp
+++ b/include/fastdds/dds/xtypes/dynamic_types/detail/dynamic_language_binding.hpp
@@ -103,7 +103,7 @@ typedef std::map<ObjectName, ObjectName> Parameters;
  * @brief This class represents the enumeration ExtensibilityKind defined by the user in the IDL file.
  * @ingroup dynamic_language_binding
  */
-enum class ExtensibilityKind : uint32_t
+enum class ExtensibilityKind : int32_t
 {
     FINAL,
     APPENDABLE,
@@ -113,7 +113,7 @@ enum class ExtensibilityKind : uint32_t
  * @brief This class represents the enumeration TryConstructKind defined by the user in the IDL file.
  * @ingroup dynamic_language_binding
  */
-enum class TryConstructKind : uint32_t
+enum class TryConstructKind : int32_t
 {
     USE_DEFAULT,
     DISCARD,

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_types.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_types.hpp
@@ -763,7 +763,7 @@ typedef uint8_t UnusedMember;
  * @brief This class represents the enumeration RemoteExceptionCode_t defined by the user in the IDL file.
  * @ingroup rpc_types
  */
-enum class RemoteExceptionCode_t : uint32_t
+enum class RemoteExceptionCode_t : int32_t
 {
     REMOTE_EX_OK,
     REMOTE_EX_UNSUPPORTED,

--- a/src/cpp/fastdds/xtypes/dynamic_types/MemberDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/MemberDescriptorImpl.cpp
@@ -229,12 +229,12 @@ bool MemberDescriptorImpl::is_consistent() noexcept
         switch (kind)
         {
             case TK_INT8:
-            case TK_UINT8:
             case TK_INT16:
-            case TK_UINT16:
             case TK_INT32:
-            case TK_UINT32:
                 break;
+            case TK_UINT8:
+            case TK_UINT16:
+            case TK_UINT32:
             case TK_INT64:
             case TK_UINT64:
             case TK_BOOLEAN:

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -66,7 +66,7 @@ namespace statistics {
  * @brief This class represents the enumeration ConnectionMode defined by the user in the IDL file.
  * @ingroup monitorservice_types
  */
-enum class ConnectionMode : uint32_t
+enum class ConnectionMode : int32_t
 {
     DATA_SHARING,
     INTRAPROCESS,

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -66,7 +66,7 @@ namespace statistics {
  * @brief This class represents the enumeration ConnectionMode defined by the user in the IDL file.
  * @ingroup monitorservice_types
  */
-enum class ConnectionMode : uint32_t
+enum class ConnectionMode : int32_t
 {
     DATA_SHARING,
     INTRAPROCESS,

--- a/test/feature/dynamic_types/DynamicTypesTests.cpp
+++ b/test/feature/dynamic_types/DynamicTypesTests.cpp
@@ -3818,7 +3818,7 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
     {
         eprosima::fastdds::testing::ScopeLogs _("disable");
         // Test with base_type being not nil.
-        type_descriptor->base_type(factory->get_primitive_type(TK_UINT32));
+        type_descriptor->base_type(factory->get_primitive_type(TK_INT32));
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
         EXPECT_FALSE(builder);
         type_descriptor->base_type(nullptr);
@@ -3828,17 +3828,17 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
         EXPECT_FALSE(builder);
         type_descriptor->bound({});
         // Test with discriminator_type set
-        type_descriptor->discriminator_type(factory->get_primitive_type(TK_UINT32));
+        type_descriptor->discriminator_type(factory->get_primitive_type(TK_INT32));
         builder = factory->create_type(type_descriptor);
         EXPECT_FALSE(builder);
         type_descriptor->discriminator_type(nullptr);
         // Test with element_type set
-        type_descriptor->element_type(factory->get_primitive_type(TK_UINT32));
+        type_descriptor->element_type(factory->get_primitive_type(TK_INT32));
         builder = factory->create_type(type_descriptor);
         EXPECT_FALSE(builder);
         type_descriptor->element_type(nullptr);
         // Test with key_element_type set
-        type_descriptor->key_element_type(factory->get_primitive_type(TK_UINT32));
+        type_descriptor->key_element_type(factory->get_primitive_type(TK_INT32));
         builder = factory->create_type(type_descriptor);
         EXPECT_FALSE(builder);
         type_descriptor->key_element_type(nullptr);
@@ -3853,20 +3853,27 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
 
     // Add three members to the enum.
     MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
-    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
     {
         // Negative case: descriptor without name.
         eprosima::fastdds::testing::ScopeLogs _("disable");
         EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_BAD_PARAMETER);
     }
     member_descriptor->name("DEFAULT");
+    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    {
+        // Negative case: descriptor type is unsigned integer
+        eprosima::fastdds::testing::ScopeLogs _("disable");
+        EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_BAD_PARAMETER);
+    }
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
     EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_OK);
     member_descriptor = traits<MemberDescriptor>::make_shared();
-    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
     member_descriptor->name("FIRST");
     EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_OK);
     member_descriptor = traits<MemberDescriptor>::make_shared();
-    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
     member_descriptor->name("SECOND");
     EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_OK);
 
@@ -3874,10 +3881,10 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
         eprosima::fastdds::testing::ScopeLogs _("disable");
         member_descriptor = traits<MemberDescriptor>::make_shared();
         // Try to add a descriptor with diferent kind.
-        member_descriptor->type(factory->get_primitive_type(TK_INT32));
+        member_descriptor->type(factory->get_primitive_type(TK_INT16));
         member_descriptor->name("THIRD");
         EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_BAD_PARAMETER);
-        member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+        member_descriptor->type(factory->get_primitive_type(TK_INT32));
         // Try to add a descriptor with a MemberId.
         member_descriptor->id(100);
         EXPECT_EQ(builder->add_member(member_descriptor), RETCODE_BAD_PARAMETER);
@@ -3944,44 +3951,56 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
     EXPECT_EQ(MEMBER_ID_INVALID, data->get_member_id_at_index(0));
 
     // Test getters and setters.
-    const uint32_t test1 {2};
-    uint32_t test2 {0};
+    const int32_t test1 {2};
+    int32_t test2 {0};
 
     //{{{ Successful setters
-    EXPECT_EQ(data->set_uint32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(2u, test2);
+    EXPECT_EQ(data->set_int32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(2, test2);
 
-    EXPECT_EQ(data->set_uint8_value(MEMBER_ID_INVALID, 3), RETCODE_OK);
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(3u, test2);
+    EXPECT_EQ(data->set_int8_value(MEMBER_ID_INVALID, -3), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(-3, test2);
 
-    EXPECT_EQ(data->set_uint16_value(MEMBER_ID_INVALID, 1), RETCODE_OK);
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(1u, test2);
+    EXPECT_EQ(data->set_uint8_value(MEMBER_ID_INVALID, 3u), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(3, test2);
+
+    EXPECT_EQ(data->set_int16_value(MEMBER_ID_INVALID, -1), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(-1, test2);
+
+    EXPECT_EQ(data->set_uint16_value(MEMBER_ID_INVALID, 1u), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(1, test2);
+
+    EXPECT_EQ(data->set_char8_value(MEMBER_ID_INVALID, 'a'), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(97, test2);
+
+    EXPECT_EQ(data->set_char16_value(MEMBER_ID_INVALID, L'a'), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(97, test2);
 
     EXPECT_EQ(data->set_boolean_value(MEMBER_ID_INVALID, false), RETCODE_OK);
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(0u, test2);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(0, test2);
 
     EXPECT_EQ(data->set_byte_value(MEMBER_ID_INVALID, 2), RETCODE_OK);
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(2u, test2);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(2, test2);
     //}}}
 
     //{{{ Failing setters
     {
         eprosima::fastdds::testing::ScopeLogs _("disable");
-        EXPECT_EQ(data->set_int32_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
-        EXPECT_EQ(data->set_int8_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
-        EXPECT_EQ(data->set_int16_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
+        EXPECT_EQ(data->set_uint32_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_int64_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_uint64_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_float32_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_float64_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_float128_value(MEMBER_ID_INVALID, 0), RETCODE_BAD_PARAMETER);
-        EXPECT_EQ(data->set_char8_value(MEMBER_ID_INVALID, 'a'), RETCODE_BAD_PARAMETER);
-        EXPECT_EQ(data->set_char16_value(MEMBER_ID_INVALID, L'a'), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_string_value(MEMBER_ID_INVALID, ""), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_wstring_value(MEMBER_ID_INVALID, L""), RETCODE_BAD_PARAMETER);
         EXPECT_EQ(data->set_int8_values(MEMBER_ID_INVALID, {0}), RETCODE_BAD_PARAMETER);
@@ -4009,10 +4028,6 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
     EXPECT_EQ(data->get_int64_value(iTest64, MEMBER_ID_INVALID), RETCODE_OK);
     EXPECT_EQ(2, iTest64);
 
-    uint64_t uTest64 {0};
-    EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(2, uTest64);
-
     double fTest64 {0};
     EXPECT_EQ(data->get_float64_value(fTest64, MEMBER_ID_INVALID), RETCODE_OK);
     EXPECT_EQ(2, fTest64);
@@ -4025,8 +4040,8 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
     //{{{ Failing getters
     {
         eprosima::fastdds::testing::ScopeLogs _("disable");
-        int32_t iTest32 {0};
-        EXPECT_EQ(data->get_int32_value(iTest32, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
+        uint32_t uTest32 {0};
+        EXPECT_EQ(data->get_uint32_value(uTest32, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
         int8_t iTest8;
         EXPECT_EQ(data->get_int8_value(iTest8, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
         uint8_t uTest8;
@@ -4035,6 +4050,8 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
         EXPECT_EQ(data->get_int16_value(iTest16, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
         uint16_t uTest16 {0};
         EXPECT_EQ(data->get_uint16_value(uTest16, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
+        uint64_t uTest64 {0};
+        EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
         float fTest32 {0};
         EXPECT_EQ(data->get_float32_value(fTest32, MEMBER_ID_INVALID), RETCODE_BAD_PARAMETER);
         char cTest8 {0};
@@ -4113,27 +4130,27 @@ TEST_F(DynamicTypesTests, DynamicType_enum)
     // Encoding/decoding
     for (auto encoding : encodings)
     {
-        uint32_t test3 {0};
+        int32_t test3 {0};
         DynamicData::_ref_type data2 {DynamicDataFactory::get_instance()->create_data(created_type)};
         encoding_decoding_test(created_type, data, data2, encoding);
-        EXPECT_EQ(data2->get_uint32_value(test3, MEMBER_ID_INVALID), RETCODE_OK);
+        EXPECT_EQ(data2->get_int32_value(test3, MEMBER_ID_INVALID), RETCODE_OK);
         EXPECT_EQ(test1, test3);
         EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data2), RETCODE_OK);
     }
 
     // Test clear functions.
     EXPECT_EQ(RETCODE_OK, data->clear_all_values());
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(0u, test2);
-    EXPECT_EQ(data->set_uint32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(0, test2);
+    EXPECT_EQ(data->set_int32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
     EXPECT_EQ(RETCODE_OK, data->clear_nonkey_values());
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(0u, test2);
-    EXPECT_EQ(data->set_uint32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(0, test2);
+    EXPECT_EQ(data->set_int32_value(MEMBER_ID_INVALID, test1), RETCODE_OK);
     EXPECT_EQ(RETCODE_OK, data->clear_value(MEMBER_ID_INVALID));
     EXPECT_EQ(RETCODE_BAD_PARAMETER, data->clear_value(100));
-    EXPECT_EQ(data->get_uint32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(0u, test2);
+    EXPECT_EQ(data->get_int32_value(test2, MEMBER_ID_INVALID), RETCODE_OK);
+    EXPECT_EQ(0, test2);
 
     EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
 }

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestType.hpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestType.hpp
@@ -58,7 +58,7 @@
  * @brief This class represents the enumeration Color defined by the user in the IDL file.
  * @ingroup ContentFilterTestType
  */
-enum class Color : uint32_t
+enum class Color : int32_t
 {
     RED,
     GREEN,
@@ -70,7 +70,7 @@ enum class Color : uint32_t
  * @brief This class represents the enumeration Material defined by the user in the IDL file.
  * @ingroup ContentFilterTestType
  */
-enum class Material : uint32_t
+enum class Material : int32_t
 {
     WOOD,
     PLASTIC,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

TypeObject doesn't allow to contain the information whether a enumeration is signed or unsigned. It only stores the *bit_bound*. To avoid conflicts we were restricting the creation of enumerations using Dynamic Language Binding to only signed integers.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#821
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

