### PR TITLE
[21158] CI - Avoid CCache in workflows and nightlys

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -23,6 +23,11 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         type: string
         required: true
+      use-ccache:
+        description: 'Use CCache to speed up the build'
+        required: false
+        type: boolean
+        default: false
 
   pull_request:
     types:
@@ -49,3 +54,4 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+      use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/nightly-mac-ci.yml
+++ b/.github/workflows/nightly-mac-ci.yml
@@ -19,6 +19,7 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: 'master'
+      use-ccache: false
 
   nightly-mac-ci-2_14_x:
     strategy:
@@ -33,6 +34,7 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.14.x'
+      use-ccache: false
 
   nightly-mac-ci-2_13_x:
     strategy:
@@ -47,6 +49,7 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.13.x'
+      use-ccache: false
 
   nightly-mac-ci-2_10_x:
     strategy:
@@ -61,6 +64,7 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.10.x'
+      use-ccache: false
 
   nightly-mac-ci-2_6_x:
     strategy:
@@ -75,3 +79,4 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.6.x'
+      use-ccache: false

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -23,7 +23,7 @@ jobs:
       fastdds-branch: 'master'
       security: ${{ matrix.security }}
       run-tests: true
-      use-ccache: true
+      use-ccache: false
 
   nightly-ubuntu-ci-2_14_x:
     strategy:
@@ -42,7 +42,7 @@ jobs:
       fastdds-branch: '2.14.x'
       security: ${{ matrix.security }}
       run-tests: true
-      use-ccache: true
+      use-ccache: false
 
   nightly-ubuntu-ci-2_13_x:
     strategy:
@@ -61,7 +61,7 @@ jobs:
       fastdds-branch: '2.13.x'
       security: ${{ matrix.security }}
       run-tests: true
-      use-ccache: true
+      use-ccache: false
 
   nightly-ubuntu-ci-2_10_x:
     strategy:
@@ -80,7 +80,7 @@ jobs:
       fastdds-branch: '2.10.x'
       security: ${{ matrix.security }}
       run-tests: true
-      use-ccache: true
+      use-ccache: false
 
   nightly-ubuntu-ci-2_6_x:
     strategy:
@@ -99,4 +99,4 @@ jobs:
       fastdds-branch: '2.6.x'
       security: ${{ matrix.security }}
       run-tests: true
-      use-ccache: true
+      use-ccache: false

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -23,6 +23,11 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         required: true
         type: string
+      use-ccache:
+        description: 'Use CCache to speed up the build'
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -84,6 +89,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ !always() }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -171,6 +172,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ !always() }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -251,6 +253,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ !always() }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -358,6 +361,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ !always() }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR performs the following improvements in this project CI:
- Avoid CCache in all workflows, keeping it configurable in most of them for debug purposes
- Avoid CCache also in nightlys
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
**Important**: Backports must remove nightly workflows
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
