### PR TITLE
[21158] CI - Improve CI inputs

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -23,6 +23,11 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         type: string
         required: true
+      run-tests:
+        description: 'Run suite of tests of Fast DDS'
+        required: false
+        type: boolean
+        default: true
       use-ccache:
         description: 'Use CCache to speed up the build'
         required: false
@@ -43,10 +48,6 @@ concurrency:
 
 jobs:
   mac-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-mac-ci.yml
     with:
       label: ${{ inputs.label || 'mac-ci' }}
@@ -54,4 +55,6 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -55,6 +55,6 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') && true || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) && true || false }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/nightly-mac-ci.yml
+++ b/.github/workflows/nightly-mac-ci.yml
@@ -19,6 +19,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: 'master'
+      run-build: true
+      run-tests: true
       use-ccache: false
 
   nightly-mac-ci-2_14_x:
@@ -34,6 +36,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.14.x'
+      run-build: true
+      run-tests: true
       use-ccache: false
 
   nightly-mac-ci-2_13_x:
@@ -49,6 +53,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.13.x'
+      run-build: true
+      run-tests: true
       use-ccache: false
 
   nightly-mac-ci-2_10_x:
@@ -64,6 +70,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.10.x'
+      run-build: true
+      run-tests: true
       use-ccache: false
 
   nightly-mac-ci-2_6_x:
@@ -79,4 +87,6 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds-branch: '2.6.x'
+      run-build: true
+      run-tests: true
       use-ccache: false

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -22,6 +22,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: 'master'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -41,6 +42,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.14.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -60,6 +62,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.13.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -79,6 +82,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.10.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -98,5 +102,6 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.6.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -19,20 +19,24 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds_branch: 'master'
+      run-build: true
+      run-tests: true
 
   nightly-windows-ci-2_14_x:
-      strategy:
-        fail-fast: false
-        matrix:
-          security:
-            - 'ON'
-            - 'OFF'
-      uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.14.x
-      with:
-        label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.14.x'
-        cmake-args: "-DSECURITY=${{ matrix.security }}"
-        ctest-args: "-LE xfail"
-        fastdds_branch: '2.14.x'
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.14.x
+    with:
+      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.14.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '2.14.x'
+      run-build: true
+      run-tests: true
 
   nightly-windows-ci-2_13_x:
     strategy:
@@ -47,6 +51,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds_branch: '2.13.x'
+      run-build: true
+      run-tests: true
 
   nightly-windows-ci-2_10_x:
     strategy:
@@ -61,6 +67,8 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds_branch: '2.10.x'
+      run-build: true
+      run-tests: true
 
   nightly-windows-ci-2_6_x:
     strategy:
@@ -75,3 +83,5 @@ jobs:
       cmake-args: "-DSECURITY=${{ matrix.security }}"
       ctest-args: "-LE xfail"
       fastdds_branch: '2.6.x'
+      run-build: true
+      run-tests: true

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -23,6 +23,15 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         required: true
         type: string
+      run-build:
+        description: 'Run build jobs of Fast DDS'
+        required: true
+        type: boolean
+      run-tests:
+        description: 'Run test suite of Fast DDS'
+        required: false
+        type: boolean
+        default: true
       use-ccache:
         description: 'Use CCache to speed up the build'
         required: false
@@ -42,6 +51,7 @@ jobs:
     # so we'll use that one for now, as clang 15 is the supported compiler for Fast DDS in macOS.
     # (see https://github.com/eProsima/Fast-DDS/blob/master/PLATFORM_SUPPORT.md#compilers)
     runs-on: macos-13
+    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -139,7 +149,7 @@ jobs:
 
       - name: Colcon test
         id: test
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
@@ -152,7 +162,7 @@ jobs:
 
       - name: Test summary
         uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
-        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ !cancelled() && inputs.run-tests == true }}
         with:
           junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
           print_summary: 'True'

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -52,8 +52,8 @@ defaults:
 
 jobs:
   asan_fastdds_build:
-    if: ${{ inputs.run_asan_fastdds == true }}
     runs-on: ubuntu-22.04
+    if: ${{ inputs.run_asan_fastdds == true }}
     steps:
       - name: Add ci-pending label if PR
         if: ${{ github.event_name == 'pull_request' }}
@@ -223,9 +223,9 @@ jobs:
             --sanitizer asan
 
   asan_discovery_server_test:
-    if: ${{ inputs.run_asan_discovery_server == true }}
     needs: asan_fastdds_build
     runs-on: ubuntu-22.04
+    if: ${{ inputs.run_asan_discovery_server == true }}
     steps:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
@@ -318,8 +318,8 @@ jobs:
             --sanitizer=asan
 
   tsan_fastdds_test:
-    if: ${{ inputs.run_tsan_fastdds == true }}
     runs-on: ubuntu-22.04
+    if: ${{ inputs.run_tsan_fastdds == true }}
     env:
       TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000
       # GCC 11.3 (Ubuntu Jammy default) produces several false positives regarding timed synchronization protocols

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -32,6 +32,10 @@ on:
         required: false
         type: boolean
         default: true
+      run-build:
+        description: 'Run build jobs of Fast DDS (standard and alternative builds)'
+        required: true
+        type: boolean
       run-tests:
         description: 'Run test suite of Fast DDS, Fast DDS python, and Fast DDS Discovery Server'
         required: false
@@ -53,6 +57,7 @@ defaults:
 jobs:
   fastdds_build:
     runs-on: ${{ inputs.os-image }}
+    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -685,6 +690,7 @@ jobs:
   fastdds_alternative_builds:
     needs: fastdds_build
     runs-on: ${{ inputs.os-image }}
+    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -3,61 +3,45 @@ name: Fast DDS Ubuntu CI reusable workflow
 on:
   workflow_call:
     inputs:
-      os-image:
-        description: 'The OS image for the workflow'
+      input_string:
+        description: 'The input string for the workflow'
         required: true
         type: string
-      label:
-        description: 'ID associated to the workflow'
+      input_separator:
+        description: 'The separator for the input string'
+        type: string
         required: true
+      key_value_separator:
+        description: 'The separator for the key-value input string'
         type: string
-      colcon-args:
-        description: 'Extra arguments for colcon cli'
-        required: false
-        type: string
-      cmake-args:
-        description: 'Extra arguments for cmake cli'
-        required: false
-        type: string
-      ctest-args:
-        description: 'Extra arguments for ctest cli'
-        required: false
-        type: string
-      fastdds-branch:
-        description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         required: true
-        type: string
-      security:
-        description: 'Enable security features'
-        required: false
-        type: boolean
-        default: true
-      run-build:
-        description: 'Run build jobs of Fast DDS (standard and alternative builds)'
-        required: true
-        type: boolean
-      run-tests:
-        description: 'Run test suite of Fast DDS, Fast DDS python, and Fast DDS Discovery Server'
-        required: false
-        type: boolean
-        default: true
-      use-ccache:
-        description: 'Use CCache to speed up the build'
-        required: false
-        type: boolean
-        default: false
 
 env:
-  security-cmake-flag: ${{ inputs.security == true && '-DSECURITY=ON' || '-DSECURITY=OFF' }}
   colcon-build-default-cmake-args: '-DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wunused-value -Woverloaded-virtual"'
 defaults:
   run:
     shell: bash
 
 jobs:
+  prepare_workflow:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Parse inputs as github env variables
+        uses: eProsima/eProsima-CI/multiplatform/parse_inputs@feature/input_parser
+        with:
+          input_string: ${{ inputs.input_string }}
+          input_separator: ${{ inputs.input_separator }}
+          key_value_separator: ${{ inputs.key_value_separator }}
+
+      - name: Set manual environment variables
+        run: |
+          echo "security-cmake-flag=${{ env.security == true && '-DSECURITY=ON' || '-DSECURITY=OFF' }}"" >> $GITHUB_ENV
+
+
   fastdds_build:
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.run-build == true }}
+    runs-on: ${{ env.os-image }}
+    needs: prepare_workflow
+    if: ${{ env.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +60,7 @@ jobs:
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           path: src/fastdds
-          ref: ${{ inputs.fastdds-branch }}
+          ref: ${{ env.fastdds-branch }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -106,7 +90,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -125,8 +109,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '-DCOMPILE_TOOLS=OFF ${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '-DCOMPILE_TOOLS=OFF ${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -134,13 +118,13 @@ jobs:
       - name: Upload build artifacts
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
+          name: fastdds_build_${{ env.label }}
           path: ${{ github.workspace }}
 
   fastdds_test:
     needs: fastdds_build
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.run-tests == true }}
+    runs-on: ${{ env.os-image }}
+    if: ${{ env.run-tests == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -150,7 +134,7 @@ jobs:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
+          name: fastdds_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -178,7 +162,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -209,8 +193,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: '${{ env.colcon-build-default-cmake-args }} -DFASTDDS_EXAMPLE_TESTS=ON'
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -220,12 +204,12 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
-          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args: ${{ env.colcon-args }}
           colcon_test_args_default: --event-handlers=console_direct+
-          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args: ${{ env.ctest-args }}
           packages_names: fastdds
           workspace: ${{ github.workspace }}
-          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', env.label, github.job, join(matrix.*, '_')) }}
 
       - name: Fast DDS test summary
         uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
@@ -239,8 +223,8 @@ jobs:
 
   fastdds_python_build:
     needs: fastdds_build
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.security == true }}
+    runs-on: ${{ env.os-image }}
+    if: ${{ env.security == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -250,7 +234,7 @@ jobs:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
+          name: fastdds_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -278,7 +262,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -301,8 +285,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ''
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -310,13 +294,13 @@ jobs:
       - name: Upload python build artifacts
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
-          name: fastdds_python_build_${{ inputs.label }}
+          name: fastdds_python_build_${{ env.label }}
           path: ${{ github.workspace }}
 
   fastdds_python_test:
     needs: fastdds_python_build
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.security == true && inputs.run-tests == true }}
+    runs-on: ${{ env.os-image }}
+    if: ${{ env.security == true && env.run-tests == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -326,7 +310,7 @@ jobs:
       - name: Download python build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_python_build_${{ inputs.label }}
+          name: fastdds_python_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -361,7 +345,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -370,8 +354,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/python_test.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ''
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -381,13 +365,13 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/python_test.meta
-          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args: ${{ env.colcon-args }}
           colcon_test_args_default: --event-handlers=console_direct+
-          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args: ${{ env.ctest-args }}
           packages_names: fastdds_python
           workspace: ${{ github.workspace }}
           workspace_dependencies: ''
-          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', env.label, github.job, join(matrix.*, '_')) }}
 
       - name: Fast DDS Python test summary
         uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
@@ -401,8 +385,8 @@ jobs:
 
   fastdds_docs_test:
     needs: fastdds_python_build
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.security == true }}
+    runs-on: ${{ env.os-image }}
+    if: ${{ env.security == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -412,7 +396,7 @@ jobs:
       - name: Download python build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_python_build_${{ inputs.label }}
+          name: fastdds_python_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -440,7 +424,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -459,7 +443,7 @@ jobs:
           ref: ${{ steps.get_fastdds_docs_branch.outputs.deduced_branch }}
 
       - name: Fetch Fast DDS CI dependencies
-        if: ${{ inputs.run-tests == true }}
+        if: ${{ env.run-tests == true }}
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.repos
@@ -477,28 +461,28 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/documentation.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
       - name: Colcon test
         id: docs_test
-        if: ${{ inputs.run-tests == true }}
+        if: ${{ env.run-tests == true }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/documentation.meta
-          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args: ${{ env.colcon-args }}
           colcon_test_args_default: --event-handlers=console_direct+
-          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args: ${{ env.ctest-args }}
           packages_names: fastdds-docs
           workspace: ${{ github.workspace }}
           workspace_dependencies: ''
-          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', env.label, github.job, join(matrix.*, '_')) }}
 
       - name: Fast DDS Docs test summary
         uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
-        if: ${{ !cancelled() && inputs.run-tests == true }}
+        if: ${{ !cancelled() && env.run-tests == true }}
         with:
           junit_reports_dir: "${{ steps.docs_test.outputs.ctest_results_path }}"
           print_summary: 'True'
@@ -508,7 +492,7 @@ jobs:
 
   fastdds_shapesdemo_build:
     needs: fastdds_build
-    runs-on: ${{ inputs.os-image }}
+    runs-on: ${{ env.os-image }}
     strategy:
       fail-fast: false
       matrix:
@@ -518,7 +502,7 @@ jobs:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
+          name: fastdds_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -546,7 +530,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -581,15 +565,15 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
   fastdds_discovery_server_test:
     needs: fastdds_build
-    runs-on: ${{ inputs.os-image }}
+    runs-on: ${{ env.os-image }}
     strategy:
       fail-fast: false
       matrix:
@@ -599,7 +583,7 @@ jobs:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
+          name: fastdds_build_${{ env.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
@@ -627,7 +611,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -657,29 +641,29 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/discovery_server.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
       - name: Colcon test
         id: discovery_server_test
-        if: ${{ inputs.run-tests == true }}
+        if: ${{ env.run-tests == true }}
         uses: eProsima/eProsima-CI/multiplatform/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/discovery_server.meta
-          colcon_test_args: ${{ inputs.colcon-args }}
+          colcon_test_args: ${{ env.colcon-args }}
           colcon_test_args_default: --event-handlers=console_direct+
-          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args: ${{ env.ctest-args }}
           packages_names: discovery-server
           workspace: ${{ github.workspace }}
           workspace_dependencies: ''
-          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
+          test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', env.label, github.job, join(matrix.*, '_')) }}
 
       - name: Discovery server test summary
         uses: eProsima/eProsima-CI/multiplatform/junit_summary@v0
-        if: ${{ !cancelled() && inputs.run-tests == true }}
+        if: ${{ !cancelled() && env.run-tests == true }}
         with:
           junit_reports_dir: "${{ steps.discovery_server_test.outputs.ctest_results_path }}"
           print_summary: 'True'
@@ -688,9 +672,9 @@ jobs:
           show_skipped: 'False'
 
   fastdds_alternative_builds:
-    needs: fastdds_build
-    runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.run-build == true }}
+    runs-on: ${{ env.os-image }}
+    needs: prepare_workflow
+    if: ${{ env.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -700,8 +684,8 @@ jobs:
       - name: Download build artifacts
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          name: fastdds_build_${{ inputs.label }}
-          path: ${{ github.workspace }}
+          path: src/fastdds
+          ref: ${{ env.fastdds-branch }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -731,7 +715,7 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ env.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -773,8 +757,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '-DSECURITY=OFF ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '-DSECURITY=OFF ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -788,8 +772,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '-DFASTDDS_STATISTICS=OFF ${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '-DFASTDDS_STATISTICS=OFF ${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -804,8 +788,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ''
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '-DCOMPILE_EXAMPLES=ON ${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '-DCOMPILE_EXAMPLES=ON ${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
@@ -819,8 +803,8 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
-          cmake_args: '-DBUILD_SHARED_LIBS=OFF ${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
+          colcon_build_args: ${{ env.colcon-args }}
+          cmake_args: '-DBUILD_SHARED_LIBS=OFF ${{ env.security-cmake-flag }} ${{ env.cmake-args }}'
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -23,6 +23,15 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         required: true
         type: string
+      run-build:
+        description: 'Run build jobs of Fast DDS'
+        required: true
+        type: boolean
+      run-tests:
+        description: 'Run test suite of Fast DDS'
+        required: false
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -31,6 +40,7 @@ defaults:
 jobs:
   reusable-windows-ci:
     runs-on: windows-2019
+    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +109,7 @@ jobs:
           packages: vcstool xmlschema
 
       - name: Update known hosts file for DNS resolver testing
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ inputs.run-tests == true }}
         run: |
           $hostfile = "$Env:SystemRoot\system32\drivers" -replace "\\", "/"
           $hostfile += "/etc/hosts"
@@ -172,7 +182,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Test
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ inputs.run-tests == true }}
         id: test
         uses: eProsima/eProsima-CI/windows/colcon_test@v0
         with:
@@ -186,7 +196,7 @@ jobs:
 
       - name: Test summary
         uses: eProsima/eProsima-CI/windows/junit_summary@v0
-        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ !cancelled() && inputs.run-tests == true }}
         with:
           junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
           print_summary: 'True'

--- a/.github/workflows/sanitizers-ci.yml
+++ b/.github/workflows/sanitizers-ci.yml
@@ -58,17 +58,12 @@ concurrency:
 
 jobs:
   sanitizers-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-sanitizers-ci.yml
     with:
       label: ${{ inputs.label || 'fastdds-sanitizers-ci' }}
-      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || github.event_name == 'pull_request' }}
-      run_asan_discovery_server: ${{ ((inputs.run_asan_discovery_server == true) && true) || github.event_name == 'pull_request' }}
-      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || github.event_name == 'pull_request' }}
+      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+      run_asan_discovery_server: ${{ ((inputs.run_asan_discovery_server == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
       colcon_build_args: ${{ inputs.colcon_build_args || '' }}
       colcon_test_args: ${{ inputs.colcon_test_args || '' }}
       cmake_args: ${{ inputs.cmake_args || '' }}

--- a/.github/workflows/sanitizers-ci.yml
+++ b/.github/workflows/sanitizers-ci.yml
@@ -61,9 +61,9 @@ jobs:
     uses: ./.github/workflows/reusable-sanitizers-ci.yml
     with:
       label: ${{ inputs.label || 'fastdds-sanitizers-ci' }}
-      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
-      run_asan_discovery_server: ${{ ((inputs.run_asan_discovery_server == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
-      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) }}
+      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
+      run_asan_discovery_server: ${{ ((inputs.run_asan_discovery_server == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
+      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
       colcon_build_args: ${{ inputs.colcon_build_args || '' }}
       colcon_test_args: ${{ inputs.colcon_test_args || '' }}
       cmake_args: ${{ inputs.cmake_args || '' }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -64,6 +64,6 @@ jobs:
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
-      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') && true || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) && true || false }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -57,13 +57,6 @@ jobs:
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
       # https://github.com/orgs/community/discussions/128118 , it has been set as a single OS job.
-      os-image: 'ubuntu-22.04'
-      label: ${{ inputs.label || 'ubuntu-ci' }}
-      colcon-args: ${{ inputs.colcon-args }}
-      cmake-args: ${{ inputs.cmake-args }}
-      ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
-      fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-      security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
-      run-build: ${{ !(github.event_name == 'pull_request') && true || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) && true || false }}
-      use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
+      input_string: "os-image: 'ubuntu-22.04'~label: ${{ inputs.label || 'ubuntu-ci' }}~colcon-args: ${{ inputs.colcon-args }}~cmake-args: ${{ inputs.cmake-args }}~ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}~fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}~security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}~run-build: ${{ !(github.event_name == 'pull_request') && true || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}~run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) && true || false }}~use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}"
+      input_separator: '~'
+      key_value_separator: ': '

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -53,11 +53,6 @@ concurrency:
 
 jobs:
   ubuntu-ci:
-
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-ubuntu-ci.yml
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
@@ -69,5 +64,6 @@ jobs:
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
+      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
       run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -23,6 +23,11 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         type: string
         required: true
+      run-tests:
+        description: 'Run suite of tests of Fast DDS'
+        required: false
+        type: boolean
+        default: true
 
   pull_request:
     types:
@@ -38,10 +43,6 @@ concurrency:
 
 jobs:
   windows-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
     uses: ./.github/workflows/reusable-windows-ci.yml
     with:
       label: ${{ inputs.label || 'windows-ci' }}
@@ -49,3 +50,5 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds_branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
+      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -50,5 +50,5 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds_branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-      run-build: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) || true }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') && true || (!contains(github.event.pull_request.labels.*.name, 'skip-ci') && !contains(github.event.pull_request.labels.*.name, 'conflicts')) && true || false }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) && true || false }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR performs the following improvements in this project CI:
- Set build and test conditions as reusable workflow inputs, so 'if's and labels are only considered in the pull request workflow, making reusable-workflows pull request event agnostic

This PR is on top of (and must be merged before):
- #4971 
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
**Important**: Backports must remove nightly workflows
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x 

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
