### PR TITLE
Improve X-Types interoperability

### DIFF
--- a/include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl
@@ -2,7 +2,7 @@
 
 // The types in this file shall be serialized with XCDR encoding version 2
 module DDS { module XTypes {
-    
+
     // ---------- Equivalence Kinds -------------------
     typedef octet EquivalenceKind;
     const octet EK_MINIMAL   = 0xF1; // 0x1111 0001
@@ -11,7 +11,7 @@ module DDS { module XTypes {
 
     // ---------- TypeKinds (begin) -------------------
     typedef octet TypeKind;
-    
+
     // Primitive TKs
     const octet TK_NONE       = 0x00;
     const octet TK_BOOLEAN    = 0x01;
@@ -46,7 +46,7 @@ module DDS { module XTypes {
     const octet TK_STRUCTURE  = 0x51;
     const octet TK_UNION      = 0x52;
     const octet TK_BITSET     = 0x53;
-      
+
     // Collection TKs
     const octet TK_SEQUENCE   = 0x60;
     const octet TK_ARRAY      = 0x61;
@@ -62,10 +62,10 @@ module DDS { module XTypes {
 
     const octet TI_PLAIN_SEQUENCE_SMALL = 0x80;
     const octet TI_PLAIN_SEQUENCE_LARGE = 0x81;
-    
+
     const octet TI_PLAIN_ARRAY_SMALL    = 0x90;
     const octet TI_PLAIN_ARRAY_LARGE    = 0x91;
-    
+
     const octet TI_PLAIN_MAP_SMALL      = 0xA0;
     const octet TI_PLAIN_MAP_LARGE      = 0xA1;
 
@@ -93,12 +93,12 @@ module DDS { module XTypes {
     // using UTF-8 encoding and without a 'nul' terminator.
     // Example: the member name "color" has NameHash {0x70, 0xDD, 0xA5, 0xDF}
     typedef octet NameHash[4];
-    
+
     // Long Bound of a collection type
     typedef unsigned long LBound;
     typedef sequence<LBound> LBoundSeq;
     const LBound INVALID_LBOUND = 0;
-    
+
     // Short Bound of a collection type
     typedef octet SBound;
     typedef sequence<SBound> SBoundSeq;
@@ -110,7 +110,7 @@ module DDS { module XTypes {
         case EK_MINIMAL:
             EquivalenceHash  hash;
     };
-       
+
     // Flags that apply to struct/union/collection/enum/bitmask/bitset
     // members/elements and DO affect type assignability
     // Depending on the flag it may not apply to members of all types
@@ -121,10 +121,10 @@ module DDS { module XTypes {
         @position(1)  TRY_CONSTRUCT2,     // T2 | 10 = USE_DEFAULT, 11 = TRIM
         @position(2)  IS_EXTERNAL,        // X  StructMember, UnionMember,
 	                                  //    CollectionElement
-        @position(3)  IS_OPTIONAL,        // O  StructMember 
+        @position(3)  IS_OPTIONAL,        // O  StructMember
         @position(4)  IS_MUST_UNDERSTAND, // M  StructMember
         @position(5)  IS_KEY,          // K  StructMember, UnionDiscriminator
-        @position(6)  IS_DEFAULT       // D  UnionMember, EnumerationLiteral 
+        @position(6)  IS_DEFAULT       // D  UnionMember, EnumerationLiteral
     };
     typedef MemberFlag   CollectionElementFlag;   // T1, T2, X
     typedef MemberFlag   StructMemberFlag;        // T1, T2, O, M, K, X
@@ -138,15 +138,15 @@ module DDS { module XTypes {
 
     // Mask used to remove the flags that do no affect assignability
     // Selects  T1, T2, O, M, K, D
-    const   unsigned short  MemberFlagMinimalMask = 0x003f;  
+    const   unsigned short  MemberFlagMinimalMask = 0x003f;
 
     // Flags that apply to type declarationa and DO affect assignability
     // Depending on the flag it may not apply to all types
     // When not all, the applicable  types are listed
     @bit_bound(16)
     bitmask TypeFlag {
-        @position(0) IS_FINAL,        // F |  
-        @position(1) IS_APPENDABLE,   // A |-  Struct, Union 
+        @position(0) IS_FINAL,        // F |
+        @position(1) IS_APPENDABLE,   // A |-  Struct, Union
         @position(2) IS_MUTABLE,      // M |   (exactly one flag)
 
         @position(3) IS_NESTED,       // N     Struct, Union
@@ -166,13 +166,13 @@ module DDS { module XTypes {
 
    // Forward declaration
    union TypeIdentifier;
-     
+
     // 1 Byte
     @extensibility(FINAL) @nested
     struct StringSTypeDefn {
     	SBound                  bound;
     };
-    
+
     // 4 Bytes
     @extensibility(FINAL) @nested
     struct StringLTypeDefn {
@@ -184,58 +184,58 @@ module DDS { module XTypes {
         EquivalenceKind        equiv_kind;
         CollectionElementFlag  element_flags;
     };
-    
+
     @extensibility(FINAL) @nested
     struct PlainSequenceSElemDefn {
         PlainCollectionHeader  header;
         SBound                 bound;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
     };
 
     @extensibility(FINAL) @nested
     struct PlainSequenceLElemDefn {
         PlainCollectionHeader  header;
         LBound                 bound;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
     };
 
     @extensibility(FINAL) @nested
     struct PlainArraySElemDefn {
         PlainCollectionHeader  header;
         SBoundSeq              array_bound_seq;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
     };
 
     @extensibility(FINAL) @nested
     struct PlainArrayLElemDefn {
         PlainCollectionHeader  header;
         LBoundSeq              array_bound_seq;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
     };
 
     @extensibility(FINAL) @nested
     struct PlainMapSTypeDefn {
         PlainCollectionHeader  header;
         SBound                 bound;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
         CollectionElementFlag  key_flags;
-        @external TypeIdentifier key_identifier; 
+        @external TypeIdentifier key_identifier;
     };
 
     @extensibility(FINAL) @nested
     struct PlainMapLTypeDefn {
         PlainCollectionHeader  header;
         LBound                 bound;
-        @external TypeIdentifier element_identifier; 
+        @external TypeIdentifier element_identifier;
         CollectionElementFlag  key_flags;
-        @external TypeIdentifier key_identifier; 
+        @external TypeIdentifier key_identifier;
     };
 
     // Used for Types that have cyclic depencencies with other types
     @extensibility(APPENDABLE) @nested
     struct StronglyConnectedComponentId {
         TypeObjectHashId sc_component_id; // Hash StronglyConnectedComponent
-        long   scc_length; // StronglyConnectedComponent.length 
+        long   scc_length; // StronglyConnectedComponent.length
         long   scc_index ; // identify type in Strongly Connected Comp.
     };
 
@@ -244,13 +244,19 @@ module DDS { module XTypes {
     struct ExtendedTypeDefn {
         // Empty. Available for future extension
     };
- 
 
-    
-    // The TypeIdentifier uniquely identifies a type (a set of equivalent 
+
+    // eProsima extension to support TypeIdentifier no value cases.
+    @final
+    struct Dummy
+    {
+    };
+
+
+    // The TypeIdentifier uniquely identifies a type (a set of equivalent
     // types according to an equivalence relationship:  COMPLETE, MNIMAL).
     //
-    // In some cases (primitive types, strings, plain types) the identifier 
+    // In some cases (primitive types, strings, plain types) the identifier
     // is a explicit description of the type.
     // In other cases the Identifier is a Hash of the type description
     //
@@ -266,31 +272,28 @@ module DDS { module XTypes {
     //   - COMMON indicates the TypeIdentifier identifies equivalent types
     //     according to both the MINIMAL and the COMMON equivalence relation.
     //     This means the TypeIdentifier is the same for both relationships
-    // 
+    //
     @extensibility(FINAL) @nested
-    union TypeIdentifier switch (octet) { 
+    union TypeIdentifier switch (@default(TK_NONE) octet) {
         // ============  Primitive types - use TypeKind ====================
-        // All primitive types fall here. 
-        // Commented-out because Unions cannot have cases with no member.
-        /*
+        // All primitive types fall here.
         case TK_NONE:
-        case TK_BOOLEAN:       
-        case TK_BYTE_TYPE:
-        case TK_INT8_TYPE:
-        case TK_INT16_TYPE:
-        case TK_INT32_TYPE:
-        case TK_INT64_TYPE:
-        case TK_UINT8_TYPE:
-        case TK_UINT16_TYPE:
-        case TK_UINT32_TYPE:
-        case TK_UINT64_TYPE:
-        case TK_FLOAT32_TYPE:
-        case TK_FLOAT64_TYPE:
-        case TK_FLOAT128_TYPE:        
-        case TK_CHAR8_TYPE:
-        case TK_CHAR16_TYPE:
-            // No Value
-        */
+        case TK_BOOLEAN:
+        case TK_BYTE:
+        case TK_INT8:
+        case TK_INT16:
+        case TK_INT32:
+        case TK_INT64:
+        case TK_UINT8:
+        case TK_UINT16:
+        case TK_UINT32:
+        case TK_UINT64:
+        case TK_FLOAT32:
+        case TK_FLOAT64:
+        case TK_FLOAT128:
+        case TK_CHAR8:
+        case TK_CHAR16:
+            Dummy                   no_value;
 
         // ============ Strings - use TypeIdentifierKind ===================
         case TI_STRING8_SMALL:
@@ -316,12 +319,12 @@ module DDS { module XTypes {
             PlainMapSTypeDefn       map_sdefn;
         case TI_PLAIN_MAP_LARGE:
             PlainMapLTypeDefn       map_ldefn;
-    
+
         // ============  Types that are mutually dependent on each other ===
         case TI_STRONGLY_CONNECTED_COMPONENT:
             StronglyConnectedComponentId  sc_component_id;
 
-        // ============  The remaining cases - use EquivalenceKind ========= 
+        // ============  The remaining cases - use EquivalenceKind =========
         case EK_COMPLETE:
         case EK_MINIMAL:
             EquivalenceHash         equivalence_hash;
@@ -330,7 +333,7 @@ module DDS { module XTypes {
         // Future extensions
         default:
             ExtendedTypeDefn        extended_defn;
-    };   
+    };
     typedef sequence<TypeIdentifier> TypeIdentifierSeq;
 
 
@@ -345,7 +348,7 @@ module DDS { module XTypes {
     struct ExtendedAnnotationParameterValue {
         // Empty. Available for future extension
     };
-    
+
     /* Literal value of an annotation member: either the default value in its
      * definition or the value applied in its usage.
      */
@@ -384,9 +387,9 @@ module DDS { module XTypes {
         case TK_ENUM:
             long                enumerated_value;
         case TK_STRING8:
-            string<ANNOTATION_STR_VALUE_MAX_LEN>  string8_value;   
+            string<ANNOTATION_STR_VALUE_MAX_LEN>  string8_value;
         case TK_STRING16:
-            wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;  
+            wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;
         default:
             ExtendedAnnotationParameterValue      extended_value;
     };
@@ -394,8 +397,8 @@ module DDS { module XTypes {
     // The application of an annotation to some type or type member
     @extensibility(APPENDABLE) @nested
     struct AppliedAnnotationParameter {
-       NameHash                  paramname_hash;          
-       AnnotationParameterValue  value;      
+       NameHash                  paramname_hash;
+       AnnotationParameterValue  value;
     };
     // Sorted by AppliedAnnotationParameter.paramname_hash
     typedef
@@ -456,7 +459,7 @@ module DDS { module XTypes {
     };
     // Ordered by the member_index
     typedef sequence<CompleteStructMember> CompleteStructMemberSeq;
-    
+
     // Member of an aggregate type
     @extensibility(APPENDABLE) @nested
     struct MinimalStructMember {
@@ -466,7 +469,7 @@ module DDS { module XTypes {
     // Ordered by common.member_id
     typedef sequence<MinimalStructMember> MinimalStructMemberSeq;
 
-    
+
     @extensibility(APPENDABLE) @nested
     struct AppliedBuiltinTypeAnnotations {
         @optional AppliedVerbatimAnnotation verbatim;  // @verbatim(...)
@@ -476,11 +479,11 @@ module DDS { module XTypes {
     struct MinimalTypeDetail {
         // Empty. Available for future extension
     };
- 
+
     @extensibility(FINAL) @nested
     struct CompleteTypeDetail {
-         @optional AppliedBuiltinTypeAnnotations  ann_builtin;        
-         @optional AppliedAnnotationSeq           ann_custom;     
+         @optional AppliedBuiltinTypeAnnotations  ann_builtin;
+         @optional AppliedAnnotationSeq           ann_custom;
          QualifiedTypeName                        type_name;
     };
 
@@ -620,7 +623,7 @@ module DDS { module XTypes {
     struct CompleteAnnotationHeader {
         QualifiedTypeName         annotation_name;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct MinimalAnnotationHeader {
         // Empty. Available for future extension
@@ -654,7 +657,7 @@ module DDS { module XTypes {
         @optional AppliedBuiltinMemberAnnotations  ann_builtin;
         @optional AppliedAnnotationSeq             ann_custom;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct MinimalAliasBody {
         CommonAliasBody       common;
@@ -664,7 +667,7 @@ module DDS { module XTypes {
     struct CompleteAliasHeader {
         CompleteTypeDetail    detail;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct MinimalAliasHeader {
         // Empty. Available for future extension
@@ -712,7 +715,7 @@ module DDS { module XTypes {
     struct CommonCollectionHeader {
         LBound                    bound;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct CompleteCollectionHeader {
         CommonCollectionHeader        common;
@@ -731,7 +734,7 @@ module DDS { module XTypes {
         CompleteCollectionHeader   header;
         CompleteCollectionElement  element;
     };
-    
+
     @extensibility(FINAL) @nested
     struct MinimalSequenceType {
         CollectionTypeFlag         collection_flag;
@@ -744,7 +747,7 @@ module DDS { module XTypes {
     struct CommonArrayHeader {
         LBoundSeq           bound_seq;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct CompleteArrayHeader {
         CommonArrayHeader   common;
@@ -786,7 +789,7 @@ module DDS { module XTypes {
         MinimalCollectionElement    key;
         MinimalCollectionElement    element;
     };
- 
+
     // --- Enumeration: ----------------------------------------------------
     typedef unsigned short BitBound;
 
@@ -796,7 +799,7 @@ module DDS { module XTypes {
         long                     value;
         EnumeratedLiteralFlag    flags;
     };
-      
+
     // Constant in an enumerated type
     @extensibility(APPENDABLE) @nested
     struct CompleteEnumeratedLiteral {
@@ -830,12 +833,12 @@ module DDS { module XTypes {
     struct MinimalEnumeratedHeader {
         CommonEnumeratedHeader  common;
     };
-    
+
     // Enumerated type
     @extensibility(FINAL) @nested
     struct CompleteEnumeratedType  {
         EnumTypeFlag                    enum_flags; // unused
-        CompleteEnumeratedHeader        header; 
+        CompleteEnumeratedHeader        header;
         CompleteEnumeratedLiteralSeq    literal_seq;
     };
 
@@ -843,9 +846,9 @@ module DDS { module XTypes {
     @extensibility(FINAL) @nested
     struct MinimalEnumeratedType  {
         EnumTypeFlag                  enum_flags; // unused
-        MinimalEnumeratedHeader       header; 
+        MinimalEnumeratedHeader       header;
         MinimalEnumeratedLiteralSeq   literal_seq;
-    };  
+    };
 
     // --- Bitmask: --------------------------------------------------------
     // Bit in a bit mask
@@ -854,12 +857,12 @@ module DDS { module XTypes {
         unsigned short         position;
         BitflagFlag            flags;
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct CompleteBitflag {
         CommonBitflag          common;
         CompleteMemberDetail   detail;
-    }; 
+    };
     // Ordered by Bitflag.position
     typedef sequence<CompleteBitflag> CompleteBitflagSeq;
 
@@ -867,7 +870,7 @@ module DDS { module XTypes {
     struct MinimalBitflag {
         CommonBitflag        common;
         MinimalMemberDetail  detail;
-    }; 
+    };
     // Ordered by Bitflag.position
     typedef sequence<MinimalBitflag> MinimalBitflagSeq;
 
@@ -882,14 +885,14 @@ module DDS { module XTypes {
 
     @extensibility(APPENDABLE) @nested
     struct CompleteBitmaskType {
-        BitmaskTypeFlag          bitmask_flags; // unused 
+        BitmaskTypeFlag          bitmask_flags; // unused
         CompleteBitmaskHeader    header;
         CompleteBitflagSeq       flag_seq;
     };
 
     @extensibility(APPENDABLE) @nested
     struct MinimalBitmaskType {
-        BitmaskTypeFlag          bitmask_flags; // unused 
+        BitmaskTypeFlag          bitmask_flags; // unused
         MinimalBitmaskHeader     header;
         MinimalBitflagSeq        flag_seq;
     };
@@ -900,14 +903,14 @@ module DDS { module XTypes {
         unsigned short        position;
         BitsetMemberFlag      flags;
         octet                 bitcount;
-        TypeKind              holder_type; // Must be primitive integer type      
+        TypeKind              holder_type; // Must be primitive integer type
     };
-    
+
     @extensibility(APPENDABLE) @nested
     struct CompleteBitfield {
         CommonBitfield           common;
         CompleteMemberDetail     detail;
-    };  
+    };
     // Ordered by Bitfield.position
     typedef sequence<CompleteBitfield> CompleteBitfieldSeq;
 
@@ -915,7 +918,7 @@ module DDS { module XTypes {
     struct MinimalBitfield {
         CommonBitfield       common;
         NameHash             name_hash;
-    };  
+    };
     // Ordered by Bitfield.position
     typedef sequence<MinimalBitfield> MinimalBitfieldSeq;
 
@@ -931,18 +934,18 @@ module DDS { module XTypes {
 
     @extensibility(APPENDABLE) @nested
     struct CompleteBitsetType  {
-        BitsetTypeFlag         bitset_flags; // unused 
+        BitsetTypeFlag         bitset_flags; // unused
         CompleteBitsetHeader   header;
         CompleteBitfieldSeq    field_seq;
     };
 
     @extensibility(APPENDABLE) @nested
     struct MinimalBitsetType  {
-        BitsetTypeFlag       bitset_flags; // unused 
-        MinimalBitsetHeader  header;   
+        BitsetTypeFlag       bitset_flags; // unused
+        MinimalBitsetHeader  header;
         MinimalBitfieldSeq   field_seq;
     };
- 
+
     // --- Type Object: ---------------------------------------------------
     // The types associated with each case selection must have extensibility
     // kind APPENDABLE or MUTABLE so that they can be extended in the future
@@ -974,10 +977,10 @@ module DDS { module XTypes {
             CompleteEnumeratedType enumerated_type;
         case TK_BITMASK:
             CompleteBitmaskType    bitmask_type;
-    
+
         // ===================  Future extensibility  ============
         default:
-            CompleteExtendedType   extended_type;    
+            CompleteExtendedType   extended_type;
     };
 
     @extensibility(MUTABLE) @nested
@@ -1008,10 +1011,10 @@ module DDS { module XTypes {
             MinimalEnumeratedType  enumerated_type;
         case TK_BITMASK:
             MinimalBitmaskType     bitmask_type;
-    
+
         // ===================  Future extensibility  ============
         default:
-            MinimalExtendedType    extended_type;    
+            MinimalExtendedType    extended_type;
     };
 
     @extensibility(APPENDABLE)  @nested
@@ -1026,7 +1029,7 @@ module DDS { module XTypes {
     // Set of TypeObjects representing a strong component: Equivalence class
     // for the Strong Connectivity relationship (mutual reachability between
     // types).
-    // Ordered by fully qualified typename lexicographic order 
+    // Ordered by fully qualified typename lexicographic order
     typedef TypeObjectSeq        StronglyConnectedComponent;
 
     @extensibility(FINAL)  @nested
@@ -1072,6 +1075,3 @@ module DDS { module XTypes {
 
 };  // end of module XTypes
 };  // end module DDS
-
-
-

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl
@@ -247,7 +247,7 @@ module DDS { module XTypes {
 
 
     // eProsima extension to support TypeIdentifier no value cases.
-    @final
+    @final @nested
     struct Dummy
     {
     };

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
@@ -399,7 +399,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {
@@ -2705,6 +2705,101 @@ private:
 
 };
 /*!
+ * @brief This class represents the structure Dummy defined by the user in the IDL file.
+ * @ingroup dds_xtypes_typeobject
+ */
+class Dummy
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport Dummy()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~Dummy()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object Dummy that will be copied.
+     */
+    eProsima_user_DllExport Dummy(
+            const Dummy& x)
+    {
+        static_cast<void>(x);
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object Dummy that will be copied.
+     */
+    eProsima_user_DllExport Dummy(
+            Dummy&& x) noexcept
+    {
+        static_cast<void>(x);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object Dummy that will be copied.
+     */
+    eProsima_user_DllExport Dummy& operator =(
+            const Dummy& x)
+    {
+
+        static_cast<void>(x);
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object Dummy that will be copied.
+     */
+    eProsima_user_DllExport Dummy& operator =(
+            Dummy&& x) noexcept
+    {
+
+        static_cast<void>(x);
+
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x Dummy object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const Dummy& x) const
+    {
+        static_cast<void>(x);
+        return true;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x Dummy object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const Dummy& x) const
+    {
+        return !(*this == x);
+    }
+
+
+
+private:
+
+
+};
+/*!
  * @brief This class represents the union TypeIdentifier defined by the user in the IDL file.
  * @ingroup dds_xtypes_typeobject
  */
@@ -2717,7 +2812,7 @@ public:
      */
     eProsima_user_DllExport TypeIdentifier()
     {
-        extended_defn_();
+        no_value_();
     }
 
     /*!
@@ -2743,46 +2838,50 @@ public:
         switch (x.selected_member_)
         {
                         case 0x00000001:
-                            string_sdefn_() = x.m_string_sdefn;
+                            no_value_() = x.m_no_value;
                             break;
 
                         case 0x00000002:
-                            string_ldefn_() = x.m_string_ldefn;
+                            string_sdefn_() = x.m_string_sdefn;
                             break;
 
                         case 0x00000003:
-                            seq_sdefn_() = x.m_seq_sdefn;
+                            string_ldefn_() = x.m_string_ldefn;
                             break;
 
                         case 0x00000004:
-                            seq_ldefn_() = x.m_seq_ldefn;
+                            seq_sdefn_() = x.m_seq_sdefn;
                             break;
 
                         case 0x00000005:
-                            array_sdefn_() = x.m_array_sdefn;
+                            seq_ldefn_() = x.m_seq_ldefn;
                             break;
 
                         case 0x00000006:
-                            array_ldefn_() = x.m_array_ldefn;
+                            array_sdefn_() = x.m_array_sdefn;
                             break;
 
                         case 0x00000007:
-                            map_sdefn_() = x.m_map_sdefn;
+                            array_ldefn_() = x.m_array_ldefn;
                             break;
 
                         case 0x00000008:
-                            map_ldefn_() = x.m_map_ldefn;
+                            map_sdefn_() = x.m_map_sdefn;
                             break;
 
                         case 0x00000009:
-                            sc_component_id_() = x.m_sc_component_id;
+                            map_ldefn_() = x.m_map_ldefn;
                             break;
 
                         case 0x0000000a:
-                            equivalence_hash_() = x.m_equivalence_hash;
+                            sc_component_id_() = x.m_sc_component_id;
                             break;
 
                         case 0x0000000b:
+                            equivalence_hash_() = x.m_equivalence_hash;
+                            break;
+
+                        case 0x0000000c:
                             extended_defn_() = x.m_extended_defn;
                             break;
 
@@ -2801,46 +2900,50 @@ public:
         switch (x.selected_member_)
         {
                         case 0x00000001:
-                            string_sdefn_() = std::move(x.m_string_sdefn);
+                            no_value_() = std::move(x.m_no_value);
                             break;
 
                         case 0x00000002:
-                            string_ldefn_() = std::move(x.m_string_ldefn);
+                            string_sdefn_() = std::move(x.m_string_sdefn);
                             break;
 
                         case 0x00000003:
-                            seq_sdefn_() = std::move(x.m_seq_sdefn);
+                            string_ldefn_() = std::move(x.m_string_ldefn);
                             break;
 
                         case 0x00000004:
-                            seq_ldefn_() = std::move(x.m_seq_ldefn);
+                            seq_sdefn_() = std::move(x.m_seq_sdefn);
                             break;
 
                         case 0x00000005:
-                            array_sdefn_() = std::move(x.m_array_sdefn);
+                            seq_ldefn_() = std::move(x.m_seq_ldefn);
                             break;
 
                         case 0x00000006:
-                            array_ldefn_() = std::move(x.m_array_ldefn);
+                            array_sdefn_() = std::move(x.m_array_sdefn);
                             break;
 
                         case 0x00000007:
-                            map_sdefn_() = std::move(x.m_map_sdefn);
+                            array_ldefn_() = std::move(x.m_array_ldefn);
                             break;
 
                         case 0x00000008:
-                            map_ldefn_() = std::move(x.m_map_ldefn);
+                            map_sdefn_() = std::move(x.m_map_sdefn);
                             break;
 
                         case 0x00000009:
-                            sc_component_id_() = std::move(x.m_sc_component_id);
+                            map_ldefn_() = std::move(x.m_map_ldefn);
                             break;
 
                         case 0x0000000a:
-                            equivalence_hash_() = std::move(x.m_equivalence_hash);
+                            sc_component_id_() = std::move(x.m_sc_component_id);
                             break;
 
                         case 0x0000000b:
+                            equivalence_hash_() = std::move(x.m_equivalence_hash);
+                            break;
+
+                        case 0x0000000c:
                             extended_defn_() = std::move(x.m_extended_defn);
                             break;
 
@@ -2859,46 +2962,50 @@ public:
         switch (x.selected_member_)
         {
                         case 0x00000001:
-                            string_sdefn_() = x.m_string_sdefn;
+                            no_value_() = x.m_no_value;
                             break;
 
                         case 0x00000002:
-                            string_ldefn_() = x.m_string_ldefn;
+                            string_sdefn_() = x.m_string_sdefn;
                             break;
 
                         case 0x00000003:
-                            seq_sdefn_() = x.m_seq_sdefn;
+                            string_ldefn_() = x.m_string_ldefn;
                             break;
 
                         case 0x00000004:
-                            seq_ldefn_() = x.m_seq_ldefn;
+                            seq_sdefn_() = x.m_seq_sdefn;
                             break;
 
                         case 0x00000005:
-                            array_sdefn_() = x.m_array_sdefn;
+                            seq_ldefn_() = x.m_seq_ldefn;
                             break;
 
                         case 0x00000006:
-                            array_ldefn_() = x.m_array_ldefn;
+                            array_sdefn_() = x.m_array_sdefn;
                             break;
 
                         case 0x00000007:
-                            map_sdefn_() = x.m_map_sdefn;
+                            array_ldefn_() = x.m_array_ldefn;
                             break;
 
                         case 0x00000008:
-                            map_ldefn_() = x.m_map_ldefn;
+                            map_sdefn_() = x.m_map_sdefn;
                             break;
 
                         case 0x00000009:
-                            sc_component_id_() = x.m_sc_component_id;
+                            map_ldefn_() = x.m_map_ldefn;
                             break;
 
                         case 0x0000000a:
-                            equivalence_hash_() = x.m_equivalence_hash;
+                            sc_component_id_() = x.m_sc_component_id;
                             break;
 
                         case 0x0000000b:
+                            equivalence_hash_() = x.m_equivalence_hash;
+                            break;
+
+                        case 0x0000000c:
                             extended_defn_() = x.m_extended_defn;
                             break;
 
@@ -2919,46 +3026,50 @@ public:
         switch (x.selected_member_)
         {
                         case 0x00000001:
-                            string_sdefn_() = std::move(x.m_string_sdefn);
+                            no_value_() = std::move(x.m_no_value);
                             break;
 
                         case 0x00000002:
-                            string_ldefn_() = std::move(x.m_string_ldefn);
+                            string_sdefn_() = std::move(x.m_string_sdefn);
                             break;
 
                         case 0x00000003:
-                            seq_sdefn_() = std::move(x.m_seq_sdefn);
+                            string_ldefn_() = std::move(x.m_string_ldefn);
                             break;
 
                         case 0x00000004:
-                            seq_ldefn_() = std::move(x.m_seq_ldefn);
+                            seq_sdefn_() = std::move(x.m_seq_sdefn);
                             break;
 
                         case 0x00000005:
-                            array_sdefn_() = std::move(x.m_array_sdefn);
+                            seq_ldefn_() = std::move(x.m_seq_ldefn);
                             break;
 
                         case 0x00000006:
-                            array_ldefn_() = std::move(x.m_array_ldefn);
+                            array_sdefn_() = std::move(x.m_array_sdefn);
                             break;
 
                         case 0x00000007:
-                            map_sdefn_() = std::move(x.m_map_sdefn);
+                            array_ldefn_() = std::move(x.m_array_ldefn);
                             break;
 
                         case 0x00000008:
-                            map_ldefn_() = std::move(x.m_map_ldefn);
+                            map_sdefn_() = std::move(x.m_map_sdefn);
                             break;
 
                         case 0x00000009:
-                            sc_component_id_() = std::move(x.m_sc_component_id);
+                            map_ldefn_() = std::move(x.m_map_ldefn);
                             break;
 
                         case 0x0000000a:
-                            equivalence_hash_() = std::move(x.m_equivalence_hash);
+                            sc_component_id_() = std::move(x.m_sc_component_id);
                             break;
 
                         case 0x0000000b:
+                            equivalence_hash_() = std::move(x.m_equivalence_hash);
+                            break;
+
+                        case 0x0000000c:
                             extended_defn_() = std::move(x.m_extended_defn);
                             break;
 
@@ -2982,46 +3093,50 @@ public:
             switch (selected_member_)
             {
                                 case 0x00000001:
-                                    ret_value = (m_string_sdefn == x.m_string_sdefn);
+                                    ret_value = (m_no_value == x.m_no_value);
                                     break;
 
                                 case 0x00000002:
-                                    ret_value = (m_string_ldefn == x.m_string_ldefn);
+                                    ret_value = (m_string_sdefn == x.m_string_sdefn);
                                     break;
 
                                 case 0x00000003:
-                                    ret_value = (m_seq_sdefn == x.m_seq_sdefn);
+                                    ret_value = (m_string_ldefn == x.m_string_ldefn);
                                     break;
 
                                 case 0x00000004:
-                                    ret_value = (m_seq_ldefn == x.m_seq_ldefn);
+                                    ret_value = (m_seq_sdefn == x.m_seq_sdefn);
                                     break;
 
                                 case 0x00000005:
-                                    ret_value = (m_array_sdefn == x.m_array_sdefn);
+                                    ret_value = (m_seq_ldefn == x.m_seq_ldefn);
                                     break;
 
                                 case 0x00000006:
-                                    ret_value = (m_array_ldefn == x.m_array_ldefn);
+                                    ret_value = (m_array_sdefn == x.m_array_sdefn);
                                     break;
 
                                 case 0x00000007:
-                                    ret_value = (m_map_sdefn == x.m_map_sdefn);
+                                    ret_value = (m_array_ldefn == x.m_array_ldefn);
                                     break;
 
                                 case 0x00000008:
-                                    ret_value = (m_map_ldefn == x.m_map_ldefn);
+                                    ret_value = (m_map_sdefn == x.m_map_sdefn);
                                     break;
 
                                 case 0x00000009:
-                                    ret_value = (m_sc_component_id == x.m_sc_component_id);
+                                    ret_value = (m_map_ldefn == x.m_map_ldefn);
                                     break;
 
                                 case 0x0000000a:
-                                    ret_value = (m_equivalence_hash == x.m_equivalence_hash);
+                                    ret_value = (m_sc_component_id == x.m_sc_component_id);
                                     break;
 
                                 case 0x0000000b:
+                                    ret_value = (m_equivalence_hash == x.m_equivalence_hash);
+                                    break;
+
+                                case 0x0000000c:
                                     ret_value = (m_extended_defn == x.m_extended_defn);
                                     break;
 
@@ -3053,9 +3168,31 @@ public:
 
         switch (__d)
         {
+                        case TK_NONE:
+                        case TK_BOOLEAN:
+                        case TK_BYTE:
+                        case TK_INT8:
+                        case TK_INT16:
+                        case TK_INT32:
+                        case TK_INT64:
+                        case TK_UINT8:
+                        case TK_UINT16:
+                        case TK_UINT32:
+                        case TK_UINT64:
+                        case TK_FLOAT32:
+                        case TK_FLOAT64:
+                        case TK_FLOAT128:
+                        case TK_CHAR8:
+                        case TK_CHAR16:
+                            if (0x00000001 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
                         case TI_STRING8_SMALL:
                         case TI_STRING16_SMALL:
-                            if (0x00000001 == selected_member_)
+                            if (0x00000002 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -3063,56 +3200,56 @@ public:
 
                         case TI_STRING8_LARGE:
                         case TI_STRING16_LARGE:
-                            if (0x00000002 == selected_member_)
-                            {
-                                valid_discriminator = true;
-                            }
-                            break;
-
-                        case TI_PLAIN_SEQUENCE_SMALL:
                             if (0x00000003 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_PLAIN_SEQUENCE_LARGE:
+                        case TI_PLAIN_SEQUENCE_SMALL:
                             if (0x00000004 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_PLAIN_ARRAY_SMALL:
+                        case TI_PLAIN_SEQUENCE_LARGE:
                             if (0x00000005 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_PLAIN_ARRAY_LARGE:
+                        case TI_PLAIN_ARRAY_SMALL:
                             if (0x00000006 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_PLAIN_MAP_SMALL:
+                        case TI_PLAIN_ARRAY_LARGE:
                             if (0x00000007 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_PLAIN_MAP_LARGE:
+                        case TI_PLAIN_MAP_SMALL:
                             if (0x00000008 == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
-                        case TI_STRONGLY_CONNECTED_COMPONENT:
+                        case TI_PLAIN_MAP_LARGE:
                             if (0x00000009 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case TI_STRONGLY_CONNECTED_COMPONENT:
+                            if (0x0000000a == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -3120,14 +3257,14 @@ public:
 
                         case EK_COMPLETE:
                         case EK_MINIMAL:
-                            if (0x0000000a == selected_member_)
+                            if (0x0000000b == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
                             break;
 
                         default:
-                            if (0x0000000b == selected_member_)
+                            if (0x0000000c == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -3151,6 +3288,59 @@ public:
     {
         return m__d;
     }
+
+    /*!
+     * @brief This function copies the value in member no_value
+     * @param _no_value New value to be copied in member no_value
+     */
+    eProsima_user_DllExport void no_value(
+            const Dummy& _no_value)
+    {
+        no_value_() = _no_value;
+        m__d = TK_NONE;
+    }
+
+    /*!
+     * @brief This function moves the value in member no_value
+     * @param _no_value New value to be moved in member no_value
+     */
+    eProsima_user_DllExport void no_value(
+            Dummy&& _no_value)
+    {
+        no_value_() = _no_value;
+        m__d = TK_NONE;
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member no_value
+     * @return Constant reference to member no_value
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport const Dummy& no_value() const
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_no_value;
+    }
+
+    /*!
+     * @brief This function returns a reference to member no_value
+     * @return Reference to member no_value
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport Dummy& no_value()
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_no_value;
+    }
+
 
     /*!
      * @brief This function copies the value in member string_sdefn
@@ -3181,7 +3371,7 @@ public:
      */
     eProsima_user_DllExport const StringSTypeDefn& string_sdefn() const
     {
-        if (0x00000001 != selected_member_)
+        if (0x00000002 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3196,7 +3386,7 @@ public:
      */
     eProsima_user_DllExport StringSTypeDefn& string_sdefn()
     {
-        if (0x00000001 != selected_member_)
+        if (0x00000002 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3234,7 +3424,7 @@ public:
      */
     eProsima_user_DllExport const StringLTypeDefn& string_ldefn() const
     {
-        if (0x00000002 != selected_member_)
+        if (0x00000003 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3249,7 +3439,7 @@ public:
      */
     eProsima_user_DllExport StringLTypeDefn& string_ldefn()
     {
-        if (0x00000002 != selected_member_)
+        if (0x00000003 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3287,7 +3477,7 @@ public:
      */
     eProsima_user_DllExport const PlainSequenceSElemDefn& seq_sdefn() const
     {
-        if (0x00000003 != selected_member_)
+        if (0x00000004 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3302,7 +3492,7 @@ public:
      */
     eProsima_user_DllExport PlainSequenceSElemDefn& seq_sdefn()
     {
-        if (0x00000003 != selected_member_)
+        if (0x00000004 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3340,7 +3530,7 @@ public:
      */
     eProsima_user_DllExport const PlainSequenceLElemDefn& seq_ldefn() const
     {
-        if (0x00000004 != selected_member_)
+        if (0x00000005 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3355,7 +3545,7 @@ public:
      */
     eProsima_user_DllExport PlainSequenceLElemDefn& seq_ldefn()
     {
-        if (0x00000004 != selected_member_)
+        if (0x00000005 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3393,7 +3583,7 @@ public:
      */
     eProsima_user_DllExport const PlainArraySElemDefn& array_sdefn() const
     {
-        if (0x00000005 != selected_member_)
+        if (0x00000006 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3408,7 +3598,7 @@ public:
      */
     eProsima_user_DllExport PlainArraySElemDefn& array_sdefn()
     {
-        if (0x00000005 != selected_member_)
+        if (0x00000006 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3446,7 +3636,7 @@ public:
      */
     eProsima_user_DllExport const PlainArrayLElemDefn& array_ldefn() const
     {
-        if (0x00000006 != selected_member_)
+        if (0x00000007 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3461,7 +3651,7 @@ public:
      */
     eProsima_user_DllExport PlainArrayLElemDefn& array_ldefn()
     {
-        if (0x00000006 != selected_member_)
+        if (0x00000007 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3499,7 +3689,7 @@ public:
      */
     eProsima_user_DllExport const PlainMapSTypeDefn& map_sdefn() const
     {
-        if (0x00000007 != selected_member_)
+        if (0x00000008 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3514,7 +3704,7 @@ public:
      */
     eProsima_user_DllExport PlainMapSTypeDefn& map_sdefn()
     {
-        if (0x00000007 != selected_member_)
+        if (0x00000008 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3552,7 +3742,7 @@ public:
      */
     eProsima_user_DllExport const PlainMapLTypeDefn& map_ldefn() const
     {
-        if (0x00000008 != selected_member_)
+        if (0x00000009 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3567,7 +3757,7 @@ public:
      */
     eProsima_user_DllExport PlainMapLTypeDefn& map_ldefn()
     {
-        if (0x00000008 != selected_member_)
+        if (0x00000009 != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3605,7 +3795,7 @@ public:
      */
     eProsima_user_DllExport const StronglyConnectedComponentId& sc_component_id() const
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3620,7 +3810,7 @@ public:
      */
     eProsima_user_DllExport StronglyConnectedComponentId& sc_component_id()
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3658,7 +3848,7 @@ public:
      */
     eProsima_user_DllExport const EquivalenceHash& equivalence_hash() const
     {
-        if (0x0000000a != selected_member_)
+        if (0x0000000b != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3673,7 +3863,7 @@ public:
      */
     eProsima_user_DllExport EquivalenceHash& equivalence_hash()
     {
-        if (0x0000000a != selected_member_)
+        if (0x0000000b != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3690,7 +3880,7 @@ public:
             const ExtendedTypeDefn& _extended_defn)
     {
         extended_defn_() = _extended_defn;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -3701,7 +3891,7 @@ public:
             ExtendedTypeDefn&& _extended_defn)
     {
         extended_defn_() = _extended_defn;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -3711,7 +3901,7 @@ public:
      */
     eProsima_user_DllExport const ExtendedTypeDefn& extended_defn() const
     {
-        if (0x0000000b != selected_member_)
+        if (0x0000000c != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3726,7 +3916,7 @@ public:
      */
     eProsima_user_DllExport ExtendedTypeDefn& extended_defn()
     {
-        if (0x0000000b != selected_member_)
+        if (0x0000000c != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -3738,7 +3928,7 @@ public:
 
 private:
 
-            StringSTypeDefn& string_sdefn_()
+            Dummy& no_value_()
             {
                 if (0x00000001 != selected_member_)
                 {
@@ -3748,6 +3938,24 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
+                    member_destructor_ = [&]() {m_no_value.~Dummy();};
+                    new(&m_no_value) Dummy();
+    ;
+                }
+
+                return m_no_value;
+            }
+
+            StringSTypeDefn& string_sdefn_()
+            {
+                if (0x00000002 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000002;
                     member_destructor_ = [&]() {m_string_sdefn.~StringSTypeDefn();};
                     new(&m_string_sdefn) StringSTypeDefn();
     ;
@@ -3758,14 +3966,14 @@ private:
 
             StringLTypeDefn& string_ldefn_()
             {
-                if (0x00000002 != selected_member_)
+                if (0x00000003 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000002;
+                    selected_member_ = 0x00000003;
                     member_destructor_ = [&]() {m_string_ldefn.~StringLTypeDefn();};
                     new(&m_string_ldefn) StringLTypeDefn();
     ;
@@ -3776,14 +3984,14 @@ private:
 
             PlainSequenceSElemDefn& seq_sdefn_()
             {
-                if (0x00000003 != selected_member_)
+                if (0x00000004 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000003;
+                    selected_member_ = 0x00000004;
                     member_destructor_ = [&]() {m_seq_sdefn.~PlainSequenceSElemDefn();};
                     new(&m_seq_sdefn) PlainSequenceSElemDefn();
     ;
@@ -3794,14 +4002,14 @@ private:
 
             PlainSequenceLElemDefn& seq_ldefn_()
             {
-                if (0x00000004 != selected_member_)
+                if (0x00000005 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000004;
+                    selected_member_ = 0x00000005;
                     member_destructor_ = [&]() {m_seq_ldefn.~PlainSequenceLElemDefn();};
                     new(&m_seq_ldefn) PlainSequenceLElemDefn();
     ;
@@ -3812,14 +4020,14 @@ private:
 
             PlainArraySElemDefn& array_sdefn_()
             {
-                if (0x00000005 != selected_member_)
+                if (0x00000006 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000005;
+                    selected_member_ = 0x00000006;
                     member_destructor_ = [&]() {m_array_sdefn.~PlainArraySElemDefn();};
                     new(&m_array_sdefn) PlainArraySElemDefn();
     ;
@@ -3830,14 +4038,14 @@ private:
 
             PlainArrayLElemDefn& array_ldefn_()
             {
-                if (0x00000006 != selected_member_)
+                if (0x00000007 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000006;
+                    selected_member_ = 0x00000007;
                     member_destructor_ = [&]() {m_array_ldefn.~PlainArrayLElemDefn();};
                     new(&m_array_ldefn) PlainArrayLElemDefn();
     ;
@@ -3848,14 +4056,14 @@ private:
 
             PlainMapSTypeDefn& map_sdefn_()
             {
-                if (0x00000007 != selected_member_)
+                if (0x00000008 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000007;
+                    selected_member_ = 0x00000008;
                     member_destructor_ = [&]() {m_map_sdefn.~PlainMapSTypeDefn();};
                     new(&m_map_sdefn) PlainMapSTypeDefn();
     ;
@@ -3866,14 +4074,14 @@ private:
 
             PlainMapLTypeDefn& map_ldefn_()
             {
-                if (0x00000008 != selected_member_)
+                if (0x00000009 != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000008;
+                    selected_member_ = 0x00000009;
                     member_destructor_ = [&]() {m_map_ldefn.~PlainMapLTypeDefn();};
                     new(&m_map_ldefn) PlainMapLTypeDefn();
     ;
@@ -3884,14 +4092,14 @@ private:
 
             StronglyConnectedComponentId& sc_component_id_()
             {
-                if (0x00000009 != selected_member_)
+                if (0x0000000a != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x00000009;
+                    selected_member_ = 0x0000000a;
                     member_destructor_ = [&]() {m_sc_component_id.~StronglyConnectedComponentId();};
                     new(&m_sc_component_id) StronglyConnectedComponentId();
     ;
@@ -3902,14 +4110,14 @@ private:
 
             EquivalenceHash& equivalence_hash_()
             {
-                if (0x0000000a != selected_member_)
+                if (0x0000000b != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x0000000a;
+                    selected_member_ = 0x0000000b;
                     member_destructor_ = [&]() {m_equivalence_hash.~EquivalenceHash();};
                     new(&m_equivalence_hash) EquivalenceHash();
     ;
@@ -3920,14 +4128,14 @@ private:
 
             ExtendedTypeDefn& extended_defn_()
             {
-                if (0x0000000b != selected_member_)
+                if (0x0000000c != selected_member_)
                 {
                     if (member_destructor_)
                     {
                         member_destructor_();
                     }
 
-                    selected_member_ = 0x0000000b;
+                    selected_member_ = 0x0000000c;
                     member_destructor_ = [&]() {m_extended_defn.~ExtendedTypeDefn();};
                     new(&m_extended_defn) ExtendedTypeDefn();
     ;
@@ -3937,10 +4145,11 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {TK_NONE};
 
     union
     {
+        Dummy m_no_value;
         StringSTypeDefn m_string_sdefn;
         StringLTypeDefn m_string_ldefn;
         PlainSequenceSElemDefn m_seq_sdefn;
@@ -5506,7 +5715,7 @@ public:
             const ExtendedAnnotationParameterValue& _extended_value)
     {
         extended_value_() = _extended_value;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -5517,7 +5726,7 @@ public:
             ExtendedAnnotationParameterValue&& _extended_value)
     {
         extended_value_() = _extended_value;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -5897,7 +6106,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {
@@ -21447,7 +21656,7 @@ public:
             const CompleteExtendedType& _extended_type)
     {
         extended_type_() = _extended_type;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -21458,7 +21667,7 @@ public:
             CompleteExtendedType&& _extended_type)
     {
         extended_type_() = _extended_type;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -21694,7 +21903,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {
@@ -22793,7 +23002,7 @@ public:
             const MinimalExtendedType& _extended_type)
     {
         extended_type_() = _extended_type;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -22804,7 +23013,7 @@ public:
             MinimalExtendedType&& _extended_type)
     {
         extended_type_() = _extended_type;
-        m__d = 0;
+        m__d = 127;
     }
 
     /*!
@@ -23040,7 +23249,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {
@@ -23418,7 +23627,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectCdrAux.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectCdrAux.hpp
@@ -175,6 +175,9 @@ constexpr uint32_t eprosima_fastdds_dds_xtypes_CompleteEnumeratedHeader_max_key_
 constexpr uint32_t eprosima_fastdds_dds_xtypes_CompleteBitsetHeader_max_cdr_typesize {653UL};
 constexpr uint32_t eprosima_fastdds_dds_xtypes_CompleteBitsetHeader_max_key_cdr_typesize {0UL};
 
+constexpr uint32_t eprosima_fastdds_dds_xtypes_Dummy_max_cdr_typesize {0UL};
+constexpr uint32_t eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize {0UL};
+
 constexpr uint32_t eprosima_fastdds_dds_xtypes_CompleteBitfield_max_cdr_typesize {1408UL};
 constexpr uint32_t eprosima_fastdds_dds_xtypes_CompleteBitfield_max_key_cdr_typesize {0UL};
 
@@ -425,6 +428,10 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::ExtendedTypeDefn& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::dds::xtypes::Dummy& data);
 
 
 

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
@@ -1308,9 +1308,9 @@ public:
     }
 
     eProsima_user_DllExport inline bool is_plain(
-        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }
@@ -1332,7 +1332,7 @@ public:
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
-    MD5 m_md5;
+    eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
 
 private:

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
@@ -1240,6 +1240,115 @@ public:
 
 };
 
+/*!
+ * @brief This class represents the TopicDataType of the type Dummy defined by the user in the IDL file.
+ * @ingroup dds_xtypes_typeobject
+ */
+class DummyPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef Dummy type;
+
+    eProsima_user_DllExport DummyPubSubType();
+
+    eProsima_user_DllExport ~DummyPubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload) override
+    {
+        return serialize(data, payload, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
+    }
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t* payload,
+            void* data) override;
+
+    eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
+            const void* const data) override
+    {
+        return getSerializedSizeProvider(data, eprosima::fastdds::dds::DEFAULT_DATA_REPRESENTATION);
+    }
+
+    eProsima_user_DllExport std::function<uint32_t()> getSerializedSizeProvider(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool getKey(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t* ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* createData() override;
+
+    eProsima_user_DllExport void deleteData(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return true;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+    eProsima_user_DllExport inline bool is_plain() const override
+    {
+        return is_plain_xcdrv1_impl();
+    }
+
+    eProsima_user_DllExport inline bool is_plain(
+        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        new (memory) Dummy();
+        return true;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+    MD5 m_md5;
+    unsigned char* m_keyBuffer;
+
+private:
+
+    static constexpr bool is_plain_xcdrv1_impl()
+    {
+        return true;
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        return true;
+    }
+
+};
+
 typedef std::vector<eprosima::fastdds::dds::xtypes::TypeIdentifier> TypeIdentifierSeq;
 typedef uint32_t MemberId;
 

--- a/include/fastdds/rtps/common/VendorId_t.hpp
+++ b/include/fastdds/rtps/common/VendorId_t.hpp
@@ -34,6 +34,7 @@ using VendorId_t = std::array<uint8_t, 2>;
 const VendorId_t c_VendorId_Unknown = {0x00, 0x00};
 const VendorId_t c_VendorId_eProsima = {0x01, 0x0F};
 const VendorId_t c_VendorId_rti_connext = {0x01, 0x01};
+const VendorId_t c_VendorId_opendds = {0x01, 0x03};
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.hpp
@@ -25,8 +25,10 @@
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include <fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp>
+#include <fastdds/rtps/common/VendorId_t.hpp>
 #include <fastdds/rtps/reader/ReaderListener.hpp>
 #include <fastdds/rtps/writer/WriterListener.hpp>
 #include <fastdds/xtypes/type_representation/TypeIdentifierWithSizeHashSpecialization.h>
@@ -36,25 +38,22 @@
 
 namespace std {
 
-template <>
-struct hash<eprosima::fastdds::dds::xtypes::TypeIdentifierSeq>
+template <> struct hash<eprosima::fastdds::dds::xtypes::TypeIdentifierSeq>
 {
-    std::size_t operator ()(
-            const eprosima::fastdds::dds::xtypes::TypeIdentifierSeq& k) const
+    std::size_t operator()(const eprosima::fastdds::dds::xtypes::TypeIdentifierSeq &k) const
     {
         std::size_t hash_value = 0;
-        for (const auto& id : k)
+        for (const auto &id : k)
         {
             hash_value ^= (static_cast<size_t>(id.equivalence_hash()[0]) << 16) |
-                    (static_cast<size_t>(id.equivalence_hash()[1]) << 8) |
-                    (static_cast<size_t>(id.equivalence_hash()[2]));
+                          (static_cast<size_t>(id.equivalence_hash()[1]) << 8) |
+                          (static_cast<size_t>(id.equivalence_hash()[2]));
         }
         return hash_value;
     }
-
 };
 
-} // std
+} // namespace std
 
 namespace eprosima {
 namespace fastdds {
@@ -76,22 +75,19 @@ class TypeLookupManager;
  */
 class TypeLookupRequestListener : public fastdds::rtps::ReaderListener, public fastdds::rtps::WriterListener
 {
-public:
-
+  public:
     /**
      * @brief Constructor.
      * @param manager Pointer to the TypeLookupManager.
      */
-    TypeLookupRequestListener(
-            TypeLookupManager* manager);
+    TypeLookupRequestListener(TypeLookupManager *manager);
 
     /**
      * @brief Destructor.
      */
     virtual ~TypeLookupRequestListener() override;
 
-protected:
-
+  protected:
     /**
      * @brief Starts the thread that process the received requests.
      */
@@ -111,19 +107,19 @@ protected:
      * @brief Gets TypeObject from TypeObjectRegistry, creates and sends reply.
      * @param request_id[in] The SampleIdentity of the request.
      * @param request[in] The request data.
+     * @param vendor_id[in] Vendor identifier which sent the request.
      */
-    void check_get_types_request(
-            SampleIdentity request_id,
-            const TypeLookup_getTypes_In& request);
+    void check_get_types_request(SampleIdentity request_id,
+                                 const TypeLookup_getTypes_In &request,
+                                 const rtps::VendorId_t &vendor_id);
 
     /**
      * @brief Gets type dependencies from TypeObjectRegistry, creates and sends reply.
      * @param request_id[in] The SampleIdentity of the request.
      * @param request[in] The request data.
      */
-    void check_get_type_dependencies_request(
-            SampleIdentity request_id,
-            const TypeLookup_getTypeDependencies_In& request);
+    void check_get_type_dependencies_request(SampleIdentity request_id,
+                                             const TypeLookup_getTypeDependencies_In &request);
 
     /**
      * @brief Creates a TypeLookup_getTypeDependencies_Out using continuation points to manage size.
@@ -132,10 +128,10 @@ protected:
      * @param continuation_point[in] The continuation point of the previous request.
      * @return The reply containing the dependent types.
      */
-    TypeLookup_getTypeDependencies_Out prepare_get_type_dependencies_response(
-            const xtypes::TypeIdentifierSeq& id_seq,
-            const std::unordered_set<xtypes::TypeIdentfierWithSize>& type_dependencies,
-            const std::vector<uint8_t>& continuation_point);
+    TypeLookup_getTypeDependencies_Out
+    prepare_get_type_dependencies_response(const xtypes::TypeIdentifierSeq &id_seq,
+                                           const std::unordered_set<xtypes::TypeIdentfierWithSize> &type_dependencies,
+                                           const std::vector<uint8_t> &continuation_point);
 
     /**
      * @brief Creates and sends the TypeLookup_Reply.
@@ -143,43 +139,35 @@ protected:
      * @param exception_code[in] The RemoteExceptionCode_t used in the header.
      * @param out[in] Reply to the query included in the received request.
      */
-    void answer_request(
-            SampleIdentity request_id,
-            rpc::RemoteExceptionCode_t exception_code,
-            TypeLookup_getTypeDependencies_Out& out);
-    void answer_request(
-            SampleIdentity request_id,
-            rpc::RemoteExceptionCode_t exception_code,
-            TypeLookup_getTypes_Out& out);
-    void answer_request(
-            SampleIdentity request_id,
-            rpc::RemoteExceptionCode_t exception_code);
+    void answer_request(SampleIdentity request_id,
+                        rpc::RemoteExceptionCode_t exception_code,
+                        TypeLookup_getTypeDependencies_Out &out);
+    void
+    answer_request(SampleIdentity request_id, rpc::RemoteExceptionCode_t exception_code, TypeLookup_getTypes_Out &out);
+    void answer_request(SampleIdentity request_id, rpc::RemoteExceptionCode_t exception_code);
 
     /**
      * @brief Method call when this class is notified of a new cache change.
      * @param reader The reader receiving the cache change.
      * @param change The cache change.
      */
-    void on_new_cache_change_added(
-            fastdds::rtps::RTPSReader* reader,
-            const fastdds::rtps::CacheChange_t* const change) override;
+    void on_new_cache_change_added(fastdds::rtps::RTPSReader *reader,
+                                   const fastdds::rtps::CacheChange_t *const change) override;
 
-    void onWriterChangeReceivedByAll(
-            fastdds::rtps::RTPSWriter*,
-            fastdds::rtps::CacheChange_t* change) override;
+    void onWriterChangeReceivedByAll(fastdds::rtps::RTPSWriter *, fastdds::rtps::CacheChange_t *change) override;
 
     //! A pointer to the typelookup manager.
-    TypeLookupManager* typelookup_manager_;
+    TypeLookupManager *typelookup_manager_;
 
     //! Mutex to protect access to requests_with_continuation_.
     std::mutex requests_with_continuation_mutex_;
 
     //! Collection of the requests that needed continuation points.
-    std::unordered_map <xtypes::TypeIdentifierSeq,
-            std::unordered_set<xtypes::TypeIdentfierWithSize>> requests_with_continuation_;
+    std::unordered_map<xtypes::TypeIdentifierSeq, std::unordered_set<xtypes::TypeIdentfierWithSize>>
+        requests_with_continuation_;
 
     eprosima::thread request_processor_thread;
-    std::queue<TypeLookup_Request> requests_queue_;
+    std::queue<std::pair<TypeLookup_Request, rtps::VendorId_t>> requests_queue_;
     std::mutex request_processor_cv_mutex_;
     std::condition_variable request_processor_cv_;
     bool processing_ = false;

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.hpp
@@ -40,17 +40,19 @@ namespace std {
 
 template <> struct hash<eprosima::fastdds::dds::xtypes::TypeIdentifierSeq>
 {
-    std::size_t operator()(const eprosima::fastdds::dds::xtypes::TypeIdentifierSeq &k) const
+    std::size_t operator ()(
+            const eprosima::fastdds::dds::xtypes::TypeIdentifierSeq& k) const
     {
         std::size_t hash_value = 0;
-        for (const auto &id : k)
+        for (const auto& id : k)
         {
             hash_value ^= (static_cast<size_t>(id.equivalence_hash()[0]) << 16) |
-                          (static_cast<size_t>(id.equivalence_hash()[1]) << 8) |
-                          (static_cast<size_t>(id.equivalence_hash()[2]));
+                    (static_cast<size_t>(id.equivalence_hash()[1]) << 8) |
+                    (static_cast<size_t>(id.equivalence_hash()[2]));
         }
         return hash_value;
     }
+
 };
 
 } // namespace std
@@ -75,19 +77,22 @@ class TypeLookupManager;
  */
 class TypeLookupRequestListener : public fastdds::rtps::ReaderListener, public fastdds::rtps::WriterListener
 {
-  public:
+public:
+
     /**
      * @brief Constructor.
      * @param manager Pointer to the TypeLookupManager.
      */
-    TypeLookupRequestListener(TypeLookupManager *manager);
+    TypeLookupRequestListener(
+            TypeLookupManager* manager);
 
     /**
      * @brief Destructor.
      */
     virtual ~TypeLookupRequestListener() override;
 
-  protected:
+protected:
+
     /**
      * @brief Starts the thread that process the received requests.
      */
@@ -107,19 +112,21 @@ class TypeLookupRequestListener : public fastdds::rtps::ReaderListener, public f
      * @brief Gets TypeObject from TypeObjectRegistry, creates and sends reply.
      * @param request_id[in] The SampleIdentity of the request.
      * @param request[in] The request data.
-     * @param vendor_id[in] Vendor identifier which sent the request.
+     * @param vendor_id[in] Vendor identifier that sent the request.
      */
-    void check_get_types_request(SampleIdentity request_id,
-                                 const TypeLookup_getTypes_In &request,
-                                 const rtps::VendorId_t &vendor_id);
+    void check_get_types_request(
+            SampleIdentity request_id,
+            const TypeLookup_getTypes_In& request,
+            const rtps::VendorId_t& vendor_id);
 
     /**
      * @brief Gets type dependencies from TypeObjectRegistry, creates and sends reply.
      * @param request_id[in] The SampleIdentity of the request.
      * @param request[in] The request data.
      */
-    void check_get_type_dependencies_request(SampleIdentity request_id,
-                                             const TypeLookup_getTypeDependencies_In &request);
+    void check_get_type_dependencies_request(
+            SampleIdentity request_id,
+            const TypeLookup_getTypeDependencies_In& request);
 
     /**
      * @brief Creates a TypeLookup_getTypeDependencies_Out using continuation points to manage size.
@@ -129,9 +136,10 @@ class TypeLookupRequestListener : public fastdds::rtps::ReaderListener, public f
      * @return The reply containing the dependent types.
      */
     TypeLookup_getTypeDependencies_Out
-    prepare_get_type_dependencies_response(const xtypes::TypeIdentifierSeq &id_seq,
-                                           const std::unordered_set<xtypes::TypeIdentfierWithSize> &type_dependencies,
-                                           const std::vector<uint8_t> &continuation_point);
+    prepare_get_type_dependencies_response(
+            const xtypes::TypeIdentifierSeq& id_seq,
+            const std::unordered_set<xtypes::TypeIdentfierWithSize>& type_dependencies,
+            const std::vector<uint8_t>& continuation_point);
 
     /**
      * @brief Creates and sends the TypeLookup_Reply.
@@ -139,32 +147,41 @@ class TypeLookupRequestListener : public fastdds::rtps::ReaderListener, public f
      * @param exception_code[in] The RemoteExceptionCode_t used in the header.
      * @param out[in] Reply to the query included in the received request.
      */
-    void answer_request(SampleIdentity request_id,
-                        rpc::RemoteExceptionCode_t exception_code,
-                        TypeLookup_getTypeDependencies_Out &out);
+    void answer_request(
+            SampleIdentity request_id,
+            rpc::RemoteExceptionCode_t exception_code,
+            TypeLookup_getTypeDependencies_Out& out);
     void
-    answer_request(SampleIdentity request_id, rpc::RemoteExceptionCode_t exception_code, TypeLookup_getTypes_Out &out);
-    void answer_request(SampleIdentity request_id, rpc::RemoteExceptionCode_t exception_code);
+    answer_request(
+            SampleIdentity request_id,
+            rpc::RemoteExceptionCode_t exception_code,
+            TypeLookup_getTypes_Out& out);
+    void answer_request(
+            SampleIdentity request_id,
+            rpc::RemoteExceptionCode_t exception_code);
 
     /**
      * @brief Method call when this class is notified of a new cache change.
      * @param reader The reader receiving the cache change.
      * @param change The cache change.
      */
-    void on_new_cache_change_added(fastdds::rtps::RTPSReader *reader,
-                                   const fastdds::rtps::CacheChange_t *const change) override;
+    void on_new_cache_change_added(
+            fastdds::rtps::RTPSReader* reader,
+            const fastdds::rtps::CacheChange_t* const change) override;
 
-    void onWriterChangeReceivedByAll(fastdds::rtps::RTPSWriter *, fastdds::rtps::CacheChange_t *change) override;
+    void onWriterChangeReceivedByAll(
+            fastdds::rtps::RTPSWriter*,
+            fastdds::rtps::CacheChange_t* change) override;
 
     //! A pointer to the typelookup manager.
-    TypeLookupManager *typelookup_manager_;
+    TypeLookupManager* typelookup_manager_;
 
     //! Mutex to protect access to requests_with_continuation_.
     std::mutex requests_with_continuation_mutex_;
 
     //! Collection of the requests that needed continuation points.
     std::unordered_map<xtypes::TypeIdentifierSeq, std::unordered_set<xtypes::TypeIdentfierWithSize>>
-        requests_with_continuation_;
+    requests_with_continuation_;
 
     eprosima::thread request_processor_thread;
     std::queue<std::pair<TypeLookup_Request, rtps::VendorId_t>> requests_queue_;

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
@@ -640,7 +640,7 @@ private:
             }
 
 
-    int32_t m__d {1};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1270,7 +1270,7 @@ private:
             }
 
 
-    int32_t m__d {1};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1638,7 +1638,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -2187,7 +2187,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.idl
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.idl
@@ -3,7 +3,7 @@
 #include "../../../../../../include/fastdds/dds/core/detail/DDSReturnCode.idl"
 #include "../../../../../../include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl"
 #include "rpc_types.idl"
-    
+
 module dds {
 module builtin {
 
@@ -59,6 +59,7 @@ module builtin {
     };
 
     // @RPCRequestType // Annotation not defined
+    @final
     struct TypeLookup_Request {
         rpc::RequestHeader header;
         TypeLookup_Call data;
@@ -73,6 +74,7 @@ module builtin {
     };
 
     // @RPCReplyType // Annotation not defined
+    @final
     struct TypeLookup_Reply {
         rpc::ReplyHeader header;
         TypeLookup_Return return_value; //This name was changed from "return" to "return_value" to avoid problems in c++

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.hpp
@@ -24,7 +24,7 @@
 
 #include "TypeLookupTypes.hpp"
 
-constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_cdr_typesize {140UL};
+constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_cdr_typesize {116UL};
 constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_key_cdr_typesize {0UL};
 
 
@@ -45,6 +45,7 @@ constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_key_cdr_typ
 
 constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_getTypes_In_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_getTypes_In_max_key_cdr_typesize {0UL};
+
 
 
 
@@ -124,7 +125,7 @@ constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_getTypes_Out_max_key_
 
 
 
-constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Request_max_cdr_typesize {388UL};
+constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Request_max_cdr_typesize {364UL};
 constexpr uint32_t eprosima_fastdds_dds_builtin_TypeLookup_Request_max_key_cdr_typesize {0UL};
 
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.ipp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.ipp
@@ -773,7 +773,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -800,7 +800,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -818,7 +818,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds::builtin;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -1001,7 +1001,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -1028,7 +1028,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -1046,7 +1046,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds::builtin;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
@@ -859,7 +859,7 @@ namespace builtin {
         ser.set_encoding_flag(
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     #endif // FASTCDR_VERSION_MAJOR > 1
 
         try
@@ -1054,7 +1054,7 @@ namespace builtin {
         ser.set_encoding_flag(
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     #endif // FASTCDR_VERSION_MAJOR > 1
 
         try

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_types.idl
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_types.idl
@@ -1,30 +1,30 @@
 //This directive is not supported yet.
 //#ifdef BASIC
 
-module dds { 
+module dds {
 
 //This directive is not supported yet.
 //#ifdef REDEFINE_DDS_TYPES
 
-  // The following DDS related types are 
+  // The following DDS related types are
   // borrowed from the RTPS v1.2 specification
   typedef octet GuidPrefix_t[12];
 
-  @nested
+  @final @nested
   struct EntityId_t
   {
     octet entityKey[3];
     octet entityKind;
   };
 
-  @nested
+  @final @nested
   struct GUID_t
   {
     GuidPrefix_t guidPrefix;
     EntityId_t entityId;
   };
 
-  @nested
+  @final @nested
   struct SequenceNumber_t
   {
     long high;
@@ -33,7 +33,7 @@ module dds {
 
 //#endif // REDEFINE_DDS_TYPES
 
-@nested
+@final @nested
 struct SampleIdentity
 {
   GUID_t           writer_guid;
@@ -58,15 +58,15 @@ enum RemoteExceptionCode_t
 
 typedef string<255> InstanceName;
 
-@nested
-struct RequestHeader 
+@final @nested
+struct RequestHeader
 {
     dds::SampleIdentity  requestId;
     InstanceName         instanceName;
 };
 
-@nested
-struct ReplyHeader 
+@final @nested
+struct ReplyHeader
 {
     dds::SampleIdentity             relatedRequestId;
     dds::rpc::RemoteExceptionCode_t remoteEx;
@@ -76,5 +76,4 @@ struct ReplyHeader
 
 }; // module dds
 
-//#endif // BASIC 
-
+//#endif // BASIC

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.hpp
@@ -24,27 +24,27 @@
 
 #include "rpc_types.hpp"
 
-constexpr uint32_t eprosima_fastdds_dds_rpc_RequestHeader_max_cdr_typesize {304UL};
+constexpr uint32_t eprosima_fastdds_dds_rpc_RequestHeader_max_cdr_typesize {284UL};
 constexpr uint32_t eprosima_fastdds_dds_rpc_RequestHeader_max_key_cdr_typesize {0UL};
 
 
-constexpr uint32_t eprosima_fastdds_dds_EntityId_t_max_cdr_typesize {8UL};
+constexpr uint32_t eprosima_fastdds_dds_EntityId_t_max_cdr_typesize {4UL};
 constexpr uint32_t eprosima_fastdds_dds_EntityId_t_max_key_cdr_typesize {0UL};
 
-constexpr uint32_t eprosima_fastdds_dds_GUID_t_max_cdr_typesize {24UL};
+constexpr uint32_t eprosima_fastdds_dds_GUID_t_max_cdr_typesize {16UL};
 constexpr uint32_t eprosima_fastdds_dds_GUID_t_max_key_cdr_typesize {0UL};
 
 
-constexpr uint32_t eprosima_fastdds_dds_rpc_ReplyHeader_max_cdr_typesize {48UL};
+constexpr uint32_t eprosima_fastdds_dds_rpc_ReplyHeader_max_cdr_typesize {28UL};
 constexpr uint32_t eprosima_fastdds_dds_rpc_ReplyHeader_max_key_cdr_typesize {0UL};
 
 
 
 
-constexpr uint32_t eprosima_fastdds_dds_SequenceNumber_t_max_cdr_typesize {12UL};
+constexpr uint32_t eprosima_fastdds_dds_SequenceNumber_t_max_cdr_typesize {8UL};
 constexpr uint32_t eprosima_fastdds_dds_SequenceNumber_t_max_key_cdr_typesize {0UL};
 
-constexpr uint32_t eprosima_fastdds_dds_SampleIdentity_max_cdr_typesize {40UL};
+constexpr uint32_t eprosima_fastdds_dds_SampleIdentity_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_dds_SampleIdentity_max_key_cdr_typesize {0UL};
 
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.ipp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.ipp
@@ -47,7 +47,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -74,7 +74,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -92,7 +92,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -139,7 +139,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -166,7 +166,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -184,7 +184,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -231,7 +231,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -258,7 +258,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -276,7 +276,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -323,7 +323,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -350,7 +350,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -368,7 +368,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -415,7 +415,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -442,7 +442,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -460,7 +460,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds::rpc;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
@@ -507,7 +507,7 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
     size_t calculated_size {calculator.begin_calculate_type_serialized_size(
                                 eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
                                 eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
                                 current_alignment)};
 
@@ -534,7 +534,7 @@ eProsima_user_DllExport void serialize(
     eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
     scdr
@@ -552,7 +552,7 @@ eProsima_user_DllExport void deserialize(
     using namespace eprosima::fastdds::dds::rpc;
 
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
             [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
@@ -79,7 +79,7 @@ bool EntityId_tPubSubType::serialize(
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
 #endif // FASTCDR_VERSION_MAJOR > 1
 
     try
@@ -273,7 +273,7 @@ bool GUID_tPubSubType::serialize(
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
 #endif // FASTCDR_VERSION_MAJOR > 1
 
     try
@@ -467,7 +467,7 @@ bool SequenceNumber_tPubSubType::serialize(
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
 #endif // FASTCDR_VERSION_MAJOR > 1
 
     try
@@ -661,7 +661,7 @@ bool SampleIdentityPubSubType::serialize(
     ser.set_encoding_flag(
         data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
         eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
 #endif // FASTCDR_VERSION_MAJOR > 1
 
     try
@@ -856,7 +856,7 @@ namespace rpc {
         ser.set_encoding_flag(
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     #endif // FASTCDR_VERSION_MAJOR > 1
 
         try
@@ -1050,7 +1050,7 @@ namespace rpc {
         ser.set_encoding_flag(
             data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     #endif // FASTCDR_VERSION_MAJOR > 1
 
         try

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
@@ -149,7 +149,7 @@ public:
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }
@@ -295,7 +295,7 @@ public:
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }
@@ -441,7 +441,7 @@ public:
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }
@@ -587,7 +587,7 @@ public:
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
         {
             return is_plain_xcdrv2_impl();
         }
@@ -831,7 +831,7 @@ namespace rpc
         eProsima_user_DllExport inline bool is_plain(
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
         {
-            if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+            if (data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
             {
                 return is_plain_xcdrv2_impl();
             }

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
@@ -46,6 +46,39 @@ namespace dds {
 
 typedef std::array<uint8_t, 12> GuidPrefix_t;
 
+#ifndef SWIG
+namespace detail {
+
+template<typename Tag, typename Tag::type M>
+struct EntityId_t_rob
+{
+    friend constexpr typename Tag::type get(
+            Tag)
+    {
+        return M;
+    }
+
+};
+
+struct EntityId_t_f
+{
+    typedef uint8_t EntityId_t::* type;
+    friend constexpr type get(
+            EntityId_t_f);
+};
+
+template struct EntityId_t_rob<EntityId_t_f, &EntityId_t::m_entityKind>;
+
+template <typename T, typename Tag>
+inline size_t constexpr EntityId_t_offset_of()
+{
+    return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+}
+
+} // namespace detail
+#endif // ifndef SWIG
+
+
 /*!
  * @brief This class represents the TopicDataType of the type EntityId_t defined by the user in the IDL file.
  * @ingroup rpc_types
@@ -110,14 +143,20 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return false;
+        return is_plain_xcdrv1_impl();
     }
 
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        static_cast<void>(data_representation);
-        return false;
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -126,8 +165,8 @@ public:
     eProsima_user_DllExport inline bool construct_sample(
             void* memory) const override
     {
-        static_cast<void>(memory);
-        return false;
+        new (memory) EntityId_t();
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
@@ -135,7 +174,56 @@ public:
     eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
 
+private:
+
+    static constexpr bool is_plain_xcdrv1_impl()
+    {
+        return 4ULL ==
+               (detail::EntityId_t_offset_of<EntityId_t, detail::EntityId_t_f>() +
+               sizeof(uint8_t));
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        return 4ULL ==
+               (detail::EntityId_t_offset_of<EntityId_t, detail::EntityId_t_f>() +
+               sizeof(uint8_t));
+    }
+
 };
+
+#ifndef SWIG
+namespace detail {
+
+template<typename Tag, typename Tag::type M>
+struct GUID_t_rob
+{
+    friend constexpr typename Tag::type get(
+            Tag)
+    {
+        return M;
+    }
+
+};
+
+struct GUID_t_f
+{
+    typedef eprosima::fastdds::dds::EntityId_t GUID_t::* type;
+    friend constexpr type get(
+            GUID_t_f);
+};
+
+template struct GUID_t_rob<GUID_t_f, &GUID_t::m_entityId>;
+
+template <typename T, typename Tag>
+inline size_t constexpr GUID_t_offset_of()
+{
+    return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+}
+
+} // namespace detail
+#endif // ifndef SWIG
+
 
 /*!
  * @brief This class represents the TopicDataType of the type GUID_t defined by the user in the IDL file.
@@ -201,14 +289,20 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return false;
+        return is_plain_xcdrv1_impl();
     }
 
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        static_cast<void>(data_representation);
-        return false;
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -217,8 +311,8 @@ public:
     eProsima_user_DllExport inline bool construct_sample(
             void* memory) const override
     {
-        static_cast<void>(memory);
-        return false;
+        new (memory) GUID_t();
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
@@ -226,7 +320,56 @@ public:
     eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
 
+private:
+
+    static constexpr bool is_plain_xcdrv1_impl()
+    {
+        return 16ULL ==
+               (detail::GUID_t_offset_of<GUID_t, detail::GUID_t_f>() +
+               sizeof(eprosima::fastdds::dds::EntityId_t));
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        return 16ULL ==
+               (detail::GUID_t_offset_of<GUID_t, detail::GUID_t_f>() +
+               sizeof(eprosima::fastdds::dds::EntityId_t));
+    }
+
 };
+
+#ifndef SWIG
+namespace detail {
+
+template<typename Tag, typename Tag::type M>
+struct SequenceNumber_t_rob
+{
+    friend constexpr typename Tag::type get(
+            Tag)
+    {
+        return M;
+    }
+
+};
+
+struct SequenceNumber_t_f
+{
+    typedef uint32_t SequenceNumber_t::* type;
+    friend constexpr type get(
+            SequenceNumber_t_f);
+};
+
+template struct SequenceNumber_t_rob<SequenceNumber_t_f, &SequenceNumber_t::m_low>;
+
+template <typename T, typename Tag>
+inline size_t constexpr SequenceNumber_t_offset_of()
+{
+    return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+}
+
+} // namespace detail
+#endif // ifndef SWIG
+
 
 /*!
  * @brief This class represents the TopicDataType of the type SequenceNumber_t defined by the user in the IDL file.
@@ -292,14 +435,20 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return false;
+        return is_plain_xcdrv1_impl();
     }
 
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        static_cast<void>(data_representation);
-        return false;
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -308,8 +457,8 @@ public:
     eProsima_user_DllExport inline bool construct_sample(
             void* memory) const override
     {
-        static_cast<void>(memory);
-        return false;
+        new (memory) SequenceNumber_t();
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
@@ -317,7 +466,56 @@ public:
     eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
 
+private:
+
+    static constexpr bool is_plain_xcdrv1_impl()
+    {
+        return 8ULL ==
+               (detail::SequenceNumber_t_offset_of<SequenceNumber_t, detail::SequenceNumber_t_f>() +
+               sizeof(uint32_t));
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        return 8ULL ==
+               (detail::SequenceNumber_t_offset_of<SequenceNumber_t, detail::SequenceNumber_t_f>() +
+               sizeof(uint32_t));
+    }
+
 };
+
+#ifndef SWIG
+namespace detail {
+
+template<typename Tag, typename Tag::type M>
+struct SampleIdentity_rob
+{
+    friend constexpr typename Tag::type get(
+            Tag)
+    {
+        return M;
+    }
+
+};
+
+struct SampleIdentity_f
+{
+    typedef eprosima::fastdds::dds::SequenceNumber_t SampleIdentity::* type;
+    friend constexpr type get(
+            SampleIdentity_f);
+};
+
+template struct SampleIdentity_rob<SampleIdentity_f, &SampleIdentity::m_sequence_number>;
+
+template <typename T, typename Tag>
+inline size_t constexpr SampleIdentity_offset_of()
+{
+    return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+}
+
+} // namespace detail
+#endif // ifndef SWIG
+
 
 /*!
  * @brief This class represents the TopicDataType of the type SampleIdentity defined by the user in the IDL file.
@@ -383,14 +581,20 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
     eProsima_user_DllExport inline bool is_plain() const override
     {
-        return false;
+        return is_plain_xcdrv1_impl();
     }
 
     eProsima_user_DllExport inline bool is_plain(
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
     {
-        static_cast<void>(data_representation);
-        return false;
+        if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+        {
+            return is_plain_xcdrv2_impl();
+        }
+        else
+        {
+            return is_plain_xcdrv1_impl();
+        }
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -399,14 +603,30 @@ public:
     eProsima_user_DllExport inline bool construct_sample(
             void* memory) const override
     {
-        static_cast<void>(memory);
-        return false;
+        new (memory) SampleIdentity();
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
     eprosima::fastdds::MD5 m_md5;
     unsigned char* m_keyBuffer;
+
+private:
+
+    static constexpr bool is_plain_xcdrv1_impl()
+    {
+        return 24ULL ==
+               (detail::SampleIdentity_offset_of<SampleIdentity, detail::SampleIdentity_f>() +
+               sizeof(eprosima::fastdds::dds::SequenceNumber_t));
+    }
+
+    static constexpr bool is_plain_xcdrv2_impl()
+    {
+        return 24ULL ==
+               (detail::SampleIdentity_offset_of<SampleIdentity, detail::SampleIdentity_f>() +
+               sizeof(eprosima::fastdds::dds::SequenceNumber_t));
+    }
 
 };
 namespace rpc
@@ -508,6 +728,39 @@ namespace rpc
 
     };
 
+    #ifndef SWIG
+    namespace detail {
+
+    template<typename Tag, typename Tag::type M>
+    struct ReplyHeader_rob
+    {
+        friend constexpr typename Tag::type get(
+                Tag)
+        {
+            return M;
+        }
+
+    };
+
+    struct ReplyHeader_f
+    {
+        typedef eprosima::fastdds::dds::rpc::RemoteExceptionCode_t ReplyHeader::* type;
+        friend constexpr type get(
+                ReplyHeader_f);
+    };
+
+    template struct ReplyHeader_rob<ReplyHeader_f, &ReplyHeader::m_remoteEx>;
+
+    template <typename T, typename Tag>
+    inline size_t constexpr ReplyHeader_offset_of()
+    {
+        return ((::size_t) &reinterpret_cast<char const volatile&>((((T*)0)->*get(Tag()))));
+    }
+
+    } // namespace detail
+    #endif // ifndef SWIG
+
+
     /*!
      * @brief This class represents the TopicDataType of the type ReplyHeader defined by the user in the IDL file.
      * @ingroup rpc_types
@@ -572,14 +825,20 @@ namespace rpc
     #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
         eProsima_user_DllExport inline bool is_plain() const override
         {
-            return false;
+            return is_plain_xcdrv1_impl();
         }
 
         eProsima_user_DllExport inline bool is_plain(
                 eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
         {
-            static_cast<void>(data_representation);
-            return false;
+            if(data_representation == eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION)
+            {
+                return is_plain_xcdrv2_impl();
+            }
+            else
+            {
+                return is_plain_xcdrv1_impl();
+            }
         }
 
     #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
@@ -588,14 +847,30 @@ namespace rpc
         eProsima_user_DllExport inline bool construct_sample(
                 void* memory) const override
         {
-            static_cast<void>(memory);
-            return false;
+            new (memory) ReplyHeader();
+            return true;
         }
 
     #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
 
         eprosima::fastdds::MD5 m_md5;
         unsigned char* m_keyBuffer;
+
+    private:
+
+        static constexpr bool is_plain_xcdrv1_impl()
+        {
+            return 28ULL ==
+                   (detail::ReplyHeader_offset_of<ReplyHeader, detail::ReplyHeader_f>() +
+                   sizeof(eprosima::fastdds::dds::rpc::RemoteExceptionCode_t));
+        }
+
+        static constexpr bool is_plain_xcdrv2_impl()
+        {
+            return 28ULL ==
+                   (detail::ReplyHeader_offset_of<ReplyHeader, detail::ReplyHeader_f>() +
+                   sizeof(eprosima::fastdds::dds::rpc::RemoteExceptionCode_t));
+        }
 
     };
 } // namespace rpc

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
@@ -135,8 +135,7 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
     }
 #endif // !defined(NDEBUG)
 
-    ExtendedTypeDefn reset_type_id;
-    type_identifier.type_identifier2().extended_defn(reset_type_id);
+    type_identifier.type_identifier2().no_value({});
 
     switch (type_identifier.type_identifier1()._d())
     {
@@ -1409,9 +1408,8 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
 {
     ReturnCode_t ret_code {eprosima::fastdds::dds::RETCODE_OK};
     traits<DynamicTypeImpl>::ref_type dynamic_type_impl {traits<DynamicType>::narrow<DynamicTypeImpl>(dynamic_type)};
-    ExtendedTypeDefn reset_type_id;
-    type_ids.type_identifier1().extended_defn(reset_type_id);
-    type_ids.type_identifier2().extended_defn(reset_type_id);
+    type_ids.type_identifier1().no_value({});
+    type_ids.type_identifier2().no_value({});
 
     switch (dynamic_type_impl->get_kind())
     {
@@ -2099,7 +2097,7 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_sequence_dynamic_type(
     else
     {
         ExtendedTypeDefn reset_type_id;
-        type_ids.type_identifier2().extended_defn(reset_type_id);
+        type_ids.type_identifier2().no_value({});
     }
 
     return ret_code;

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
@@ -360,6 +360,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_s_string_type_identifier(
         bool wstring)
 {
     type_ids.type_identifier1().string_sdefn(string);
+    type_ids.type_identifier2().no_value({});
     if (wstring)
     {
         type_ids.type_identifier1()._d(TI_STRING16_SMALL);
@@ -377,6 +378,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_l_string_type_identifier(
     string_ldefn_consistency(string);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().string_ldefn(string);
+    type_ids.type_identifier2().no_value({});
     if (wstring)
     {
         type_ids.type_identifier1()._d(TI_STRING16_LARGE);
@@ -393,6 +395,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_s_sequence_type_identifier(
     seq_sdefn_consistency(plain_seq);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().seq_sdefn(plain_seq);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 
@@ -405,6 +408,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_l_sequence_type_identifier(
     seq_ldefn_consistency(plain_seq);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().seq_ldefn(plain_seq);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 
@@ -417,6 +421,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_s_array_type_identifier(
     array_sdefn_consistency(plain_array);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().array_sdefn(plain_array);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 
@@ -429,6 +434,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_l_array_type_identifier(
     array_ldefn_consistency(plain_array);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().array_ldefn(plain_array);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 
@@ -441,6 +447,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_s_map_type_identifier(
     map_sdefn_consistency(plain_map);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().map_sdefn(plain_map);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 
@@ -453,6 +460,7 @@ ReturnCode_t TypeObjectUtils::build_and_register_l_map_type_identifier(
     map_ldefn_consistency(plain_map);
 #endif // !defined(NDEBUG)
     type_ids.type_identifier1().map_ldefn(plain_map);
+    type_ids.type_identifier2().no_value({});
     return type_object_registry_observer().register_type_identifier(type_name, type_ids);
 }
 

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
@@ -1242,6 +1242,78 @@ void serialize_key(
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const eprosima::fastdds::dds::xtypes::Dummy& data,
+        size_t& current_alignment)
+{
+    using namespace eprosima::fastdds::dds::xtypes;
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::dds::xtypes::Dummy& data)
+{
+    using namespace eprosima::fastdds::dds::xtypes;
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    static_cast<void>(data);
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        eprosima::fastdds::dds::xtypes::Dummy& data)
+{
+    using namespace eprosima::fastdds::dds::xtypes;
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                static_cast<void>(data);
+                static_cast<void>(dcdr);
+                static_cast<void>(mid);
+                return false;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::dds::xtypes::Dummy& data)
+{
+    using namespace eprosima::fastdds::dds::xtypes;
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
         const eprosima::fastdds::dds::xtypes::TypeIdentifier& data,
         size_t& current_alignment)
 {
@@ -1261,61 +1333,81 @@ eProsima_user_DllExport size_t calculate_serialized_size(
 
     switch (data._d())
     {
+                case TK_NONE:
+                case TK_BOOLEAN:
+                case TK_BYTE:
+                case TK_INT8:
+                case TK_INT16:
+                case TK_INT32:
+                case TK_INT64:
+                case TK_UINT8:
+                case TK_UINT16:
+                case TK_UINT32:
+                case TK_UINT64:
+                case TK_FLOAT32:
+                case TK_FLOAT64:
+                case TK_FLOAT128:
+                case TK_CHAR8:
+                case TK_CHAR16:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                                data.no_value(), current_alignment);
+                    break;
+
                 case TI_STRING8_SMALL:
                 case TI_STRING16_SMALL:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
                                 data.string_sdefn(), current_alignment);
                     break;
 
                 case TI_STRING8_LARGE:
                 case TI_STRING16_LARGE:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
                                 data.string_ldefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_SEQUENCE_SMALL:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
                                 data.seq_sdefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_SEQUENCE_LARGE:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
                                 data.seq_ldefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_ARRAY_SMALL:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
                                 data.array_sdefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_ARRAY_LARGE:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
                                 data.array_ldefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_MAP_SMALL:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
                                 data.map_sdefn(), current_alignment);
                     break;
 
                 case TI_PLAIN_MAP_LARGE:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
                                 data.map_ldefn(), current_alignment);
                     break;
 
                 case TI_STRONGLY_CONNECTED_COMPONENT:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
                                 data.sc_component_id(), current_alignment);
                     break;
 
                 case EK_COMPLETE:
                 case EK_MINIMAL:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
                                 data.equivalence_hash(), current_alignment);
                     break;
 
                 default:
-                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
                                 data.extended_defn(), current_alignment);
                     break;
 
@@ -1344,51 +1436,70 @@ eProsima_user_DllExport void serialize(
 
     switch (data._d())
     {
+                case TK_NONE:
+                case TK_BOOLEAN:
+                case TK_BYTE:
+                case TK_INT8:
+                case TK_INT16:
+                case TK_INT32:
+                case TK_INT64:
+                case TK_UINT8:
+                case TK_UINT16:
+                case TK_UINT32:
+                case TK_UINT64:
+                case TK_FLOAT32:
+                case TK_FLOAT64:
+                case TK_FLOAT128:
+                case TK_CHAR8:
+                case TK_CHAR16:
+                    scdr << eprosima::fastcdr::MemberId(1) << data.no_value();
+                    break;
+
                 case TI_STRING8_SMALL:
                 case TI_STRING16_SMALL:
-                    scdr << eprosima::fastcdr::MemberId(1) << data.string_sdefn();
+                    scdr << eprosima::fastcdr::MemberId(2) << data.string_sdefn();
                     break;
 
                 case TI_STRING8_LARGE:
                 case TI_STRING16_LARGE:
-                    scdr << eprosima::fastcdr::MemberId(2) << data.string_ldefn();
+                    scdr << eprosima::fastcdr::MemberId(3) << data.string_ldefn();
                     break;
 
                 case TI_PLAIN_SEQUENCE_SMALL:
-                    scdr << eprosima::fastcdr::MemberId(3) << data.seq_sdefn();
+                    scdr << eprosima::fastcdr::MemberId(4) << data.seq_sdefn();
                     break;
 
                 case TI_PLAIN_SEQUENCE_LARGE:
-                    scdr << eprosima::fastcdr::MemberId(4) << data.seq_ldefn();
+                    scdr << eprosima::fastcdr::MemberId(5) << data.seq_ldefn();
                     break;
 
                 case TI_PLAIN_ARRAY_SMALL:
-                    scdr << eprosima::fastcdr::MemberId(5) << data.array_sdefn();
+                    scdr << eprosima::fastcdr::MemberId(6) << data.array_sdefn();
                     break;
 
                 case TI_PLAIN_ARRAY_LARGE:
-                    scdr << eprosima::fastcdr::MemberId(6) << data.array_ldefn();
+                    scdr << eprosima::fastcdr::MemberId(7) << data.array_ldefn();
                     break;
 
                 case TI_PLAIN_MAP_SMALL:
-                    scdr << eprosima::fastcdr::MemberId(7) << data.map_sdefn();
+                    scdr << eprosima::fastcdr::MemberId(8) << data.map_sdefn();
                     break;
 
                 case TI_PLAIN_MAP_LARGE:
-                    scdr << eprosima::fastcdr::MemberId(8) << data.map_ldefn();
+                    scdr << eprosima::fastcdr::MemberId(9) << data.map_ldefn();
                     break;
 
                 case TI_STRONGLY_CONNECTED_COMPONENT:
-                    scdr << eprosima::fastcdr::MemberId(9) << data.sc_component_id();
+                    scdr << eprosima::fastcdr::MemberId(10) << data.sc_component_id();
                     break;
 
                 case EK_COMPLETE:
                 case EK_MINIMAL:
-                    scdr << eprosima::fastcdr::MemberId(10) << data.equivalence_hash();
+                    scdr << eprosima::fastcdr::MemberId(11) << data.equivalence_hash();
                     break;
 
                 default:
-                    scdr << eprosima::fastcdr::MemberId(11) << data.extended_defn();
+                    scdr << eprosima::fastcdr::MemberId(12) << data.extended_defn();
                     break;
 
     }
@@ -1416,6 +1527,29 @@ eProsima_user_DllExport void deserialize(
 
                     switch (discriminator)
                     {
+                                                case TK_NONE:
+                                                case TK_BOOLEAN:
+                                                case TK_BYTE:
+                                                case TK_INT8:
+                                                case TK_INT16:
+                                                case TK_INT32:
+                                                case TK_INT64:
+                                                case TK_UINT8:
+                                                case TK_UINT16:
+                                                case TK_UINT32:
+                                                case TK_UINT64:
+                                                case TK_FLOAT32:
+                                                case TK_FLOAT64:
+                                                case TK_FLOAT128:
+                                                case TK_CHAR8:
+                                                case TK_CHAR16:
+                                                    {
+                                                        eprosima::fastdds::dds::xtypes::Dummy no_value_value;
+                                                        data.no_value(std::move(no_value_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
                                                 case TI_STRING8_SMALL:
                                                 case TI_STRING16_SMALL:
                                                     {
@@ -1513,6 +1647,25 @@ eProsima_user_DllExport void deserialize(
                 {
                     switch (data._d())
                     {
+                                                case TK_NONE:
+                                                case TK_BOOLEAN:
+                                                case TK_BYTE:
+                                                case TK_INT8:
+                                                case TK_INT16:
+                                                case TK_INT32:
+                                                case TK_INT64:
+                                                case TK_UINT8:
+                                                case TK_UINT16:
+                                                case TK_UINT32:
+                                                case TK_UINT64:
+                                                case TK_FLOAT32:
+                                                case TK_FLOAT64:
+                                                case TK_FLOAT128:
+                                                case TK_CHAR8:
+                                                case TK_CHAR16:
+                                                    dcdr >> data.no_value();
+                                                    break;
+
                                                 case TI_STRING8_SMALL:
                                                 case TI_STRING16_SMALL:
                                                     dcdr >> data.string_sdefn();

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
@@ -2173,6 +2173,200 @@ void ExtendedTypeDefnPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
+DummyPubSubType::DummyPubSubType()
+{
+    setName("eprosima::fastdds::dds::xtypes::Dummy");
+    uint32_t type_size =
+#if FASTCDR_VERSION_MAJOR == 1
+        static_cast<uint32_t>(Dummy::getMaxCdrSerializedSize());
+#else
+        eprosima_fastdds_dds_xtypes_Dummy_max_cdr_typesize;
+#endif
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    m_typeSize = type_size + 4; /*encapsulation*/
+    m_isGetKeyDefined = false;
+    uint32_t keyLength = eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize > 16 ? eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize : 16;
+    m_keyBuffer = reinterpret_cast<unsigned char*>(malloc(keyLength));
+    memset(m_keyBuffer, 0, keyLength);
+}
+
+DummyPubSubType::~DummyPubSubType()
+{
+    if (m_keyBuffer != nullptr)
+    {
+        free(m_keyBuffer);
+    }
+}
+
+bool DummyPubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t* payload,
+        DataRepresentationId_t data_representation)
+{
+    const Dummy* p_type = static_cast<const Dummy*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload->encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+#if FASTCDR_VERSION_MAJOR > 1
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+#endif // FASTCDR_VERSION_MAJOR > 1
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+#if FASTCDR_VERSION_MAJOR == 1
+    payload->length = static_cast<uint32_t>(ser.getSerializedDataLength());
+#else
+    payload->length = static_cast<uint32_t>(ser.get_serialized_data_length());
+#endif // FASTCDR_VERSION_MAJOR == 1
+    return true;
+}
+
+bool DummyPubSubType::deserialize(
+        SerializedPayload_t* payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        Dummy* p_type = static_cast<Dummy*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload->data), payload->length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN
+#if FASTCDR_VERSION_MAJOR == 1
+                , eprosima::fastcdr::Cdr::CdrType::DDS_CDR
+#endif // FASTCDR_VERSION_MAJOR == 1
+                );
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload->encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+std::function<uint32_t()> DummyPubSubType::getSerializedSizeProvider(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    return [data, data_representation]() -> uint32_t
+           {
+#if FASTCDR_VERSION_MAJOR == 1
+               static_cast<void>(data_representation);
+               return static_cast<uint32_t>(type::getCdrSerializedSize(*static_cast<Dummy*>(data))) +
+                      4u /*encapsulation*/;
+#else
+               try
+               {
+                   eprosima::fastcdr::CdrSizeCalculator calculator(
+                       data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                       eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                   size_t current_alignment {0};
+                   return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                               *static_cast<const Dummy*>(data), current_alignment)) +
+                           4u /*encapsulation*/;
+               }
+               catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+               {
+                   return 0;
+               }
+#endif // FASTCDR_VERSION_MAJOR == 1
+           };
+}
+
+void* DummyPubSubType::createData()
+{
+    return reinterpret_cast<void*>(new Dummy());
+}
+
+void DummyPubSubType::deleteData(
+        void* data)
+{
+    delete(reinterpret_cast<Dummy*>(data));
+}
+
+bool DummyPubSubType::getKey(
+        const void* const data,
+        InstanceHandle_t* handle,
+        bool force_md5)
+{
+    if (!m_isGetKeyDefined)
+    {
+        return false;
+    }
+
+    const Dummy* p_type = static_cast<const Dummy*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(m_keyBuffer),
+            eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+#if FASTCDR_VERSION_MAJOR == 1
+    p_type->serializeKey(ser);
+#else
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+#endif // FASTCDR_VERSION_MAJOR == 1
+    if (force_md5 || eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize > 16)
+    {
+        m_md5.init();
+#if FASTCDR_VERSION_MAJOR == 1
+        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.getSerializedDataLength()));
+#else
+        m_md5.update(m_keyBuffer, static_cast<unsigned int>(ser.get_serialized_data_length()));
+#endif // FASTCDR_VERSION_MAJOR == 1
+        m_md5.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle->value[i] = m_md5.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle->value[i] = m_keyBuffer[i];
+        }
+    }
+    return true;
+}
+
+void DummyPubSubType::register_type_object_representation()
+{
+    EPROSIMA_LOG_WARNING(XTYPES_TYPE_REPRESENTATION,
+        "TypeObject type representation support disabled in generated code");
+}
+
 
 
 

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -995,6 +995,20 @@ bool ReaderProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_TYPE_INFORMATION:
                     {
+                        VendorId_t local_vendor_id = source_vendor_id;
+                        if (c_VendorId_Unknown == local_vendor_id)
+                        {
+                            local_vendor_id = ((c_VendorId_Unknown == vendor_id) ? c_VendorId_eProsima : vendor_id);
+                        }
+
+                        // Ignore this PID when coming from other vendors
+                        if (c_VendorId_eProsima != local_vendor_id)
+                        {
+                            EPROSIMA_LOG_INFO(RTPS_PROXY_DATA,
+                                    "Ignoring PID" << pid << " from vendor " << local_vendor_id);
+                            return true;
+                        }
+
                         if (!dds::QosPoliciesSerializer<dds::xtypes::TypeInformationParameter>::read_from_cdr_message(
                                     type_information(), msg, plength))
                         {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -960,6 +960,20 @@ bool WriterProxyData::readFromCDRMessage(
                     }
                     case fastdds::dds::PID_TYPE_INFORMATION:
                     {
+                        VendorId_t local_vendor_id = source_vendor_id;
+                        if (c_VendorId_Unknown == local_vendor_id)
+                        {
+                            local_vendor_id = ((c_VendorId_Unknown == vendor_id) ? c_VendorId_eProsima : vendor_id);
+                        }
+
+                        // Ignore this PID when coming from other vendors
+                        if (c_VendorId_eProsima != local_vendor_id)
+                        {
+                            EPROSIMA_LOG_INFO(RTPS_PROXY_DATA,
+                                    "Ignoring PID" << pid << " from vendor " << local_vendor_id);
+                            return true;
+                        }
+
                         if (!dds::QosPoliciesSerializer<dds::xtypes::TypeInformationParameter>::
                                 read_from_cdr_message(type_information(), msg, plength))
                         {

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -2258,7 +2258,7 @@ private:
             }
 
 
-    StatusKind::StatusKind m__d {1};
+    StatusKind::StatusKind m__d {2147483647};
 
     union
     {

--- a/src/cpp/statistics/types/types.hpp
+++ b/src/cpp/statistics/types/types.hpp
@@ -3900,7 +3900,7 @@ private:
             }
 
 
-    uint32_t m__d {1};
+    uint32_t m__d {2147483647};
 
     union
     {

--- a/test/blackbox/types/core/core_types.hpp
+++ b/test/blackbox/types/core/core_types.hpp
@@ -4592,7 +4592,7 @@ public:
             const SubmessageHeader& _unknown_submsg)
     {
         unknown_submsg_() = _unknown_submsg;
-        m__d = 1;
+        m__d = 127;
     }
 
     /*!
@@ -4603,7 +4603,7 @@ public:
             SubmessageHeader&& _unknown_submsg)
     {
         unknown_submsg_() = _unknown_submsg;
-        m__d = 1;
+        m__d = 127;
     }
 
     /*!
@@ -4731,7 +4731,7 @@ private:
             }
 
 
-    char m__d {1};
+    char m__d {127};
 
     union
     {

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -2258,7 +2258,7 @@ private:
             }
 
 
-    StatusKind::StatusKind m__d {1};
+    StatusKind::StatusKind m__d {2147483647};
 
     union
     {

--- a/test/blackbox/types/statistics/types.hpp
+++ b/test/blackbox/types/statistics/types.hpp
@@ -3900,7 +3900,7 @@ private:
             }
 
 
-    uint32_t m__d {1};
+    uint32_t m__d {2147483647};
 
     union
     {

--- a/test/dds-types-test/declarations.hpp
+++ b/test/dds-types-test/declarations.hpp
@@ -678,7 +678,7 @@ private:
             }
 
 
-    int32_t m__d {2};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1761,7 +1761,7 @@ private:
             }
 
 
-    int32_t m__d {2};
+    int32_t m__d {2147483647};
 
     union
     {

--- a/test/dds-types-test/external.hpp
+++ b/test/dds-types-test/external.hpp
@@ -3762,7 +3762,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {
@@ -4380,7 +4380,7 @@ private:
             }
 
 
-    uint8_t m__d {0};
+    uint8_t m__d {127};
 
     union
     {

--- a/test/dds-types-test/helpers/basic_inner_types.hpp
+++ b/test/dds-types-test/helpers/basic_inner_types.hpp
@@ -670,7 +670,7 @@ public:
             int16_t _shortValue)
     {
         shortValue_() = _shortValue;
-        m__d = 2;
+        m__d = 2147483647;
     }
 
     /*!
@@ -762,7 +762,7 @@ private:
             }
 
 
-    int32_t m__d {2};
+    int32_t m__d {2147483647};
 
     union
     {

--- a/test/dds-types-test/unions.hpp
+++ b/test/dds-types-test/unions.hpp
@@ -306,7 +306,7 @@ private:
             }
 
 
-    int32_t m__d {1};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -565,7 +565,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -824,7 +824,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1083,7 +1083,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1342,7 +1342,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1601,7 +1601,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -1860,7 +1860,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -2119,7 +2119,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -2378,7 +2378,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -2637,7 +2637,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -2896,7 +2896,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -3155,7 +3155,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -3414,7 +3414,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -3684,7 +3684,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -3954,7 +3954,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -4224,7 +4224,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -4494,7 +4494,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -4753,7 +4753,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -5023,7 +5023,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -5282,7 +5282,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -5552,7 +5552,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -5822,7 +5822,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -6092,7 +6092,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -6362,7 +6362,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -6632,7 +6632,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -6902,7 +6902,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -7248,7 +7248,7 @@ private:
             }
 
 
-    int16_t m__d {0};
+    int16_t m__d {32767};
 
     union
     {
@@ -7595,7 +7595,7 @@ private:
             }
 
 
-    uint16_t m__d {0};
+    uint16_t m__d {32767};
 
     union
     {
@@ -7942,7 +7942,7 @@ private:
             }
 
 
-    int32_t m__d {0};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -8289,7 +8289,7 @@ private:
             }
 
 
-    uint32_t m__d {0};
+    uint32_t m__d {2147483647};
 
     union
     {
@@ -8636,7 +8636,7 @@ private:
             }
 
 
-    int64_t m__d {0};
+    int64_t m__d {9223372036854775807};
 
     union
     {
@@ -8983,7 +8983,7 @@ private:
             }
 
 
-    uint64_t m__d {0};
+    uint64_t m__d {9223372036854775807};
 
     union
     {
@@ -9667,7 +9667,7 @@ private:
             }
 
 
-    uint8_t m__d {2};
+    uint8_t m__d {127};
 
     union
     {
@@ -10014,7 +10014,7 @@ private:
             }
 
 
-    char m__d {1};
+    char m__d {127};
 
     union
     {
@@ -10361,7 +10361,7 @@ private:
             }
 
 
-    wchar_t m__d {1};
+    wchar_t m__d {32767};
 
     union
     {
@@ -11482,7 +11482,7 @@ private:
             }
 
 
-    InnerAliasHelper m__d {0};
+    InnerAliasHelper m__d {2147483647};
 
     union
     {
@@ -12145,7 +12145,7 @@ private:
             }
 
 
-    int32_t m__d {5};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -12743,7 +12743,7 @@ public:
             const std::vector<int16_t>& _f)
     {
         f_() = _f;
-        m__d = 5;
+        m__d = 2147483647;
     }
 
     /*!
@@ -12754,7 +12754,7 @@ public:
             std::vector<int16_t>&& _f)
     {
         f_() = _f;
-        m__d = 5;
+        m__d = 2147483647;
     }
 
     /*!
@@ -12900,7 +12900,7 @@ private:
             }
 
 
-    int32_t m__d {5};
+    int32_t m__d {2147483647};
 
     union
     {
@@ -18368,6 +18368,432 @@ private:
 
     Union_Several_Fields_With_Default m_var_union_several_fields_with_default;
 
+};
+/*!
+ * @brief This class represents the union DefaultAnnotation defined by the user in the IDL file.
+ * @ingroup unions
+ */
+class DefaultAnnotation
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport DefaultAnnotation()
+    {
+        a_();
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~DefaultAnnotation()
+    {
+        if (member_destructor_)
+        {
+            member_destructor_();
+        }
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object DefaultAnnotation that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotation(
+            const DefaultAnnotation& x)
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = x.m_a;
+                            break;
+
+                        case 0x00000002:
+                            b_() = x.m_b;
+                            break;
+
+                        case 0x00000003:
+                            c_() = x.m_c;
+                            break;
+
+        }
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object DefaultAnnotation that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotation(
+            DefaultAnnotation&& x) noexcept
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = std::move(x.m_a);
+                            break;
+
+                        case 0x00000002:
+                            b_() = std::move(x.m_b);
+                            break;
+
+                        case 0x00000003:
+                            c_() = std::move(x.m_c);
+                            break;
+
+        }
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object DefaultAnnotation that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotation& operator =(
+            const DefaultAnnotation& x)
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = x.m_a;
+                            break;
+
+                        case 0x00000002:
+                            b_() = x.m_b;
+                            break;
+
+                        case 0x00000003:
+                            c_() = x.m_c;
+                            break;
+
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object DefaultAnnotation that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotation& operator =(
+            DefaultAnnotation&& x) noexcept
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = std::move(x.m_a);
+                            break;
+
+                        case 0x00000002:
+                            b_() = std::move(x.m_b);
+                            break;
+
+                        case 0x00000003:
+                            c_() = std::move(x.m_c);
+                            break;
+
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x DefaultAnnotation object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const DefaultAnnotation& x) const
+    {
+        bool ret_value {false};
+
+        if (m__d == x.m__d &&
+                selected_member_ == x.selected_member_)
+        {
+            switch (selected_member_)
+            {
+                                case 0x00000001:
+                                    ret_value = (m_a == x.m_a);
+                                    break;
+
+                                case 0x00000002:
+                                    ret_value = (m_b == x.m_b);
+                                    break;
+
+                                case 0x00000003:
+                                    ret_value = (m_c == x.m_c);
+                                    break;
+
+            }
+        }
+
+        return ret_value;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x DefaultAnnotation object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const DefaultAnnotation& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets the discriminator value.
+     * @param __d New value for the discriminator.
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the new value doesn't correspond to the selected union member.
+     */
+    eProsima_user_DllExport void _d(
+            int32_t __d)
+    {
+        bool valid_discriminator = false;
+
+        switch (__d)
+        {
+                        case 0:
+                            if (0x00000001 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case 1:
+                            if (0x00000002 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        default:
+                            if (0x00000003 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+        }
+
+        if (!valid_discriminator)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("Discriminator doesn't correspond with the selected union member");
+        }
+
+        m__d = __d;
+    }
+
+    /*!
+     * @brief This function returns the value of the discriminator.
+     * @return Value of the discriminator
+     */
+    eProsima_user_DllExport int32_t _d() const
+    {
+        return m__d;
+    }
+
+    /*!
+     * @brief This function sets a value in member a
+     * @param _a New value for member a
+     */
+    eProsima_user_DllExport void a(
+            uint8_t _a)
+    {
+        a_() = _a;
+        m__d = 0;
+    }
+
+    /*!
+     * @brief This function returns the value of member a
+     * @return Value of member a
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport uint8_t a() const
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_a;
+    }
+
+    /*!
+     * @brief This function returns a reference to member a
+     * @return Reference to member a
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport uint8_t& a()
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_a;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member b
+     * @param _b New value for member b
+     */
+    eProsima_user_DllExport void b(
+            int16_t _b)
+    {
+        b_() = _b;
+        m__d = 1;
+    }
+
+    /*!
+     * @brief This function returns the value of member b
+     * @return Value of member b
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int16_t b() const
+    {
+        if (0x00000002 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_b;
+    }
+
+    /*!
+     * @brief This function returns a reference to member b
+     * @return Reference to member b
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int16_t& b()
+    {
+        if (0x00000002 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_b;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member c
+     * @param _c New value for member c
+     */
+    eProsima_user_DllExport void c(
+            int32_t _c)
+    {
+        c_() = _c;
+        m__d = 2147483647;
+    }
+
+    /*!
+     * @brief This function returns the value of member c
+     * @return Value of member c
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int32_t c() const
+    {
+        if (0x00000003 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_c;
+    }
+
+    /*!
+     * @brief This function returns a reference to member c
+     * @return Reference to member c
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int32_t& c()
+    {
+        if (0x00000003 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_c;
+    }
+
+
+
+private:
+
+            uint8_t& a_()
+            {
+                if (0x00000001 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000001;
+                    member_destructor_ = nullptr;
+                    m_a = {0};
+    ;
+                }
+
+                return m_a;
+            }
+
+            int16_t& b_()
+            {
+                if (0x00000002 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000002;
+                    member_destructor_ = nullptr;
+                    m_b = {0};
+    ;
+                }
+
+                return m_b;
+            }
+
+            int32_t& c_()
+            {
+                if (0x00000003 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000003;
+                    member_destructor_ = nullptr;
+                    m_c = {0};
+    ;
+                }
+
+                return m_c;
+            }
+
+
+    int32_t m__d {0};
+
+    union
+    {
+        uint8_t m_a;
+        int16_t m_b;
+        int32_t m_c;
+    };
+
+    uint32_t selected_member_ {0x0FFFFFFFu};
+
+    std::function<void()> member_destructor_;
 };
 
 #endif // _FAST_DDS_GENERATED_UNIONS_HPP_

--- a/test/dds-types-test/unionsCdrAux.hpp
+++ b/test/dds-types-test/unionsCdrAux.hpp
@@ -123,6 +123,7 @@ constexpr uint32_t UnionSeveralFieldsWithDefault_max_key_cdr_typesize {0UL};
 
 
 
+
 constexpr uint32_t UnionDiscriminatorOctet_max_cdr_typesize {24UL};
 constexpr uint32_t UnionDiscriminatorOctet_max_key_cdr_typesize {0UL};
 
@@ -373,6 +374,7 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionSeveralFieldsWithDefault& data);
+
 
 
 } // namespace fastcdr

--- a/test/dds-types-test/unionsCdrAux.ipp
+++ b/test/dds-types-test/unionsCdrAux.ipp
@@ -8079,6 +8079,148 @@ void serialize_key(
 }
 
 
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const DefaultAnnotation& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0), data._d(),
+                    current_alignment);
+
+    switch (data._d())
+    {
+                case 0:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                                data.a(), current_alignment);
+                    break;
+
+                case 1:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                                data.b(), current_alignment);
+                    break;
+
+                default:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                                data.c(), current_alignment);
+                    break;
+
+    }
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const DefaultAnnotation& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr << eprosima::fastcdr::MemberId(0) << data._d();
+
+    switch (data._d())
+    {
+                case 0:
+                    scdr << eprosima::fastcdr::MemberId(1) << data.a();
+                    break;
+
+                case 1:
+                    scdr << eprosima::fastcdr::MemberId(2) << data.b();
+                    break;
+
+                default:
+                    scdr << eprosima::fastcdr::MemberId(3) << data.c();
+                    break;
+
+    }
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        DefaultAnnotation& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                if (0 == mid.id)
+                {
+                    int32_t discriminator;
+                    dcdr >> discriminator;
+
+                    switch (discriminator)
+                    {
+                                                case 0:
+                                                    {
+                                                        uint8_t a_value{0};
+                                                        data.a(std::move(a_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
+                                                case 1:
+                                                    {
+                                                        int16_t b_value{0};
+                                                        data.b(std::move(b_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
+                                                default:
+                                                    {
+                                                        int32_t c_value{0};
+                                                        data.c(std::move(c_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
+                    }
+                }
+                else
+                {
+                    switch (data._d())
+                    {
+                                                case 0:
+                                                    dcdr >> data.a();
+                                                    break;
+
+                                                case 1:
+                                                    dcdr >> data.b();
+                                                    break;
+
+                                                default:
+                                                    dcdr >> data.c();
+                                                    break;
+
+                    }
+                    ret_value = false;
+                }
+                return ret_value;
+            });
+}
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/test/dds-types-test/unionsPubSubTypes.cxx
+++ b/test/dds-types-test/unionsPubSubTypes.cxx
@@ -7945,5 +7945,6 @@ void UnionSeveralFieldsWithDefaultPubSubType::register_type_object_representatio
 }
 
 
+
 // Include auxiliary functions like for serializing/deserializing.
 #include "unionsCdrAux.ipp"

--- a/test/dds-types-test/unionsPubSubTypes.hpp
+++ b/test/dds-types-test/unionsPubSubTypes.hpp
@@ -3770,5 +3770,6 @@ public:
 
 };
 
+
 #endif // FAST_DDS_GENERATED__UNIONS_PUBSUBTYPES_HPP
 

--- a/test/dds-types-test/unionsTypeObjectSupport.cxx
+++ b/test/dds-types-test/unionsTypeObjectSupport.cxx
@@ -6937,4 +6937,165 @@ void register_UnionSeveralFieldsWithDefault_type_identifier(
         }
     }
 }
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_DefaultAnnotation_type_identifier(
+        TypeIdentifierPair& type_ids_DefaultAnnotation)
+{
+    ReturnCode_t return_code_DefaultAnnotation {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_DefaultAnnotation =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "DefaultAnnotation", type_ids_DefaultAnnotation);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotation)
+    {
+        UnionTypeFlag union_flags_DefaultAnnotation = TypeObjectUtils::build_union_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_DefaultAnnotation = "DefaultAnnotation";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_DefaultAnnotation;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_DefaultAnnotation;
+        CompleteTypeDetail detail_DefaultAnnotation = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_DefaultAnnotation, ann_custom_DefaultAnnotation, type_name_DefaultAnnotation.to_string());
+        CompleteUnionHeader header_DefaultAnnotation = TypeObjectUtils::build_complete_union_header(detail_DefaultAnnotation);
+        UnionDiscriminatorFlag member_flags_DefaultAnnotation = TypeObjectUtils::build_union_discriminator_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false);
+        return_code_DefaultAnnotation =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "_int32_t", type_ids_DefaultAnnotation);
+
+        if (return_code_DefaultAnnotation != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "Union discriminator TypeIdentifier unknown to TypeObjectRegistry.");
+            return;
+        }
+        CommonDiscriminatorMember common_DefaultAnnotation;
+        if (EK_COMPLETE == type_ids_DefaultAnnotation.type_identifier1()._d() || TK_NONE == type_ids_DefaultAnnotation.type_identifier2()._d())
+        {
+            common_DefaultAnnotation = TypeObjectUtils::build_common_discriminator_member(member_flags_DefaultAnnotation, type_ids_DefaultAnnotation.type_identifier1());
+        }
+        else if (EK_COMPLETE == type_ids_DefaultAnnotation.type_identifier2()._d())
+        {
+            common_DefaultAnnotation = TypeObjectUtils::build_common_discriminator_member(member_flags_DefaultAnnotation, type_ids_DefaultAnnotation.type_identifier2());
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "DefaultAnnotation discriminator TypeIdentifier inconsistent.");
+            return;
+        }
+        type_ann_builtin_DefaultAnnotation.reset();
+        ann_custom_DefaultAnnotation.reset();
+        AppliedAnnotationSeq tmp_ann_custom_discriminator;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_discriminator;
+        if (!tmp_ann_custom_discriminator.empty())
+        {
+            ann_custom_DefaultAnnotation = tmp_ann_custom_discriminator;
+        }
+
+        CompleteDiscriminatorMember discriminator_DefaultAnnotation = TypeObjectUtils::build_complete_discriminator_member(common_DefaultAnnotation,
+                type_ann_builtin_DefaultAnnotation, ann_custom_DefaultAnnotation);
+        CompleteUnionMemberSeq member_seq_DefaultAnnotation;
+        {
+            return_code_DefaultAnnotation =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_byte", type_ids_DefaultAnnotation);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotation)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "a Union member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            UnionMemberFlag member_flags_a = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_a;
+            TypeObjectUtils::add_union_case_label(label_seq_a, static_cast<int32_t>(0));
+            MemberId member_id_a = 0x00000001;
+            bool common_a_ec {false};
+            CommonUnionMember common_a {TypeObjectUtils::build_common_union_member(member_id_a,
+                    member_flags_a, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_DefaultAnnotation,
+                        common_a_ec), label_seq_a)};
+            if (!common_a_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union a member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_a = "a";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_a;
+            ann_custom_DefaultAnnotation.reset();
+            CompleteMemberDetail detail_a = TypeObjectUtils::build_complete_member_detail(name_a, member_ann_builtin_a, ann_custom_DefaultAnnotation);
+            CompleteUnionMember member_a = TypeObjectUtils::build_complete_union_member(common_a, detail_a);
+            TypeObjectUtils::add_complete_union_member(member_seq_DefaultAnnotation, member_a);
+        }
+        {
+            return_code_DefaultAnnotation =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int16_t", type_ids_DefaultAnnotation);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotation)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "b Union member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            UnionMemberFlag member_flags_b = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_b;
+            TypeObjectUtils::add_union_case_label(label_seq_b, static_cast<int32_t>(1));
+            MemberId member_id_b = 0x00000002;
+            bool common_b_ec {false};
+            CommonUnionMember common_b {TypeObjectUtils::build_common_union_member(member_id_b,
+                    member_flags_b, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_DefaultAnnotation,
+                        common_b_ec), label_seq_b)};
+            if (!common_b_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union b member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_b = "b";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_b;
+            ann_custom_DefaultAnnotation.reset();
+            CompleteMemberDetail detail_b = TypeObjectUtils::build_complete_member_detail(name_b, member_ann_builtin_b, ann_custom_DefaultAnnotation);
+            CompleteUnionMember member_b = TypeObjectUtils::build_complete_union_member(common_b, detail_b);
+            TypeObjectUtils::add_complete_union_member(member_seq_DefaultAnnotation, member_b);
+        }
+        {
+            return_code_DefaultAnnotation =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_DefaultAnnotation);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotation)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "c Union member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            UnionMemberFlag member_flags_c = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    true, false);
+            UnionCaseLabelSeq label_seq_c;
+            MemberId member_id_c = 0x00000003;
+            bool common_c_ec {false};
+            CommonUnionMember common_c {TypeObjectUtils::build_common_union_member(member_id_c,
+                    member_flags_c, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_DefaultAnnotation,
+                        common_c_ec), label_seq_c)};
+            if (!common_c_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union c member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_c = "c";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_c;
+            ann_custom_DefaultAnnotation.reset();
+            CompleteMemberDetail detail_c = TypeObjectUtils::build_complete_member_detail(name_c, member_ann_builtin_c, ann_custom_DefaultAnnotation);
+            CompleteUnionMember member_c = TypeObjectUtils::build_complete_union_member(common_c, detail_c);
+            TypeObjectUtils::add_complete_union_member(member_seq_DefaultAnnotation, member_c);
+        }
+        CompleteUnionType union_type_DefaultAnnotation = TypeObjectUtils::build_complete_union_type(union_flags_DefaultAnnotation, header_DefaultAnnotation, discriminator_DefaultAnnotation,
+                member_seq_DefaultAnnotation);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_union_type_object(union_type_DefaultAnnotation, type_name_DefaultAnnotation.to_string(), type_ids_DefaultAnnotation))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "DefaultAnnotation already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
 

--- a/test/dds-types-test/unionsTypeObjectSupport.hpp
+++ b/test/dds-types-test/unionsTypeObjectSupport.hpp
@@ -1022,6 +1022,18 @@ eProsima_user_DllExport void register_UnionSeveralFields_type_identifier(
  */
 eProsima_user_DllExport void register_UnionSeveralFieldsWithDefault_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register DefaultAnnotation related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_DefaultAnnotation_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesUnionsDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesUnionsDDSTypesTests.cpp
@@ -2740,6 +2740,10 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_UnionSeveralFieldsWithDefault)
     EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
 }
 
+// This union is custom and serves to test a specific case used in internal type of DDS X-Types (TypeIdentifier).
+// No supported by Dynamic Language Binding.
+// TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_DefaultAnnotation)
+
 } // dds
 } // fastdds
 } // eprosima


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR brings:

- Changes in some IDL files to improve X-Types interoperability.
- Not taking into account the TypeInformation from other vendors.

Depends on:
- #4978
- eprosima/fast-dds-gen#361
- eprosima/fast-dds-docs#854

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
