### PR TITLE
[21219] Remove Valgrind build dependency for profiling tests

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -710,7 +710,7 @@ jobs:
       - name: Install apt dependencies
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
-          packages: libasio-dev libtinyxml2-dev libssl-dev valgrind
+          packages: libasio-dev libtinyxml2-dev libssl-dev
           update: false
           upgrade: false
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,10 +78,7 @@ endif()
 # Profiling tests using valgrind
 ###############################################################################
 if(NOT ((MSVC OR MSVC_IDE)) AND PROFILING_TESTS)
-    find_program(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)
-    if(CTEST_MEMORYCHECK_COMMAND)
-        add_subdirectory(profiling)
-    endif()
+    add_subdirectory(profiling)
 endif()
 
 ###############################################################################

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -54,6 +54,14 @@ if(Python3_Interpreter_FOUND)
     ###############################################################################
     # MemoryTest
     ###############################################################################
+    find_program(VALGRIND_PROGRAM NAMES valgrind)
+
+    # If valgrind is not found, set it to "valgrind" so that the test can be run with
+    # the appropriate environment set at runtime.
+    if (${VALGRIND_PROGRAM} STREQUAL "valgrind-NOTFOUND")
+        set(VALGRIND_PROGRAM "valgrind")
+    endif()
+
     add_test(NAME MemoryTest
         COMMAND ${Python3_EXECUTABLE} memory_tests.py)
 
@@ -67,7 +75,7 @@ if(Python3_Interpreter_FOUND)
     set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
         "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
     set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
-        "VALGRIND_BIN=${CTEST_MEMORYCHECK_COMMAND}")
+        "VALGRIND_BIN=${VALGRIND_PROGRAM}")
     if(SECURITY)
         set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
             "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
@@ -89,7 +97,7 @@ if(Python3_Interpreter_FOUND)
     set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
         "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
     set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
-        "VALGRIND_BIN=valgrind")
+        "VALGRIND_BIN=${VALGRIND_PROGRAM}")
     if(SECURITY)
         set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
             "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes the `valgrind` build dependency for building profiling tests, as its installation was causing CI problems due to 404 responses from ubuntu's security repositories.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_ The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
