### PR TITLE
[21219] Build profiling tests as alternate build in Ubuntu CI 

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -683,6 +683,7 @@ jobs:
           show_skipped: 'False'
 
   fastdds_alternative_builds:
+    needs: fastdds_build
     runs-on: ${{ inputs.os-image }}
     strategy:
       fail-fast: false
@@ -690,11 +691,11 @@ jobs:
         cmake-build-type:
           - 'RelWithDebInfo'
     steps:
-      - name: Sync eProsima/Fast-DDS repository
-        uses: eProsima/eProsima-CI/external/checkout@v0
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
-          path: src/fastrtps
-          ref: ${{ inputs.fastdds-branch }}
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
 
       - name: Install Fix Python version
         uses: eProsima/eProsima-CI/external/setup-python@v0
@@ -719,7 +720,7 @@ jobs:
       - name: Install Python dependencies
         uses: eProsima/eProsima-CI/multiplatform/install_python_packages@v0
         with:
-          packages: vcstool xmlschema
+          packages: vcstool xmlschema msparser
           upgrade: false
 
       - name: Setup CCache
@@ -728,12 +729,38 @@ jobs:
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch Fast DDS dependencies
-        uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
+      - name: Sync osrf/osrf_testing_tools_cpp repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
         with:
-          vcs_repos_file: ${{ github.workspace }}/src/fastrtps/fastrtps.repos
-          destination_workspace: src
-          skip_existing: 'true'
+          repository: osrf/osrf_testing_tools_cpp
+          path: src/osrf_testing_tools_cpp
+          ref: 1.4.0
+
+      - name: OSRF testing tools build
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ''
+          colcon_build_args: ${{ inputs.colcon-args }} --packages-select osrf_testing_tools_cpp
+          cmake_args: '-DBUILD_TESTING=OFF'
+          cmake_args_default: ''
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+
+      - name: Profilling tests build
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastrtps/.github/workflows/config/fastdds_build.meta
+          colcon_build_args: ${{ inputs.colcon-args }} --packages-up-to fastrtps
+          cmake_args: '-DPROFILING_TESTS=ON ${{ inputs.cmake-args }}'
+          cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ${{ github.workspace }}/install
+
+      - name: Clean workspace - Profiling tests
+        run: |
+          cd ${{ github.workspace }}
+          rm -rf build install log src/osrf_testing_tools_cpp
 
       - name: No security colcon build
         continue-on-error: true

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,10 +77,7 @@ endif()
 # Profiling tests using valgrind
 ###############################################################################
 if(NOT ((MSVC OR MSVC_IDE)) AND PROFILING_TESTS)
-    find_program(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)
-    if(CTEST_MEMORYCHECK_COMMAND)
-        add_subdirectory(profiling)
-    endif()
+    add_subdirectory(profiling)
 endif()
 
 ###############################################################################

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -54,6 +54,14 @@ if(Python3_Interpreter_FOUND)
     ###############################################################################
     # MemoryTest
     ###############################################################################
+    find_program(VALGRIND_PROGRAM NAMES valgrind)
+
+    # If valgrind is not found, set it to "valgrind" so that the test can be run with
+    # the appropriate environment set at runtime.
+    if (${VALGRIND_PROGRAM} STREQUAL "valgrind-NOTFOUND")
+        set(VALGRIND_PROGRAM "valgrind")
+    endif()
+
     add_test(NAME MemoryTest
         COMMAND ${Python3_EXECUTABLE} memory_tests.py)
 
@@ -67,7 +75,7 @@ if(Python3_Interpreter_FOUND)
     set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
         "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
     set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
-        "VALGRIND_BIN=${CTEST_MEMORYCHECK_COMMAND}")
+        "VALGRIND_BIN=${VALGRIND_PROGRAM}")
     if(SECURITY)
         set_property(TEST MemoryTest APPEND PROPERTY ENVIRONMENT
             "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")
@@ -89,7 +97,7 @@ if(Python3_Interpreter_FOUND)
     set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
         "PROFILING_BINS=$<TARGET_FILE:MemoryTest>")
     set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
-        "VALGRIND_BIN=valgrind")
+        "VALGRIND_BIN=${VALGRIND_PROGRAM}")
     if(SECURITY)
         set_property(TEST CyclesTest APPEND PROPERTY ENVIRONMENT
             "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs")

--- a/test/profiling/MemoryTestTypes.cpp
+++ b/test/profiling/MemoryTestTypes.cpp
@@ -36,6 +36,14 @@ bool MemoryDataType::serialize(void*data,SerializedPayload_t* payload)
     return true;
 }
 
+bool MemoryDataType::serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::dds::DataRepresentationId_t)
+{
+    return serialize(data,payload);
+}
+
 bool MemoryDataType::deserialize(SerializedPayload_t* payload,void * data)
 {
     MemoryType* lt = (MemoryType*)data;
@@ -58,6 +66,11 @@ std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(void* data)
     };
 }
 
+std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(void* data, eprosima::fastdds::dds::DataRepresentationId_t)
+{
+    return getSerializedSizeProvider(data);
+}
+
 void* MemoryDataType::createData()
 {
 
@@ -77,6 +90,15 @@ bool TestCommandDataType::serialize(void*data,SerializedPayload_t* payload)
     payload->length = 4;
     return true;
 }
+
+bool TestCommandDataType::serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::dds::DataRepresentationId_t)
+{
+    return serialize(data,payload);
+}
+
 bool TestCommandDataType::deserialize(SerializedPayload_t* payload,void * data)
 {
     TestCommandType* t = (TestCommandType*)data;
@@ -97,6 +119,11 @@ std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(void*)
 
         return size;
     };
+}
+
+std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(void* data, eprosima::fastdds::dds::DataRepresentationId_t)
+{
+    return getSerializedSizeProvider(data);
 }
 
 void* TestCommandDataType::createData()

--- a/test/profiling/MemoryTestTypes.cpp
+++ b/test/profiling/MemoryTestTypes.cpp
@@ -22,51 +22,58 @@
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
 
-bool MemoryDataType::serialize(void*data,SerializedPayload_t* payload)
+bool MemoryDataType::serialize(
+        void* data,
+        SerializedPayload_t* payload)
 {
     MemoryType* lt = (MemoryType*)data;
 
 
     *(uint32_t*)payload->data = lt->seqnum;
-    *(uint32_t*)(payload->data+4) = (uint32_t)lt->data.size();
+    *(uint32_t*)(payload->data + 4) = (uint32_t)lt->data.size();
 
     //std::copy(lt->data.begin(),lt->data.end(),payload->data+8);
     memcpy(payload->data + 8, lt->data.data(), lt->data.size());
-    payload->length = (uint32_t)(8+lt->data.size());
+    payload->length = (uint32_t)(8 + lt->data.size());
     return true;
 }
 
 bool MemoryDataType::serialize(
-            void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
-            eprosima::fastdds::dds::DataRepresentationId_t)
+        void* data,
+        eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+        eprosima::fastdds::dds::DataRepresentationId_t)
 {
-    return serialize(data,payload);
+    return serialize(data, payload);
 }
 
-bool MemoryDataType::deserialize(SerializedPayload_t* payload,void * data)
+bool MemoryDataType::deserialize(
+        SerializedPayload_t* payload,
+        void* data)
 {
     MemoryType* lt = (MemoryType*)data;
     lt->seqnum = *(uint32_t*)payload->data;
-    uint32_t siz = *(uint32_t*)(payload->data+4);
-    std::copy(payload->data+8,payload->data+8+siz,lt->data.begin());
+    uint32_t siz = *(uint32_t*)(payload->data + 4);
+    std::copy(payload->data + 8, payload->data + 8 + siz, lt->data.begin());
     return true;
 }
 
-std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(void* data)
+std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(
+        void* data)
 {
     return [data]() -> uint32_t
-    {
-        MemoryType *tdata = static_cast<MemoryType*>(data);
-        uint32_t size = 0;
+           {
+               MemoryType* tdata = static_cast<MemoryType*>(data);
+               uint32_t size = 0;
 
-        size = (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + tdata->data.size());
+               size = (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + tdata->data.size());
 
-        return size;
-    };
+               return size;
+           };
 }
 
-std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(void* data, eprosima::fastdds::dds::DataRepresentationId_t)
+std::function<uint32_t()> MemoryDataType::getSerializedSizeProvider(
+        void* data,
+        eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return getSerializedSizeProvider(data);
 }
@@ -76,14 +83,17 @@ void* MemoryDataType::createData()
 
     return (void*)new MemoryType();
 }
-void MemoryDataType::deleteData(void* data)
+
+void MemoryDataType::deleteData(
+        void* data)
 {
 
     delete((MemoryType*)data);
 }
 
-
-bool TestCommandDataType::serialize(void*data,SerializedPayload_t* payload)
+bool TestCommandDataType::serialize(
+        void* data,
+        SerializedPayload_t* payload)
 {
     TestCommandType* t = (TestCommandType*)data;
     *(TESTCOMMAND*)payload->data = t->m_command;
@@ -92,14 +102,16 @@ bool TestCommandDataType::serialize(void*data,SerializedPayload_t* payload)
 }
 
 bool TestCommandDataType::serialize(
-            void* data,
-            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
-            eprosima::fastdds::dds::DataRepresentationId_t)
+        void* data,
+        eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+        eprosima::fastdds::dds::DataRepresentationId_t)
 {
-    return serialize(data,payload);
+    return serialize(data, payload);
 }
 
-bool TestCommandDataType::deserialize(SerializedPayload_t* payload,void * data)
+bool TestCommandDataType::deserialize(
+        SerializedPayload_t* payload,
+        void* data)
 {
     TestCommandType* t = (TestCommandType*)data;
     //	cout << "PAYLOAD LENGTH: "<<payload->length << endl;
@@ -109,19 +121,22 @@ bool TestCommandDataType::deserialize(SerializedPayload_t* payload,void * data)
     return true;
 }
 
-std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(void*)
+std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
+        void*)
 {
     return []() -> uint32_t
-    {
-        uint32_t size = 0;
+           {
+               uint32_t size = 0;
 
-        size = (uint32_t)sizeof(uint32_t);
+               size = (uint32_t)sizeof(uint32_t);
 
-        return size;
-    };
+               return size;
+           };
 }
 
-std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(void* data, eprosima::fastdds::dds::DataRepresentationId_t)
+std::function<uint32_t()> TestCommandDataType::getSerializedSizeProvider(
+        void* data,
+        eprosima::fastdds::dds::DataRepresentationId_t)
 {
     return getSerializedSizeProvider(data);
 }
@@ -131,7 +146,9 @@ void* TestCommandDataType::createData()
 
     return (void*)new TestCommandType();
 }
-void TestCommandDataType::deleteData(void* data)
+
+void TestCommandDataType::deleteData(
+        void* data)
 {
 
     delete((TestCommandType*)data);

--- a/test/profiling/MemoryTestTypes.h
+++ b/test/profiling/MemoryTestTypes.h
@@ -24,63 +24,98 @@
 
 class MemoryType
 {
-    public:
+public:
 
-        uint32_t seqnum;
-        std::vector<uint8_t> data;
+    uint32_t seqnum;
+    std::vector<uint8_t> data;
 
-        MemoryType(): seqnum(0) {}
+    MemoryType()
+        : seqnum(0)
+    {
+    }
 
-        MemoryType(uint32_t number) :
-            seqnum(0), data(number,0) {}
+    MemoryType(
+            uint32_t number)
+        : seqnum(0)
+        , data(number, 0)
+    {
+    }
 
-        ~MemoryType() {}
+    ~MemoryType()
+    {
+    }
+
 };
 
 
-inline bool operator==(const MemoryType& lt1, const MemoryType& lt2)
+inline bool operator ==(
+        const MemoryType& lt1,
+        const MemoryType& lt2)
 {
-    if(lt1.seqnum!=lt2.seqnum)
-        return false;
-    if(lt1.data.size()!=lt2.data.size())
-        return false;
-    for(size_t i = 0;i<lt1.data.size();++i)
+    if (lt1.seqnum != lt2.seqnum)
     {
-        if(lt1.data.at(i) != lt2.data.at(i))
+        return false;
+    }
+    if (lt1.data.size() != lt2.data.size())
+    {
+        return false;
+    }
+    for (size_t i = 0; i < lt1.data.size(); ++i)
+    {
+        if (lt1.data.at(i) != lt2.data.at(i))
+        {
             return false;
+        }
     }
     return true;
 }
 
 class MemoryDataType : public eprosima::fastrtps::TopicDataType
 {
-    public:
-        MemoryDataType()
-        {
-            setName("MemoryType");
-            m_typeSize = 17000;
-            m_isGetKeyDefined = false;
-        };
-        ~MemoryDataType(){};
-        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
-        bool serialize(
+public:
+
+    MemoryDataType()
+    {
+        setName("MemoryType");
+        m_typeSize = 17000;
+        m_isGetKeyDefined = false;
+    }
+
+    ~MemoryDataType()
+    {
+    }
+
+    bool serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+    bool serialize(
             void* data,
             eprosima::fastrtps::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
-        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
-        std::function<uint32_t()> getSerializedSizeProvider(
+    bool deserialize(
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            void* data) override;
+    std::function<uint32_t()> getSerializedSizeProvider(
+            void* data) override;
+    std::function<uint32_t()> getSerializedSizeProvider(
             void* data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
-        void* createData() override;
-        void deleteData(void* data) override;
-        bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
-            (void)force_md5;
-            return false;
-        }
+    void* createData() override;
+    void deleteData(
+            void* data) override;
+    bool getKey(
+            void* /*data*/,
+            eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/,
+            bool force_md5 = false) override
+    {
+        (void)force_md5;
+        return false;
+    }
+
 };
 
-enum TESTCOMMAND:uint32_t{
+enum TESTCOMMAND : uint32_t
+{
     DEFAULT,
     READY,
     BEGIN,
@@ -91,38 +126,61 @@ enum TESTCOMMAND:uint32_t{
 typedef struct TestCommandType
 {
     TESTCOMMAND m_command;
-    TestCommandType(){
+    TestCommandType()
+    {
         m_command = DEFAULT;
     }
-    TestCommandType(TESTCOMMAND com):m_command(com){}
+
+    TestCommandType(
+            TESTCOMMAND com)
+        : m_command(com)
+    {
+    }
+
 }TestCommandType;
 
 class TestCommandDataType : public eprosima::fastrtps::TopicDataType
 {
-    public:
-        TestCommandDataType()
-        {
-            setName("TestCommandType");
-            m_typeSize = 4;
-            m_isGetKeyDefined = false;
-        };
-        ~TestCommandDataType(){};
-        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
-        bool serialize(
+public:
+
+    TestCommandDataType()
+    {
+        setName("TestCommandType");
+        m_typeSize = 4;
+        m_isGetKeyDefined = false;
+    }
+
+    ~TestCommandDataType()
+    {
+    }
+
+    bool serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+    bool serialize(
             void* data,
             eprosima::fastrtps::rtps::SerializedPayload_t* payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
-        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
-        std::function<uint32_t()> getSerializedSizeProvider(
+    bool deserialize(
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            void* data) override;
+    std::function<uint32_t()> getSerializedSizeProvider(
+            void* data) override;
+    std::function<uint32_t()> getSerializedSizeProvider(
             void* data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
-        void* createData() override;
-        void deleteData(void* data) override;
-        bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
-            (void)force_md5;
-            return false;
-        }
+    void* createData() override;
+    void deleteData(
+            void* data) override;
+    bool getKey(
+            void* /*data*/,
+            eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/,
+            bool force_md5 = false) override
+    {
+        (void)force_md5;
+        return false;
+    }
+
 };
 
 

--- a/test/profiling/MemoryTestTypes.h
+++ b/test/profiling/MemoryTestTypes.h
@@ -62,15 +62,22 @@ class MemoryDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~MemoryDataType(){};
-        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data, eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(
+            void* data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;
-        }        
+        }
 };
 
 enum TESTCOMMAND:uint32_t{
@@ -100,15 +107,22 @@ class TestCommandDataType : public eprosima::fastrtps::TopicDataType
             m_isGetKeyDefined = false;
         };
         ~TestCommandDataType(){};
-        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload);
-        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data);
-        std::function<uint32_t()> getSerializedSizeProvider(void* data);
-        void* createData();
-        void deleteData(void* data);
+        bool serialize(void*data,eprosima::fastrtps::rtps::SerializedPayload_t* payload) override;
+        bool serialize(
+            void* data,
+            eprosima::fastrtps::rtps::SerializedPayload_t* payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+        bool deserialize(eprosima::fastrtps::rtps::SerializedPayload_t* payload,void * data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(void* data) override;
+        std::function<uint32_t()> getSerializedSizeProvider(
+            void* data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+        void* createData() override;
+        void deleteData(void* data) override;
         bool getKey(void* /*data*/, eprosima::fastrtps::rtps::InstanceHandle_t* /*ihandle*/, bool force_md5 = false) override {
             (void)force_md5;
             return false;
-        }        
+        }
 };
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is a combination of backporting #4986 with the addition of the CI changes introduced in #4960. It enable compilation of profiling tests in Ubuntu CI.

As it only affects the alternative builds step, `no-test` label is added.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_ The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.