### PR TITLE
[21224] Update release support table 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,6 +58,6 @@
 - [ ] The PR has a milestone assigned.
 - [ ] The title and description correctly express the PR's purpose.
 - [ ] Check contributor checklist is correct.
-- [ ] If this is a critical bug fix, backports to the critical-only supported branches has been requested.
+- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
 - [ ] Check CI results: changes do not issue any warning.
 - [ ] Check CI results: failing tests are unrelated with the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,6 +58,6 @@
 - [ ] The PR has a milestone assigned.
 - [ ] The title and description correctly express the PR's purpose.
 - [ ] Check contributor checklist is correct.
-- [ ] If critical bug fix, backport to the 2.6.x branch has been opened.
+- [ ] If this is a critical bug fix, backports to the critical-only supported branches has been requested.
 - [ ] Check CI results: changes do not issue any warning.
 - [ ] Check CI results: failing tests are unrelated with the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 <!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->
 
 <!--
-    In case of critical bug fix, please uncomment following line with LTS supported 2.6.x branch.
+    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
 -->
 <!-- @Mergifyio backport 2.6.x -->
 
@@ -52,12 +52,12 @@
 - [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
     <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
 - [ ] Applicable backports have been included in the description.
-<!-- If critical bug fix, make sure that a backport to the 2.6.x branch is opened. -->
 
 ## Reviewer Checklist
 
 - [ ] The PR has a milestone assigned.
 - [ ] The title and description correctly express the PR's purpose.
 - [ ] Check contributor checklist is correct.
+- [ ] If critical bug fix, backport to the 2.6.x branch has been opened.
 - [ ] Check CI results: changes do not issue any warning.
 - [ ] Check CI results: failing tests are unrelated with the changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,12 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->
+<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->
+
+<!--
+    In case of critical bug fix, please uncomment following line with LTS supported 2.6.x branch.
+-->
+<!-- @Mergifyio backport 2.6.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->
@@ -47,6 +52,7 @@
 - [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
     <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
 - [ ] Applicable backports have been included in the description.
+<!-- If critical bug fix, make sure that a backport to the 2.6.x branch is opened. -->
 
 ## Reviewer Checklist
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,6 @@ For more information check the FIWARE Catalogue entry for [Robotics](https://git
 Write to evaluation.support@eprosima.com or mention @EProsima on Twitter.
 We are curious to get to know your use case!
 
-## Supported platforms
-
-More information about the official support can be found [here](https://github.com/eProsima/Fast-DDS/blob/master/PLATFORM_SUPPORT.md#platform-support)
-
-* Linux [![Linux ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux/lastCompletedBuild/badge/icon?subject=%20%20%20Linux%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux)
-* Linux-aarch64 [![Linux arm64 ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_linux_aarch64/lastCompletedBuild/badge/icon?subject=%20%20%20Linux-aarch64%20CI%20)](http://jenkins.eprosima.com:8080/view/Nightly/job/nightly_fastdds_sec_master_linux_aarch64/)
-* Windows [![Windows ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v142/lastCompletedBuild/badge/icon?subject=%20%20%20%20Windows%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_windows/label=windows-secure,platform=x64,toolset=v142)
-* Mac [![Mac ci](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac/lastCompletedBuild/badge/icon?subject=%20%20%20%20%20%20%20Mac%20CI%20)](http://jenkins.eprosima.com:8080/job/nightly_fastdds_sec_master_mac)
-
 ## Installation Guide
 You can get either a binary distribution of *eprosima Fast DDS* or compile the library yourself from source.
 Please, refer to [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_linux.html) for the complete installation guide.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ For more information check the FIWARE Catalogue entry for [Robotics](https://git
 Write to evaluation.support@eprosima.com or mention @EProsima on Twitter.
 We are curious to get to know your use case!
 
+## Supported platforms
+
+More information about the official support can be found [here](https://github.com/eProsima/Fast-DDS/blob/master/PLATFORM_SUPPORT.md#platform-support)
+
 ## Installation Guide
 You can get either a binary distribution of *eprosima Fast DDS* or compile the library yourself from source.
 Please, refer to [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/installation/binaries/binaries_linux.html) for the complete installation guide.

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -14,18 +14,18 @@ Before the minor release end of life (EOL) date, a final patch release including
 Long Term Supported (LTS) versions may have an extended supported period for only critical issues and security fixes, where no other ABI compatible neither bug fixes will be backported.
 This period applies since the end of standard support date to the end of life (EOL) date.
 
-The table below outlines the *eProsima Fast DDS* currently supported versions and their support cycles:
+## *eProsima Fast DDS* currently supported versions and their support cycles
 
-|Version branch|Release Date|End of Standard Support Date|EOL Date|
-|--------------|------------|----------------------------|--------|
-|v2.14.x (LTS)|March 2024|March 2025 [^*]|March 2025 [^*]|
-|v2.13.x|December 2023|July 2024|July 2024|
-|v2.10.x (LTS)|March 2023|May 2025 [^*]|May 2025|
-|v2.6.x (LTS)|March 2022|July 2024|May 2025|
+|Version|Version branch|Latest Release|Release Date|End of Standard Support Date|EOL Date|
+|-------|--------------|--------------|------------|----------------------------|--------|
+|2.14|v2.14.x (LTS)|[v2.14.2](https://fast-dds.docs.eprosima.com/en/v2.14.2/notes/notes.html)|March 2024|March 2025 [^*]|March 2025 [^*]|
+|2.13|v2.13.x|[v2.13.5](https://fast-dds.docs.eprosima.com/en/v2.13.5/notes/notes.html)|December 2023|July 2024|July 2024|
+|2.10|v2.10.x (LTS)|[v2.10.4](https://fast-dds.docs.eprosima.com/en/v2.10.4/notes/notes.html)|March 2023|October 2024 [^*]|May 2025|
+|2.6|v2.6.x (LTS)|[v2.6.8](https://fast-dds.docs.eprosima.com/en/v2.6.8/notes/notes.html)|March 2022|July 2024|May 2025[^*]|
 
 [^*]: Support may be extended.
 
-Moreover, the following table records the lifecycle of previously supported Fast DDS versions.
+## *eProsima Fast DDS* previously supported versions.
 
 |Version branch|Release Date|EOL Date|
 |--------------|------------|--------|

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -17,14 +17,14 @@ The table below outlines the *eProsima Fast DDS* minor releases and their suppor
 |Version branch|Release Date|End of Standard Support Date|EOL Date|
 |--------------|------------|----------------------------|--------|
 |***v2.14.x (LTS)***|***March 2024***|***March 2025 [^*]***|***March 2025 [^*]***|
-|***v2.13.x***|***December 2023***|***June 2024***|***June 2024***|
+|***v2.13.x***|***December 2023***|***July 2024***|***July 2024***|
 |v2.12.x|September 2023|March 2024|March 2024|
 |v2.11.x|July 2023|January 2024|January 2024|
-|***v2.10.x (LTS)***|***March 2023***|***May 2024 [^*]***|***May 2024 [^*]***|
+|***v2.10.x (LTS)***|***March 2023***|***May 2025 [^*]***|***May 2025 [^*]***|
 |v2.9.x|December 2022|July 2023|July 2023|
 |v2.8.x|September 2022|March 2023|March 2023|
 |v2.7.x|July 2022|January 2023|January 2023|
-|***v2.6.x (LTS)***|***March 2022***|***May 2024 [^*]***|***May 2024 [^*]***|
+|***v2.6.x (LTS)***|***March 2022***|***July 2024 [^*]***|***May 2025 [^*]***|
 |v2.5.x|December 2021|June 2022|June 2022|
 |v2.4.x|September 2021|March 2022|March 2022|
 |v2.3.x|March 2021|November 2022|November 2022|

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -18,29 +18,29 @@ This period applies since the end of standard support date to the end of life (E
 
 |Version|Version branch|Latest Release|Release Date|End of Standard Support Date|EOL Date|
 |-------|--------------|--------------|------------|----------------------------|--------|
-|2.14|v2.14.x (LTS)|[v2.14.2](https://fast-dds.docs.eprosima.com/en/v2.14.2/notes/notes.html)|March 2024|March 2025 [^*]|March 2025 [^*]|
-|2.13|v2.13.x|[v2.13.5](https://fast-dds.docs.eprosima.com/en/v2.13.5/notes/notes.html)|December 2023|July 2024|July 2024|
-|2.10|v2.10.x (LTS)|[v2.10.4](https://fast-dds.docs.eprosima.com/en/v2.10.4/notes/notes.html)|March 2023|October 2024 [^*]|May 2025|
-|2.6|v2.6.x (LTS)|[v2.6.8](https://fast-dds.docs.eprosima.com/en/v2.6.8/notes/notes.html)|March 2022|July 2024|May 2025[^*]|
+|2.14|[2.14.x](https://github.com/eProsima/Fast-DDS/tree/2.14.x) (LTS)|[v2.14.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.2)|March 2024|March 2025 [^*]|March 2025 [^*]|
+|2.13|[2.13.x](https://github.com/eProsima/Fast-DDS/tree/2.13.x)|[v2.13.5](https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.5)|December 2023|July 2024|July 2024|
+|2.10|[2.10.x](https://github.com/eProsima/Fast-DDS/tree/2.10.x) (LTS)|[v2.10.4](https://github.com/eProsima/Fast-DDS/releases/tag/v2.10.4)|March 2023|May 2025 [^*]|May 2025|
+|2.6|[2.6.x](https://github.com/eProsima/Fast-DDS/tree/2.6.x) (LTS)|[v2.6.8](https://github.com/eProsima/Fast-DDS/releases/tag/v2.6.8)|March 2022|July 2024|May 2025[^*]|
 
 [^*]: Support may be extended.
 
 ## *eProsima Fast DDS* previously supported versions.
 
-|Version branch|Release Date|EOL Date|
-|--------------|------------|--------|
-|v2.12.x|September 2023|March 2024|
-|v2.11.x|July 2023|January 2024|
-|v2.9.x|December 2022|July 2023|
-|v2.8.x|September 2022|March 2023|
-|v2.7.x|July 2022|January 2023|
-|v2.5.x|December 2021|June 2022|
-|v2.4.x|September 2021|March 2022|
-|v2.3.x|March 2021|November 2022|
-|v2.2.x|January 2021|February 2022|
-|v2.1.x|November 2020|May 2023|
-|v2.0.x|June 2020|February 2022|
-|v1.10.x|April 2020|February 2022|
-|v1.9.x|August 2019|February 2022|
-|v1.8.x|May 2019|February 2022|
-|v1.7.x|December 2018|February 2022|
+|Version|Version branch|Latest Release|Release Date|EOL Date|
+|-------|--------------|--------------|------------|--------|
+|2.12|[2.12.x](https://github.com/eProsima/Fast-DDS/tree/2.12.x)|[v2.12.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.12.2)|September 2023|March 2024|
+|2.11|[2.11.x](https://github.com/eProsima/Fast-DDS/tree/2.11.x)|[v2.11.3](https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.3)|July 2023|January 2024|
+|2.9|[2.9.x](https://github.com/eProsima/Fast-DDS/tree/2.9.x)|[v2.9.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.9.2)|December 2022|July 2023|
+|2.8|[2.8.x](https://github.com/eProsima/Fast-DDS/tree/2.8.x)|[v2.8.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.8.2)|September 2022|March 2023|
+|2.7|[2.7.x](https://github.com/eProsima/Fast-DDS/tree/2.7.x)|[v2.7.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.7.2)|July 2022|January 2023|
+|2.5|[2.5.x](https://github.com/eProsima/Fast-DDS/tree/2.5.x)|[v2.5.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.5.2)|December 2021|June 2022|
+|2.4|[2.4.x](https://github.com/eProsima/Fast-DDS/tree/2.4.x)|[v2.4.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.4.2)|September 2021|March 2022|
+|2.3|[2.3.x](https://github.com/eProsima/Fast-DDS/tree/2.3.x)|[v2.3.6](https://github.com/eProsima/Fast-DDS/releases/tag/v2.3.6)|March 2021|November 2022|
+|2.2|[2.2.x](https://github.com/eProsima/Fast-DDS/tree/2.2.x)|[v2.2.1](https://github.com/eProsima/Fast-DDS/releases/tag/v2.2.1)|January 2021|February 2022|
+|2.1|[2.1.x](https://github.com/eProsima/Fast-DDS/tree/2.1.x)|[v2.1.4](https://github.com/eProsima/Fast-DDS/releases/tag/v2.1.4)|November 2020|May 2023|
+|2.0|[2.0.x](https://github.com/eProsima/Fast-DDS/tree/2.0.x)|[v2.0.3](https://github.com/eProsima/Fast-DDS/releases/tag/v2.0.3)|June 2020|February 2022|
+|1.10|[1.10.x](https://github.com/eProsima/Fast-DDS/tree/1.10.x)|[v1.10.1](https://github.com/eProsima/Fast-DDS/releases/tag/v1.10.1)|April 2020|February 2022|
+|1.9|[1.9.x](https://github.com/eProsima/Fast-DDS/tree/1.9.x)|[v1.9.5](https://github.com/eProsima/Fast-DDS/releases/tag/v1.9.5)|August 2019|February 2022|
+|1.8|[1.8.x](https://github.com/eProsima/Fast-DDS/tree/1.8.x)|[v1.8.5](https://github.com/eProsima/Fast-DDS/releases/tag/v1.8.5)|May 2019|February 2022|
+|1.7|[1.7.x](https://github.com/eProsima/Fast-DDS/tree/1.7.x)|[v1.7.3](https://github.com/eProsima/Fast-DDS/releases/tag/v1.7.3)|December 2018|February 2022|

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -14,26 +14,26 @@ Before the minor release end of life (EOL) date, a final patch release including
 
 The table below outlines the *eProsima Fast DDS* minor releases and their support cycles:
 
-|Version branch|Release Date|EOL Date|
-|--------------|------------|--------|
-|***v2.14.x (LTS)***|***March 2024***|***March 2025 [^*]***|
-|***v2.13.x***|***December 2023***|***June 2024***|
-|v2.12.x|September 2023|March 2024|
-|v2.11.x|July 2023|January 2024|
-|***v2.10.x (LTS)***|***March 2023***|***May 2024 [^*]***|
-|v2.9.x|December 2022|July 2023|
-|v2.8.x|September 2022|March 2023|
-|v2.7.x|July 2022|January 2023|
-|***v2.6.x (LTS)***|***March 2022***|***May 2024 [^*]***|
-|v2.5.x|December 2021|June 2022|
-|v2.4.x|September 2021|March 2022|
-|v2.3.x|March 2021|November 2022|
-|v2.2.x|January 2021|February 2022|
-|v2.1.x|November 2020|May 2023|
-|v2.0.x|June 2020|February 2022|
-|v1.10.x|April 2020|February 2022|
-|v1.9.x|August 2019|February 2022|
-|v1.8.x|May 2019|February 2022|
-|v1.7.x|December 2018|February 2022|
+|Version branch|Release Date|End of Standard Support Date|EOL Date|
+|--------------|------------|----------------------------|--------|
+|***v2.14.x (LTS)***|***March 2024***|***March 2025 [^*]***|***March 2025 [^*]***|
+|***v2.13.x***|***December 2023***|***June 2024***|***June 2024***|
+|v2.12.x|September 2023|March 2024|March 2024|
+|v2.11.x|July 2023|January 2024|January 2024|
+|***v2.10.x (LTS)***|***March 2023***|***May 2024 [^*]***|***May 2024 [^*]***|
+|v2.9.x|December 2022|July 2023|July 2023|
+|v2.8.x|September 2022|March 2023|March 2023|
+|v2.7.x|July 2022|January 2023|January 2023|
+|***v2.6.x (LTS)***|***March 2022***|***May 2024 [^*]***|***May 2024 [^*]***|
+|v2.5.x|December 2021|June 2022|June 2022|
+|v2.4.x|September 2021|March 2022|March 2022|
+|v2.3.x|March 2021|November 2022|November 2022|
+|v2.2.x|January 2021|February 2022|February 2022|
+|v2.1.x|November 2020|May 2023|May 2023|
+|v2.0.x|June 2020|February 2022|February 2022|
+|v1.10.x|April 2020|February 2022|February 2022|
+|v1.9.x|August 2019|February 2022|February 2022|
+|v1.8.x|May 2019|February 2022|February 2022|
+|v1.7.x|December 2018|February 2022|February 2022|
 
 [^*]: Support may be extended.

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -12,30 +12,35 @@ However, the life of certain branches can be extended depending on costumer and 
 Within the support period of any minor version, there may be several patch releases that either add new functionalities in an ABI compatible way or fix possible issues.
 Before the minor release end of life (EOL) date, a final patch release including the latest fixes will be made available if there are any changes not included in any previous patch release of the same minor version.
 Long Term Supported (LTS) versions may have an extended supported period for only critical issues and security fixes, where no other ABI compatible neither bug fixes will be backported.
+This period applies since the end of standard support date to the end of life (EOL) date.
 
-The table below outlines the *eProsima Fast DDS* minor releases and their support cycles:
+The table below outlines the *eProsima Fast DDS* currently supported versions and their support cycles:
 
 |Version branch|Release Date|End of Standard Support Date|EOL Date|
 |--------------|------------|----------------------------|--------|
-|***v2.14.x (LTS)***|***March 2024***|***March 2025 [^1]***|***March 2025 [^1]***|
-|***v2.13.x***|***December 2023***|***July 2024***|***July 2024***|
-|v2.12.x|September 2023|March 2024|March 2024|
-|v2.11.x|July 2023|January 2024|January 2024|
-|***v2.10.x (LTS)***|***March 2023***|***May 2025 [^1]***|***May 2025 [^2]***|
-|v2.9.x|December 2022|July 2023|July 2023|
-|v2.8.x|September 2022|March 2023|March 2023|
-|v2.7.x|July 2022|January 2023|January 2023|
-|***v2.6.x (LTS)***|***March 2022***|***July 2024 ***|***May 2025 [^2]***|
-|v2.5.x|December 2021|June 2022|June 2022|
-|v2.4.x|September 2021|March 2022|March 2022|
-|v2.3.x|March 2021|November 2022|November 2022|
-|v2.2.x|January 2021|February 2022|February 2022|
-|v2.1.x|November 2020|May 2023|May 2023|
-|v2.0.x|June 2020|February 2022|February 2022|
-|v1.10.x|April 2020|February 2022|February 2022|
-|v1.9.x|August 2019|February 2022|February 2022|
-|v1.8.x|May 2019|February 2022|February 2022|
-|v1.7.x|December 2018|February 2022|February 2022|
+|v2.14.x (LTS)|March 2024|March 2025 [^*]|March 2025 [^*]|
+|v2.13.x|December 2023|July 2024|July 2024|
+|v2.10.x (LTS)|March 2023|May 2025 [^*]|May 2025|
+|v2.6.x (LTS)|March 2022|July 2024|May 2025|
 
-[^1]: Support may be extended.
-[^2]: Critical and security fixes support restricted until EOL Date.
+[^*]: Support may be extended.
+
+Moreover, the following table records the lifecycle of previously supported Fast DDS versions.
+
+|Version branch|Release Date|EOL Date|
+|--------------|------------|--------|
+|v2.12.x|September 2023|March 2024|
+|v2.11.x|July 2023|January 2024|
+|v2.9.x|December 2022|July 2023|
+|v2.8.x|September 2022|March 2023|
+|v2.7.x|July 2022|January 2023|
+|v2.5.x|December 2021|June 2022|
+|v2.4.x|September 2021|March 2022|
+|v2.3.x|March 2021|November 2022|
+|v2.2.x|January 2021|February 2022|
+|v2.1.x|November 2020|May 2023|
+|v2.0.x|June 2020|February 2022|
+|v1.10.x|April 2020|February 2022|
+|v1.9.x|August 2019|February 2022|
+|v1.8.x|May 2019|February 2022|
+|v1.7.x|December 2018|February 2022|

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -11,20 +11,21 @@ By default, *eProsima Fast DDS* minor releases have a lifecycle of **6 months**.
 However, the life of certain branches can be extended depending on costumer and user needs.
 Within the support period of any minor version, there may be several patch releases that either add new functionalities in an ABI compatible way or fix possible issues.
 Before the minor release end of life (EOL) date, a final patch release including the latest fixes will be made available if there are any changes not included in any previous patch release of the same minor version.
+Long Term Supported (LTS) versions may have an extended supported period for only critical issues and security fixes, where no other ABI compatible neither bug fixes will be backported.
 
 The table below outlines the *eProsima Fast DDS* minor releases and their support cycles:
 
 |Version branch|Release Date|End of Standard Support Date|EOL Date|
 |--------------|------------|----------------------------|--------|
-|***v2.14.x (LTS)***|***March 2024***|***March 2025 [^*]***|***March 2025 [^*]***|
+|***v2.14.x (LTS)***|***March 2024***|***March 2025 [^1]***|***March 2025 [^1]***|
 |***v2.13.x***|***December 2023***|***July 2024***|***July 2024***|
 |v2.12.x|September 2023|March 2024|March 2024|
 |v2.11.x|July 2023|January 2024|January 2024|
-|***v2.10.x (LTS)***|***March 2023***|***May 2025 [^*]***|***May 2025 [^*]***|
+|***v2.10.x (LTS)***|***March 2023***|***May 2025 [^1]***|***May 2025 [^2]***|
 |v2.9.x|December 2022|July 2023|July 2023|
 |v2.8.x|September 2022|March 2023|March 2023|
 |v2.7.x|July 2022|January 2023|January 2023|
-|***v2.6.x (LTS)***|***March 2022***|***July 2024 [^*]***|***May 2025 [^*]***|
+|***v2.6.x (LTS)***|***March 2022***|***July 2024 ***|***May 2025 [^2]***|
 |v2.5.x|December 2021|June 2022|June 2022|
 |v2.4.x|September 2021|March 2022|March 2022|
 |v2.3.x|March 2021|November 2022|November 2022|
@@ -36,4 +37,5 @@ The table below outlines the *eProsima Fast DDS* minor releases and their suppor
 |v1.8.x|May 2019|February 2022|February 2022|
 |v1.7.x|December 2018|February 2022|February 2022|
 
-[^*]: Support may be extended.
+[^1]: Support may be extended.
+[^2]: Critical and security fixes support restricted until EOL Date.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR updates the release support table with the internal decisions regarding the EOL of the current LTS and supported Fast DDS branches.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
