### PR TITLE
Make more flexible EDP::valid_matching with TypeInformation [21260]

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -67,6 +67,16 @@ static bool is_partition_empty(
     return partition.size() <= 1 && 0 == strlen(partition.name());
 }
 
+static bool compare(
+        const dds::xtypes::TypeInformation& t1,
+        const dds::xtypes::TypeInformation& t2)
+{
+    return (dds::xtypes::TK_NONE != t1.complete().typeid_with_size().type_id()._d()
+           && t1.complete().typeid_with_size() == t2.complete().typeid_with_size())
+           || (dds::xtypes::TK_NONE != t1.minimal().typeid_with_size().type_id()._d()
+           && t1.minimal().typeid_with_size() == t2.minimal().typeid_with_size());
+}
+
 EDP::EDP(
         PDP* p,
         RTPSParticipantImpl* part)
@@ -515,7 +525,7 @@ bool EDP::valid_matching(
     if ((wdata->has_type_information() && wdata->type_information().assigned()) &&
             (rdata->has_type_information() && rdata->type_information().assigned()))
     {
-        if (wdata->type_information().type_information != rdata->type_information().type_information)
+        if (!compare(wdata->type_information().type_information, rdata->type_information().type_information))
         {
             reason.set(MatchingFailureMask::different_typeinfo);
             return false;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -67,7 +67,7 @@ static bool is_partition_empty(
     return partition.size() <= 1 && 0 == strlen(partition.name());
 }
 
-static bool compare(
+static bool is_same_type(
         const dds::xtypes::TypeInformation& t1,
         const dds::xtypes::TypeInformation& t2)
 {
@@ -525,7 +525,7 @@ bool EDP::valid_matching(
     if ((wdata->has_type_information() && wdata->type_information().assigned()) &&
             (rdata->has_type_information() && rdata->type_information().assigned()))
     {
-        if (!compare(wdata->type_information().type_information, rdata->type_information().type_information))
+        if (!is_same_type(wdata->type_information().type_information, rdata->type_information().type_information))
         {
             reason.set(MatchingFailureMask::different_typeinfo);
             return false;

--- a/test/mock/rtps/ReaderProxyData/fastdds/rtps/builtin/data/ReaderProxyData.hpp
+++ b/test/mock/rtps/ReaderProxyData/fastdds/rtps/builtin/data/ReaderProxyData.hpp
@@ -215,12 +215,13 @@ public:
 
     bool has_type_information () const
     {
-        return false;
+        return has_type_info_;
     }
 
     void type_information(
             const fastdds::dds::xtypes::TypeInformationParameter& other_type_info)
     {
+        has_type_info_ = true;
         type_info_ = other_type_info;
     }
 
@@ -231,6 +232,7 @@ public:
 
     fastdds::dds::xtypes::TypeInformationParameter& type_information()
     {
+        has_type_info_ = true;
         return type_info_;
     }
 
@@ -349,6 +351,7 @@ private:
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
     fastdds::rtps::ContentFilterProperty content_filter_;
+    bool has_type_info_ {false};
 
 };
 

--- a/test/mock/rtps/WriterProxyData/fastdds/rtps/builtin/data/WriterProxyData.hpp
+++ b/test/mock/rtps/WriterProxyData/fastdds/rtps/builtin/data/WriterProxyData.hpp
@@ -194,12 +194,13 @@ public:
 
     bool has_type_information () const
     {
-        return false;
+        return has_type_info_;
     }
 
     void type_information(
             const fastdds::dds::xtypes::TypeInformationParameter& other_type_info)
     {
+        has_type_info_ = true;
         type_info_ = other_type_info;
     }
 
@@ -210,6 +211,7 @@ public:
 
     fastdds::dds::xtypes::TypeInformationParameter& type_information()
     {
+        has_type_info_ = true;
         return type_info_;
     }
 
@@ -321,6 +323,7 @@ private:
     InstanceHandle_t m_key;
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
+    bool has_type_info_ {false};
 };
 
 } // namespace rtps

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -501,6 +501,61 @@ TEST(MatchingFailureMask, matching_failure_mask_overflow)
     EXPECT_TRUE(mask.test(EDP::MatchingFailureMask::different_typeinfo));
 }
 
+TEST_F(EdpTests, CheckTypeIdentifierComparation)
+{
+    dds::xtypes::TypeIdentifier minimal;
+    minimal.equivalence_hash({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
+    minimal._d(dds::xtypes::EK_MINIMAL);
+    dds::xtypes::TypeIdentifier complete;
+    complete.equivalence_hash({2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+    complete._d(dds::xtypes::EK_COMPLETE);
+
+    wdata->type_information().assigned(true);
+    rdata->type_information().assigned(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    rdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    check_expectations(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    rdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id().no_value({});
+    check_expectations(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    rdata->type_information().type_information.complete().typeid_with_size().type_id().no_value({});
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    check_expectations(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id().no_value({});
+    rdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    check_expectations(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id().no_value({});
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    rdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    check_expectations(true);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id().no_value({});
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id().no_value({});
+    rdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    check_expectations(false);
+
+    wdata->type_information().type_information.complete().typeid_with_size().type_id(complete);
+    wdata->type_information().type_information.minimal().typeid_with_size().type_id(minimal);
+    rdata->type_information().type_information.complete().typeid_with_size().type_id().no_value({});
+    rdata->type_information().type_information.minimal().typeid_with_size().type_id().no_value({});
+    check_expectations(false);
+}
+
 
 } // namespace rtps
 } // namespace fastdds


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Currently `EDP::valid_matching` expects both TypeInfomation are exactly equal. This PR makes this checking more flexible, allowing to pass when they have only `EK_COMPLETE` or `EK_MINIMAL` equals.

Depends on:
- #4985 
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- *N/A* If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- *N/A* Check CI results: failing tests are unrelated with the changes.
