### PR TITLE
[19563] Fix non-defined duration Qos in configuration example

### DIFF
--- a/examples/cpp/configuration/CLIParser.hpp
+++ b/examples/cpp/configuration/CLIParser.hpp
@@ -45,10 +45,10 @@ class CLIParser
         int32_t max_samples = 5000;
         int32_t max_instances = 10;
         int32_t max_samples_per_instance = 400;
-        uint32_t deadline = fastdds::Duration_t::INFINITE_SECONDS;
-        uint32_t lifespan = fastdds::Duration_t::INFINITE_SECONDS;
-        uint32_t liveliness_lease = fastdds::Duration_t::INFINITE_SECONDS;
-        uint32_t liveliness_assert = fastdds::Duration_t::INFINITE_SECONDS - 1;
+        uint32_t deadline = 0;
+        uint32_t lifespan = 0;
+        uint32_t liveliness_lease = 0;
+        uint32_t liveliness_assert = 0;
         std::string partitions = "";
         std::string profile_participant = "";
         std::string topic_name = "configuration_topic";
@@ -76,7 +76,7 @@ public:
     struct publisher_config : public entity_config
     {
         uint16_t wait = 0;
-        uint32_t ack_keep_duration = fastdds::Duration_t::INFINITE_SECONDS;
+        uint32_t ack_keep_duration = 0;
         uint32_t interval = 100;
         uint32_t msg_size = 10;
         uint32_t ownership_strength = 0;

--- a/examples/cpp/configuration/PublisherApp.cpp
+++ b/examples/cpp/configuration/PublisherApp.cpp
@@ -139,16 +139,30 @@ PublisherApp::PublisherApp(
                       "DataWriter initialization failed: ownership strength is only valid with exclusive ownership");
         }
         writer_qos.ownership_strength().value = config.ownership_strength;
-        writer_qos.deadline().period = eprosima::fastdds::Duration_t(config.deadline * 1e-3);
+        if (config.deadline > 0)
+        {
+            writer_qos.deadline().period = eprosima::fastdds::Duration_t(config.deadline * 1e-3);
+        }
         writer_qos.reliable_writer_qos().disable_positive_acks.enabled = config.disable_positive_ack;
-        writer_qos.reliable_writer_qos().disable_positive_acks.duration = eprosima::fastdds::Duration_t(
-            config.ack_keep_duration * 1e-3);
-        writer_qos.lifespan().duration = eprosima::fastdds::Duration_t(config.lifespan * 1e-3);
+        if (config.ack_keep_duration > 0)
+        {
+            writer_qos.reliable_writer_qos().disable_positive_acks.duration = eprosima::fastdds::Duration_t(
+                config.ack_keep_duration * 1e-3);
+        }
+        if (config.lifespan > 0)
+        {
+            writer_qos.lifespan().duration = eprosima::fastdds::Duration_t(config.lifespan * 1e-3);
+        }
         writer_qos.liveliness().kind = config.liveliness;
-        writer_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(
-            config.liveliness_lease * 1e-3);
-        writer_qos.liveliness().announcement_period = eprosima::fastdds::Duration_t(
-            config.liveliness_assert * 1e-3);
+        if (config.liveliness_lease > 0)
+        {
+            writer_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(config.liveliness_lease * 1e-3);
+        }
+        if (config.liveliness_assert > 0)
+        {
+            writer_qos.liveliness().announcement_period = eprosima::fastdds::Duration_t(
+                config.liveliness_assert * 1e-3);
+        }
         writer_ = publisher_->create_datawriter(topic_, writer_qos, this, StatusMask::all());
     }
     else

--- a/examples/cpp/configuration/README.md
+++ b/examples/cpp/configuration/README.md
@@ -138,6 +138,8 @@ Otherwise, the entities are considered incompatible (and they will not match).
 The argument **``-i``** ``<period>`` or **``--interval``** ``<period>`` configures the **publisher** application with the sending samples period (in milliseconds).
 It should be always **greater** than the deadline period, otherwise ``on_offered_deadline_missed`` will be triggered any time a sample is sent.
 
+If **``--deadline``** is not configured, it takes the _eProsima Fast DDS_ default value (infinite).
+
 ## Disable positive ACKs QoS
 
 Using argument **``--disable-positive-ack``** will configure  the corresponding endpoint to **not** exchange positive acknowledge messages.
@@ -171,6 +173,8 @@ The following table represents the compatibility matrix (compatible ✔️ vs in
 </table>
 
 The argument **``--ack-keep-duration``** ``<duration>`` configures the **publisher** application with the duration (in milliseconds) it keeps the data before considering it as acknowledged.
+
+If **``--ack-keep-duration``** is not configured, it takes the _eProsima Fast DDS_ default value (infinite).
 
 ## Durability QoS
 
@@ -281,6 +285,9 @@ The following table represents the compatibility matrix (compatible ✔️ vs in
 
 The argument **``-i``** ``<period>`` or **``--interval``** ``<period>`` configures the **publisher** application with the sending samples period (in milliseconds).
 It should be always **lower** than the liveliness lease duration, otherwise liveliness will be lost after sending each sample and recovered when sending the next sample.
+
+
+If **``--liveliness``**  or  **``--liveliness-assert``** are not configured, they take the _eProsima Fast DDS_ default values (infinite).
 
 ## Ownership QoS
 

--- a/examples/cpp/configuration/SubscriberApp.cpp
+++ b/examples/cpp/configuration/SubscriberApp.cpp
@@ -125,14 +125,25 @@ SubscriberApp::SubscriberApp(
         reader_qos.resource_limits().max_instances = config.max_instances;
         reader_qos.resource_limits().max_samples_per_instance = config.max_samples_per_instance;
         reader_qos.ownership().kind = config.ownership;
-        reader_qos.deadline().period = eprosima::fastdds::Duration_t(config.deadline * 1e-3);
+        if (config.deadline > 0)
+        {
+            reader_qos.deadline().period = eprosima::fastdds::Duration_t(config.deadline * 1e-3);
+        }
         reader_qos.reliable_reader_qos().disable_positive_acks.enabled = config.disable_positive_ack;
-        reader_qos.lifespan().duration = eprosima::fastdds::Duration_t(config.lifespan * 1e-3);
+        if (config.lifespan > 0)
+        {
+            reader_qos.lifespan().duration = eprosima::fastdds::Duration_t(config.lifespan * 1e-3);
+        }
         reader_qos.liveliness().kind = config.liveliness;
-        reader_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(
-            config.liveliness_lease * 1e-3);
-        reader_qos.liveliness().announcement_period = eprosima::fastdds::Duration_t(
-            config.liveliness_assert * 1e-3);
+        if (config.liveliness_lease > 0)
+        {
+            reader_qos.liveliness().lease_duration = eprosima::fastdds::Duration_t(config.liveliness_lease * 1e-3);
+        }
+        if (config.liveliness_assert > 0)
+        {
+            reader_qos.liveliness().announcement_period = eprosima::fastdds::Duration_t(
+                config.liveliness_assert * 1e-3);
+        }
         reader_ = subscriber_->create_datareader(topic_, reader_qos, this, StatusMask::all());
     }
     else


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Duration QoS were not behaving as expected when they were not configured through the CLI. This PR only set up those QoS if the related argument has been provided in the CLI.

**Note**: This PR is in top of (and must be merged after):
- #4958 
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A**  If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

