### PR TITLE
[21232] Fix flaky latency tests on mac

### DIFF
--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -207,7 +207,7 @@ bool ReaderLocator::send(
     return true;
 }
 
-RTPSReader* ReaderLocator::local_reader()
+BaseReader* ReaderLocator::local_reader()
 {
     if (!local_reader_)
     {

--- a/src/cpp/rtps/writer/ReaderLocator.hpp
+++ b/src/cpp/rtps/writer/ReaderLocator.hpp
@@ -31,7 +31,7 @@ namespace rtps {
 
 class RTPSParticipantImpl;
 class RTPSWriter;
-class RTPSReader;
+class BaseReader;
 class IDataSharingNotifier;
 
 /**
@@ -67,10 +67,10 @@ public:
         return is_local_reader_;
     }
 
-    RTPSReader* local_reader();
+    BaseReader* local_reader();
 
     void local_reader(
-            RTPSReader* local_reader)
+            BaseReader* local_reader)
     {
         local_reader_ = local_reader;
     }
@@ -260,7 +260,7 @@ private:
     LocatorSelectorEntry async_locator_info_;
     bool expects_inline_qos_;
     bool is_local_reader_;
-    RTPSReader* local_reader_;
+    BaseReader* local_reader_;
     std::vector<GuidPrefix_t> guid_prefix_as_vector_;
     std::vector<GUID_t> guid_as_vector_;
     IDataSharingNotifier* datasharing_notifier_;

--- a/src/cpp/rtps/writer/ReaderProxy.hpp
+++ b/src/cpp/rtps/writer/ReaderProxy.hpp
@@ -40,6 +40,7 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
+class BaseReader;
 class StatefulWriter;
 class TimedEvent;
 class RTPSReader;
@@ -289,7 +290,7 @@ public:
      * Get the local reader on the same process (if any).
      * @return The local reader on the same process.
      */
-    inline RTPSReader* local_reader()
+    inline BaseReader* local_reader()
     {
         return locator_info_.local_reader();
     }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -473,14 +473,14 @@ bool StatefulWriter::intraprocess_delivery(
         CacheChange_t* change,
         ReaderProxy* reader_proxy)
 {
-    RTPSReader* reader = reader_proxy->local_reader();
+    BaseReader* reader = reader_proxy->local_reader();
     if (reader)
     {
         if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
         {
             change->write_params.sample_identity(change->write_params.related_sample_identity());
         }
-        return BaseReader::downcast(reader)->process_data_msg(change);
+        return reader->process_data_msg(change);
     }
     return false;
 }

--- a/test/mock/rtps/ReaderLocator/rtps/writer/ReaderLocator.hpp
+++ b/test/mock/rtps/ReaderLocator/rtps/writer/ReaderLocator.hpp
@@ -33,7 +33,7 @@ namespace rtps {
 
 class RTPSParticipantImpl;
 class RTPSWriter;
-class RTPSReader;
+class BaseReader;
 class IDataSharingNotifier;
 
 /**
@@ -202,7 +202,7 @@ public:
         return false;
     }
 
-    RTPSReader* local_reader()
+    BaseReader* local_reader()
     {
         return nullptr;
     }

--- a/test/performance/latency/LatencyTestPublisher.cpp
+++ b/test/performance/latency/LatencyTestPublisher.cpp
@@ -661,7 +661,7 @@ void LatencyTestPublisher::run()
 
 void LatencyTestPublisher::destroy_user_entities()
 {
-    // Static type endpoints shpuld have been removed for each payload iteration
+    // Static type endpoints should have been removed for each payload iteration
     if (dynamic_types_)
     {
         destroy_data_endpoints();

--- a/test/performance/latency/LatencyTestPublisher.cpp
+++ b/test/performance/latency/LatencyTestPublisher.cpp
@@ -57,29 +57,6 @@ LatencyTestPublisher::LatencyTestPublisher()
 
 LatencyTestPublisher::~LatencyTestPublisher()
 {
-    // Static type endpoints shpuld have been removed for each payload iteration
-    if (dynamic_types_)
-    {
-        destroy_data_endpoints();
-    }
-    else if (nullptr != data_writer_
-            || nullptr != data_reader_
-            || nullptr != latency_data_pub_topic_
-            || nullptr != latency_data_sub_topic_
-            || !latency_data_type_)
-    {
-        EPROSIMA_LOG_ERROR(LATENCYPUBLISHER, "ERROR unregistering the DATA type and/or removing the endpoints");
-    }
-
-    subscriber_->delete_datareader(command_reader_);
-    participant_->delete_subscriber(subscriber_);
-
-    publisher_->delete_datawriter(command_writer_);
-    participant_->delete_publisher(publisher_);
-
-    participant_->delete_topic(latency_command_sub_topic_);
-    participant_->delete_topic(latency_command_pub_topic_);
-
     std::string TestCommandType("TestCommandType");
     participant_->unregister_type(TestCommandType);
 
@@ -680,6 +657,32 @@ void LatencyTestPublisher::run()
         export_csv("_minimum_", str_reliable, *output_files_[MINIMUM_INDEX]);
         export_csv("_average_", str_reliable, *output_files_[AVERAGE_INDEX]);
     }
+}
+
+void LatencyTestPublisher::destroy_user_entities()
+{
+    // Static type endpoints shpuld have been removed for each payload iteration
+    if (dynamic_types_)
+    {
+        destroy_data_endpoints();
+    }
+    else if (nullptr != data_writer_
+            || nullptr != data_reader_
+            || nullptr != latency_data_pub_topic_
+            || nullptr != latency_data_sub_topic_
+            || !latency_data_type_)
+    {
+        EPROSIMA_LOG_ERROR(LATENCYPUBLISHER, "ERROR unregistering the DATA type and/or removing the endpoints");
+    }
+
+    subscriber_->delete_datareader(command_reader_);
+    participant_->delete_subscriber(subscriber_);
+
+    publisher_->delete_datawriter(command_writer_);
+    participant_->delete_publisher(publisher_);
+
+    participant_->delete_topic(latency_command_sub_topic_);
+    participant_->delete_topic(latency_command_pub_topic_);
 }
 
 void LatencyTestPublisher::export_csv(

--- a/test/performance/latency/LatencyTestPublisher.hpp
+++ b/test/performance/latency/LatencyTestPublisher.hpp
@@ -100,6 +100,8 @@ public:
 
     void run();
 
+    void destroy_user_entities();
+
 private:
 
     bool init_dynamic_types();

--- a/test/performance/latency/LatencyTestSubscriber.cpp
+++ b/test/performance/latency/LatencyTestSubscriber.cpp
@@ -51,29 +51,6 @@ LatencyTestSubscriber::LatencyTestSubscriber()
 
 LatencyTestSubscriber::~LatencyTestSubscriber()
 {
-    // Static type endpoints should have been remove for each payload iteration
-    if (dynamic_types_)
-    {
-        destroy_data_endpoints();
-    }
-    else if (nullptr != data_writer_
-            || nullptr != data_reader_
-            || nullptr != latency_data_pub_topic_
-            || nullptr != latency_data_sub_topic_
-            || !latency_data_type_)
-    {
-        EPROSIMA_LOG_ERROR(LATENCYSUBSCRIBER, "ERROR unregistering the DATA type and/or removing the endpoints");
-    }
-
-    subscriber_->delete_datareader(command_reader_);
-    participant_->delete_subscriber(subscriber_);
-
-    publisher_->delete_datawriter(command_writer_);
-    participant_->delete_publisher(publisher_);
-
-    participant_->delete_topic(latency_command_sub_topic_);
-    participant_->delete_topic(latency_command_pub_topic_);
-
     std::string TestCommandType("TestCommandType");
     participant_->unregister_type(TestCommandType);
 
@@ -639,6 +616,32 @@ void LatencyTestSubscriber::run()
             break;
         }
     }
+}
+
+void LatencyTestSubscriber::destroy_user_entities()
+{
+    // Static type endpoints should have been remove for each payload iteration
+    if (dynamic_types_)
+    {
+        destroy_data_endpoints();
+    }
+    else if (nullptr != data_writer_
+            || nullptr != data_reader_
+            || nullptr != latency_data_pub_topic_
+            || nullptr != latency_data_sub_topic_
+            || !latency_data_type_)
+    {
+        EPROSIMA_LOG_ERROR(LATENCYSUBSCRIBER, "ERROR unregistering the DATA type and/or removing the endpoints");
+    }
+
+    subscriber_->delete_datareader(command_reader_);
+    participant_->delete_subscriber(subscriber_);
+
+    publisher_->delete_datawriter(command_writer_);
+    participant_->delete_publisher(publisher_);
+
+    participant_->delete_topic(latency_command_sub_topic_);
+    participant_->delete_topic(latency_command_pub_topic_);
 }
 
 bool LatencyTestSubscriber::test(

--- a/test/performance/latency/LatencyTestSubscriber.hpp
+++ b/test/performance/latency/LatencyTestSubscriber.hpp
@@ -60,6 +60,8 @@ public:
 
     void run();
 
+    void destroy_user_entities();
+
     bool test(
             uint32_t datasize);
 

--- a/test/performance/latency/main_LatencyTest.cpp
+++ b/test/performance/latency/main_LatencyTest.cpp
@@ -503,6 +503,7 @@ int main(
                 dynamic_types, data_sharing, data_loans, shared_memory, forced_domain, data_sizes))
         {
             latency_publisher.run();
+            latency_publisher.destroy_user_entities();
         }
         else
         {
@@ -518,6 +519,7 @@ int main(
                 xml_config_file, dynamic_types, data_sharing, data_loans, shared_memory, forced_domain, data_sizes))
         {
             latency_subscriber.run();
+            latency_subscriber.destroy_user_entities();
         }
         else
         {
@@ -568,6 +570,13 @@ int main(
             {
                 sub.join();
             }
+
+            for (auto& sub : latency_subscribers)
+            {
+                sub->destroy_user_entities();
+            }
+
+            latency_publisher.destroy_user_entities();
         }
         else
         {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Some of the `Latency tests` failed in mac from time to time, in particular, the intraprocess ones. Analysis revealed the following backtrace:
```
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::BaseReader::downcast(eprosima::fastdds::rtps::RTPSReader*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/reader/BaseReader.cpp:236)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::StatefulWriter::intraprocess_delivery(eprosima::fastdds::rtps::CacheChange_t*, eprosima::fastdds::rtps::ReaderProxy*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/writer/StatefulWriter.cpp:483)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::StatefulWriter::deliver_sample_to_intraprocesses(eprosima::fastdds::rtps::CacheChange_t*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/writer/StatefulWriter.cpp:642)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::StatefulWriter::deliver_sample_nts(eprosima::fastdds::rtps::CacheChange_t*, eprosima::fastdds::rtps::RTPSMessageGroup&, eprosima::fastdds::rtps::LocatorSelectorSender&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/writer/StatefulWriter.cpp:2194)
libfastdds.3.0.0.dylib!std::__1::enable_if<std::is_base_of<eprosima::fastdds::rtps::FlowControllerPureSyncPublishMode, eprosima::fastdds::rtps::FlowControllerSyncPublishMode>::value, bool>::type eprosima::fastdds::rtps::FlowControllerImpl<eprosima::fastdds::rtps::FlowControllerSyncPublishMode, eprosima::fastdds::rtps::FlowControllerFifoSchedule>::add_new_sample_impl<eprosima::fastdds::rtps::FlowControllerSyncPublishMode>(eprosima::fastdds::rtps::RTPSWriter*, eprosima::fastdds::rtps::CacheChange_t*, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp:1191)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::FlowControllerImpl<eprosima::fastdds::rtps::FlowControllerSyncPublishMode, eprosima::fastdds::rtps::FlowControllerFifoSchedule>::add_new_sample(eprosima::fastdds::rtps::RTPSWriter*, eprosima::fastdds::rtps::CacheChange_t*, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp:1012)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::StatefulWriter::unsent_change_added_to_history(eprosima::fastdds::rtps::CacheChange_t*, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/writer/StatefulWriter.cpp:455)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::WriterHistory::notify_writer(eprosima::fastdds::rtps::CacheChange_t*, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/history/WriterHistory.cpp:124)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::WriterHistory::add_change_(eprosima::fastdds::rtps::CacheChange_t*, eprosima::fastdds::rtps::WriteParams&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/history/WriterHistory.cpp:145)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::WriterHistory::add_change(eprosima::fastdds::rtps::CacheChange_t*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/history/WriterHistory.cpp:52)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::EDPSimple::removeLocalReader(eprosima::fastdds::rtps::RTPSReader*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp:738)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::BuiltinProtocols::removeLocalReader(eprosima::fastdds::rtps::RTPSReader*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/builtin/BuiltinProtocols.cpp:304)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::RTPSParticipantImpl::deleteUserEndpoint(eprosima::fastdds::rtps::GUID_t const&) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/participant/RTPSParticipantImpl.cpp:2140)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::RTPSDomainImpl::removeRTPSReader(eprosima::fastdds::rtps::RTPSReader*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/RTPSDomain.cpp:532)
libfastdds.3.0.0.dylib!eprosima::fastdds::rtps::RTPSDomain::removeRTPSReader(eprosima::fastdds::rtps::RTPSReader*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/rtps/RTPSDomain.cpp:516)
libfastdds.3.0.0.dylib!eprosima::fastdds::dds::DataReaderImpl::stop() (/Users/mardom/dds_ws/src/fastdds/src/cpp/fastdds/subscriber/DataReaderImpl.cpp:335)
libfastdds.3.0.0.dylib!eprosima::fastdds::dds::DataReaderImpl::~DataReaderImpl() (/Users/mardom/dds_ws/src/fastdds/src/cpp/fastdds/subscriber/DataReaderImpl.cpp:349)
libfastdds.3.0.0.dylib!eprosima::fastdds::statistics::dds::DataReaderImpl::~DataReaderImpl() (/Users/mardom/dds_ws/src/fastdds/src/cpp/statistics/fastdds/subscriber/DataReaderImpl.hpp:43)
libfastdds.3.0.0.dylib!eprosima::fastdds::statistics::dds::DataReaderImpl::~DataReaderImpl() (/Users/mardom/dds_ws/src/fastdds/src/cpp/statistics/fastdds/subscriber/DataReaderImpl.hpp:43)
libfastdds.3.0.0.dylib!eprosima::fastdds::statistics::dds::DataReaderImpl::~DataReaderImpl() (/Users/mardom/dds_ws/src/fastdds/src/cpp/statistics/fastdds/subscriber/DataReaderImpl.hpp:43)
libfastdds.3.0.0.dylib!eprosima::fastdds::dds::SubscriberImpl::delete_datareader(eprosima::fastdds::dds::DataReader const*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/fastdds/subscriber/SubscriberImpl.cpp:298)
libfastdds.3.0.0.dylib!eprosima::fastdds::dds::Subscriber::delete_datareader(eprosima::fastdds::dds::DataReader const*) (/Users/mardom/dds_ws/src/fastdds/src/cpp/fastdds/subscriber/Subscriber.cpp:129)
LatencyTest!LatencyTestPublisher::~LatencyTestPublisher() (/Users/mardom/dds_ws/src/fastdds/test/performance/latency/LatencyTestPublisher.cpp:74)
LatencyTest!LatencyTestPublisher::~LatencyTestPublisher() (/Users/mardom/dds_ws/src/fastdds/test/performance/latency/LatencyTestPublisher.cpp:59)
```
In `intraprocess` there is a race in destruction since the `LatencySubsriber` deletes its participant and then, when the `LatencyPublisher` deletes their entites it tries to access the `EDP` builtins on the `LatencySubscriber` which are deleted.

This PR lets the user endpoints be destroyed while guaranteeing that both are alive before deleting the participants.

In addition, proposes a refactor for using a `BaseReader` instead of a `RTPSReader` for the `local_reader_` member of the `readerproxy` to save up a `dynamic_cast` when downcasting.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __NO__ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- __NO__ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__ New feature has been added to the `versions.md` file (if applicable).
- __NO__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
