### PR TITLE
[21288] Remove doxygen directive @group in enumerations and typedefs

### DIFF
--- a/include/fastdds/rtps/common/ChangeKind_t.hpp
+++ b/include/fastdds/rtps/common/ChangeKind_t.hpp
@@ -26,15 +26,14 @@ namespace fastdds {
 namespace rtps {
 
 /**
- * @enum ChangeKind_t, different types of CacheChange_t.
- * @ingroup COMMON_MODULE
+ * Enumerates the different types of CacheChange_t.
  */
 enum FASTDDS_EXPORTED_API ChangeKind_t
 {
-    ALIVE,                            //!< ALIVE
-    NOT_ALIVE_DISPOSED,               //!< NOT_ALIVE_DISPOSED
-    NOT_ALIVE_UNREGISTERED,           //!< NOT_ALIVE_UNREGISTERED
-    NOT_ALIVE_DISPOSED_UNREGISTERED   //!< NOT_ALIVE_DISPOSED_UNREGISTERED
+    ALIVE,                          //!< ALIVE
+    NOT_ALIVE_DISPOSED,             //!< NOT_ALIVE_DISPOSED
+    NOT_ALIVE_UNREGISTERED,         //!< NOT_ALIVE_UNREGISTERED
+    NOT_ALIVE_DISPOSED_UNREGISTERED //!< NOT_ALIVE_DISPOSED_UNREGISTERED
 };
 
 } // namespace rtps

--- a/include/fastdds/rtps/common/FragmentNumber.hpp
+++ b/include/fastdds/rtps/common/FragmentNumber.hpp
@@ -23,9 +23,9 @@
 #include <fastdds/rtps/common/Types.hpp>
 #include <fastdds/utils/fixed_size_bitmap.hpp>
 
-#include <set>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <set>
 
 namespace eprosima {
 namespace fastdds {
@@ -33,8 +33,7 @@ namespace rtps {
 
 using FragmentNumber_t = uint32_t;
 
-//!Structure FragmentNumberSet_t, contains a group of fragmentnumbers.
-//!@ingroup COMMON_MODULE
+//! Structure FragmentNumberSet_t, contains a group of fragmentnumbers.
 using FragmentNumberSet_t = BitmapRange<FragmentNumber_t>;
 
 inline std::ostream& operator <<(

--- a/include/fastdds/rtps/common/MatchingInfo.hpp
+++ b/include/fastdds/rtps/common/MatchingInfo.hpp
@@ -14,7 +14,6 @@
 
 /**
  * @file MatchingInfo.hpp
- *
  */
 
 #ifndef FASTDDS_RTPS_COMMON__MATCHINGINFO_HPP
@@ -27,9 +26,8 @@ namespace fastdds {
 namespace rtps {
 
 /**
- * @enum MatchingStatus, indicates whether the matched publication/subscription method of the PublisherListener or SubscriberListener has
+ * Indicates whether the matched publication/subscription method of the PublisherListener or SubscriberListener has
  * been called for a matching or a removal of a remote endpoint.
- * @ingroup COMMON_MODULE
  */
 #if defined(_WIN32)
 enum FASTDDS_EXPORTED_API MatchingStatus
@@ -37,10 +35,9 @@ enum FASTDDS_EXPORTED_API MatchingStatus
 #else
 enum MatchingStatus
 {
-#endif // if defined(_WIN32)
-    MATCHED_MATCHING,//!< MATCHED_MATCHING, new publisher/subscriber found
-    REMOVED_MATCHING //!< REMOVED_MATCHING, publisher/subscriber removed
-
+#endif                // if defined(_WIN32)
+    MATCHED_MATCHING, //!< MATCHED_MATCHING, new publisher/subscriber found
+    REMOVED_MATCHING  //!< REMOVED_MATCHING, publisher/subscriber removed
 };
 
 /**
@@ -51,7 +48,7 @@ class FASTDDS_EXPORTED_API MatchingInfo
 {
 public:
 
-    //!Default constructor
+    //! Default constructor
     MatchingInfo()
         : status(MATCHED_MATCHING)
     {
@@ -73,9 +70,9 @@ public:
     {
     }
 
-    //!Status
+    //! Status
     MatchingStatus status;
-    //!Remote endpoint GUID
+    //! Remote endpoint GUID
     GUID_t remoteEndpointGuid;
 };
 } // namespace rtps

--- a/include/fastdds/rtps/common/SequenceNumber.hpp
+++ b/include/fastdds/rtps/common/SequenceNumber.hpp
@@ -32,7 +32,6 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-
 //!@brief Structure SequenceNumber_t, different for each change in the same writer.
 //!@ingroup COMMON_MODULE
 struct FASTDDS_EXPORTED_API SequenceNumber_t
@@ -42,7 +41,7 @@ struct FASTDDS_EXPORTED_API SequenceNumber_t
     //!
     uint32_t low = 0;
 
-    //!Default constructor
+    //! Default constructor
     SequenceNumber_t() noexcept
     {
         high = 0;
@@ -64,8 +63,7 @@ struct FASTDDS_EXPORTED_API SequenceNumber_t
     /*!
      * @param u
      */
-    explicit
-    SequenceNumber_t(
+    explicit SequenceNumber_t(
             uint64_t u) noexcept
         : high(static_cast<int32_t>(u >> 32u))
         , low(static_cast<uint32_t>(u))
@@ -110,7 +108,7 @@ struct FASTDDS_EXPORTED_API SequenceNumber_t
     {
         assert(inc >= 0);
         uint32_t aux_low = low;
-        low +=  static_cast<uint32_t>(inc);
+        low += static_cast<uint32_t>(inc);
 
         if (low < aux_low)
         {
@@ -124,7 +122,7 @@ struct FASTDDS_EXPORTED_API SequenceNumber_t
 
     static SequenceNumber_t unknown() noexcept
     {
-        return { -1, 0 };
+        return {-1, 0};
     }
 
 };
@@ -366,8 +364,7 @@ struct SequenceNumberDiff
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-//!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
-//!@ingroup COMMON_MODULE
+//! Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 using SequenceNumberSet_t = BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/Types.hpp
+++ b/include/fastdds/rtps/common/Types.hpp
@@ -19,9 +19,9 @@
 #ifndef FASTDDS_RTPS_COMMON__TYPES_HPP
 #define FASTDDS_RTPS_COMMON__TYPES_HPP
 
-#include <stddef.h>
-#include <iostream>
 #include <cstdint>
+#include <iostream>
+#include <stddef.h>
 #include <stdint.h>
 
 #include <fastdds/fastdds_dll.hpp>
@@ -34,7 +34,6 @@ namespace rtps {
 
 /*!
  * @brief This enumeration represents endianness types.
- * @ingroup COMMON_MODULE
  */
 enum Endianness_t
 {
@@ -44,38 +43,35 @@ enum Endianness_t
     LITTLEEND = 0x0
 };
 
-//!Reliability enum used for internal purposes
-//!@ingroup COMMON_MODULE
+//! Reliability enum used for internal purposes
 typedef enum ReliabilityKind_t
 {
     RELIABLE,
     BEST_EFFORT
-}ReliabilityKind_t;
+} ReliabilityKind_t;
 
-//!Durability kind
-//!@ingroup COMMON_MODULE
+//! Durability kind
 typedef enum DurabilityKind_t
 {
     VOLATILE,        //!< Volatile Durability
     TRANSIENT_LOCAL, //!< Transient Local Durability
     TRANSIENT,       //!< Transient Durability.
     PERSISTENT       //!< NOT IMPLEMENTED.
-}DurabilityKind_t;
+} DurabilityKind_t;
 
-//!Endpoint kind
-//!@ingroup COMMON_MODULE
+//! Endpoint kind
 typedef enum EndpointKind_t
 {
     READER,
     WRITER
-}EndpointKind_t;
+} EndpointKind_t;
 
-//!Topic kind
+//! Topic kind
 typedef enum TopicKind_t
 {
     NO_KEY,
     WITH_KEY
-}TopicKind_t;
+} TopicKind_t;
 
 #if FASTDDS_IS_BIG_ENDIAN_TARGET
 constexpr Endianness_t DEFAULT_ENDIAN = BIGEND;
@@ -84,8 +80,8 @@ constexpr Endianness_t DEFAULT_ENDIAN = LITTLEEND;
 #endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 using octet = unsigned char;
-//typedef unsigned int uint;
-//typedef unsigned short ushort;
+// typedef unsigned int uint;
+// typedef unsigned short ushort;
 using SubmessageFlag = unsigned char;
 using BuiltinEndpointSet_t = uint32_t;
 using NetworkConfigSet_t = uint32_t;
@@ -108,7 +104,8 @@ struct FASTDDS_EXPORTED_API ProtocolVersion_t
     octet m_major;
     octet m_minor;
 
-    ProtocolVersion_t():
+    ProtocolVersion_t()
+        :
 #if HAVE_SECURITY
         // As imposed by DDSSEC11-93
         ProtocolVersion_t(2, 3)
@@ -116,7 +113,6 @@ struct FASTDDS_EXPORTED_API ProtocolVersion_t
         ProtocolVersion_t(2, 2)
 #endif // if HAVE_SECURITY
     {
-
     }
 
     ProtocolVersion_t(
@@ -125,7 +121,6 @@ struct FASTDDS_EXPORTED_API ProtocolVersion_t
         : m_major(maj)
         , m_minor(min)
     {
-
     }
 
     bool operator ==(


### PR DESCRIPTION
This fixes a bug between doxygen >1.9.7 and breathe 4.35.0

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This fixes a bug between doxygen >1.9.7 and breathe 4.35.0.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

