### PR TITLE
[21114] Remove doxygen warnings (#4700, #5011)

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2798,8 +2798,9 @@ public:
     //! Thread settings for the builtin transports reception threads
     rtps::ThreadSettings builtin_transports_reception_threads_;
 
-    /*! Maximum message size used to avoid fragmentation, set ONLY in LARGE_DATA. If this value is
-     * not zero, the network factory will allow the initialization of UDP transports with maxMessageSize
+    /*!
+     * @brief Maximum message size used to avoid fragmentation, set ONLY in LARGE_DATA.
+     * If this value is not zero, the network factory will allow the initialization of UDP transports with maxMessageSize
      * higher than 65500K.
      */
     uint32_t max_msg_size_no_frag;

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -673,6 +673,7 @@ public:
      *
      * @param[out] participant_handles Reference to the vector where discovered participants will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_discovered_participants(
@@ -684,6 +685,7 @@ public:
      * @param[out] participant_data Reference to the ParticipantBuiltinTopicData object to return the data
      * @param participant_handle InstanceHandle of DomainParticipant to retrieve the data from
      * @return RETCODE_OK if everything correct, PRECONDITION_NOT_MET if participant does not exist
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_discovered_participant_data(
@@ -695,6 +697,7 @@ public:
      *
      * @param[out] topic_handles Reference to the vector where discovered topics will be returned
      * @return RETCODE_OK if everything correct, error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_discovered_topics(

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -139,7 +139,7 @@ public:
      * Returns all participants that belongs to the specified domain_id.
      *
      * @param domain_id
-     * @return previously created DomainParticipants within the specified domain
+     * @return previously created DomainParticipant instances within the specified domain
      */
     RTPS_DllAPI std::vector<DomainParticipant*> lookup_participants(
             DomainId_t domain_id) const;

--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -187,9 +187,7 @@ public:
     /*!
      * This method is called when a participant discovers a new Type
      * The ownership of all object belongs to the caller so if needs to be used after the
-     * method ends, a full copy should be perform (except for dyn_type due to its shared_ptr nature.
-     * For example:
-     * fastrtps::types::TypeIdentifier new_type_id = \*identifier;
+     * method ends, a full copy should be perform (except for dyn_type due to its shared_ptr nature).
      */
     virtual void on_type_discovery(
             DomainParticipant* participant,

--- a/include/fastdds/dds/domain/DomainParticipantListener.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantListener.hpp
@@ -187,7 +187,7 @@ public:
     /*!
      * This method is called when a participant discovers a new Type
      * The ownership of all object belongs to the caller so if needs to be used after the
-     * method ends, a full copy should be perform (except for dyn_type due to its shared_ptr nature).
+     * method ends, a full copy should be performed (except for dyn_type due to its shared_ptr nature).
      */
     virtual void on_type_discovery(
             DomainParticipant* participant,

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -514,6 +514,7 @@ public:
      * @param[out] subscription_data subscription data struct
      * @param subscription_handle InstanceHandle_t of the subscription
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscription_data(
@@ -525,6 +526,7 @@ public:
      *
      * @param[out] subscription_handles Vector where the InstanceHandle_t are returned
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscriptions(

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -217,6 +217,7 @@ public:
      * @brief Indicates to FastDDS that the contained DataWriters are about to be modified
      *
      * @return RETCODE_OK if successful, an error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t suspend_publications();
@@ -225,6 +226,7 @@ public:
      * @brief Indicates to FastDDS that the modifications to the DataWriters are complete.
      *
      * @return RETCODE_OK if successful, an error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t resume_publications();
@@ -233,6 +235,7 @@ public:
      * @brief Signals the beginning of a set of coherent cache changes using the Datawriters attached to the publisher
      *
      * @return RETCODE_OK if successful, an error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t begin_coherent_changes();
@@ -241,6 +244,7 @@ public:
      * @brief Signals the end of a set of coherent cache changes
      *
      * @return RETCODE_OK if successful, an error code otherwise
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t end_coherent_changes();
@@ -322,6 +326,8 @@ public:
      * @param[out] writer_qos
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
+     *
+     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
             fastdds::dds::DataWriterQos& writer_qos,

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -136,6 +136,7 @@ public:
      *
      * @param[in] max_wait Max blocking time for this operation.
      * @return RETCODE_OK if there is new unread message, ReturnCode_t::RETCODE_TIMEOUT if timeout
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t wait_for_historical_data(
@@ -764,6 +765,7 @@ public:
      * @param[in] handle
      *
      * @return Any of the standard return codes.
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_key_value(
@@ -976,6 +978,7 @@ public:
      * @param[out] publication_data publication data struct
      * @param publication_handle InstanceHandle_t of the publication
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_publication_data(
@@ -987,6 +990,7 @@ public:
      *
      * @param[out] publication_handles Vector where the InstanceHandle_t are returned
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_publications(

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -234,6 +234,7 @@ public:
      * @param view_states Vector of ViewStateKind
      * @param instance_states Vector of InstanceStateKind
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_datareaders(
@@ -254,6 +255,7 @@ public:
      * attached to the Subscriber.
      *
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t begin_access();
@@ -263,6 +265,7 @@ public:
      * the Subscriber.
      *
      * @return RETCODE_OK
+     *
      * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t end_access();
@@ -360,6 +363,8 @@ public:
      * @param[in, out] reader_qos
      * @param[in] topic_qos
      * @return RETCODE_OK if successful, an error code otherwise
+     *
+     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI static ReturnCode_t copy_from_topic_qos(
             DataReaderQos& reader_qos,

--- a/include/fastdds/rtps/common/ChangeKind_t.hpp
+++ b/include/fastdds/rtps/common/ChangeKind_t.hpp
@@ -26,8 +26,7 @@ namespace fastrtps {
 namespace rtps {
 
 /**
- * @enum ChangeKind_t, different types of CacheChange_t.
- * @ingroup COMMON_MODULE
+ * Enumerates the different types of CacheChange_t.
  */
 enum RTPS_DllAPI ChangeKind_t
 {

--- a/include/fastdds/rtps/common/FragmentNumber.h
+++ b/include/fastdds/rtps/common/FragmentNumber.h
@@ -19,37 +19,38 @@
 #ifndef _FASTDDS_RTPS_RPTS_ELEM_FRAGNUM_H_
 #define _FASTDDS_RTPS_RPTS_ELEM_FRAGNUM_H_
 
+#include <algorithm>
+#include <cmath>
+#include <set>
+
+#include <fastdds/rtps/common/Types.h>
 #include <fastrtps/fastrtps_dll.h>
 #include <fastrtps/utils/fixed_size_bitmap.hpp>
-#include <fastdds/rtps/common/Types.h>
 
-#include <set>
-#include <cmath>
-#include <algorithm>
-
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 using FragmentNumber_t = uint32_t;
 
 //!Structure FragmentNumberSet_t, contains a group of fragmentnumbers.
-//!@ingroup COMMON_MODULE
 using FragmentNumberSet_t = BitmapRange<FragmentNumber_t>;
 
-inline std::ostream& operator<<(std::ostream& output, const FragmentNumberSet_t& fns)
+inline std::ostream& operator <<(
+        std::ostream& output,
+        const FragmentNumberSet_t& fns)
 {
     output << fns.base() << ":";
     fns.for_each([&](FragmentNumber_t it)
-    {
-        output << it << "-";
-    });
+            {
+                output << it << "-";
+            });
 
     return output;
 }
 
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
 
 #endif /* _FASTDDS_RTPS_RPTS_ELEM_FRAGNUM_H_ */

--- a/include/fastdds/rtps/common/MatchingInfo.h
+++ b/include/fastdds/rtps/common/MatchingInfo.h
@@ -22,22 +22,23 @@
 
 #include <fastdds/rtps/common/Guid.h>
 
-namespace eprosima{
-namespace fastrtps{
-namespace rtps{
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
 
 /**
- * @enum MatchingStatus, indicates whether the matched publication/subscription method of the PublisherListener or SubscriberListener has
+ * Indicates whether the matched publication/subscription method of the PublisherListener or SubscriberListener has
  * been called for a matching or a removal of a remote endpoint.
- * @ingroup COMMON_MODULE
  */
 #if defined(_WIN32)
-    enum RTPS_DllAPI MatchingStatus{
+enum RTPS_DllAPI MatchingStatus
+{
 #else
-        enum MatchingStatus{
-#endif
-    MATCHED_MATCHING,//!< MATCHED_MATCHING, new publisher/subscriber found
-    REMOVED_MATCHING //!< REMOVED_MATCHING, publisher/subscriber removed
+enum MatchingStatus
+{
+#endif  // if defined(_WIN32)
+    MATCHED_MATCHING,  //!< MATCHED_MATCHING, new publisher/subscriber found
+    REMOVED_MATCHING   //!< REMOVED_MATCHING, publisher/subscriber removed
 
 };
 
@@ -48,21 +49,36 @@ namespace rtps{
 class RTPS_DllAPI MatchingInfo
 {
 public:
-    //!Default constructor
-    MatchingInfo():status(MATCHED_MATCHING){};
+
+    //! Default constructor
+    MatchingInfo()
+        : status(MATCHED_MATCHING)
+    {
+    }
+
     /**
-    * @param stat Status
-    * @param guid GUID
-    */
-    MatchingInfo(MatchingStatus stat,const GUID_t&guid):status(stat),remoteEndpointGuid(guid){};
-    ~MatchingInfo(){};
-    //!Status
+     * @param stat Status
+     * @param guid GUID
+     */
+    MatchingInfo(
+            MatchingStatus stat,
+            const GUID_t& guid)
+        : status(stat)
+        , remoteEndpointGuid(guid)
+    {
+    }
+
+    ~MatchingInfo()
+    {
+    }
+
+    //! Status
     MatchingStatus status;
-    //!Remote endpoint GUID
+    //! Remote endpoint GUID
     GUID_t remoteEndpointGuid;
 };
-}
-}
-}
+} // namespace rtps
+} // namespace fastrtps
+} // namespace eprosima
 
 #endif /* _FASTDDS_RTPS_MATCHINGINFO_H_ */

--- a/include/fastdds/rtps/common/SequenceNumber.h
+++ b/include/fastdds/rtps/common/SequenceNumber.h
@@ -32,7 +32,6 @@ namespace eprosima {
 namespace fastrtps {
 namespace rtps {
 
-
 //!@brief Structure SequenceNumber_t, different for each change in the same writer.
 //!@ingroup COMMON_MODULE
 struct RTPS_DllAPI SequenceNumber_t
@@ -42,7 +41,7 @@ struct RTPS_DllAPI SequenceNumber_t
     //!
     uint32_t low = 0;
 
-    //!Default constructor
+    //! Default constructor
     SequenceNumber_t() noexcept
     {
         high = 0;
@@ -366,8 +365,7 @@ struct SequenceNumberDiff
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
-//!Structure SequenceNumberSet_t, contains a group of sequencenumbers.
-//!@ingroup COMMON_MODULE
+//! Structure SequenceNumberSet_t, contains a group of sequencenumbers.
 using SequenceNumberSet_t = BitmapRange<SequenceNumber_t, SequenceNumberDiff, 256>;
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -19,14 +19,13 @@
 #ifndef _FASTDDS_RTPS_COMMON_TYPES_H_
 #define _FASTDDS_RTPS_COMMON_TYPES_H_
 
-#include <stddef.h>
-#include <iostream>
+#include <cstddef>
 #include <cstdint>
-#include <stdint.h>
-
-#include <fastrtps/fastrtps_dll.h>
+#include <cstdint>
+#include <iostream>
 
 #include <fastdds/rtps/common/VendorId_t.hpp>
+#include <fastrtps/fastrtps_dll.h>
 
 namespace eprosima {
 namespace fastrtps {
@@ -34,7 +33,6 @@ namespace rtps {
 
 /*!
  * @brief This enumeration represents endianness types.
- * @ingroup COMMON_MODULE
  */
 enum Endianness_t
 {
@@ -44,38 +42,35 @@ enum Endianness_t
     LITTLEEND = 0x0
 };
 
-//!Reliability enum used for internal purposes
-//!@ingroup COMMON_MODULE
+//! Reliability enum used for internal purposes
 typedef enum ReliabilityKind_t
 {
     RELIABLE,
     BEST_EFFORT
-}ReliabilityKind_t;
+} ReliabilityKind_t;
 
-//!Durability kind
-//!@ingroup COMMON_MODULE
+//! Durability kind
 typedef enum DurabilityKind_t
 {
     VOLATILE,        //!< Volatile Durability
     TRANSIENT_LOCAL, //!< Transient Local Durability
     TRANSIENT,       //!< Transient Durability.
     PERSISTENT       //!< NOT IMPLEMENTED.
-}DurabilityKind_t;
+} DurabilityKind_t;
 
-//!Endpoint kind
-//!@ingroup COMMON_MODULE
+//! Endpoint kind
 typedef enum EndpointKind_t
 {
     READER,
     WRITER
-}EndpointKind_t;
+} EndpointKind_t;
 
-//!Topic kind
+//! Topic kind
 typedef enum TopicKind_t
 {
     NO_KEY,
     WITH_KEY
-}TopicKind_t;
+} TopicKind_t;
 
 #if FASTDDS_IS_BIG_ENDIAN_TARGET
 constexpr Endianness_t DEFAULT_ENDIAN = BIGEND;
@@ -84,8 +79,8 @@ constexpr Endianness_t DEFAULT_ENDIAN = LITTLEEND;
 #endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 using octet = unsigned char;
-//typedef unsigned int uint;
-//typedef unsigned short ushort;
+// typedef unsigned int uint;
+// typedef unsigned short ushort;
 using SubmessageFlag = unsigned char;
 using BuiltinEndpointSet_t = uint32_t;
 using NetworkConfigSet_t = uint32_t;

--- a/include/fastdds/rtps/common/Types.h
+++ b/include/fastdds/rtps/common/Types.h
@@ -79,8 +79,6 @@ constexpr Endianness_t DEFAULT_ENDIAN = LITTLEEND;
 #endif // if FASTDDS_IS_BIG_ENDIAN_TARGET
 
 using octet = unsigned char;
-// typedef unsigned int uint;
-// typedef unsigned short ushort;
 using SubmessageFlag = unsigned char;
 using BuiltinEndpointSet_t = uint32_t;
 using NetworkConfigSet_t = uint32_t;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is a manual backport to 2.14.x of two PRs:

* #4700
* #5011 

This work has been done so the following docs PR passes CI:

* eProsima/Fast-DDS-docs#796

Related PRs:

* eProsima/Fast-DDS-python/pull/154
* eProsima/Fast-DDS-docs#796

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x]  Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_:  Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_:  New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
     - Related documentation PR: eProsima/Fast-DDS-docs#796
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
