### PR TITLE
[21244] Migrate `2.6.x` ci jobs from nighties to weeklies

### DIFF
--- a/.github/workflows/nightly-mac-ci.yml
+++ b/.github/workflows/nightly-mac-ci.yml
@@ -66,17 +66,3 @@ jobs:
       fastdds-branch: '2.10.x'
       use-ccache: false
 
-  nightly-mac-ci-2_6_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        security:
-          - 'ON'
-          - 'OFF'
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.6.x
-    with:
-      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.6.x'
-      cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: "-LE xfail"
-      fastdds-branch: '2.6.x'
-      use-ccache: false

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -82,21 +82,3 @@ jobs:
       run-tests: true
       use-ccache: false
 
-  nightly-ubuntu-ci-2_6_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-        security:
-          - true
-          - false
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.6.x'
-      ctest-args: "-LE xfail"
-      fastdds-branch: '2.6.x'
-      security: ${{ matrix.security }}
-      run-tests: true
-      use-ccache: false

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -62,16 +62,3 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds_branch: '2.10.x'
 
-  nightly-windows-ci-2_6_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        security:
-          - 'ON'
-          - 'OFF'
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.6.x
-    with:
-      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.6.x'
-      cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: "-LE xfail"
-      fastdds_branch: '2.6.x'

--- a/.github/workflows/weekly-mac-ci.yml
+++ b/.github/workflows/weekly-mac-ci.yml
@@ -1,0 +1,23 @@
+name: Fast DDS MacOS CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+
+  weekly-mac-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.6.x
+    with:
+      label: 'weekly-sec-${{ matrix.security }}-mac-ci-2.6.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.6.x'
+      use-ccache: false

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -1,0 +1,27 @@
+name: Fast DDS Ubuntu CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+
+  weekly-ubuntu-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        os-image:
+          - 'ubuntu-22.04'
+        security:
+          - true
+          - false
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
+    with:
+      os-image: ${{ matrix.os-image }}
+      label: '${{ matrix.os-image }}-weekly-sec-${{ matrix.security }}-ubuntu-ci-2.6.x'
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.6.x'
+      security: ${{ matrix.security }}
+      run-tests: true
+      use-ccache: false

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -11,15 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-image:
-          - 'ubuntu-22.04'
         security:
           - true
           - false
     uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.6.x
     with:
-      os-image: ${{ matrix.os-image }}
-      label: '${{ matrix.os-image }}-weekly-sec-${{ matrix.security }}-ubuntu-ci-2.6.x'
+      os-image: 'ubuntu-20.04'
+      label: 'weekly-sec-${{ matrix.security }}-ubuntu-ci-2.6.x'
       ctest-args: "-LE xfail"
       fastdds-branch: '2.6.x'
       security: ${{ matrix.security }}

--- a/.github/workflows/weekly-windows-ci.yml
+++ b/.github/workflows/weekly-windows-ci.yml
@@ -1,0 +1,22 @@
+name: Fast DDS Windows CI (weekly)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * 1' # Run at minute 0 on Monday
+
+jobs:
+
+  weekly-windows-ci-2_6_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        security:
+          - 'ON'
+          - 'OFF'
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.6.x
+    with:
+      label: 'weekly-sec-${{ matrix.security }}-windows-ci-2.6.x'
+      cmake-args: "-DSECURITY=${{ matrix.security }}"
+      ctest-args: "-LE xfail"
+      fastdds_branch: '2.6.x'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes `2.6.x` nighties and sets up weekly jobs for running on `2.6.x`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __NO__ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- __NO__ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- __NO__ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- __NO__ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__ New feature has been added to the `versions.md` file (if applicable).
- __NO__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- __NO__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- **N/A** Check CI results: changes do not issue any warning.
- **N/A**Check CI results: failing tests are unrelated with the changes.
