### PR TITLE
[21114] Adjust doxygen so Fast DDS Python pydoc makes RTD build

### DIFF
--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -447,8 +447,10 @@ public:
      *
      * @param[in] data Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
      * @param[in] handle InstanceHandle of the data
-     * @return RETCODE_PRECONDITION_NOT_MET if the handle introduced does not match with the one associated to the data,
-     * RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
+     *
+     * @return RETCODE_PRECONDITION_NOT_MET if the handle introduced does not match with the one associated to the data.
+     * @return RETCODE_OK if the data is correctly sent.
+     * @return RETCODE_ERROR otherwise.
      */
     RTPS_DllAPI ReturnCode_t dispose(
             void* data,

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -248,8 +248,8 @@ public:
      *
      * @param[in] instance Sample used to deduce instance's key in case of `handle` parameter is HANDLE_NIL.
      * @param[in] handle Instance's key to be unregistered.
-     * @return Returns the operation's result.
-     * If the operation finishes successfully, ReturnCode_t::RETCODE_OK is returned.
+     *
+     * @return ReturnCode_t
      */
     RTPS_DllAPI ReturnCode_t unregister_instance(
             void* instance,

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -198,12 +198,14 @@ public:
 
     /*!
      * @brief Informs that the application will be modifying a particular instance.
+     *
      * It gives an opportunity to the middleware to pre-configure itself to improve performance.
+     * The returned handle could be used in successive `write` or `dispose` operations.
      *
      * @param[in] instance Sample used to get the instance's key.
+     *
      * @return Handle containing the instance's key.
-     * This handle could be used in successive `write` or `dispose` operations.
-     * In case of error, HANDLE_NIL will be returned.
+     * @return HANDLE_NIL in case of error.
      */
     RTPS_DllAPI InstanceHandle_t register_instance(
             void* instance);

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -562,11 +562,11 @@ public:
      *
      * If the DataReader has no samples that meet the constraints, the return value will be RETCODE_NO_DATA.
      *
-     * @param[in,out] data_values     A LoanableCollection object where the received data samples will be returned.
-     * @param[in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
-     * @param[in]     max_samples     The maximum number of samples to be returned. If the special value
-     *                                @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are.
-     * @param[in]     a_condition     A ReadCondition that returned @c data_values must pass
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are.
+     * @param [in]     a_condition     A ReadCondition that returned @c data_values must pass
      *
      * @return Any of the standard return codes.
      */

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -590,17 +590,17 @@ public:
      *
      * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
      *
-     * @param[in,out] data_values     A LoanableCollection object where the received data samples will be returned.
-     * @param[in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
-     * @param[in]     max_samples     The maximum number of samples to be returned. If the special value
-     *                                @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
-     *                                available, up to the limits described in the documentation for @ref read().
-     * @param[in]     a_handle        The specified instance to return samples for. The method will fail with
-     *                                RETCODE_BAD_PARAMETER if the handle does not correspond to an existing
-     *                                data-object known to the DataReader.
-     * @param[in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
-     * @param[in]     view_states     Only data samples with @c view_state matching one of these will be returned.
-     * @param[in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     a_handle        The specified instance to return samples for. The method will fail with
+     *                                 RETCODE_BAD_PARAMETER if the handle does not correspond to an existing
+     *                                 data-object known to the DataReader.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
      *
      * @return Any of the standard return codes.
      */

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -630,16 +630,16 @@ public:
      *
      * If the DataReader has no samples that meet the constraints, the operations fails with RETCODE_NO_DATA.
      *
-     * @param[in,out] data_values     A LoanableCollection object where the received data samples will be returned.
-     * @param[in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
-     * @param[in]     max_samples     The maximum number of samples to be returned. If the special value
-     *                                @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
-     *                                available, up to the limits described in the documentation for @ref read().
-     * @param[in]     previous_handle The 'next smallest' instance with a value greater than this value that has
-     *                                available samples will be returned.
-     * @param[in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
-     * @param[in]     view_states     Only data samples with @c view_state matching one of these will be returned.
-     * @param[in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     sample_states   Only data samples with @c sample_state matching one of these will be returned.
+     * @param [in]     view_states     Only data samples with @c view_state matching one of these will be returned.
+     * @param [in]     instance_states Only data samples with @c instance_state matching one of these will be returned.
      *
      * @return Any of the standard return codes.
      */

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -669,14 +669,14 @@ public:
      *
      * If the DataReader has no samples that meet the constraints, the return value will be RETCODE_NO_DATA
      *
-     * @param[in,out] data_values     A LoanableCollection object where the received data samples will be returned.
-     * @param[in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
-     * @param[in]     max_samples     The maximum number of samples to be returned. If the special value
-     *                                @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
-     *                                available, up to the limits described in the documentation for @ref read().
-     * @param[in]     previous_handle The 'next smallest' instance with a value greater than this value that has
-     *                                available samples will be returned.
-     * @param[in]     a_condition     A ReadCondition that returned @c data_values must pass
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     a_condition     A ReadCondition that returned @c data_values must pass
      *
      * @return Any of the standard return codes.
      */

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -455,7 +455,7 @@ public:
      * This operation accesses a collection of Data values from the DataReader. The behavior is identical to
      * @ref read_next_instance except that all samples returned satisfy the specified condition. In other words, on
      * success all returned samples belong to the same instance, and the instance is the instance with
-     * ‘smallest’ @c instance_handle among the ones that verify (a) @c instance_handle >= @c previous_handle and (b) have samples
+     * 'smallest' @c instance_handle among the ones that verify (a) @c instance_handle >= @c previous_handle and (b) have samples
      * for which the specified ReadCondition evaluates to TRUE.
      *
      * Similar to the operation @ref read_next_instance it is possible to call
@@ -464,19 +464,19 @@ public:
      *
      * The behavior of the @ref read_next_instance_w_condition operation follows the same rules than the read operation
      * regarding the pre-conditions and post-conditions for the @c data_values and @c sample_infos collections. Similar
-     * to read, the @ref read_next_instance_w_condition operation may ‘loan’ elements to the output collections which
+     * to read, the @ref read_next_instance_w_condition operation may 'loan' elements to the output collections which
      * must then be returned by means of @ref return_loan.
      *
      * If the DataReader has no samples that meet the constraints, the return value will be RETCODE_NO_DATA.
      *
-     * @param[in,out] data_values     A LoanableCollection object where the received data samples will be returned.
-     * @param[in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
-     * @param[in]     max_samples     The maximum number of samples to be returned. If the special value
-     *                                @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
-     *                                available, up to the limits described in the documentation for @ref read().
-     * @param[in]     previous_handle The 'next smallest' instance with a value greater than this value that has
-     *                                available samples will be returned.
-     * @param[in]     a_condition     A ReadCondition that returned @c data_values must pass
+     * @param [in,out] data_values     A LoanableCollection object where the received data samples will be returned.
+     * @param [in,out] sample_infos    A SampleInfoSeq object where the received sample info will be returned.
+     * @param [in]     max_samples     The maximum number of samples to be returned. If the special value
+     *                                 @ref LENGTH_UNLIMITED is provided, as many samples will be returned as are
+     *                                 available, up to the limits described in the documentation for @ref read().
+     * @param [in]     previous_handle The 'next smallest' instance with a value greater than this value that has
+     *                                 available samples will be returned.
+     * @param [in]     a_condition     A ReadCondition that returned @c data_values must pass
      *
      * @return Any of the standard return codes.
      */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adjusts some Doxydoc so that the pydoc generated for Fast DDS Python does not make RTD build failed. This PR is a follow up of:

* #5016

This PR is related to:

* eProsima/Fast-DDS-docs#796

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#796
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
