### PR TITLE
[21293] Fix destruction data-race on participant removal in intra-process

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -41,6 +41,7 @@
 #include <rtps/network/utils/external_locators.hpp>
 #include <rtps/participant/RTPSParticipantImpl.hpp>
 #include <rtps/reader/BaseReader.hpp>
+#include <rtps/reader/LocalReaderPointer.hpp>
 #include <rtps/RTPSDomainImpl.hpp>
 #include <rtps/transport/TCPv4Transport.h>
 #include <rtps/transport/TCPv6Transport.h>

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -690,7 +690,7 @@ RTPSParticipantImpl* RTPSDomainImpl::find_local_participant(
     return nullptr;
 }
 
-BaseReader* RTPSDomainImpl::find_local_reader(
+std::shared_ptr<LocalReaderPointer> RTPSDomainImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
     auto instance = get_instance();
@@ -704,7 +704,7 @@ BaseReader* RTPSDomainImpl::find_local_reader(
         }
     }
 
-    return nullptr;
+    return std::shared_ptr<LocalReaderPointer>(nullptr);
 }
 
 BaseWriter* RTPSDomainImpl::find_local_writer(

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -30,6 +30,7 @@
 #include <fastdds/rtps/writer/RTPSWriter.hpp>
 
 #include <rtps/reader/BaseReader.hpp>
+#include <rtps/reader/LocalReaderPointer.hpp>
 #include <rtps/writer/BaseWriter.hpp>
 #include <utils/shared_memory/BoostAtExitRegistry.hpp>
 #include <utils/SystemInfo.hpp>

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -175,7 +175,7 @@ public:
      *
      * @returns A pointer to a local reader given its endpoint guid, or nullptr if not found.
      */
-    static BaseReader* find_local_reader(
+    static std::shared_ptr<LocalReaderPointer> find_local_reader(
             const GUID_t& reader_guid);
 
     /**

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1350,7 +1350,7 @@ bool RTPSParticipantImpl::createReader(
     return create_reader(ReaderOut, param, entityId, isBuiltin, enable, callback);
 }
 
-BaseReader* RTPSParticipantImpl::find_local_reader(
+std::shared_ptr<LocalReaderPointer> RTPSParticipantImpl::find_local_reader(
         const GUID_t& reader_guid)
 {
     shared_lock<shared_mutex> _(endpoints_list_mutex);
@@ -1359,11 +1359,11 @@ BaseReader* RTPSParticipantImpl::find_local_reader(
     {
         if (reader->getGuid() == reader_guid)
         {
-            return reader;
+            return reader->get_local_pointer();
         }
     }
 
-    return nullptr;
+    return std::shared_ptr<LocalReaderPointer>();
 }
 
 BaseWriter* RTPSParticipantImpl::find_local_writer(
@@ -1960,6 +1960,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
 
     bool found = false, found_in_users = false;
     Endpoint* p_endpoint = nullptr;
+    BaseReader* reader = nullptr;
 
     if (endpoint.entityId.is_writer())
     {
@@ -1994,6 +1995,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
         {
             if ((*rit)->getGuid().entityId == endpoint.entityId) //Found it
             {
+                reader = *rit;
                 m_userReaderList.erase(rit);
                 found_in_users = true;
                 break;
@@ -2004,6 +2006,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
         {
             if ((*rit)->getGuid().entityId == endpoint.entityId) //Found it
             {
+                reader = *rit;
                 p_endpoint = *rit;
                 m_allReaderList.erase(rit);
                 found = true;
@@ -2062,6 +2065,10 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
 #endif // if HAVE_SECURITY
     }
 
+    if (reader)
+    {
+        reader->local_actions_on_reader_removed();
+    }
     delete(p_endpoint);
     return true;
 }
@@ -2148,6 +2155,11 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
             (m_security_manager.*unregister_endpoint[kind])(endpoint->getGuid());
         }
 #endif // if HAVE_SECURITY
+
+        if (kind == READER)
+        {
+            static_cast<BaseReader*>(endpoint)->local_actions_on_reader_removed();
+        }
 
         // remove the endpoints
         delete(endpoint);
@@ -2874,8 +2886,11 @@ bool RTPSParticipantImpl::register_in_reader(
     }
     else if (!fastdds::statistics::is_statistics_builtin(reader_guid.entityId))
     {
-        BaseReader* reader = find_local_reader(reader_guid);
-        res = reader->add_statistics_listener(listener);
+        LocalReaderPointer::Instance local_reader(find_local_reader(reader_guid));
+        if (local_reader)
+        {
+            res = local_reader->add_statistics_listener(listener);
+        }
     }
 
     return res;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -56,6 +56,7 @@
 #include <rtps/messages/SendBuffersManager.hpp>
 #include <rtps/network/NetworkFactory.hpp>
 #include <rtps/network/ReceiverResource.h>
+#include <rtps/reader/LocalReaderPointer.hpp>
 #include <rtps/resources/ResourceEvent.h>
 #include <statistics/rtps/monitor-service/interfaces/IConnectionsObserver.hpp>
 #include <statistics/rtps/monitor-service/interfaces/IConnectionsQueryable.hpp>
@@ -477,7 +478,7 @@ public:
     /***
      * @returns A pointer to a local reader given its endpoint guid, or nullptr if not found.
      */
-    BaseReader* find_local_reader(
+    std::shared_ptr<LocalReaderPointer> find_local_reader(
             const GUID_t& reader_guid);
 
     /***

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -107,6 +107,11 @@ BaseReader::BaseReader(
     setup_datasharing(att);
 }
 
+void BaseReader::local_actions_on_reader_removed()
+{
+    local_ptr_->deactivate();
+}
+
 BaseReader::~BaseReader()
 {
     EPROSIMA_LOG_INFO(RTPS_READER, "Removing reader " << this->getGuid().entityId);
@@ -270,6 +275,11 @@ void BaseReader::allow_unknown_writers()
 {
     assert(fastdds::rtps::EntityId_t::unknown() != trusted_writer_entity_id_);
     accept_messages_from_unkown_writers_ = true;
+}
+
+std::shared_ptr<LocalReaderPointer> BaseReader::get_local_pointer()
+{
+    return local_ptr_;
 }
 
 bool BaseReader::reserve_cache(
@@ -500,6 +510,8 @@ void BaseReader::init(
     {
         fixed_payload_size_ = history_->m_att.payloadMaxSize;
     }
+
+    local_ptr_ = std::make_shared<LocalReaderPointer>(this);
 
     EPROSIMA_LOG_INFO(RTPS_READER, "RTPSReader created correctly");
 }

--- a/src/cpp/rtps/reader/BaseReader.hpp
+++ b/src/cpp/rtps/reader/BaseReader.hpp
@@ -309,7 +309,7 @@ public:
     /**
      * @brief Waits for not being referenced/used by any other entity.
      */
-    void local_actions_on_reader_removed();
+    virtual void local_actions_on_reader_removed();
 
 #ifdef FASTDDS_STATISTICS
 

--- a/src/cpp/rtps/reader/BaseReader.hpp
+++ b/src/cpp/rtps/reader/BaseReader.hpp
@@ -42,6 +42,8 @@
 #include <fastdds/statistics/rtps/StatisticsCommon.hpp>
 #include <fastdds/utils/TimedConditionVariable.hpp>
 
+#include <rtps/reader/LocalReaderPointer.hpp>
+
 namespace eprosima {
 
 namespace fastdds {
@@ -162,6 +164,14 @@ public:
     {
         return datasharing_listener_;
     }
+
+    /**
+     * @brief Retrieves the local pointer to this reader
+     * to be used by other local entities.
+     *
+     * @return Local pointer to this reader.
+     */
+    std::shared_ptr<LocalReaderPointer> get_local_pointer();
 
     /**
      * @brief Reserve a CacheChange_t.
@@ -295,6 +305,11 @@ public:
             const fastdds::rtps::SequenceNumber_t& gapStart,
             const fastdds::rtps::SequenceNumberSet_t& gapList,
             VendorId_t origin_vendor_id = c_VendorId_Unknown) = 0;
+
+    /**
+     * @brief Waits for not being referenced/used by any other entity.
+     */
+    void local_actions_on_reader_removed();
 
 #ifdef FASTDDS_STATISTICS
 
@@ -454,6 +469,9 @@ protected:
 
     /// Trusted writer (for Builtin)
     fastdds::rtps::EntityId_t trusted_writer_entity_id_;
+
+    /// RefCountedPointer of this instance.
+    std::shared_ptr<LocalReaderPointer> local_ptr_;
 
 private:
 

--- a/src/cpp/rtps/reader/LocalReaderPointer.hpp
+++ b/src/cpp/rtps/reader/LocalReaderPointer.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file LocalReaderPointer.hpp
+ */
+
+#ifndef FASTDDS_RTPS_READER__LOCALREADERPOINTER_HPP
+#define FASTDDS_RTPS_READER__LOCALREADERPOINTER_HPP
+
+#include <utils/RefCountedPointer.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+class BaseReader;
+
+using LocalReaderPointer = RefCountedPointer<BaseReader>;
+
+}  // namespace rtps
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif // FASTDDS_RTPS_READER__LOCALREADERPOINTER_HPP

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -45,7 +45,7 @@ ReaderLocator::ReaderLocator(
     , async_locator_info_(max_unicast_locators, max_multicast_locators)
     , expects_inline_qos_(false)
     , is_local_reader_(false)
-    , local_reader_(nullptr)
+    , local_reader_()
     , guid_prefix_as_vector_(1u)
     , guid_as_vector_(1u)
     , datasharing_notifier_(nullptr)
@@ -84,7 +84,7 @@ bool ReaderLocator::start(
 
         is_local_reader_ = RTPSDomainImpl::should_intraprocess_between(owner_->getGuid(), remote_guid);
         is_datasharing &= !is_local_reader_;
-        local_reader_ = nullptr;
+        local_reader_.reset();
 
         if (!is_local_reader_ && !is_datasharing)
         {
@@ -177,7 +177,7 @@ void ReaderLocator::stop()
     guid_prefix_as_vector_.at(0) = c_GuidPrefix_Unknown;
     expects_inline_qos_ = false;
     is_local_reader_ = false;
-    local_reader_ = nullptr;
+    local_reader_.reset();
 }
 
 bool ReaderLocator::send(
@@ -206,13 +206,13 @@ bool ReaderLocator::send(
     return true;
 }
 
-BaseReader* ReaderLocator::local_reader()
+LocalReaderPointer::Instance ReaderLocator::local_reader()
 {
     if (!local_reader_)
     {
         local_reader_ = RTPSDomainImpl::find_local_reader(general_locator_info_.remote_guid);
     }
-    return local_reader_;
+    return LocalReaderPointer::Instance(local_reader_);
 }
 
 bool ReaderLocator::is_datasharing_reader() const
@@ -222,15 +222,13 @@ bool ReaderLocator::is_datasharing_reader() const
 
 void ReaderLocator::datasharing_notify()
 {
-    RTPSReader* reader = nullptr;
     if (is_local_reader())
     {
-        reader = local_reader();
-    }
-
-    if (reader)
-    {
-        BaseReader::downcast(reader)->datasharing_listener()->notify(true);
+        LocalReaderPointer::Instance reader = local_reader();
+        if (reader)
+        {
+            reader->datasharing_listener()->notify(true);
+        }
     }
     else
     {

--- a/src/cpp/rtps/writer/ReaderLocator.hpp
+++ b/src/cpp/rtps/writer/ReaderLocator.hpp
@@ -25,6 +25,8 @@
 #include <fastdds/rtps/messages/RTPSMessageSenderInterface.hpp>
 #include <fastdds/rtps/common/LocatorSelectorEntry.hpp>
 
+#include <rtps/reader/LocalReaderPointer.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -67,10 +69,10 @@ public:
         return is_local_reader_;
     }
 
-    BaseReader* local_reader();
+    LocalReaderPointer::Instance local_reader();
 
     void local_reader(
-            BaseReader* local_reader)
+            std::shared_ptr<LocalReaderPointer> local_reader)
     {
         local_reader_ = local_reader;
     }
@@ -260,7 +262,7 @@ private:
     LocatorSelectorEntry async_locator_info_;
     bool expects_inline_qos_;
     bool is_local_reader_;
-    BaseReader* local_reader_;
+    std::shared_ptr<LocalReaderPointer> local_reader_;
     std::vector<GuidPrefix_t> guid_prefix_as_vector_;
     std::vector<GUID_t> guid_as_vector_;
     IDataSharingNotifier* datasharing_notifier_;

--- a/src/cpp/rtps/writer/ReaderProxy.hpp
+++ b/src/cpp/rtps/writer/ReaderProxy.hpp
@@ -290,7 +290,7 @@ public:
      * Get the local reader on the same process (if any).
      * @return The local reader on the same process.
      */
-    inline BaseReader* local_reader()
+    inline LocalReaderPointer::Instance local_reader()
     {
         return locator_info_.local_reader();
     }

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -405,14 +405,14 @@ bool StatefulWriter::intraprocess_delivery(
         CacheChange_t* change,
         ReaderProxy* reader_proxy)
 {
-    BaseReader* reader = reader_proxy->local_reader();
-    if (reader)
+    LocalReaderPointer::Instance local_reader = reader_proxy->local_reader();
+    if (local_reader)
     {
         if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
         {
             change->write_params.sample_identity(change->write_params.related_sample_identity());
         }
-        return reader->process_data_msg(change);
+        return local_reader->process_data_msg(change);
     }
     return false;
 }
@@ -422,10 +422,10 @@ bool StatefulWriter::intraprocess_gap(
         const SequenceNumber_t& first_seq,
         const SequenceNumber_t& last_seq)
 {
-    RTPSReader* reader = reader_proxy->local_reader();
-    if (reader)
+    LocalReaderPointer::Instance local_reader = reader_proxy->local_reader();
+    if (local_reader)
     {
-        return BaseReader::downcast(reader)->process_gap_msg(
+        return local_reader->process_gap_msg(
             m_guid, first_seq, SequenceNumberSet_t(last_seq), c_VendorId_eProsima);
     }
 
@@ -437,12 +437,11 @@ bool StatefulWriter::intraprocess_heartbeat(
         bool liveliness)
 {
     bool returned_value = false;
+    LocalReaderPointer::Instance local_reader = reader_proxy->local_reader();
 
-    std::lock_guard<RecursiveTimedMutex> guardW(mp_mutex);
-    RTPSReader* reader = RTPSDomainImpl::find_local_reader(reader_proxy->guid());
-
-    if (reader)
+    if (local_reader)
     {
+        std::lock_guard<RecursiveTimedMutex> guardW(mp_mutex);
         SequenceNumber_t first_seq = get_seq_num_min();
         SequenceNumber_t last_seq = get_seq_num_max();
 
@@ -459,7 +458,7 @@ bool StatefulWriter::intraprocess_heartbeat(
                 (liveliness || reader_proxy->has_changes()))
         {
             increment_hb_count();
-            returned_value = BaseReader::downcast(reader)->process_heartbeat_msg(
+            returned_value = local_reader->process_heartbeat_msg(
                 m_guid, heartbeat_count_, first_seq, last_seq, true, liveliness, c_VendorId_eProsima);
         }
     }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -963,13 +963,9 @@ bool StatelessWriter::get_connections(
         //! intraprocess
         for_matched_readers(matched_local_readers_, [&connection, &connection_list](ReaderLocator& reader)
                 {
-                    LocalReaderPointer::Instance local_reader = reader.local_reader();
-                    if (local_reader)
-                    {
-                        connection.guid(fastdds::statistics::to_statistics_type(local_reader->getGuid()));
-                        connection.mode(fastdds::statistics::ConnectionMode::INTRAPROCESS);
-                        connection_list.push_back(connection);
-                    }
+                    connection.guid(fastdds::statistics::to_statistics_type(reader.remote_guid()));
+                    connection.mode(fastdds::statistics::ConnectionMode::INTRAPROCESS);
+                    connection_list.push_back(connection);
 
                     return false;
                 });

--- a/src/cpp/utils/RefCountedPointer.hpp
+++ b/src/cpp/utils/RefCountedPointer.hpp
@@ -196,7 +196,7 @@ private:
 
     /**
      * Indicates whether the pointee is still alive
-     * and the accessing the pointer is valid.
+     * and accessing the pointer is valid.
      */
     std::atomic<bool> is_active_;
 

--- a/src/cpp/utils/RefCountedPointer.hpp
+++ b/src/cpp/utils/RefCountedPointer.hpp
@@ -56,6 +56,10 @@ public:
 
     class Instance;
 
+    /**
+     * @brief Explicit constructor.
+     * @param ptr Pointer to manage.
+     */
     explicit RefCountedPointer(
             T* ptr)
         : ptr_(ptr)
@@ -76,10 +80,19 @@ public:
     RefCountedPointer& operator =(
             RefCountedPointer&&) = delete;
 
+    /**
+     * @brief Class to manage the local pointer instance.
+     * It will increase the reference count on construction and decrease
+     * it on destruction. Provides a facade to access the pointee.
+     */
     class Instance
     {
     public:
 
+        /**
+         * @brief Constructor.
+         * @param parent Shared pointer reference to its RefCountedPointer.
+         */
         explicit Instance(
                 const std::shared_ptr<RefCountedPointer<T>>& parent)
             : parent_(parent)
@@ -91,6 +104,9 @@ public:
             }
         }
 
+        /**
+         * @brief Destructor.
+         */
         ~Instance()
         {
             if (parent_)
@@ -147,12 +163,18 @@ public:
 
 private:
 
+    /**
+     * @brief Increase the reference count.
+     */
     void inc_instances()
     {
         std::unique_lock<std::mutex> lock(mutex_);
         ++instances_;
     }
 
+    /**
+     * @brief Decrease the reference count.
+     */
     void dec_instances()
     {
         std::unique_lock<std::mutex> lock(mutex_);
@@ -163,12 +185,26 @@ private:
         }
     }
 
+    /**
+     * Pointer to the managed object.
+     */
     T* const ptr_;
 
+    /**
+     * Indicates whether the pointee is still alive
+     * and the accessing the pointer is valid.
+     */
     std::atomic<bool> is_active_;
 
+    /**
+     * Protections for the number of instances.
+     */
     mutable std::mutex mutex_;
     std::condition_variable cv_;
+
+    /**
+     * Number of active instances (currently using the pointee).
+     */
     size_t instances_;
 };
 

--- a/src/cpp/utils/RefCountedPointer.hpp
+++ b/src/cpp/utils/RefCountedPointer.hpp
@@ -59,6 +59,9 @@ public:
     /**
      * @brief Explicit constructor.
      * @param ptr Pointer to manage.
+     *
+     * @pre nullptr != ptr. We must ensure that the pointer we
+     * are manaing is valid.
      */
     explicit RefCountedPointer(
             T* ptr)
@@ -66,6 +69,7 @@ public:
         , is_active_(true)
         , instances_(0)
     {
+        assert(nullptr != ptr);
     }
 
     ~RefCountedPointer() = default;

--- a/src/cpp/utils/RefCountedPointer.hpp
+++ b/src/cpp/utils/RefCountedPointer.hpp
@@ -1,0 +1,178 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RefCountedPointer.hpp
+ */
+
+#ifndef UTILS__REFCOUNTEDPOINTER_HPP
+#define UTILS__REFCOUNTEDPOINTER_HPP
+
+#include <atomic>
+#include <cassert>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+namespace eprosima {
+namespace fastdds {
+
+/**
+ * @brief Class to manage a local pointer with reference counting.
+ *
+ * It is similar to std::shared_ptr, but designed for cases where
+ * a shared pointer cannot be used due to API restrictions.
+ *
+ * USAGE:
+ * - On T class:
+ *   - Add a shared_ptr<RefCountedPointer<T>> local_ptr_ member.
+ *   - Call local_ptr_->deactivate() before destroying T.
+ *
+ * - On classes that need to use a pointer to T:
+ *   - Keep a copy of the shared_ptr<RefCountedPointer<T>>.
+ *   - Whenever you need to access T:
+ *     RefCountedPointer<T>::Instance instance(local_ptr_)
+ *     if (instance)
+ *     {
+ *         ptr->method();
+ *     }
+ */
+template<typename T>
+class RefCountedPointer
+{
+public:
+
+    class Instance;
+
+    explicit RefCountedPointer(
+            T* ptr)
+        : ptr_(ptr)
+        , is_active_(true)
+        , instances_(0)
+    {
+    }
+
+    ~RefCountedPointer() = default;
+
+    // Non-copyable and non-movable
+    RefCountedPointer(
+            const RefCountedPointer&) = delete;
+    RefCountedPointer& operator =(
+            const RefCountedPointer&) = delete;
+    RefCountedPointer(
+            RefCountedPointer&&) = delete;
+    RefCountedPointer& operator =(
+            RefCountedPointer&&) = delete;
+
+    class Instance
+    {
+    public:
+
+        explicit Instance(
+                const std::shared_ptr<RefCountedPointer<T>>& parent)
+            : parent_(parent)
+            , ptr_(parent && parent->is_active_ ? parent->ptr_ : nullptr)
+        {
+            if (parent_)
+            {
+                parent_->inc_instances();
+            }
+        }
+
+        ~Instance()
+        {
+            if (parent_)
+            {
+                parent_->dec_instances();
+            }
+        }
+
+        // Non-copyable, default movable
+        Instance(
+                const Instance&) = delete;
+        Instance& operator =(
+                const Instance&) = delete;
+        Instance(
+                Instance&&) = default;
+        Instance& operator =(
+                Instance&&) = default;
+
+        /**
+         * @brief operator to check if the pointer is valid.
+         */
+        operator bool() const
+        {
+            return nullptr != ptr_;
+        }
+
+        /**
+         * @brief operator to call the T methods.
+         */
+        T* operator ->() const
+        {
+            assert(nullptr != ptr_);
+            return ptr_;
+        }
+
+    private:
+
+        std::shared_ptr<RefCountedPointer<T>> parent_;
+        T* const ptr_;
+    };
+
+    /**
+     * @brief Ensure no more valid local pointer instances are created, and wait for current ones to die.
+     */
+    void deactivate()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        is_active_ = false;
+        cv_.wait(lock, [this]() -> bool
+                {
+                    return instances_ == 0;
+                });
+    }
+
+private:
+
+    void inc_instances()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        ++instances_;
+    }
+
+    void dec_instances()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        --instances_;
+        if (instances_ == 0)
+        {
+            cv_.notify_one();
+        }
+    }
+
+    T* const ptr_;
+
+    std::atomic<bool> is_active_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    size_t instances_;
+};
+
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif // UTILS__REFCOUNTEDPOINTER_HPP

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -46,6 +46,7 @@
 #include "BlackboxTests.hpp"
 #include "mock/BlackboxMockConsumer.h"
 #include "../api/dds-pim/CustomPayloadPool.hpp"
+#include "../api/dds-pim/PubSubParticipant.hpp"
 #include "../api/dds-pim/PubSubReader.hpp"
 #include "../api/dds-pim/PubSubWriter.hpp"
 #include "../api/dds-pim/PubSubWriterReader.hpp"
@@ -930,6 +931,86 @@ TEST(DDSBasic, register_two_identical_typesupports)
     TypeSupport type_support_2;
     type_support_2.reset(new HelloWorldPubSubType());
     EXPECT_EQ(RETCODE_OK, participant->register_type(type_support_2));
+}
+
+/**
+ * @test This is a regression test for Redmine Issue 21293.
+ * The destruction among intra-process participants should be correctly performed.
+ * local_reader() has to return a valid pointer.
+ *
+ */
+TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
+{
+    namespace dds = eprosima::fastdds::dds;
+    auto factory = dds::DomainParticipantFactory::get_instance();
+
+    // Set intraprocess delivery to full
+    LibrarySettings library_settings;
+    factory->get_library_settings(library_settings);
+    auto old_library_settings = library_settings;
+    library_settings.intraprocess_delivery = INTRAPROCESS_FULL;
+    factory->set_library_settings(library_settings);
+
+    {
+        auto participant_1 = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(1u, 1u, 1u, 1u);
+
+        ASSERT_TRUE(participant_1->init_participant());
+        participant_1->pub_topic_name(TEST_TOPIC_NAME);
+        ASSERT_TRUE(participant_1->init_publisher(0u));
+        participant_1->sub_topic_name(TEST_TOPIC_NAME + "_Return");
+        ASSERT_TRUE(participant_1->init_subscriber(0u));
+
+        std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> reception_participants;
+
+        size_t num_reception_participants = 5;
+
+        for (size_t i = 0; i < num_reception_participants; i++)
+        {
+            reception_participants.push_back(std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(1u, 1u, 1u, 1u));
+            ASSERT_TRUE(reception_participants.back()->init_participant());
+            reception_participants.back()->sub_topic_name(TEST_TOPIC_NAME);
+            ASSERT_TRUE(reception_participants.back()->init_subscriber(0u));
+            reception_participants.back()->pub_topic_name(TEST_TOPIC_NAME + "_Return");
+            ASSERT_TRUE(reception_participants.back()->init_publisher(0u));
+        }
+
+        participant_1->wait_discovery(std::chrono::seconds::zero(), num_reception_participants, true);
+
+        participant_1->pub_wait_discovery(num_reception_participants);
+        participant_1->sub_wait_discovery(num_reception_participants);
+
+        auto data_12 = default_helloworld_data_generator();
+
+        std::thread p1_thread([&participant_1, &data_12]()
+                {
+                    auto data_size = data_12.size();
+                    for (size_t i = 0; i < data_size; i++)
+                    {
+                        participant_1->send_sample(data_12.back());
+                        data_12.pop_back();
+                    }
+                });
+
+        std::vector<std::thread> reception_threads;
+        for (auto& reception_participant : reception_participants)
+        {
+            reception_threads.emplace_back([&reception_participant]()
+                {
+                    auto data_21 = default_helloworld_data_generator();
+                    for (auto& data : data_21)
+                    {
+                        reception_participant->send_sample(data);
+                        data_21.pop_back();
+                    }
+                });
+        }
+
+        p1_thread.join();
+        for (auto& rec_thread : reception_threads)
+        {
+            rec_thread.join();
+        }
+    }
 }
 
 } // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -974,10 +974,10 @@ TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
             ASSERT_TRUE(reception_participants.back()->init_publisher(0u));
         }
 
-        participant_1->wait_discovery(std::chrono::seconds::zero(), num_reception_participants, true);
+        participant_1->wait_discovery(std::chrono::seconds::zero(), (uint8_t)num_reception_participants, true);
 
-        participant_1->pub_wait_discovery(num_reception_participants);
-        participant_1->sub_wait_discovery(num_reception_participants);
+        participant_1->pub_wait_discovery((unsigned int)num_reception_participants);
+        participant_1->sub_wait_discovery((unsigned int)num_reception_participants);
 
         auto data_12 = default_helloworld_data_generator();
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -996,15 +996,15 @@ TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
         for (auto& reception_participant : reception_participants)
         {
             reception_threads.emplace_back([&reception_participant]()
-                {
-                    auto data_21 = default_helloworld_data_generator();
-                    for (auto& data : data_21)
                     {
-                        reception_participant->send_sample(data);
-                    }
+                        auto data_21 = default_helloworld_data_generator();
+                        for (auto& data : data_21)
+                        {
+                            reception_participant->send_sample(data);
+                        }
 
-                    reception_participant.reset();
-                });
+                        reception_participant.reset();
+                    });
         }
 
         p1_thread.join();

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -962,7 +962,7 @@ TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
 
         std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> reception_participants;
 
-        size_t num_reception_participants = 5;
+        size_t num_reception_participants = 50;
 
         for (size_t i = 0; i < num_reception_participants; i++)
         {
@@ -992,6 +992,7 @@ TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
                 });
 
         std::vector<std::thread> reception_threads;
+        reception_threads.reserve(num_reception_participants);
         for (auto& reception_participant : reception_participants)
         {
             reception_threads.emplace_back([&reception_participant]()
@@ -1000,8 +1001,9 @@ TEST(DDSBasic, successful_destruction_among_intraprocess_participants)
                     for (auto& data : data_21)
                     {
                         reception_participant->send_sample(data);
-                        data_21.pop_back();
                     }
+
+                    reception_participant.reset();
                 });
         }
 

--- a/test/mock/rtps/ReaderLocator/rtps/writer/ReaderLocator.hpp
+++ b/test/mock/rtps/ReaderLocator/rtps/writer/ReaderLocator.hpp
@@ -27,6 +27,8 @@
 #include <fastdds/rtps/common/SequenceNumber.hpp>
 #include <fastdds/rtps/messages/RTPSMessageSenderInterface.hpp>
 
+#include <rtps/reader/LocalReaderPointer.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
@@ -202,9 +204,9 @@ public:
         return false;
     }
 
-    BaseReader* local_reader()
+    LocalReaderPointer::Instance local_reader()
     {
-        return nullptr;
+        return LocalReaderPointer::Instance(std::shared_ptr<LocalReaderPointer>());
     }
 
     bool is_datasharing_reader() const

--- a/test/unittest/utils/CMakeLists.txt
+++ b/test/unittest/utils/CMakeLists.txt
@@ -71,6 +71,9 @@ set(SYSTEMINFOTESTS_SOURCE
 set(TREETESTS_SOURCE
     TreeNodeTests.cpp)
 
+set(REF_COUNTED_POINTER_TESTS_SOURCE
+    RefCountedPointerTests.cpp)
+
 include_directories(mock/)
 
 add_executable(StringMatchingTests ${STRINGMATCHINGTESTS_SOURCE})
@@ -177,6 +180,11 @@ add_executable(TreeNodeTests ${TREETESTS_SOURCE})
 target_include_directories(TreeNodeTests PRIVATE ${PROJECT_SOURCE_DIR}/src/cpp)
 target_link_libraries(TreeNodeTests PUBLIC GTest::gtest)
 gtest_discover_tests(TreeNodeTests)
+
+add_executable(RefCountedPointerTests ${REF_COUNTED_POINTER_TESTS_SOURCE})
+target_include_directories(RefCountedPointerTests PRIVATE ${PROJECT_SOURCE_DIR}/src/cpp)
+target_link_libraries(RefCountedPointerTests PUBLIC GTest::gtest)
+gtest_discover_tests(RefCountedPointerTests)
 
 ###############################################################################
 # Necessary files

--- a/test/unittest/utils/RefCountedPointerTests.cpp
+++ b/test/unittest/utils/RefCountedPointerTests.cpp
@@ -1,0 +1,182 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <utils/RefCountedPointer.hpp>
+
+using namespace std;
+
+namespace eprosima {
+namespace fastdds {
+
+struct EntityMock
+{
+    EntityMock()
+        : local_pointer(std::make_shared<RefCountedPointer<EntityMock>>(this))
+        , n_times_data_processed(0)
+    {
+    }
+
+    std::shared_ptr<RefCountedPointer<EntityMock>> get_refcounter_pointer() const
+    {
+        return local_pointer;
+    }
+
+    void dummy_process_data(void*)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ++n_times_data_processed;
+    }
+
+    void destroy()
+    {
+        local_pointer->deactivate();
+    }
+
+    std::shared_ptr<RefCountedPointer<EntityMock>> local_pointer;
+    std::atomic<size_t> n_times_data_processed;
+};
+
+enum class RoutineStatus
+{
+    NON_INITIALIZED,
+    SUCCESS,
+    FAILURE
+};
+
+struct EntityOwner
+{
+    EntityOwner(
+            const EntityMock& entity)
+        : entity_ptr(entity.get_refcounter_pointer())
+        , routine_status(RoutineStatus::NON_INITIALIZED)
+    {
+    }
+
+    void spawn_routine()
+    {
+        th = std::thread([&]()
+        {
+            RefCountedPointer<EntityMock>::Instance entity_instance(entity_ptr);
+            if (entity_instance)
+            {
+                entity_instance->dummy_process_data(nullptr);
+                routine_status = RoutineStatus::SUCCESS;
+            }
+            else
+            {
+                routine_status = RoutineStatus::FAILURE;
+            }
+        });
+    }
+
+    void join()
+    {
+        th.join();
+    }
+
+    std::shared_ptr<RefCountedPointer<EntityMock>> entity_ptr;
+    RoutineStatus routine_status;
+    std::thread th;
+};
+
+class RefCountedPointerTests : public ::testing::Test
+{
+public:
+
+    static constexpr std::size_t n_owners = 5;
+
+    void SetUp() override
+    {
+        owners_.reserve(5);
+        for (std::size_t i = 0; i < n_owners; ++i)
+        {
+            owners_.emplace_back(entity_);
+        }
+    }
+
+    void TearDown() override
+    {
+        for (std::size_t i = 0; i < n_owners; ++i)
+        {
+            owners_[i].join();
+        }
+    }
+
+protected:
+
+    EntityMock entity_;
+    std::vector<EntityOwner> owners_;
+};
+
+TEST_F(RefCountedPointerTests, refcountedpointer_inactive)
+{
+    // Make the first owner spawn a routine
+    owners_[0].spawn_routine();
+
+    // Wait for the routine to finish
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ASSERT_EQ(owners_[0].routine_status, RoutineStatus::SUCCESS);
+
+    // Destroy the entity
+    entity_.destroy();
+
+    // Make the rest of the owners spawn a routine
+    for (std::size_t i = 1; i < n_owners; ++i)
+    {
+        owners_[i].spawn_routine();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // The routine should fail
+        ASSERT_EQ(owners_[i].routine_status, RoutineStatus::FAILURE);
+    }
+
+    // The entity should have been processed only once
+    ASSERT_EQ(1, entity_.n_times_data_processed);
+}
+
+TEST_F(RefCountedPointerTests, refcounterpointer_deactivate_waits_for_no_references)
+{
+    // Spawn some routines
+    for (std::size_t i = 0; i < n_owners; ++i)
+    {
+        owners_[i].spawn_routine();
+    }
+
+    // Ensure owners' routines have started
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    auto t0 = std::chrono::steady_clock::now();
+    entity_.destroy();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+
+    std::cout << "Elapsed time: " << elapsed << " ms" << std::endl;
+    ASSERT_GT(elapsed, 50); // destroy should have taken at least 50 ms. Being strict it should be 80, but we allow some margin
+    ASSERT_EQ(entity_.n_times_data_processed, 5);
+}
+
+} // namespace fastdds
+} // namespace eprosima
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/utils/RefCountedPointerTests.cpp
+++ b/test/unittest/utils/RefCountedPointerTests.cpp
@@ -38,7 +38,8 @@ struct EntityMock
         return local_pointer;
     }
 
-    void dummy_process_data(void*)
+    void dummy_process_data(
+            void*)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         ++n_times_data_processed;
@@ -72,18 +73,18 @@ struct EntityOwner
     void spawn_routine()
     {
         th = std::thread([&]()
-        {
-            RefCountedPointer<EntityMock>::Instance entity_instance(entity_ptr);
-            if (entity_instance)
-            {
-                entity_instance->dummy_process_data(nullptr);
-                routine_status = RoutineStatus::SUCCESS;
-            }
-            else
-            {
-                routine_status = RoutineStatus::FAILURE;
-            }
-        });
+                        {
+                            RefCountedPointer<EntityMock>::Instance entity_instance(entity_ptr);
+                            if (entity_instance)
+                            {
+                                entity_instance->dummy_process_data(nullptr);
+                                routine_status = RoutineStatus::SUCCESS;
+                            }
+                            else
+                            {
+                                routine_status = RoutineStatus::FAILURE;
+                            }
+                        });
     }
 
     void join()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses a race issue happening in stressed intraprocess scenarios when `EDP's` writer intends to use the remote local reader pointer of an already removed participant. This happens because the participant hasn't received the other's one disposal yet (as it goes through transport). 

Some [ci flaky tests](https://github.com/eProsima/Fast-DDS/actions/runs/10829350591/job/30046734211) have already been identified to be related with this issue.

The proposed solution introduces a new state in the Readers `LocalReaderViewStatus` in which the reader will notify that it is inactive as soon as it is destroyed and *noone* is using it.
On the other side, the remote local writers using pointers to it, now holds a `LocalReaderPointer` which wraps the raw reader's pointer plus the view. An internal counter now accounts for the number of references.

Thanks @MiguelCompany for helping with the final's solution design.

*Note: the test may be launched with `--restest-until-fail 20` or so, in order to reproduce the issue. For a more frequent failure, review can launch the `colcon test` with the `taskset -c 0,1` prefix to make the test to stress more and make it fail more frequently.* 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
