### PR TITLE
[21267] Add Ubuntu weekly ci

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -22,6 +22,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: 'master'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -41,6 +42,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.14.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -60,6 +62,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.13.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -79,6 +82,7 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.10.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -27,6 +27,10 @@ on:
         description: 'Branch or tag of Fast DDS repository (https://github.com/eProsima/Fast-DDS)'
         required: true
         type: string
+      fastcdr-branch:
+        description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
+        required: false
+        type: string
       security:
         description: 'Enable security features'
         required: false
@@ -104,6 +108,20 @@ jobs:
         if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Fast CDR branch
+        id: get_fastcdr_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-CDR
+          fallback_branch: master
+
+      - name: Download Fast CDR
+        run: |
+            cd src
+            git clone -b ${{ steps.get_fastcdr_branch.outputs.deduced_branch }} https://github.com/eProsima/Fast-CDR.git fastcdr
+            cd ..
+        shell: bash
 
       - name: Fetch Fast DDS dependencies
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: true
+      run-build:
+        description: 'Build Fast DDS (CI skipped otherwise)'
+        required: false
+        type: boolean
+        default: true
       run-tests:
         description: 'Run test suite of Fast DDS, Fast DDS python, and Fast DDS Discovery Server'
         required: false
@@ -57,6 +62,7 @@ defaults:
 jobs:
   fastdds_build:
     runs-on: ${{ inputs.os-image }}
+    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -320,7 +320,7 @@ jobs:
         uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
-          colcon_build_args: ${{ inputs.colcon-args }}
+          colcon_build_args: ${{ inputs.colcon-args }} --packages-select fastdds_python
           cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
           cmake_args_default: ''
           cmake_build_type: ${{ matrix.cmake-build-type }}

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -31,6 +31,7 @@ on:
         description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
         required: false
         type: string
+        default: 'master'
       security:
         description: 'Enable security features'
         required: false
@@ -120,14 +121,14 @@ jobs:
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-CDR
-          fallback_branch: master
+          fallback_branch: ${{ inputs.fastcdr-branch }}
 
       - name: Download Fast CDR
-        run: |
-            cd src
-            git clone -b ${{ steps.get_fastcdr_branch.outputs.deduced_branch }} https://github.com/eProsima/Fast-CDR.git fastcdr
-            cd ..
-        shell: bash
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/Fast-CDR
+          path: ${{ github.workspace }}/src/fastcdr
+          ref: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
 
       - name: Fetch Fast DDS dependencies
         uses: eProsima/eProsima-CI/multiplatform/vcs_import@v0
@@ -324,6 +325,7 @@ jobs:
           cmake_args: '${{ env.security-cmake-flag }} ${{ inputs.cmake-args }}'
           cmake_args_default: ''
           cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace_dependencies: ${{ github.workspace }}/install
           workspace: ${{ github.workspace }}
 
       - name: Upload python build artifacts

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -141,22 +141,10 @@ jobs:
           skip_existing: 'true'
 
       - name: Prepare build meta file
-        run: |
-            $build_meta_file = '${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build.meta'
-            $test_meta_file = '${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta'
-            $build_test_meta_file = '${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build_test.meta'
-
-            # Read the content of the build meta file
-            $build_meta_content = Get-Content -Path $build_meta_file
-
-            # Read the content of the test meta file, starting from line 4 (skipping "name" line [1], cmake project name line [2] and "cmake-args" line [3])
-            $test_meta_content = Get-Content -Path $test_meta_file | Select-Object -Skip 3
-
-            # Combine the content of the build meta file and the test meta file
-            $combined_content = $build_meta_content + $test_meta_content
-
-            # Write the combined content to the build test meta file
-            $combined_content | Out-File -FilePath $build_test_meta_file -Encoding UTF8
+        uses: eProsima/eProsima-CI/windows/merge_yaml_metas@v0
+        with:
+          metas: "@('${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta', '${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta')"
+          path: '${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build_test.meta'
 
       - name: Build
         id: build

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -54,10 +54,7 @@ concurrency:
 jobs:
   ubuntu-ci:
 
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-ubuntu-ci.yml
     with:
       # It would be desirable to have a matrix of ubuntu OS for this job, but due to the issue opened in this ticket:
@@ -69,5 +66,6 @@ jobs:
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
+      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
       run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -20,11 +20,12 @@ jobs:
     uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.14.x
     with:
       os-image: 'ubuntu-22.04'
-      label: '${{ matrix.os-image }}-weekly-sec-${{ matrix.security }}-fastcdr-${{ matrix.fastcdr-branch }}-ubuntu-ci-2.14.x'
+      label: 'weekly-sec-${{ matrix.security }}-fastcdr-${{ matrix.fastcdr-branch }}-ubuntu-ci-2.14.x'
       ctest-args: "-LE xfail"
       fastdds-branch: '2.14.x'
       fastcdr-branch: ${{ matrix.fastcdr-branch }}
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false
 
@@ -42,5 +43,6 @@ jobs:
       ctest-args: "-LE xfail"
       fastdds-branch: '2.6.x'
       security: ${{ matrix.security }}
+      run-build: true
       run-tests: true
       use-ccache: false

--- a/.github/workflows/weekly-ubuntu-ci.yml
+++ b/.github/workflows/weekly-ubuntu-ci.yml
@@ -7,6 +7,27 @@ on:
 
 jobs:
 
+  weekly-ubuntu-ci-2_14_x:
+    strategy:
+      fail-fast: false
+      matrix:
+        fastcdr-branch:
+          - '1.1.x'
+          - '2.x'
+        security:
+          - true
+          - false
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.14.x
+    with:
+      os-image: 'ubuntu-22.04'
+      label: '${{ matrix.os-image }}-weekly-sec-${{ matrix.security }}-fastcdr-${{ matrix.fastcdr-branch }}-ubuntu-ci-2.14.x'
+      ctest-args: "-LE xfail"
+      fastdds-branch: '2.14.x'
+      fastcdr-branch: ${{ matrix.fastcdr-branch }}
+      security: ${{ matrix.security }}
+      run-tests: true
+      use-ccache: false
+
   weekly-ubuntu-ci-2_6_x:
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses the following points related to the github CI:

* Change windows reusable ci to use new merge meta files eProsima CI action
* Add weekly ubuntu CI to test 2.x branches with CDR 1.1.x
* move the if (!skip-ci) inside the reusable workflows (as done in other repos with the run-build input), but keep the if (!conflicts) in the PR workflow so the GitHub CI requirement is not satisfied if skipped by conflicts.
* Refactor ubuntu ci - python build job:
  build packages-select `fastdds_python` package

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
