### PR TITLE
[21329] All `DataWriter::write` overload shall return `RerturnCode_t` type

### DIFF
--- a/examples/cpp/configuration/PublisherApp.cpp
+++ b/examples/cpp/configuration/PublisherApp.cpp
@@ -272,7 +272,7 @@ bool PublisherApp::publish()
     if (!is_stopped())
     {
         configuration_.index(configuration_.index() + 1);
-        ret = writer_->write(&configuration_);
+        ret = (RETCODE_OK == writer_->write(&configuration_));
     }
     return ret;
 }

--- a/examples/cpp/content_filter/PublisherApp.cpp
+++ b/examples/cpp/content_filter/PublisherApp.cpp
@@ -175,7 +175,7 @@ bool PublisherApp::publish()
     if (!is_stopped())
     {
         hello_.index(hello_.index() + 1);
-        ret = writer_->write(&hello_);
+        ret = (RETCODE_OK == writer_->write(&hello_));
     }
     return ret;
 }

--- a/examples/cpp/custom_payload_pool/PublisherApp.cpp
+++ b/examples/cpp/custom_payload_pool/PublisherApp.cpp
@@ -158,7 +158,7 @@ bool PublisherApp::publish()
     if (!is_stopped())
     {
         hello_.index(hello_.index() + 1);
-        ret = writer_->write(&hello_);
+        ret = (RETCODE_OK == writer_->write(&hello_));
     }
     return ret;
 }

--- a/examples/cpp/dds/RequestReplyExample/CalculatorClient.cpp
+++ b/examples/cpp/dds/RequestReplyExample/CalculatorClient.cpp
@@ -154,7 +154,8 @@ public:
         request.x(x);
         request.y(y);
 
-        if (request_writer_->write(static_cast<void*>(&request), listener_.write_params))
+        if (eprosima::fastdds::dds::RETCODE_OK ==
+                request_writer_->write(static_cast<void*>(&request), listener_.write_params))
         {
             std::unique_lock<std::mutex> lock(listener_.reception_mutex);
             listener_.reception_cv.wait(lock, [&]()

--- a/examples/cpp/delivery_mechanisms/PubSubApp.cpp
+++ b/examples/cpp/delivery_mechanisms/PubSubApp.cpp
@@ -394,7 +394,7 @@ bool PubSubApp::publish()
         DeliveryMechanisms* delivery_mechanisms_ = static_cast<DeliveryMechanisms*>(sample_);
         delivery_mechanisms_->index() = ++index_of_last_sample_sent_;
         memcpy(delivery_mechanisms_->message().data(), "Delivery mechanisms", sizeof("Delivery mechanisms"));
-        ret = writer_->write(sample_);
+        ret = (RETCODE_OK == writer_->write(sample_));
         std::cout << "Sample: '" << delivery_mechanisms_->message().data() << "' with index: '"
                   << delivery_mechanisms_->index() << "' SENT" << std::endl;
     }

--- a/examples/cpp/delivery_mechanisms/PublisherApp.cpp
+++ b/examples/cpp/delivery_mechanisms/PublisherApp.cpp
@@ -289,7 +289,7 @@ bool PublisherApp::publish()
         DeliveryMechanisms* delivery_mechanisms_ = static_cast<DeliveryMechanisms*>(sample_);
         delivery_mechanisms_->index() = ++index_of_last_sample_sent_;
         memcpy(delivery_mechanisms_->message().data(), "Delivery mechanisms", sizeof("Delivery mechanisms"));
-        ret = writer_->write(sample_);
+        ret = (RETCODE_OK == writer_->write(sample_));
         std::cout << "Sample: '" << delivery_mechanisms_->message().data() << "' with index: '"
                   << delivery_mechanisms_->index() << "' SENT" << std::endl;
     }

--- a/examples/cpp/discovery_server/ClientPublisherApp.cpp
+++ b/examples/cpp/discovery_server/ClientPublisherApp.cpp
@@ -270,7 +270,7 @@ bool ClientPublisherApp::publish()
     if (!is_stopped())
     {
         hello_.index(hello_.index() + 1);
-        ret = writer_->write(&hello_);
+        ret = (RETCODE_OK == writer_->write(&hello_));
     }
     return ret;
 }

--- a/examples/cpp/hello_world/PublisherApp.cpp
+++ b/examples/cpp/hello_world/PublisherApp.cpp
@@ -156,7 +156,7 @@ bool PublisherApp::publish()
     if (!is_stopped())
     {
         hello_.index(hello_.index() + 1);
-        ret = writer_->write(&hello_);
+        ret = (RETCODE_OK == writer_->write(&hello_));
     }
     return ret;
 }

--- a/examples/cpp/xtypes/PublisherApp.cpp
+++ b/examples/cpp/xtypes/PublisherApp.cpp
@@ -210,7 +210,7 @@ bool PublisherApp::publish()
         set_uint32_value(hello_, "index", index);
 
         // Publish the sample
-        ret = writer_->write(&hello_);
+        ret = (RETCODE_OK == writer_->write(&hello_));
     }
     return ret;
 }

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -128,7 +128,7 @@ public:
      * Write data to the topic.
      *
      * @param data Pointer to the data
-     * @return RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
+     * @return RETCODE_OK if the data is correctly sent or a ReturnCode related to the specific error otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t write(
             const void* const data);
@@ -138,7 +138,7 @@ public:
      *
      * @param data Pointer to the data
      * @param params Extra write parameters.
-     * @return RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
+     * @return RETCODE_OK if the data is correctly sent or a ReturnCode related to the specific error otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t write(
             const void* const data,

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -128,9 +128,9 @@ public:
      * Write data to the topic.
      *
      * @param data Pointer to the data
-     * @return True if correct, false otherwise
+     * @return RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
      */
-    FASTDDS_EXPORTED_API bool write(
+    FASTDDS_EXPORTED_API ReturnCode_t write(
             const void* const data);
 
     /**
@@ -138,9 +138,9 @@ public:
      *
      * @param data Pointer to the data
      * @param params Extra write parameters.
-     * @return True if correct, false otherwise
+     * @return RETCODE_OK if the data is correctly sent and RETCODE_ERROR otherwise.
      */
-    FASTDDS_EXPORTED_API bool write(
+    FASTDDS_EXPORTED_API ReturnCode_t write(
             const void* const data,
             fastdds::rtps::WriteParams& params);
 

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -78,13 +78,13 @@ ReturnCode_t DataWriter::discard_loan(
     return impl_->discard_loan(sample);
 }
 
-bool DataWriter::write(
+ReturnCode_t DataWriter::write(
         const void* const data)
 {
     return impl_->write(data);
 }
 
-bool DataWriter::write(
+ReturnCode_t DataWriter::write(
         const void* const data,
         fastdds::rtps::WriteParams& params)
 {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -634,29 +634,29 @@ ReturnCode_t DataWriterImpl::discard_loan(
     return RETCODE_OK;
 }
 
-bool DataWriterImpl::write(
+ReturnCode_t DataWriterImpl::write(
         const void* const data)
 {
     if (writer_ == nullptr)
     {
-        return false;
+        return RETCODE_NOT_ENABLED;
     }
 
     EPROSIMA_LOG_INFO(DATA_WRITER, "Writing new data");
-    return RETCODE_OK == create_new_change(ALIVE, data);
+    return create_new_change(ALIVE, data);
 }
 
-bool DataWriterImpl::write(
+ReturnCode_t DataWriterImpl::write(
         const void* const data,
         fastdds::rtps::WriteParams& params)
 {
     if (writer_ == nullptr)
     {
-        return false;
+        return RETCODE_NOT_ENABLED;
     }
 
     EPROSIMA_LOG_INFO(DATA_WRITER, "Writing new data with WriteParams");
-    return RETCODE_OK == create_new_change_with_params(ALIVE, data, params);
+    return create_new_change_with_params(ALIVE, data, params);
 }
 
 ReturnCode_t DataWriterImpl::check_write_preconditions(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -164,9 +164,9 @@ public:
      *
      * @param data Pointer to the data.
      *
-     * @return true if data is correctly delivered to the lower layers, false otherwise.
+     * @return any of the standard return codes.
      */
-    bool write(
+    ReturnCode_t write(
             const void* const data);
 
     /**
@@ -175,9 +175,9 @@ public:
      * @param data Pointer to the data.
      * @param params Extra write parameters.
      *
-     * @return true if data is correctly delivered to the lower layers, false otherwise.
+     * @return any of the standard return codes.
      */
-    bool write(
+    ReturnCode_t write(
             const void* const data,
             fastdds::rtps::WriteParams& params);
 

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -416,7 +416,7 @@ public:
             type& msg,
             unsigned int index = 0)
     {
-        return std::get<2>(publishers_[index])->write((void*)&msg);
+        return (eprosima::fastdds::dds::RETCODE_OK == std::get<2>(publishers_[index])->write((void*)&msg));
     }
 
     void assert_liveliness_participant()

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -513,7 +513,7 @@ public:
 
         while (it != msgs.end())
         {
-            if (datawriter_->write((void*)&(*it)))
+            if (eprosima::fastdds::dds::RETCODE_OK == datawriter_->write((void*)&(*it)))
             {
                 default_send_print<type>(*it);
                 it = msgs.erase(it);
@@ -553,7 +553,7 @@ public:
             type& msg)
     {
         default_send_print(msg);
-        return datawriter_->write((void*)&msg);
+        return (eprosima::fastdds::dds::RETCODE_OK == datawriter_->write((void*)&msg));
     }
 
     eprosima::fastdds::dds::ReturnCode_t send_sample(

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -547,7 +547,7 @@ public:
 
         while (it != msgs.end())
         {
-            if (datawriter_->write((void*)&(*it)))
+            if (eprosima::fastdds::dds::RETCODE_OK == datawriter_->write((void*)&(*it)))
             {
                 for (auto& tuple : entities_extra_)
                 {

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
@@ -158,7 +158,7 @@ void ReqRepHelloWorldReplier::newNumber(
     hello.index(number);
     hello.message("GoodBye");
     wparams.related_sample_identity(sample_identity);
-    ASSERT_EQ(reply_datawriter_->write((void*)&hello, wparams), true);
+    ASSERT_EQ(reply_datawriter_->write((void*)&hello, wparams), eprosima::fastdds::dds::RETCODE_OK);
 }
 
 void ReqRepHelloWorldReplier::wait_discovery()

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
@@ -239,7 +239,7 @@ void ReqRepHelloWorldRequester::send(
         current_number_ = number;
     }
 
-    ASSERT_EQ(request_datawriter_->write((void*)&hello, wparams), true);
+    ASSERT_EQ(request_datawriter_->write((void*)&hello, wparams), eprosima::fastdds::dds::RETCODE_OK);
     related_sample_identity_ = wparams.sample_identity();
     ASSERT_NE(related_sample_identity_.sequence_number(), eprosima::fastdds::rtps::SequenceNumber_t());
 }

--- a/test/blackbox/api/dds-pim/TCPReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/api/dds-pim/TCPReqRepHelloWorldReplier.cpp
@@ -194,7 +194,7 @@ void TCPReqRepHelloWorldReplier::newNumber(
     hello.index(number);
     hello.message("GoodBye");
     wparams.related_sample_identity(sample_identity);
-    ASSERT_EQ(reply_datawriter_->write((void*)&hello, wparams), true);
+    ASSERT_EQ(reply_datawriter_->write((void*)&hello, wparams), RETCODE_OK);
 }
 
 void TCPReqRepHelloWorldReplier::wait_discovery(

--- a/test/blackbox/api/dds-pim/TCPReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/api/dds-pim/TCPReqRepHelloWorldRequester.cpp
@@ -331,7 +331,7 @@ void TCPReqRepHelloWorldRequester::send(
         current_number_ = number;
     }
 
-    ASSERT_EQ(request_datawriter_->write((void*)&hello, wparams), true);
+    ASSERT_EQ(request_datawriter_->write((void*)&hello, wparams), RETCODE_OK);
     related_sample_identity_ = wparams.sample_identity();
     ASSERT_NE(related_sample_identity_.sequence_number(), SequenceNumber_t());
 }

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -488,8 +488,8 @@ TEST(DDSBasic, PidRelatedSampleIdentity)
     write_params.related_sample_identity() = related_sample_identity_;
 
     // Publish the new value, deduce the instance handle
-    bool write_ret = native_writer.write((void*)&data, write_params);
-    ASSERT_EQ(true, write_ret);
+    ReturnCode_t write_ret = native_writer.write((void*)&data, write_params);
+    ASSERT_EQ(RETCODE_OK, write_ret);
 
     DataReader& native_reader = reliable_reader.get_native_reader();
 

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -388,7 +388,7 @@ TEST(DDSDataReader, ConsistentReliabilityWhenIntraprocess)
     auto writer = publisher->create_datawriter( topic, writer_qos );
 
     auto data = HelloWorld{};
-    ASSERT_TRUE(writer->write( &data ));
+    ASSERT_EQ(writer->write( &data ), eprosima::fastdds::dds::RETCODE_OK);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -253,7 +253,7 @@ public:
         {
             for (auto& writer : writers_)
             {
-                if (writer->write((void*)&(*it)))
+                if (RETCODE_OK == writer->write((void*)&(*it)))
                 {
                     default_send_print<HelloWorld>(*it);
                     it = msgs.erase(it);
@@ -276,7 +276,7 @@ public:
     {
         if (!writers_.empty())
         {
-            return writers_.back()->write(&sample);
+            return (RETCODE_OK == writers_.back()->write(&sample));
         }
 
         return false;

--- a/test/performance/latency/LatencyTestPublisher.cpp
+++ b/test/performance/latency/LatencyTestPublisher.cpp
@@ -766,7 +766,7 @@ bool LatencyTestPublisher::test(
     times_.clear();
     TestCommandType command;
     command.m_command = READY;
-    if (!command_writer_->write(&command))
+    if (RETCODE_OK != command_writer_->write(&command))
     {
         EPROSIMA_LOG_ERROR(LatencyTest, "Publisher cannot publish READY command");
         return false;
@@ -852,7 +852,7 @@ bool LatencyTestPublisher::test(
         start_time_ = std::chrono::steady_clock::now();
 
         // Data publishing
-        if (!data_writer_->write(data))
+        if (RETCODE_OK != data_writer_->write(data))
         {
             // return the loan
             if (data_loans_)

--- a/test/performance/latency/LatencyTestSubscriber.cpp
+++ b/test/performance/latency/LatencyTestSubscriber.cpp
@@ -548,7 +548,7 @@ void LatencyTestSubscriber::LatencyDataReaderListener::on_data_available(
             std::chrono::duration<uint32_t, std::nano> bounce_time(end_time - start_time);
             reinterpret_cast<LatencyType*>(echoed_loan)->bounce = bounce_time.count();
 
-            if (!sub->data_writer_->write(echoed_loan))
+            if (RETCODE_OK != sub->data_writer_->write(echoed_loan))
             {
                 EPROSIMA_LOG_ERROR(LatencyTest, "Problem echoing Publisher test data with loan");
                 sub->data_writer_->discard_loan(echoed_loan);
@@ -582,7 +582,7 @@ void LatencyTestSubscriber::LatencyDataReaderListener::on_data_available(
                     reinterpret_cast<LatencyType*>(data)->bounce = 0;
                 }
 
-                if (!sub->data_writer_->write(data))
+                if (RETCODE_OK != sub->data_writer_->write(data))
                 {
                     EPROSIMA_LOG_INFO(LatencyTest, "Problem echoing Publisher test data");
                 }
@@ -707,7 +707,7 @@ bool LatencyTestSubscriber::test(
     received_ = 0;
     TestCommandType command;
     command.m_command = BEGIN;
-    if (!command_writer_->write(&command))
+    if (RETCODE_OK != command_writer_->write(&command))
     {
         EPROSIMA_LOG_ERROR(LatencyTest, "Subscriber fail to publish the BEGIN command");
         return false;
@@ -752,7 +752,7 @@ bool LatencyTestSubscriber::test(
     }
 
     command.m_command = END;
-    if (!command_writer_->write(&command))
+    if (RETCODE_OK != command_writer_->write(&command))
     {
         EPROSIMA_LOG_ERROR(LatencyTest, "Subscriber fail to publish the END command");
         return false;

--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -754,7 +754,7 @@ bool ThroughputPublisher::test(
                     // initialize and send the sample
                     static_cast<ThroughputType*>(data)->seqnum = ++seqnum;
 
-                    if (!data_writer_->write(data))
+                    if (RETCODE_OK != data_writer_->write(data))
                     {
                         data_writer_->discard_loan(data);
                     }

--- a/test/performance/video/VideoTestPublisher.cpp
+++ b/test/performance/video/VideoTestPublisher.cpp
@@ -591,7 +591,7 @@ GstFlowReturn VideoTestPublisher::new_sample(
 
                     if (rand() % 100 > sub->m_dropRate)
                     {
-                        if (!sub->mp_data_dw->write((void*)sub->mp_video_out))
+                        if (RETCODE_OK != sub->mp_data_dw->write((void*)sub->mp_video_out))
                         {
                             std::cout << "VideoPublication::run -> Cannot write video" << std::endl;
                         }

--- a/test/profiling/allocations/AllocTestPublisher.cpp
+++ b/test/profiling/allocations/AllocTestPublisher.cpp
@@ -220,7 +220,7 @@ bool AllocTestPublisher::publish()
     if (is_matched())
     {
         data_.index(data_.index() + 1);
-        ret = writer_->write(&data_);
+        ret = (RETCODE_OK == writer_->write(&data_));
     }
     return ret;
 }

--- a/test/realtime/UserThreadNonBlockedTest.cpp
+++ b/test/realtime/UserThreadNonBlockedTest.cpp
@@ -243,7 +243,7 @@ TEST_F(UserThreadNonBlockedTest, remove_previous_sample_on_history)
             std::thread([&]
                     {
                         auto now = std::chrono::steady_clock::now();
-                        bool returned_value = datawriter_->write(reinterpret_cast<void*>(&sample));
+                        bool returned_value = (RETCODE_OK == datawriter_->write(reinterpret_cast<void*>(&sample)));
                         auto end = std::chrono::steady_clock::now();
                         promise.set_value_at_thread_exit( std::pair<bool, std::chrono::microseconds>(returned_value,
                         std::chrono::duration_cast<std::chrono::microseconds>(end - now)));
@@ -301,7 +301,7 @@ TEST_F(UserThreadNonBlockedTest, write_sample_besteffort)
             std::thread([&]
                     {
                         auto now = std::chrono::steady_clock::now();
-                        bool returned_value = datawriter_->write(reinterpret_cast<void*>(&sample));
+                        bool returned_value = (RETCODE_OK == datawriter_->write(reinterpret_cast<void*>(&sample)));
                         auto end = std::chrono::steady_clock::now();
                         promise.set_value_at_thread_exit( std::pair<bool, std::chrono::microseconds>(returned_value,
                         std::chrono::duration_cast<std::chrono::microseconds>(end - now)));
@@ -359,7 +359,7 @@ TEST_F(UserThreadNonBlockedTest, write_sample_reliable)
             std::thread([&]
                     {
                         auto now = std::chrono::steady_clock::now();
-                        bool returned_value = datawriter_->write(reinterpret_cast<void*>(&sample));
+                        bool returned_value = (RETCODE_OK == datawriter_->write(reinterpret_cast<void*>(&sample)));
                         auto end = std::chrono::steady_clock::now();
                         promise.set_value_at_thread_exit( std::pair<bool, std::chrono::microseconds>(returned_value,
                         std::chrono::duration_cast<std::chrono::microseconds>(end - now)));
@@ -418,7 +418,7 @@ TEST_F(UserThreadNonBlockedTest, write_async_sample_besteffort)
             std::thread([&]
                     {
                         auto now = std::chrono::steady_clock::now();
-                        bool returned_value = datawriter_->write(reinterpret_cast<void*>(&sample));
+                        bool returned_value = (RETCODE_OK == datawriter_->write(reinterpret_cast<void*>(&sample)));
                         auto end = std::chrono::steady_clock::now();
                         promise.set_value_at_thread_exit( std::pair<bool, std::chrono::microseconds>(returned_value,
                         std::chrono::duration_cast<std::chrono::microseconds>(end - now)));
@@ -477,7 +477,7 @@ TEST_F(UserThreadNonBlockedTest, write_async_sample_reliable)
             std::thread([&]
                     {
                         auto now = std::chrono::steady_clock::now();
-                        bool returned_value = datawriter_->write(reinterpret_cast<void*>(&sample));
+                        bool returned_value = (RETCODE_OK == datawriter_->write(reinterpret_cast<void*>(&sample)));
                         auto end = std::chrono::steady_clock::now();
                         promise.set_value_at_thread_exit( std::pair<bool, std::chrono::microseconds>(returned_value,
                         std::chrono::duration_cast<std::chrono::microseconds>(end - now)));

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1686,7 +1686,7 @@ void lookup_instance_test(
 {
     // Send sample with key value 0
     data.index(0);
-    EXPECT_TRUE(writer->write(&data));
+    EXPECT_EQ(RETCODE_OK, writer->write(&data));
     // Ensure it arrived to the DataReader
     EXPECT_TRUE(reader->wait_for_unread_message({ 1, 0 }));
 
@@ -2529,7 +2529,7 @@ TEST_F(DataReaderTests, check_key_history_wholesomeness_on_unmatch)
     sample.index(0);
     sample.message(msg);
 
-    ASSERT_TRUE(data_writer_->write(&sample));
+    ASSERT_EQ(RETCODE_OK, data_writer_->write(&sample));
 
     // wait till the DataReader receives the data
     ASSERT_TRUE(data_reader_->wait_for_unread_message(Duration_t(3, 0)));

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -157,17 +157,17 @@ public:
         return RETCODE_OK;
     }
 
-    bool write(
+    ReturnCode_t write(
             const void* const )
     {
-        return true;
+        return RETCODE_OK;
     }
 
-    bool write(
+    ReturnCode_t write(
             const void* const,
             fastdds::rtps::WriteParams& )
     {
-        return true;
+        return RETCODE_OK;
     }
 
     ReturnCode_t write(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
There were different `DataWriter::write` methods that return either `bool` or a `ReturnCode_t`.
This PR makes them all return a `ReturnCode_t` type, and updates their usage among the repo code.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Related impl PRs:
- Fast DDS Python - https://github.com/eProsima/Fast-DDS-python/pull/158
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

