### PR TITLE
[21310] Set 2.13.x as EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->
+<!-- @Mergifyio backport 2.14.x 2.10.x -->
 
 <!--
     In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.

--- a/.github/workflows/nightly-mac-ci.yml
+++ b/.github/workflows/nightly-mac-ci.yml
@@ -36,21 +36,6 @@ jobs:
       fastdds-branch: '2.14.x'
       use-ccache: false
 
-  nightly-mac-ci-2_13_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        security:
-          - 'ON'
-          - 'OFF'
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-mac-ci.yml@2.13.x
-    with:
-      label: 'nightly-sec-${{ matrix.security }}-mac-ci-2.13.x'
-      cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: "-LE xfail"
-      fastdds-branch: '2.13.x'
-      use-ccache: false
-
   nightly-mac-ci-2_10_x:
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-sanitizers-ci.yml
+++ b/.github/workflows/nightly-sanitizers-ci.yml
@@ -34,20 +34,6 @@ jobs:
       fastdds_ref: '2.14.x'
       discovery_server_ref: 'v1.2.2'
 
-  nightly-sanitizers-ci-2_13_x:
-      uses: eProsima/Fast-DDS/.github/workflows/reusable-sanitizers-ci.yml@2.13.x
-      with:
-        label: 'nightly-sec-sanitizers-ci-2.13.x'
-        run_asan_fastdds: true
-        run_asan_discovery_server: true
-        run_tsan_fastdds: true
-        colcon_build_args: ''
-        colcon_test_args: ''
-        cmake_args: ''
-        ctest_args: ''
-        fastdds_ref: '2.13.x'
-        discovery_server_ref: 'v1.2.2'
-
   nightly-sanitizers-ci-2_10_x:
     uses: eProsima/Fast-DDS/.github/workflows/reusable-sanitizers-ci.yml@2.10.x
     with:

--- a/.github/workflows/nightly-sanitizers-ci.yml
+++ b/.github/workflows/nightly-sanitizers-ci.yml
@@ -47,17 +47,3 @@ jobs:
       ctest_args: ''
       fastdds_ref: '2.10.x'
       discovery_server_ref: 'v1.2.1'
-
-  nightly-sanitizers-ci-2_6_x:
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-sanitizers-ci.yml@2.6.x
-    with:
-      label: 'nightly-sec-sanitizers-ci-2.6.x'
-      run_asan_fastdds: true
-      run_asan_discovery_server: true
-      run_tsan_fastdds: true
-      colcon_build_args: ''
-      colcon_test_args: ''
-      cmake_args: ''
-      ctest_args: ''
-      fastdds_ref: '2.6.x'
-      discovery_server_ref: 'v1.2.1'

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -46,26 +46,6 @@ jobs:
       run-tests: true
       use-ccache: false
 
-  nightly-ubuntu-ci-2_13_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        os-image:
-          - 'ubuntu-22.04'
-        security:
-          - true
-          - false
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-ubuntu-ci.yml@2.13.x
-    with:
-      os-image: ${{ matrix.os-image }}
-      label: '${{ matrix.os-image }}-nightly-sec-${{ matrix.security }}-ubuntu-ci-2.13.x'
-      ctest-args: "-LE xfail"
-      fastdds-branch: '2.13.x'
-      security: ${{ matrix.security }}
-      run-build: true
-      run-tests: true
-      use-ccache: false
-
   nightly-ubuntu-ci-2_10_x:
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -34,20 +34,6 @@ jobs:
         ctest-args: "-LE xfail"
         fastdds_branch: '2.14.x'
 
-  nightly-windows-ci-2_13_x:
-    strategy:
-      fail-fast: false
-      matrix:
-        security:
-          - 'ON'
-          - 'OFF'
-    uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@2.13.x
-    with:
-      label: 'nightly-sec-${{ matrix.security }}-windows-ci-2.13.x'
-      cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: "-LE xfail"
-      fastdds_branch: '2.13.x'
-
   nightly-windows-ci-2_10_x:
     strategy:
       fail-fast: false

--- a/.github/workflows/weekly-sanitizers-ci.yml
+++ b/.github/workflows/weekly-sanitizers-ci.yml
@@ -1,0 +1,21 @@
+name: Fast DDS Sanitizers CI (weekly)
+
+on:
+    workflow_dispatch:
+    schedule:
+      - cron: '0 0 * * 1' # Run at minute 0 on Monday
+
+jobs:
+  weekly-sanitizers-ci-2_6_x:
+    uses: eProsima/Fast-DDS/.github/workflows/reusable-sanitizers-ci.yml@2.6.x
+    with:
+      label: 'weekly-sec-sanitizers-ci-2.6.x'
+      run_asan_fastdds: true
+      run_asan_discovery_server: true
+      run_tsan_fastdds: true
+      colcon_build_args: ''
+      colcon_test_args: ''
+      cmake_args: ''
+      ctest_args: ''
+      fastdds_ref: '2.6.x'
+      discovery_server_ref: 'v1.2.1'

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -19,7 +19,6 @@ This period applies since the end of standard support date to the end of life (E
 |Version|Version branch|Latest Release|Release Date|End of Standard Support Date|EOL Date|
 |-------|--------------|--------------|------------|----------------------------|--------|
 |2.14|[2.14.x](https://github.com/eProsima/Fast-DDS/tree/2.14.x) (LTS)|[v2.14.3](https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.3)|March 2024|March 2025 [^*]|March 2025 [^*]|
-|2.13|[2.13.x](https://github.com/eProsima/Fast-DDS/tree/2.13.x)|[v2.13.5](https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.5)|December 2023|July 2024|July 2024|
 |2.10|[2.10.x](https://github.com/eProsima/Fast-DDS/tree/2.10.x) (LTS)|[v2.10.4](https://github.com/eProsima/Fast-DDS/releases/tag/v2.10.4)|March 2023|May 2025 [^*]|May 2025|
 |2.6|[2.6.x](https://github.com/eProsima/Fast-DDS/tree/2.6.x) (LTS)|[v2.6.9](https://github.com/eProsima/Fast-DDS/releases/tag/v2.6.9)|March 2022|July 2024|May 2025[^*]|
 
@@ -29,6 +28,7 @@ This period applies since the end of standard support date to the end of life (E
 
 |Version|Version branch|Latest Release|Release Date|EOL Date|
 |-------|--------------|--------------|------------|--------|
+|2.13|[2.13.x](https://github.com/eProsima/Fast-DDS/tree/2.13.x)|[v2.13.6](https://github.com/eProsima/Fast-DDS/releases/tag/v2.13.6)|December 2023|July 2024|
 |2.12|[2.12.x](https://github.com/eProsima/Fast-DDS/tree/2.12.x)|[v2.12.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.12.2)|September 2023|March 2024|
 |2.11|[2.11.x](https://github.com/eProsima/Fast-DDS/tree/2.11.x)|[v2.11.3](https://github.com/eProsima/Fast-DDS/releases/tag/v2.11.3)|July 2023|January 2024|
 |2.9|[2.9.x](https://github.com/eProsima/Fast-DDS/tree/2.9.x)|[v2.9.2](https://github.com/eProsima/Fast-DDS/releases/tag/v2.9.2)|December 2022|July 2023|


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR sets 2.13.x as EOL, and fixes nigtly sanizer job for 2.6x (OOS)
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- **N/A** Check CI results: changes do not issue any warning.
- **N/A** Check CI results: failing tests are unrelated with the changes.

