### PR TITLE
[21371] Change monitor service writer entity id

### DIFF
--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -68,7 +68,7 @@ namespace rtps {
 #define ENTITYID_DS_SERVER_VIRTUAL_READER 0x00030074
 
 #ifdef FASTDDS_STATISTICS
-#define ENTITYID_MONITOR_SERVICE_WRITER 0x004000D2
+#define ENTITYID_MONITOR_SERVICE_WRITER 0x00400072
 #endif // ifdef FASTDDS_STATISTICS
 
 //!@brief Structure EntityId_t, entity id part of GUID_t.

--- a/include/fastdds/rtps/common/EntityId_t.hpp
+++ b/include/fastdds/rtps/common/EntityId_t.hpp
@@ -68,7 +68,7 @@ namespace rtps {
 #define ENTITYID_DS_SERVER_VIRTUAL_READER 0x00030074
 
 #ifdef FASTDDS_STATISTICS
-#define ENTITYID_MONITOR_SERVICE_WRITER 0x00400072
+#define ENTITYID_MONITOR_SERVICE_WRITER 0x004000D2
 #endif // ifdef FASTDDS_STATISTICS
 
 //!@brief Structure EntityId_t, entity id part of GUID_t.

--- a/src/cpp/statistics/rtps/GuidUtils.hpp
+++ b/src/cpp/statistics/rtps/GuidUtils.hpp
@@ -41,7 +41,6 @@ inline bool is_monitor_service_builtin(
     return ENTITYID_MONITOR_SERVICE_WRITER == entity_id.to_uint32();
 }
 
-
 /**
  * Checks whether an entity id corresponds to a builtin statistics writer.
  * @param [in] entity_id The entity id to check.

--- a/src/cpp/statistics/rtps/GuidUtils.hpp
+++ b/src/cpp/statistics/rtps/GuidUtils.hpp
@@ -37,7 +37,11 @@ namespace statistics {
 inline bool is_monitor_service_builtin(
         const fastdds::rtps::EntityId_t& entity_id)
 {
+#ifdef FASTDDS_STATISTICS
     return ENTITYID_MONITOR_SERVICE_WRITER == entity_id.to_uint32();
+#endif // ifdef FASTDDS_STATISTICS
+    static_cast<void>(entity_id);
+    return false;
 }
 
 /**

--- a/src/cpp/statistics/rtps/GuidUtils.hpp
+++ b/src/cpp/statistics/rtps/GuidUtils.hpp
@@ -37,11 +37,12 @@ namespace statistics {
 inline bool is_monitor_service_builtin(
         const fastdds::rtps::EntityId_t& entity_id)
 {
+    bool ret = false;
 #ifdef FASTDDS_STATISTICS
-    return ENTITYID_MONITOR_SERVICE_WRITER == entity_id.to_uint32();
+    ret = ENTITYID_MONITOR_SERVICE_WRITER == entity_id.to_uint32();
 #endif // ifdef FASTDDS_STATISTICS
     static_cast<void>(entity_id);
-    return false;
+    return ret;
 }
 
 /**

--- a/src/cpp/statistics/rtps/GuidUtils.hpp
+++ b/src/cpp/statistics/rtps/GuidUtils.hpp
@@ -23,11 +23,24 @@
 
 #include <fastdds/rtps/common/EntityId_t.hpp>
 
+#include <statistics/rtps/GuidUtils.hpp>
 #include <statistics/types/types.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace statistics {
+
+/**
+ * Checks whether an entity id corresponds to a builtin monitor service writer.
+ * @param [in] entity_id The entity id to check.
+ * @return true when the entity id corresponds to a builtin monitor service writer.
+ */
+inline bool is_monitor_service_builtin(
+        const fastdds::rtps::EntityId_t& entity_id)
+{
+    return ENTITYID_MONITOR_SERVICE_WRITER == entity_id.to_uint32();
+}
+
 
 /**
  * Checks whether an entity id corresponds to a builtin statistics writer.
@@ -37,7 +50,7 @@ namespace statistics {
 inline bool is_statistics_builtin(
         const fastdds::rtps::EntityId_t& entity_id)
 {
-    return 0x60 == (0xE0 & entity_id.value[3]);
+    return 0x60 == (0xE0 & entity_id.value[3]) || is_monitor_service_builtin(entity_id);
 }
 
 /**

--- a/src/cpp/statistics/rtps/GuidUtils.hpp
+++ b/src/cpp/statistics/rtps/GuidUtils.hpp
@@ -23,7 +23,6 @@
 
 #include <fastdds/rtps/common/EntityId_t.hpp>
 
-#include <statistics/rtps/GuidUtils.hpp>
 #include <statistics/types/types.hpp>
 
 namespace eprosima {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

The EntityID of the MonitorService DataWriter is `0x004000D2`, which is not included in the statistics data writer range ([GuidUtils.hpp::37](https://github.com/eProsima/Fast-DDS/blob/4e8dd38f0550b4a5d963b4d82dfe7a988db07ee1/src/cpp/statistics/rtps/GuidUtils.hpp#L37)).

Hence, the discovery database fails to recognize the DataWriter and issues an error ([DiscoveryDataBase.cpp::400](https://github.com/eProsima/Fast-DDS/blob/4e8dd38f0550b4a5d963b4d82dfe7a988db07ee1/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp#L400)) when the writer is discovered.

@Mergifyio 2.14.x
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [X] The PR has a milestone assigned.
- [X] The title and description correctly express the PR's purpose.
- [X] Check contributor checklist is correct.
- [X] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [X] Check CI results: changes do not issue any warning.
- [X] Check CI results: failing tests are unrelated with the changes.
