### PR TITLE
[20181] Hotfix: Secure simple participants with `initialpeers` over `TCP` match

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -307,14 +307,13 @@ bool PDPSimple::createPDPEndpoints()
 
         endpoints = secure_endpoints;
         endpoints->reader.listener_.reset(new PDPSecurityInitiatorListener(this,
-                [this](const ParticipantProxyData& participant_data)
+                [this, secure_endpoints](const ParticipantProxyData& participant_data)
                 {
-                    auto secure_pdp_endpoints =
-                    static_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
-                    std::lock_guard<fastdds::RecursiveTimedMutex> wlock(secure_pdp_endpoints->writer.writer_->getMutex());
+                    assert(secure_endpoints == builtin_endpoints_.get());
+                    std::lock_guard<fastdds::RecursiveTimedMutex> wlock(secure_endpoints->writer.writer_->getMutex());
 
                     CacheChange_t* change = nullptr;
-                    secure_pdp_endpoints->writer.history_->get_earliest_change(&change);
+                    secure_endpoints->writer.history_->get_earliest_change(&change);
 
                     if (change != nullptr)
                     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -568,8 +568,13 @@ void PDPSimple::removeRemoteEndpoints(
         ParticipantProxyData* pdata)
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "For RTPSParticipant: " << pdata->m_guid);
+    unmatch_pdp_remote_endpoints(pdata->m_guid);
+}
 
-    GUID_t guid = pdata->m_guid;
+void PDPSimple::unmatch_pdp_remote_endpoints(
+        const GUID_t& participant_guid)
+{
+    GUID_t guid = participant_guid;
 
     {
         auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
@@ -601,6 +606,7 @@ void PDPSimple::notifyAboveRemoteEndpoints(
 {
     if (notify_secure_endpoints)
     {
+        unmatch_pdp_remote_endpoints(pdata.m_guid);
         match_pdp_remote_endpoints(pdata, true, false);
     }
     else

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -306,7 +306,34 @@ bool PDPSimple::createPDPEndpoints()
         secure_endpoints->secure_reader.listener_.reset(new PDPListener(this));
 
         endpoints = secure_endpoints;
-        endpoints->reader.listener_.reset(new PDPSecurityInitiatorListener(this));
+        endpoints->reader.listener_.reset(new PDPSecurityInitiatorListener(this,
+                [this](const ParticipantProxyData& participant_data)
+                {
+                    auto secure_pdp_endpoints =
+                    static_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
+                    std::lock_guard<fastdds::RecursiveTimedMutex> wlock(secure_pdp_endpoints->writer.writer_->getMutex());
+
+                    CacheChange_t* change = nullptr;
+                    secure_pdp_endpoints->writer.history_->get_earliest_change(&change);
+
+                    if (change != nullptr)
+                    {
+                        std::vector<GUID_t> remote_readers;
+                        LocatorList_t locators;
+
+                        // Send discovery information through the non-secure PDP writer
+                        remote_readers.emplace_back(participant_data.m_guid.guidPrefix, c_EntityId_SPDPReader);
+
+                        fastdds::rtps::FakeWriter writer(getRTPSParticipant(), c_EntityId_SPDPWriter);
+
+                        for (auto& locator : participant_data.metatraffic_locators.unicast)
+                        {
+                            locators.push_back(locator);
+                        }
+
+                        direct_send(getRTPSParticipant(), locators, remote_readers, *change, writer);
+                    }
+                }));
     }
     else
 #endif  // HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.h
@@ -146,6 +146,14 @@ private:
             bool notify_secure_endpoints,
             bool writer_only);
 
+    /**
+     * @brief Unmatch PDP endpoints with a remote participant.
+     *
+     * @param participant_guid GUID of the remote participant.
+     */
+    void unmatch_pdp_remote_endpoints(
+            const GUID_t& participant_guid);
+
     void assign_low_level_remote_endpoints(
             const ParticipantProxyData& pdata,
             bool notify_secure_endpoints);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.h
@@ -143,7 +143,8 @@ private:
 
     void match_pdp_remote_endpoints(
             const ParticipantProxyData& pdata,
-            bool notify_secure_endpoints);
+            bool notify_secure_endpoints,
+            bool writer_only);
 
     void assign_low_level_remote_endpoints(
             const ParticipantProxyData& pdata,

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -5032,7 +5032,7 @@ TEST(Security, security_with_initial_peers_over_tcpv4_correctly_behaves)
     Locator_t wan_locator;
     IPFinder::getIP4Address(&all_locators);
 
-    for (auto &locator : all_locators)
+    for (auto& locator : all_locators)
     {
         if (!IPLocator::isLocal(locator))
         {
@@ -5049,8 +5049,8 @@ TEST(Security, security_with_initial_peers_over_tcpv4_correctly_behaves)
     LocatorList_t initial_peers;
     initial_peers.push_back(wan_locator);
     tcp_client.disable_builtin_transport()
-              .add_user_transport_to_pparams(tcp_client_transport_descriptor)
-              .initial_peers(initial_peers);
+            .add_user_transport_to_pparams(tcp_client_transport_descriptor)
+            .initial_peers(initial_peers);
 
     auto tcp_server_transport_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
     tcp_server_transport_descriptor->listening_ports.push_back(server_listening_port);
@@ -5059,7 +5059,7 @@ TEST(Security, security_with_initial_peers_over_tcpv4_correctly_behaves)
     std::cout << "SETTING WAN address to " <<  wan_locator << std::endl;
 
     tcp_server.disable_builtin_transport()
-              .add_user_transport_to_pparams(tcp_server_transport_descriptor);
+            .add_user_transport_to_pparams(tcp_server_transport_descriptor);
 
     // Configure security
     const std::string governance_file("governance_helloworld_all_enable.smime");

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -27,6 +27,7 @@
 #include <fastdds/rtps/common/EntityId_t.hpp>
 #include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
+#include <fastdds/utils/IPFinder.hpp>
 #include <gtest/gtest.h>
 
 #include "../utils/filter_helpers.hpp"
@@ -5014,6 +5015,77 @@ TEST(Security, ValidateAuthenticationHandshakeProperties)
     writer.waitAuthorized();
 
     ASSERT_TRUE(auth_elapsed_time < max_time);
+}
+
+// Regression test for Redmine issue #20181
+// Two simple secure participants with tcp transport and initial peers must match.
+// It basically tests that the PDPSecurityInitiatorListener
+// in PDPSimple answers back with the proxy data.
+TEST(Security, security_with_initial_peers_over_tcpv4_correctly_behaves)
+{
+    // Create
+    PubSubWriter<HelloWorldPubSubType> tcp_client("HelloWorldTopic_TCP");
+    PubSubReader<HelloWorldPubSubType> tcp_server("HelloWorldTopic_TCP");
+
+    // Search for a valid WAN address
+    LocatorList_t all_locators;
+    Locator_t wan_locator;
+    IPFinder::getIP4Address(&all_locators);
+
+    for (auto &locator : all_locators)
+    {
+        if (!IPLocator::isLocal(locator))
+        {
+            wan_locator = locator;
+            break;
+        }
+    }
+
+    uint16_t server_listening_port = 11810;
+    wan_locator.port = server_listening_port;
+    wan_locator.kind = LOCATOR_KIND_TCPv4;
+
+    auto tcp_client_transport_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+    LocatorList_t initial_peers;
+    initial_peers.push_back(wan_locator);
+    tcp_client.disable_builtin_transport()
+              .add_user_transport_to_pparams(tcp_client_transport_descriptor)
+              .initial_peers(initial_peers);
+
+    auto tcp_server_transport_descriptor = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+    tcp_server_transport_descriptor->listening_ports.push_back(server_listening_port);
+    IPLocator::copyIPv4(wan_locator, tcp_server_transport_descriptor->wan_addr);
+
+    std::cout << "SETTING WAN address to " <<  wan_locator << std::endl;
+
+    tcp_server.disable_builtin_transport()
+              .add_user_transport_to_pparams(tcp_server_transport_descriptor);
+
+    // Configure security
+    const std::string governance_file("governance_helloworld_all_enable.smime");
+    const std::string permissions_file("permissions_helloworld.smime");
+    CommonPermissionsConfigure(tcp_server, tcp_client, governance_file, permissions_file);
+
+    tcp_server.init();
+    tcp_client.init();
+
+    ASSERT_TRUE(tcp_server.isInitialized());
+    ASSERT_TRUE(tcp_client.isInitialized());
+
+    tcp_server.waitAuthorized();
+    tcp_client.waitAuthorized();
+
+    tcp_server.wait_discovery();
+    tcp_client.wait_discovery();
+
+    ASSERT_TRUE(tcp_server.is_matched());
+    ASSERT_TRUE(tcp_client.is_matched());
+
+    auto data = default_helloworld_data_generator();
+    tcp_server.startReception(data);
+    tcp_client.send(data);
+    ASSERT_TRUE(data.empty());
+    tcp_server.block_for_all(std::chrono::seconds(10));
 }
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a behavior that changed in https://github.com/eProsima/Fast-DDS/commit/f2e5ce making simple secure participants not match.

The `tcp client` sends its `DATA[P]` to the tcp server, the server starts the security handshake but the client is not able to accept the security handshake request because it does not have the discovery information from the server participant.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
