### PR TITLE
[21387] Fix build issues and update CI infrastructure to detect them

### DIFF
--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -844,3 +844,14 @@ jobs:
           cmake_args_default: ${{ env.colcon-build-default-cmake-args }}
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
+
+      - name: Clean workspace - No shared libs
+        run: |
+          cd ${{ github.workspace }}
+          rm -rf build install log
+
+      - name: Vanilla colcon build
+        uses: eProsima/eProsima-CI/multiplatform/colcon_build@v0
+        with:
+          cmake_build_type: ${{ matrix.cmake-build-type }}
+          workspace: ${{ github.workspace }}

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -140,18 +140,12 @@ jobs:
           destination_workspace: src
           skip_existing: 'true'
 
-      - name: Prepare build meta file
-        uses: eProsima/eProsima-CI/windows/merge_yaml_metas@v0
-        with:
-          metas: "@('${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta', '${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta')"
-          path: '${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build_test.meta'
-
       - name: Build
         id: build
         continue-on-error: false
         uses: eProsima/eProsima-CI/windows/colcon_build@v0
         with:
-          colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build_test.meta
+          colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build.meta ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta
           colcon_build_args: ${{ inputs.colcon-args }}
           # The following Fast DDS CMake options need to be specified here instead of in the meta files
           # because they vary from platform to platform

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,13 +63,20 @@ if(MSVC OR MSVC_IDE)
     # C5038 data member 'member1' will be initialized after data member 'member2'
     # C4100 'identifier' : unreferenced formal parameter (matches clang -Wunused-lambda-capture)
     add_compile_options(/w34101 /w34189 /w34555 /w34715 /w35038 /w44100)
+    # Treat warnings as errors
+    add_compile_options(/WX)
 
     if(EPROSIMA_BUILD)
         string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
     endif()
 else()
+    # Treat warnings as errors
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -Werror")
+    # Add some generic warnings common to all compilers
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-switch-bool")
+    # Add compiler specific options
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,16 +63,11 @@ if(MSVC OR MSVC_IDE)
     # C5038 data member 'member1' will be initialized after data member 'member2'
     # C4100 'identifier' : unreferenced formal parameter (matches clang -Wunused-lambda-capture)
     add_compile_options(/w34101 /w34189 /w34555 /w34715 /w35038 /w44100)
-    # Treat warnings as errors
-    add_compile_options(/WX)
 
     if(EPROSIMA_BUILD)
         string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
     endif()
 else()
-    # Treat warnings as errors
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Werror")
     # Add some generic warnings common to all compilers
     set(CMAKE_CXX_FLAGS
         "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-switch-bool")
@@ -181,6 +176,20 @@ if (SANITIZER)
     else()
         message(WARNING "Sanitizer option not supported. Continuing without any code instrumentation... ")
 
+    endif()
+endif()
+
+###############################################################################
+# Set warnings as errors if the thread sanitizer is not being used
+###############################################################################
+string(FIND ${CMAKE_CXX_FLAGS} "-fsanitize=thread" SANITIZER_THREAD)
+if (${SANITIZER_THREAD} EQUAL -1)
+    message(STATUS "Setting warnings as errors...")
+    if(MSVC OR MSVC_IDE)
+        add_compile_options(/WX)
+    else()
+        set(CMAKE_CXX_FLAGS
+            "${CMAKE_CXX_FLAGS} -Werror")
     endif()
 endif()
 

--- a/examples/cpp/static_edp_discovery/CLIParser.hpp
+++ b/examples/cpp/static_edp_discovery/CLIParser.hpp
@@ -18,7 +18,17 @@
 #include <fstream>
 
 #ifdef _WIN32
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif // ifndef NOMINMAX
+
 #include <windows.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif // ifndef PATH_MAX
+
 #else
 #include <unistd.h>
 #include <libgen.h>

--- a/examples/cpp/static_edp_discovery/PublisherApp.hpp
+++ b/examples/cpp/static_edp_discovery/PublisherApp.hpp
@@ -78,7 +78,7 @@ private:
 
     TypeSupport type_;
 
-    int16_t matched_;
+    int32_t matched_;
 
     uint16_t samples_;
 

--- a/examples/cpp/topic_instances/CLIParser.hpp
+++ b/examples/cpp/topic_instances/CLIParser.hpp
@@ -29,6 +29,22 @@ namespace fastdds {
 namespace examples {
 namespace topic_instances {
 
+// The code here has been taken from the notes in https://en.cppreference.com/w/cpp/string/byte/toupper
+// Note how the argument passed is cast into an unsigned char to avoid undefined behavior
+static char my_toupper(
+        char c)
+{
+    return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+}
+
+// The code here has been taken from the notes in https://en.cppreference.com/w/cpp/string/byte/tolower
+// Note how the argument passed is cast into an unsigned char to avoid undefined behavior
+static char my_tolower (
+        char c)
+{
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+}
+
 using dds::Log;
 
 class CLIParser
@@ -349,8 +365,8 @@ public:
                             input == "Circle" || input == "Square" || input == "Triangle" ||
                             input == "circle" || input == "square" || input == "triangle")
                     {
-                        transform(input.begin(), input.begin() + 1, input.begin(), ::toupper);
-                        transform(input.begin() + 1, input.end(), input.begin() + 1, ::tolower);
+                        transform(input.begin(), input.begin() + 1, input.begin(), my_toupper);
+                        transform(input.begin() + 1, input.end(), input.begin() + 1, my_tolower);
                         if (config.entity == CLIParser::EntityKind::PUBLISHER)
                         {
                             config.pub_config.topic_name = input;
@@ -618,7 +634,7 @@ public:
                         std::string c;
                         while (std::getline(iss, c, ','))
                         {
-                            transform(c.begin(), c.end(), c.begin(), ::toupper);
+                            transform(c.begin(), c.end(), c.begin(), my_toupper);
                             if (c == "RED" || c == "BLUE" || c == "GREEN" || c == "YELLOW" || c == "ORANGE" ||
                                     c == "CYAN" || c == "MAGENTA" || c == "PURPLE" || c == "GREY" || c == "BLACK")
                             {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -856,6 +856,7 @@ bool EDP::pairingWriter(
 
     BaseWriter* writer = BaseWriter::downcast(W);
     const GUID_t& writer_guid = writer->getGuid();
+    static_cast<void>(writer_guid); // Void cast to force usage if LOG_INFO and SECURITY are disabled
 
     EPROSIMA_LOG_INFO(RTPS_EDP, writer_guid << " in topic: \"" << wdata.topicName() << "\"");
     std::lock_guard<std::recursive_mutex> pguard(*mp_PDP->getMutex());

--- a/src/cpp/utils/UnitsParser.cpp
+++ b/src/cpp/utils/UnitsParser.cpp
@@ -20,12 +20,14 @@
 #include <utils/UnitsParser.hpp>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <limits>
 #include <map>
 #include <regex>
 #include <set>
 #include <stdexcept>
+#include <string>
 
 namespace eprosima {
 namespace fastdds {
@@ -35,19 +37,13 @@ namespace utils {
 void to_uppercase(
         std::string& st) noexcept
 {
-    std::transform(st.begin(), st.end(), st.begin(),
-            [](char c)
+    // These lambda has been taken from the notes in https://en.cppreference.com/w/cpp/string/byte/toupper
+    // Note how the argument passed is unsigned char to avoid undefined behavior
+    auto my_toupper = [](unsigned char c)
             {
-                //TODO Carlos: use std::toupper after update VS2019
-                if (c >= 'a' && c <= 'z')
-                {
-                    return static_cast<char>(c - 'a' + 'A');
-                }
-                else
-                {
-                    return static_cast<char>(c);
-                }
-            });
+                return static_cast<char>(std::toupper(c));
+            };
+    std::transform(st.begin(), st.end(), st.begin(), my_toupper);
 }
 
 uint32_t parse_value_and_units(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Due to an infrastructure issue with an internal action for Windows, the CI was not properly applying some CMake arguments while testing Fast DDS on Windows. Among others, the examples were not built, so CI passed even though.

This PR fixes the build issue, and tests the changes in the infrastructure to ensure it does not happen anymore.

It was detected also a build issue when security and log info were disabled. In this PR it has been introduced a CI job that builds Fast DDS without any additional arguments / flags, and the error fix has been introduced too.

Finally, building with warnings as error has been set also from the main CMakeLists.txt file.

Related eProsima-CI pr:
- https://github.com/eProsima/eProsima-CI/pull/116
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

