### PR TITLE
[21357] Remove `TopicAttributes` from public APIs and make it private in `xmlparser`

### DIFF
--- a/examples/cpp/discovery_server/ClientPublisherApp.cpp
+++ b/examples/cpp/discovery_server/ClientPublisherApp.cpp
@@ -198,6 +198,11 @@ ClientPublisherApp::ClientPublisherApp(
         wqos.durability().kind = VOLATILE_DURABILITY_QOS;
     }
 
+    // So as not to overwriter the first sample
+    // if we publish inmediately after the discovery
+    // and the suscription is not prepared yet
+    wqos.history().depth = 5;
+
     writer_ = publisher_->create_datawriter(topic_, wqos, this);
 
     if (writer_ == nullptr)

--- a/examples/cpp/rtps/ReaderApp.cpp
+++ b/examples/cpp/rtps/ReaderApp.cpp
@@ -29,7 +29,7 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
+#include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/reader/RTPSReader.hpp>
@@ -114,17 +114,16 @@ ReaderApp::ReaderApp(
 
     std::cout << "Registering RTPS Reader" << std::endl;
 
-    TopicAttributes topic_att;
-    topic_att.topicKind = NO_KEY;
-    topic_att.topicDataType = "HelloWorld";
-    topic_att.topicName = topic_name;
+    SubscriptionBuiltinTopicData sub_builtin_data;
+    sub_builtin_data.topic_name = topic_name;
+    sub_builtin_data.type_name = "HelloWorld";
 
     eprosima::fastdds::dds::ReaderQos reader_qos;
     reader_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
     reader_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->registerReader(rtps_reader_, topic_att, reader_qos))
+    if (!rtps_participant_->register_reader(rtps_reader_, sub_builtin_data, reader_qos))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/examples/cpp/rtps/ReaderApp.cpp
+++ b/examples/cpp/rtps/ReaderApp.cpp
@@ -29,7 +29,7 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/reader/RTPSReader.hpp>
@@ -114,14 +114,16 @@ ReaderApp::ReaderApp(
 
     std::cout << "Registering RTPS Reader" << std::endl;
 
-    SubscriptionBuiltinTopicData sub_builtin_data;
-    sub_builtin_data.topic_name = topic_name;
-    sub_builtin_data.type_name = "HelloWorld";
-    sub_builtin_data.durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    sub_builtin_data.reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    TopicDescription topic_desc;
+    topic_desc.topic_name = topic_name;
+    topic_desc.type_name = "HelloWorld";
+
+    eprosima::fastdds::dds::ReaderQos reader_qos;
+    reader_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    reader_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->register_reader(rtps_reader_, sub_builtin_data))
+    if (!rtps_participant_->register_reader(rtps_reader_, topic_desc, reader_qos))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/examples/cpp/rtps/ReaderApp.cpp
+++ b/examples/cpp/rtps/ReaderApp.cpp
@@ -117,13 +117,11 @@ ReaderApp::ReaderApp(
     SubscriptionBuiltinTopicData sub_builtin_data;
     sub_builtin_data.topic_name = topic_name;
     sub_builtin_data.type_name = "HelloWorld";
-
-    eprosima::fastdds::dds::ReaderQos reader_qos;
-    reader_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    reader_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    sub_builtin_data.durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    sub_builtin_data.reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->register_reader(rtps_reader_, sub_builtin_data, reader_qos))
+    if (!rtps_participant_->register_reader(rtps_reader_, sub_builtin_data))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/examples/cpp/rtps/WriterApp.cpp
+++ b/examples/cpp/rtps/WriterApp.cpp
@@ -108,13 +108,11 @@ WriterApp::WriterApp(
     PublicationBuiltinTopicData pub_builtin_data;
     pub_builtin_data.type_name = "HelloWorld";
     pub_builtin_data.topic_name = topic_name;
-
-    eprosima::fastdds::dds::WriterQos writer_qos;
-    writer_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    writer_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    pub_builtin_data.durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    pub_builtin_data.reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->register_writer(rtps_writer_, pub_builtin_data, writer_qos))
+    if (!rtps_participant_->register_writer(rtps_writer_, pub_builtin_data))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/examples/cpp/rtps/WriterApp.cpp
+++ b/examples/cpp/rtps/WriterApp.cpp
@@ -29,7 +29,7 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
-#include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/RTPSDomain.hpp>
@@ -105,14 +105,16 @@ WriterApp::WriterApp(
 
     std::cout << "Registering RTPS Writer" << std::endl;
 
-    PublicationBuiltinTopicData pub_builtin_data;
-    pub_builtin_data.type_name = "HelloWorld";
-    pub_builtin_data.topic_name = topic_name;
-    pub_builtin_data.durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-    pub_builtin_data.reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    TopicDescription topic_desc;
+    topic_desc.type_name = "HelloWorld";
+    topic_desc.topic_name = topic_name;
+
+    eprosima::fastdds::dds::WriterQos writer_qos;
+    writer_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    writer_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->register_writer(rtps_writer_, pub_builtin_data))
+    if (!rtps_participant_->register_writer(rtps_writer_, topic_desc, writer_qos))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/examples/cpp/rtps/WriterApp.cpp
+++ b/examples/cpp/rtps/WriterApp.cpp
@@ -28,8 +28,8 @@
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
+#include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/RTPSDomain.hpp>
@@ -105,17 +105,16 @@ WriterApp::WriterApp(
 
     std::cout << "Registering RTPS Writer" << std::endl;
 
-    TopicAttributes topic_att;
-    topic_att.topicKind = NO_KEY;
-    topic_att.topicDataType = "HelloWorld";
-    topic_att.topicName = topic_name;
+    PublicationBuiltinTopicData pub_builtin_data;
+    pub_builtin_data.type_name = "HelloWorld";
+    pub_builtin_data.topic_name = topic_name;
 
     eprosima::fastdds::dds::WriterQos writer_qos;
     writer_qos.m_durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
     writer_qos.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
 
     // Register entity
-    if (!rtps_participant_->registerWriter(rtps_writer_, topic_att, writer_qos))
+    if (!rtps_participant_->register_writer(rtps_writer_, pub_builtin_data, writer_qos))
     {
         throw std::runtime_error("Entity registration failed");
     }

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -586,9 +586,15 @@ public:
             const fastdds::dds::Duration_t& max_wait);
 
     /**
-     * @brief A method to retrieve the publication data discovery information of this writer.
+     * Retrieve the publication data discovery information.
+     *
+     * @param [out] publication_data The publication data discovery information.
+     *
+     * @return NOT_ENABLED if the writer has not been enabled.
+     * @return OK if the publication data is returned.
      */
-    FASTDDS_EXPORTED_API PublicationBuiltinTopicData get_publication_builtin_topic_data() const;
+    FASTDDS_EXPORTED_API ReturnCode_t get_publication_builtin_topic_data(
+            PublicationBuiltinTopicData& publication_data) const;
 
 protected:
 

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -19,6 +19,7 @@
 #ifndef FASTDDS_DDS_PUBLISHER__DATAWRITER_HPP
 #define FASTDDS_DDS_PUBLISHER__DATAWRITER_HPP
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/core/ReturnCode.hpp>
@@ -28,9 +29,9 @@
 #include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/fastdds_dll.hpp>
 #include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
-#include <fastdds/fastdds_dll.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -583,6 +584,11 @@ public:
             const void* const instance,
             const InstanceHandle_t& handle,
             const fastdds::dds::Duration_t& max_wait);
+
+    /**
+     * @brief A method to retrieve the publication data discovery information of this writer.
+     */
+    FASTDDS_EXPORTED_API PublicationBuiltinTopicData get_publication_builtin_topic_data() const;
 
 protected:
 

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -37,9 +37,6 @@ class Publisher;
 
 namespace eprosima {
 namespace fastdds {
-
-class TopicAttributes;
-
 namespace rtps {
 
 class IPayloadPool;

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/core/Entity.hpp>
 #include <fastdds/dds/core/LoanableCollection.hpp>
 #include <fastdds/dds/core/LoanableSequence.hpp>
@@ -1075,6 +1076,13 @@ public:
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_listening_locators(
             rtps::LocatorList& locators) const;
+
+    /**
+     * @brief A method to retrieve the subscription data discovery information.
+     *
+     * @return The discovery information of the subscription.
+     */
+    FASTDDS_EXPORTED_API SubscriptionBuiltinTopicData get_subscription_builtin_topic_data() const;
 
 protected:
 

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -1078,11 +1078,15 @@ public:
             rtps::LocatorList& locators) const;
 
     /**
-     * @brief A method to retrieve the subscription data discovery information.
+     * Retrieve the subscription data discovery information.
      *
-     * @return The discovery information of the subscription.
+     * @param [out] subscription_data The subscription data discovery information.
+     *
+     * @return NOT_ENABLED if the reader has not been enabled.
+     * @return OK if the subscription data is returned.
      */
-    FASTDDS_EXPORTED_API SubscriptionBuiltinTopicData get_subscription_builtin_topic_data() const;
+    FASTDDS_EXPORTED_API ReturnCode_t get_subscription_builtin_topic_data(
+            SubscriptionBuiltinTopicData& subscription_data) const;
 
 protected:
 

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -40,9 +40,6 @@ class Subscriber;
 
 namespace eprosima {
 namespace fastdds {
-
-class TopicAttributes;
-
 namespace rtps {
 
 class IPayloadPool;

--- a/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
+++ b/include/fastdds/dds/subscriber/qos/DataReaderQos.hpp
@@ -25,14 +25,11 @@
 #include <fastdds/dds/subscriber/qos/ReaderQos.hpp>
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/fastdds_dll.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
-
-using TopicAttributesQos = fastdds::TopicAttributes;
 
 //! Qos Policy to configure the DisablePositiveACKsQos and the reader attributes
 class RTPSReliableReaderQos

--- a/include/fastdds/dds/topic/qos/TopicQos.hpp
+++ b/include/fastdds/dds/topic/qos/TopicQos.hpp
@@ -21,7 +21,6 @@
 #define FASTDDS_DDS_TOPIC_QOS__TOPICQOS_HPP
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 
 #include <fastdds/dds/log/Log.hpp>
 

--- a/include/fastdds/rtps/RTPSDomain.hpp
+++ b/include/fastdds/rtps/RTPSDomain.hpp
@@ -29,7 +29,6 @@
 #include <fastdds/rtps/common/Types.hpp>
 #include <fastdds/rtps/history/IPayloadPool.hpp>
 #include <fastdds/rtps/history/IChangePool.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -250,18 +249,6 @@ public:
      */
     FASTDDS_EXPORTED_API static bool set_library_settings(
             const fastdds::LibrarySettings& library_settings);
-
-    /**
-     * @brief Get the TopicAttributes from XML profile.
-     *
-     * @param profile_name Topic profile name.
-     * @param topic_att TopicAttributes object where the attributes are returned.
-     * @return bool true if the profile exists.
-     *              false otherwise.
-     */
-    FASTDDS_EXPORTED_API static bool get_topic_attributes_from_profile(
-            const std::string& profile_name,
-            TopicAttributes& topic_att);
 
 private:
 

--- a/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
@@ -37,11 +37,16 @@ namespace rtps {
 /// Structure PublicationBuiltinTopicData, contains the information on a discovered publication.
 struct PublicationBuiltinTopicData
 {
+    PublicationBuiltinTopicData()
+    {
+        reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+    }
+
     /// Builtin topic Key
-    BuiltinTopicKey_t key;
+    BuiltinTopicKey_t key{{0, 0, 0}};
 
     /// Builtin participant topic Key
-    BuiltinTopicKey_t participant_key;
+    BuiltinTopicKey_t participant_key{{0, 0, 0}};
 
     /// Topic name
     fastcdr::string_255 topic_name;

--- a/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
@@ -36,10 +36,10 @@ namespace rtps {
 struct SubscriptionBuiltinTopicData
 {
     /// Builtin topic Key
-    BuiltinTopicKey_t key;
+    BuiltinTopicKey_t key{{0, 0, 0}};
 
     /// Builtin participant topic Key
-    BuiltinTopicKey_t participant_key;
+    BuiltinTopicKey_t participant_key{{0,0,0}};
 
     /// Topic name
     fastcdr::string_255 topic_name;

--- a/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
@@ -39,7 +39,7 @@ struct SubscriptionBuiltinTopicData
     BuiltinTopicKey_t key{{0, 0, 0}};
 
     /// Builtin participant topic Key
-    BuiltinTopicKey_t participant_key{{0,0,0}};
+    BuiltinTopicKey_t participant_key{{0, 0, 0}};
 
     /// Topic name
     fastcdr::string_255 topic_name;

--- a/include/fastdds/rtps/builtin/data/TopicDescription.hpp
+++ b/include/fastdds/rtps/builtin/data/TopicDescription.hpp
@@ -1,0 +1,51 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file TopicDescription.hpp
+ */
+
+#ifndef FASTDDS_RTPS_BUILTIN_DATA__TOPICDESCRIPTION_HPP
+#define FASTDDS_RTPS_BUILTIN_DATA__TOPICDESCRIPTION_HPP
+
+#include <cstdint>
+#include <string>
+
+#include <fastcdr/cdr/fixed_size_string.hpp>
+
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+/// Structure TopicDescription, used to register an endpoint on a topic.
+struct TopicDescription
+{
+    /// Topic name
+    fastcdr::string_255 topic_name;
+
+    /// Type name
+    fastcdr::string_255 type_name;
+
+    /// Type information
+    dds::xtypes::TypeInformationParameter type_information;
+
+};
+
+}   // namespace rtps
+}   // namespace fastdds
+}   // namespace eprosima
+
+#endif // FASTDDS_RTPS_BUILTIN_DATA__TOPICDESCRIPTION_HPP

--- a/include/fastdds/rtps/common/LocatorList.hpp
+++ b/include/fastdds/rtps/common/LocatorList.hpp
@@ -23,6 +23,7 @@
 
 #include <fastdds/rtps/common/Locator.hpp>
 #include <fastdds/rtps/common/LocatorsIterator.hpp>
+#include <fastdds/utils/collections/ResourceLimitedVector.hpp>
 
 #include <vector>
 #include <cstdint>
@@ -374,6 +375,16 @@ public:
         }
 
         return false;
+    }
+
+    // Copy the inner locator list to a ResourceLimitedVector locator list.
+    FASTDDS_EXPORTED_API void copy_to(
+            eprosima::fastdds::ResourceLimitedVector<Locator>& locator_list) const
+    {
+        for(auto& locator : m_locators)
+        {
+            locator_list.emplace_back(locator);
+        }
     }
 
 private:

--- a/include/fastdds/rtps/common/LocatorList.hpp
+++ b/include/fastdds/rtps/common/LocatorList.hpp
@@ -381,7 +381,7 @@ public:
     FASTDDS_EXPORTED_API void copy_to(
             eprosima::fastdds::ResourceLimitedVector<Locator>& locator_list) const
     {
-        for(auto& locator : m_locators)
+        for (auto& locator : m_locators)
         {
             locator_list.emplace_back(locator);
         }

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -154,14 +154,12 @@ public:
      * Register a Reader in the BuiltinProtocols.
      * @param rtps_reader      Pointer to the RTPSReader.
      * @param sub_builtin_data Contains the discovery information of the reader.
-     * @param rqos             ReaderQos.
      * @param content_filter   Optional content filtering information.
      * @return True if correctly registered.
      */
     bool register_reader(
             RTPSReader* rtps_reader,
             const SubscriptionBuiltinTopicData& sub_builtin_data,
-            const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -139,15 +139,15 @@ public:
     uint32_t getRTPSParticipantID() const;
 
     /**
-     * Register a RTPSWriter in the builtin Protocols.
-     * @param Writer Pointer to the RTPSWriter.
-     * @param topicAtt Topic Attributes where you want to register it.
+     * Register a Writer in the BuiltinProtocols.
+     * @param rtps_writer Pointer to the RTPSWriter.
+     * @param pub_builtin_data Contains the discovery information of the writer.
      * @param wqos WriterQos.
      * @return True if correctly registered.
      */
-    bool registerWriter(
-            RTPSWriter* Writer,
-            const TopicAttributes& topicAtt,
+    bool register_writer(
+            RTPSWriter* rtps_writer,
+            const PublicationBuiltinTopicData& pub_builtin_data,
             const fastdds::dds::WriterQos& wqos);
 
     /**
@@ -172,15 +172,13 @@ public:
             const RTPSParticipantAttributes& patt);
 
     /**
-     * Update writer QOS
-     * @param Writer to update
-     * @param topicAtt Topic Attributes where you want to register it.
-     * @param wqos New writer QoS
-     * @return true on success
+     * Update local writer QoS
+     * @param rtps_writer      Writer to update.
+     * @param wqos             New QoS for the writer.
+     * @return True on success
      */
-    bool updateWriter(
-            RTPSWriter* Writer,
-            const TopicAttributes& topicAtt,
+    bool update_writer(
+            RTPSWriter* rtps_writer,
             const fastdds::dds::WriterQos& wqos);
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -142,13 +142,11 @@ public:
      * Register a Writer in the BuiltinProtocols.
      * @param rtps_writer Pointer to the RTPSWriter.
      * @param pub_builtin_data Contains the discovery information of the writer.
-     * @param wqos WriterQos.
      * @return True if correctly registered.
      */
     bool register_writer(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data,
-            const fastdds::dds::WriterQos& wqos);
+            const PublicationBuiltinTopicData& pub_builtin_data);
 
     /**
      * Register a Reader in the BuiltinProtocols.

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -151,16 +151,16 @@ public:
             const fastdds::dds::WriterQos& wqos);
 
     /**
-     * Register a RTPSReader in the builtin Protocols.
-     * @param Reader          Pointer to the RTPSReader.
-     * @param topicAtt        Topic Attributes where you want to register it.
-     * @param rqos            ReaderQos.
-     * @param content_filter  Optional content filtering information.
+     * Register a Reader in the BuiltinProtocols.
+     * @param rtps_reader      Pointer to the RTPSReader.
+     * @param sub_builtin_data Contains the discovery information of the reader.
+     * @param rqos             ReaderQos.
+     * @param content_filter   Optional content filtering information.
      * @return True if correctly registered.
      */
-    bool registerReader(
-            RTPSReader* Reader,
-            const TopicAttributes& topicAtt,
+    bool register_reader(
+            RTPSReader* rtps_reader,
+            const SubscriptionBuiltinTopicData& sub_builtin_data,
             const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 
@@ -182,16 +182,14 @@ public:
             const fastdds::dds::WriterQos& wqos);
 
     /**
-     * Update reader QOS
-     * @param Reader          Pointer to the RTPSReader to update
-     * @param topicAtt        Topic Attributes where you want to register it.
-     * @param rqos            New reader QoS
-     * @param content_filter  Optional content filtering information.
-     * @return true on success
+     * Update local reader QoS
+     * @param rtps_reader      Reader to update.
+     * @param rqos             New QoS for the reader.
+     * @param content_filter   Optional content filtering information.
+     * @return True on success
      */
-    bool updateReader(
-            RTPSReader* Reader,
-            const TopicAttributes& topicAtt,
+    bool update_reader(
+            RTPSReader* rtps_reader,
             const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -152,14 +152,18 @@ public:
 
     /**
      * Register a Reader in the BuiltinProtocols.
-     * @param rtps_reader      Pointer to the RTPSReader.
-     * @param sub_builtin_data Contains the discovery information of the reader.
-     * @param content_filter   Optional content filtering information.
+     *
+     * @param rtps_reader     Pointer to the RTPSReader.
+     * @param topic           Information regarding the topic where the reader is registering.
+     * @param qos             Qos policies of the reader.
+     * @param content_filter  Optional content filtering information.
+     *
      * @return True if correctly registered.
      */
     bool register_reader(
             RTPSReader* rtps_reader,
-            const SubscriptionBuiltinTopicData& sub_builtin_data,
+            const TopicDescription& topic,
+            const fastdds::dds::ReaderQos& qos,
             const ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -53,9 +53,6 @@ struct IStatusObserver;
 #endif //FASTDDS_STATISTICS
 
 namespace fastdds {
-
-class TopicAttributes;
-
 namespace rtps {
 
 struct PublicationBuiltinTopicData;
@@ -64,6 +61,7 @@ class RTPSParticipantListener;
 class RTPSWriter;
 class RTPSReader;
 struct SubscriptionBuiltinTopicData;
+struct TopicDescription;
 class EndpointAttributes;
 class WriterAttributes;
 class ReaderAttributes;
@@ -140,13 +138,17 @@ public:
 
     /**
      * Register a Writer in the BuiltinProtocols.
-     * @param rtps_writer Pointer to the RTPSWriter.
-     * @param pub_builtin_data Contains the discovery information of the writer.
+     *
+     * @param rtps_writer  Pointer to the RTPSWriter.
+     * @param topic        Information regarding the topic where the writer is registering.
+     * @param qos          Qos policies of the writer.
+     *
      * @return True if correctly registered.
      */
     bool register_writer(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data);
+            const TopicDescription& topic,
+            const fastdds::dds::WriterQos& qos);
 
     /**
      * Register a Reader in the BuiltinProtocols.

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -116,7 +116,6 @@ set(${PROJECT_NAME}_source_files
     rtps/attributes/RTPSParticipantAttributes.cpp
     rtps/attributes/ServerAttributes.cpp
     rtps/attributes/ThreadSettings.cpp
-    rtps/attributes/TopicAttributes.cpp
     rtps/builtin/BuiltinProtocols.cpp
     rtps/builtin/data/ParticipantProxyData.cpp
     rtps/builtin/data/ProxyDataConverters.cpp
@@ -237,6 +236,7 @@ set(${PROJECT_NAME}_source_files
     utils/SystemInfo.cpp
     utils/TimedConditionVariable.cpp
     utils/UnitsParser.cpp
+    xmlparser/attributes/TopicAttributes.cpp
     xmlparser/XMLDynamicParser.cpp
     xmlparser/XMLElementParser.cpp
     xmlparser/XMLEndpointParser.cpp

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -67,6 +67,7 @@
 #include <xmlparser/attributes/ReplierAttributes.hpp>
 #include <xmlparser/attributes/RequesterAttributes.hpp>
 #include <xmlparser/attributes/SubscriberAttributes.hpp>
+#include <xmlparser/attributes/TopicAttributes.hpp>
 #include <xmlparser/XMLProfileManager.h>
 
 namespace eprosima {
@@ -116,7 +117,7 @@ DomainParticipantImpl::DomainParticipantImpl(
     XMLProfileManager::getDefaultSubscriberAttributes(sub_attr);
     utils::set_qos_from_attributes(default_sub_qos_, sub_attr);
 
-    TopicAttributes top_attr;
+    xmlparser::TopicAttributes top_attr;
     XMLProfileManager::getDefaultTopicAttributes(top_attr);
     utils::set_qos_from_attributes(default_topic_qos_, top_attr);
 
@@ -1114,7 +1115,7 @@ void DomainParticipantImpl::reset_default_topic_qos()
 {
     // TODO (ILG): Change when we have full XML support for DDS QoS profiles
     TopicImpl::set_qos(default_topic_qos_, TOPIC_QOS_DEFAULT, true);
-    TopicAttributes attr;
+    xmlparser::TopicAttributes attr;
     XMLProfileManager::getDefaultTopicAttributes(attr);
     utils::set_qos_from_attributes(default_topic_qos_, attr);
 }
@@ -1128,7 +1129,7 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
         const std::string& profile_name,
         TopicQos& qos) const
 {
-    TopicAttributes attr;
+    xmlparser::TopicAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
     {
         qos = default_topic_qos_;
@@ -1405,7 +1406,7 @@ Topic* DomainParticipantImpl::create_topic_with_profile(
         const StatusMask& mask)
 {
     // TODO (ILG): Change when we have full XML support for DDS QoS profiles
-    TopicAttributes attr;
+    xmlparser::TopicAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
     {
         TopicQos qos = default_topic_qos_;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1885,6 +1885,55 @@ DomainParticipantListener* DomainParticipantImpl::get_listener_for(
     return nullptr;
 }
 
+bool DomainParticipantImpl::fill_type_information(
+        const TypeSupport& type,
+        xtypes::TypeInformationParameter& type_information)
+{
+    using utils::to_type_propagation;
+    using utils::TypePropagation;
+
+    auto properties = qos_.properties();
+    auto type_propagation = to_type_propagation(properties);
+    bool should_assign_type_information =
+        (TypePropagation::TYPEPROPAGATION_ENABLED == type_propagation) ||
+        (TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH == type_propagation);
+
+    if (should_assign_type_information && (xtypes::TK_NONE != type->type_identifiers().type_identifier1()._d()))
+    {
+        xtypes::TypeInformation type_info;
+
+        if (RETCODE_OK ==
+            fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_information(
+                type->type_identifiers(), type_info))
+        {
+            switch (type_propagation)
+            {
+                case TypePropagation::TYPEPROPAGATION_ENABLED:
+                {
+                    // Use both complete and minimal type information
+                    type_information.type_information = type_info;
+                    break;
+                }
+                case TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH:
+                {
+                    // Use minimal type information only
+                    type_information.type_information.minimal() = type_info.minimal();
+                    break;
+                }
+                default:
+                    // This should never happen as other cases are protected by should_assign_type_information
+                    assert(false);
+                    break;
+            }
+
+            type_information.assigned(true);
+            return true;
+        }
+    }
+
+    return false;
+}
+
 }  // namespace dds
 }  // namespace fastdds
 }  // namespace eprosima

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1895,16 +1895,16 @@ bool DomainParticipantImpl::fill_type_information(
     auto properties = qos_.properties();
     auto type_propagation = to_type_propagation(properties);
     bool should_assign_type_information =
-        (TypePropagation::TYPEPROPAGATION_ENABLED == type_propagation) ||
-        (TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH == type_propagation);
+            (TypePropagation::TYPEPROPAGATION_ENABLED == type_propagation) ||
+            (TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH == type_propagation);
 
     if (should_assign_type_information && (xtypes::TK_NONE != type->type_identifiers().type_identifier1()._d()))
     {
         xtypes::TypeInformation type_info;
 
         if (RETCODE_OK ==
-            fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_information(
-                type->type_identifiers(), type_info))
+                fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_information(
+                    type->type_identifiers(), type_info))
         {
             switch (type_propagation)
             {

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -508,6 +508,18 @@ public:
         return id_counter_;
     }
 
+    /**
+     * @brief Fill a TypeInformationParameter with the type information of a TypeSupport.
+     *
+     * @param type              TypeSupport to get the type information from.
+     * @param type_information  TypeInformationParameter to fill.
+     *
+     * @return true if the constraints for propagating the type information are met.
+     */
+    bool fill_type_information(
+            const TypeSupport& type,
+            xtypes::TypeInformationParameter& type_information);
+
 protected:
 
     //!Domain id

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -308,6 +308,11 @@ ReturnCode_t DataWriter::wait_for_acknowledgments(
     return impl_->wait_for_acknowledgments(instance, handle, max_wait);
 }
 
+PublicationBuiltinTopicData DataWriter::get_publication_builtin_topic_data() const
+{
+    return impl_->get_publication_builtin_topic_data();
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -308,9 +308,10 @@ ReturnCode_t DataWriter::wait_for_acknowledgments(
     return impl_->wait_for_acknowledgments(instance, handle, max_wait);
 }
 
-PublicationBuiltinTopicData DataWriter::get_publication_builtin_topic_data() const
+ReturnCode_t DataWriter::get_publication_builtin_topic_data(
+        PublicationBuiltinTopicData& publication_data) const
 {
-    return impl_->get_publication_builtin_topic_data();
+    return impl_->get_publication_builtin_topic_data(publication_data);
 }
 
 } // namespace dds

--- a/src/cpp/fastdds/publisher/DataWriterHistory.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.cpp
@@ -69,7 +69,8 @@ DataWriterHistory::DataWriterHistory(
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy,
         std::function<void (const fastdds::rtps::InstanceHandle_t&)> unack_sample_remove_functor)
-    : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
+    : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize,
+            mempolicy), payload_pool, change_pool)
     , history_qos_(history_qos)
     , resource_limited_qos_(resource_limits_qos)
     , topic_kind_(topic_kind)
@@ -278,7 +279,7 @@ bool DataWriterHistory::add_pub_change(
         {
             EPROSIMA_LOG_INFO(RTPS_HISTORY,
                     " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
-                    << " and " << change->serializedPayload.length << " bytes");
+                               << " and " << change->serializedPayload.length << " bytes");
             returnedValue = true;
         }
     }

--- a/src/cpp/fastdds/publisher/DataWriterHistory.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.cpp
@@ -23,6 +23,7 @@
 
 #include <fastdds/dds/common/InstanceHandle.hpp>
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/writer/RTPSWriter.hpp>
 
@@ -35,20 +36,22 @@ namespace dds {
 using namespace eprosima::fastdds::rtps;
 
 HistoryAttributes DataWriterHistory::to_history_attributes(
-        const TopicAttributes& topic_att,
+        const HistoryQosPolicy& history_qos,
+        const ResourceLimitsQosPolicy& resource_limits_qos,
+        const rtps::TopicKind_t& topic_kind,
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy)
 {
-    auto initial_samples = topic_att.resourceLimitsQos.allocated_samples;
-    auto max_samples = topic_att.resourceLimitsQos.max_samples;
-    auto extra_samples = topic_att.resourceLimitsQos.extra_samples;
+    auto initial_samples = resource_limits_qos.allocated_samples;
+    auto max_samples = resource_limits_qos.max_samples;
+    auto extra_samples = resource_limits_qos.extra_samples;
 
-    if (topic_att.historyQos.kind != KEEP_ALL_HISTORY_QOS)
+    if (history_qos.kind != KEEP_ALL_HISTORY_QOS)
     {
-        max_samples = topic_att.historyQos.depth;
-        if (topic_att.getTopicKind() != NO_KEY)
+        max_samples = history_qos.depth;
+        if (topic_kind != NO_KEY)
         {
-            max_samples *= topic_att.resourceLimitsQos.max_instances;
+            max_samples *= resource_limits_qos.max_instances;
         }
 
         initial_samples = std::min(initial_samples, max_samples);
@@ -60,14 +63,16 @@ HistoryAttributes DataWriterHistory::to_history_attributes(
 DataWriterHistory::DataWriterHistory(
         const std::shared_ptr<IPayloadPool>& payload_pool,
         const std::shared_ptr<IChangePool>& change_pool,
-        const TopicAttributes& topic_att,
+        const HistoryQosPolicy& history_qos,
+        const ResourceLimitsQosPolicy& resource_limits_qos,
+        const rtps::TopicKind_t& topic_kind,
         uint32_t payloadMaxSize,
         MemoryManagementPolicy_t mempolicy,
         std::function<void (const fastdds::rtps::InstanceHandle_t&)> unack_sample_remove_functor)
-    : WriterHistory(to_history_attributes(topic_att, payloadMaxSize, mempolicy), payload_pool, change_pool)
-    , history_qos_(topic_att.historyQos)
-    , resource_limited_qos_(topic_att.resourceLimitsQos)
-    , topic_att_(topic_att)
+    : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
+    , history_qos_(history_qos)
+    , resource_limited_qos_(resource_limits_qos)
+    , topic_kind_(topic_kind)
     , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
 {
     if (resource_limited_qos_.max_samples <= 0)
@@ -92,7 +97,7 @@ DataWriterHistory::~DataWriterHistory()
 
 void DataWriterHistory::rebuild_instances()
 {
-    if (topic_att_.getTopicKind() == WITH_KEY)
+    if (topic_kind_ == WITH_KEY)
     {
         for (CacheChange_t* change : m_changes)
         {
@@ -114,7 +119,7 @@ bool DataWriterHistory::register_instance(
     payload = nullptr;
 
     /// Preconditions
-    if (topic_att_.getTopicKind() == NO_KEY)
+    if (topic_kind_ == NO_KEY)
     {
         return false;
     }
@@ -148,7 +153,7 @@ bool DataWriterHistory::prepare_change(
     {
         bool ret = false;
         bool is_acked = change_is_acked_or_fully_delivered(m_changes.front());
-        InstanceHandle_t instance = topic_att_.getTopicKind() == NO_KEY ?
+        InstanceHandle_t instance = topic_kind_ == NO_KEY ?
                 HANDLE_NIL : m_changes.front()->instanceHandle;
 
         if (history_qos_.kind == KEEP_ALL_HISTORY_QOS)
@@ -168,7 +173,7 @@ bool DataWriterHistory::prepare_change(
         else if (!ret)
         {
             EPROSIMA_LOG_WARNING(RTPS_HISTORY,
-                    "Attempting to add Data to Full WriterCache: " << topic_att_.getTopicDataType());
+                    "Attempting to add Data to Full WriterCache.");
             return false;
         }
     }
@@ -176,8 +181,8 @@ bool DataWriterHistory::prepare_change(
     assert(!m_isHistoryFull);
 
     // For NO_KEY we can directly add the change
-    bool add = (topic_att_.getTopicKind() == NO_KEY);
-    if (topic_att_.getTopicKind() == WITH_KEY)
+    bool add = (topic_kind_ == NO_KEY);
+    if (topic_kind_ == WITH_KEY)
     {
         t_m_Inst_Caches::iterator vit;
 
@@ -272,8 +277,7 @@ bool DataWriterHistory::add_pub_change(
 #endif // if HAVE_STRICT_REALTIME
         {
             EPROSIMA_LOG_INFO(RTPS_HISTORY,
-                    topic_att_.getTopicDataType()
-                    << " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
+                    " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
                     << " and " << change->serializedPayload.length << " bytes");
             returnedValue = true;
         }
@@ -380,7 +384,7 @@ bool DataWriterHistory::remove_change_pub(
     std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
 #endif // if HAVE_STRICT_REALTIME
 
-    if (topic_att_.getTopicKind() == NO_KEY)
+    if (topic_kind_ == NO_KEY)
     {
         if (remove_change(change, max_blocking_time))
         {
@@ -439,7 +443,7 @@ bool DataWriterHistory::remove_instance_changes(
         return false;
     }
 
-    if (topic_att_.getTopicKind() == NO_KEY)
+    if (topic_kind_ == NO_KEY)
     {
         EPROSIMA_LOG_ERROR(RTPS_HISTORY, "Cannot be removed instance changes of a NO_KEY DataType");
         return false;
@@ -484,12 +488,12 @@ bool DataWriterHistory::set_next_deadline(
     }
     std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
 
-    if (topic_att_.getTopicKind() == NO_KEY)
+    if (topic_kind_ == NO_KEY)
     {
         next_deadline_us_ = next_deadline_us;
         return true;
     }
-    else if (topic_att_.getTopicKind() == WITH_KEY)
+    else if (topic_kind_ == WITH_KEY)
     {
         if (keyed_changes_.find(handle) == keyed_changes_.end())
         {
@@ -514,7 +518,7 @@ bool DataWriterHistory::get_next_deadline(
     }
     std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
 
-    if (topic_att_.getTopicKind() == WITH_KEY)
+    if (topic_kind_ == WITH_KEY)
     {
         auto min = std::min_element(
             keyed_changes_.begin(),
@@ -530,7 +534,7 @@ bool DataWriterHistory::get_next_deadline(
         next_deadline_us = min->second.next_deadline_us;
         return true;
     }
-    else if (topic_att_.getTopicKind() == NO_KEY)
+    else if (topic_kind_ == NO_KEY)
     {
         next_deadline_us = next_deadline_us_;
         return true;
@@ -558,7 +562,7 @@ bool DataWriterHistory::wait_for_acknowledgement_last_change(
         std::unique_lock<RecursiveTimedMutex>& lock,
         const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
 {
-    if (WITH_KEY == topic_att_.getTopicKind())
+    if (WITH_KEY == topic_kind_)
     {
         // Find the instance
         t_m_Inst_Caches::iterator vit = keyed_changes_.find(handle);

--- a/src/cpp/fastdds/publisher/DataWriterHistory.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.hpp
@@ -24,7 +24,6 @@
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/history/IChangePool.hpp>
@@ -48,21 +47,25 @@ class DataWriterHistory : public rtps::WriterHistory
 public:
 
     static rtps::HistoryAttributes to_history_attributes(
-            const TopicAttributes& topic_att,
+            const HistoryQosPolicy& history_qos,
+            const ResourceLimitsQosPolicy& resource_limits_qos,
+            const rtps::TopicKind_t& topic_kind,
             uint32_t payloadMaxSize,
             rtps::MemoryManagementPolicy_t mempolicy);
 
     /**
      * Constructor of the DataWriterHistory.
-     * @param topic_att TopicAttributed
-     * @param payloadMax Maximum payload size.
-     * @param mempolicy Set whether the payloads can dynamically resized or not.
+     * @param pub_builtin_data  Information on the publication.
+     * @param payloadMax        Maximum payload size.
+     * @param mempolicy         Set whether the payloads can dynamically resized or not.
      * @param unack_sample_remove_functor Functor to call DDS listener callback on_unacknowledged_sample_removed
      */
     DataWriterHistory(
             const std::shared_ptr<rtps::IPayloadPool>& payload_pool,
             const std::shared_ptr<rtps::IChangePool>& change_pool,
-            const TopicAttributes& topic_att,
+            const HistoryQosPolicy& history_qos,
+            const ResourceLimitsQosPolicy& resource_limits_qos,
+            const rtps::TopicKind_t& topic_kind,
             uint32_t payloadMax,
             rtps::MemoryManagementPolicy_t mempolicy,
             std::function<void (const rtps::InstanceHandle_t&)> unack_sample_remove_functor);
@@ -152,8 +155,7 @@ public:
     #endif // if HAVE_STRICT_REALTIME
             {
                 EPROSIMA_LOG_INFO(RTPS_HISTORY,
-                        topic_att_.getTopicDataType()
-                        << " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
+                        " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
                         << " and " << change->serializedPayload.length << " bytes");
                 returnedValue = true;
             }
@@ -257,8 +259,8 @@ private:
     HistoryQosPolicy history_qos_;
     //!ResourceLimitsQosPolicy values.
     ResourceLimitsQosPolicy resource_limited_qos_;
-    //!Topic Attributes
-    TopicAttributes topic_att_;
+    //!TopicKind
+    rtps::TopicKind_t topic_kind_;
 
     //! Unacknowledged sample removed functor
     std::function<void (const rtps::InstanceHandle_t&)> unacknowledged_sample_removed_functor_;

--- a/src/cpp/fastdds/publisher/DataWriterHistory.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.hpp
@@ -55,10 +55,15 @@ public:
 
     /**
      * Constructor of the DataWriterHistory.
-     * @param pub_builtin_data  Information on the publication.
-     * @param payloadMax        Maximum payload size.
-     * @param mempolicy         Set whether the payloads can dynamically resized or not.
-     * @param unack_sample_remove_functor Functor to call DDS listener callback on_unacknowledged_sample_removed
+     *
+     * @param payload_pool                 Pool to use for allocation of payloads.
+     * @param change_pool                  Pool to use for allocation of changes.
+     * @param history_qos                  HistoryQosPolicy of the DataWriter creating this history.
+     * @param resource_limits_qos          ResourceLimitsQosPolicy of the DataWriter creating this history.
+     * @param topic_kind                   TopicKind of the DataWriter creating this history.
+     * @param payloadMax                   Maximum payload size.
+     * @param mempolicy                    Set whether the payloads can dynamically resized or not.
+     * @param unack_sample_remove_functor  Functor to call DDS listener callback on_unacknowledged_sample_removed
      */
     DataWriterHistory(
             const std::shared_ptr<rtps::IPayloadPool>& payload_pool,

--- a/src/cpp/fastdds/publisher/DataWriterHistory.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.hpp
@@ -156,7 +156,7 @@ public:
             {
                 EPROSIMA_LOG_INFO(RTPS_HISTORY,
                         " Change " << change->sequenceNumber << " added with key: " << change->instanceHandle
-                        << " and " << change->serializedPayload.length << " bytes");
+                                   << " and " << change->serializedPayload.length << " bytes");
                 returnedValue = true;
             }
         }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1766,9 +1766,12 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
     publication_data.guid = guid();
     publication_data.participant_guid = publisher_->get_participant()->guid();
 
-    
-    publication_data.persistence_guid.guidPrefix = writer_->get_participant_impl()->get_persistence_guid_prefix();
-    publication_data.persistence_guid.entityId = c_EntityId_RTPSParticipant;
+    const std::string* pers_guid = PropertyPolicyHelper::find_property(qos_.properties(), "dds.persistence.guid");
+    if (pers_guid)
+    {
+        // Load persistence_guid from property
+        std::istringstream(pers_guid->c_str()) >> publication_data.persistence_guid;
+    }
 
     qos_.endpoint().unicast_locator_list.copy_to(publication_data.remote_locators.unicast);
     qos_.endpoint().multicast_locator_list.copy_to(publication_data.remote_locators.multicast);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1782,7 +1782,7 @@ PublicationBuiltinTopicData DataWriterImpl::get_publication_builtin_topic_data()
     if (rtps_participant_impl_is_valid)
     {
         pub_builtin_data.loopback_transformation =
-            writer_->get_participant_impl()->network_factory().network_configuration();
+                writer_->get_participant_impl()->network_factory().network_configuration();
     }
 
     return pub_builtin_data;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -35,7 +35,6 @@
 #include <fastdds/domain/DomainParticipantImpl.hpp>
 #include <fastdds/publisher/filtering/DataWriterFilteredChangePool.hpp>
 #include <fastdds/publisher/PublisherImpl.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/RTPSDomain.hpp>
 #include <fastdds/rtps/writer/RTPSWriter.hpp>
@@ -53,6 +52,7 @@
 #include <rtps/writer/BaseWriter.hpp>
 #include <rtps/writer/StatefulWriter.hpp>
 #include <utils/TimeConversion.hpp>
+#include <utils/BuiltinTopicKeyConversions.hpp>
 #ifdef FASTDDS_STATISTICS
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <statistics/types/monitorservice_types.hpp>
@@ -473,7 +473,7 @@ ReturnCode_t DataWriterImpl::enable()
             wqos.m_partition.push_back(partition_name.c_str());
         }
     }
-    publisher_->rtps_participant()->registerWriter(writer_, get_topic_attributes(qos_, *topic_, type_), wqos);
+    publisher_->rtps_participant()->register_writer(writer_, get_publication_builtin_topic_data(), wqos);
 
     return RETCODE_OK;
 }
@@ -1179,7 +1179,7 @@ void DataWriterImpl::publisher_qos_updated()
     {
         //NOTIFY THE BUILTIN PROTOCOLS THAT THE WRITER HAS CHANGED
         WriterQos wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
-        publisher_->rtps_participant()->updateWriter(writer_, get_topic_attributes(qos_, *topic_, type_), wqos);
+        publisher_->rtps_participant()->update_writer(writer_, wqos);
     }
 }
 
@@ -1228,9 +1228,8 @@ ReturnCode_t DataWriterImpl::set_qos(
         }
 
         //Notify the participant that a Writer has changed its QOS
-        fastdds::TopicAttributes topic_att = get_topic_attributes(qos_, *topic_, type_);
         WriterQos wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
-        publisher_->rtps_participant()->updateWriter(writer_, topic_att, wqos);
+        publisher_->rtps_participant()->update_writer(writer_, wqos);
 
         // Deadline
         if (qos_.deadline().period != dds::c_TimeInfinite)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1758,7 +1758,7 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
     publication_data.data_sharing = qos_.data_sharing();
 
     if (publication_data.data_sharing.kind() != OFF &&
-        publication_data.data_sharing.domain_ids().empty())
+            publication_data.data_sharing.domain_ids().empty())
     {
         publication_data.data_sharing.add_domain_id(utils::default_domain_id());
     }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -228,7 +228,9 @@ void DataWriterImpl::create_history(
 {
     history_.reset(new DataWriterHistory(
                 payload_pool, change_pool,
-                get_topic_attributes(qos_, *topic_, type_),
+                qos_.history(),
+                qos_.resource_limits(),
+                (type_->is_compute_key_provided ? WITH_KEY : NO_KEY),
                 type_->max_serialized_type_size,
                 qos_.endpoint().history_memory_policy,
                 [this](
@@ -245,9 +247,10 @@ ReturnCode_t DataWriterImpl::enable()
 {
     assert(writer_ == nullptr);
 
-    auto topic_att = get_topic_attributes(qos_, *topic_, type_);
     auto history_att = DataWriterHistory::to_history_attributes(
-        topic_att, type_->max_serialized_type_size, qos_.endpoint().history_memory_policy);
+        qos_.history(),
+        qos_.resource_limits(), (type_->is_compute_key_provided ? WITH_KEY : NO_KEY), type_->max_serialized_type_size,
+        qos_.endpoint().history_memory_policy);
     pool_config_ = PoolConfig::from_history_attributes(history_att);
 
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -382,9 +382,15 @@ public:
             const char* filter_class_name);
 
     /**
-     * @brief A method to retrieve the publication data discovery information.
+     * Retrieve the publication data discovery information.
+     *
+     * @param [out] publication_data The publication data discovery information.
+     *
+     * @return NOT_ENABLED if the writer has not been enabled.
+     * @return OK if the publication data is returned.
      */
-    PublicationBuiltinTopicData get_publication_builtin_topic_data() const;
+    ReturnCode_t get_publication_builtin_topic_data(
+            PublicationBuiltinTopicData& publication_data) const;
 
 protected:
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -585,11 +585,6 @@ protected:
             fastdds::rtps::WriteParams& wparams,
             const InstanceHandle_t& handle);
 
-    fastdds::TopicAttributes get_topic_attributes(
-            const DataWriterQos& qos,
-            const Topic& topic,
-            const TypeSupport& type);
-
     static void set_qos(
             DataWriterQos& to,
             const DataWriterQos& from,

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/dds/core/ReturnCode.hpp>
 #include <fastdds/dds/core/status/BaseStatus.hpp>
 #include <fastdds/dds/core/status/DeadlineMissedStatus.hpp>
@@ -33,8 +34,8 @@
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/LocatorList.hpp>
-#include <fastdds/rtps/common/WriteParams.hpp>
 #include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
 #include <fastdds/rtps/history/IChangePool.hpp>
 #include <fastdds/rtps/history/IPayloadPool.hpp>
 #include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
@@ -379,6 +380,11 @@ public:
      */
     void filter_is_being_removed(
             const char* filter_class_name);
+
+    /**
+     * @brief A method to retrieve the publication data discovery information.
+     */
+    PublicationBuiltinTopicData get_publication_builtin_topic_data() const;
 
 protected:
 

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -488,9 +488,10 @@ ReturnCode_t DataReader::get_listening_locators(
     return impl_->get_listening_locators(locators);
 }
 
-SubscriptionBuiltinTopicData DataReader::get_subscription_builtin_topic_data() const
+ReturnCode_t DataReader::get_subscription_builtin_topic_data(
+        SubscriptionBuiltinTopicData& subscription_data) const
 {
-    return impl_->get_subscription_builtin_topic_data();
+    return impl_->get_subscription_builtin_topic_data(subscription_data);
 }
 
 } /* namespace dds */

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -488,6 +488,11 @@ ReturnCode_t DataReader::get_listening_locators(
     return impl_->get_listening_locators(locators);
 }
 
+SubscriptionBuiltinTopicData DataReader::get_subscription_builtin_topic_data() const
+{
+    return impl_->get_subscription_builtin_topic_data();
+}
+
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -2231,7 +2231,7 @@ ReturnCode_t DataReaderImpl::get_subscription_builtin_topic_data(
     subscription_data.group_data = subscriber_->qos_.group_data();
 
     // X-Types 1.3
-    if(subscriber_->get_participant_impl()->fill_type_information(type_, subscription_data.type_information))
+    if (subscriber_->get_participant_impl()->fill_type_information(type_, subscription_data.type_information))
     {
         subscription_data.type_consistency = qos_.type_consistency();
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -53,6 +53,7 @@
 #include <rtps/resources/ResourceEvent.h>
 #include <rtps/RTPSDomainImpl.hpp>
 #include <utils/TimeConversion.hpp>
+#include <utils/BuiltinTopicKeyConversions.hpp>
 #ifdef FASTDDS_STATISTICS
 #include <statistics/fastdds/domain/DomainParticipantImpl.hpp>
 #include <statistics/types/monitorservice_types.hpp>
@@ -297,7 +298,11 @@ ReturnCode_t DataReaderImpl::enable()
     {
         filter_property = &content_topic->filter_property;
     }
-    if (!subscriber_->rtps_participant()->registerReader(reader_, topic_attributes(), rqos, filter_property))
+    if (!subscriber_->rtps_participant()->register_reader(
+                reader_,
+                get_subscription_builtin_topic_data(),
+                rqos,
+                filter_property))
     {
         EPROSIMA_LOG_ERROR(DATA_READER, "Could not register reader on discovery protocols");
 
@@ -834,7 +839,7 @@ void DataReaderImpl::update_rtps_reader_qos()
             filter_property = &content_topic->filter_property;
         }
         ReaderQos rqos = qos_.get_readerqos(get_subscriber()->get_qos());
-        subscriber_->rtps_participant()->updateReader(reader_, topic_attributes(), rqos, filter_property);
+        subscriber_->rtps_participant()->update_reader(reader_, rqos, filter_property);
         // TODO(eduponz): RTPSReader attributes must be updated here
     }
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -278,7 +278,7 @@ ReturnCode_t DataReaderImpl::enable()
 
     // Register the reader
     fastdds::rtps::TopicDescription topic_desc;
-    topic_desc.topic_name = topic_->get_name();
+    topic_desc.topic_name = topic_->get_impl()->get_rtps_topic_name();
     topic_desc.type_name = topic_->get_type_name();
     subscriber_->get_participant_impl()->fill_type_information(type_, topic_desc.type_information);
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -2218,16 +2218,16 @@ ReturnCode_t DataReaderImpl::get_subscription_builtin_topic_data(
     auto properties = subscriber_->get_participant()->get_qos().properties();
     auto type_propagation = to_type_propagation(properties);
     bool should_assign_type_information =
-        (TypePropagation::TYPEPROPAGATION_ENABLED == type_propagation) ||
-        (TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH == type_propagation);
+            (TypePropagation::TYPEPROPAGATION_ENABLED == type_propagation) ||
+            (TypePropagation::TYPEPROPAGATION_MINIMAL_BANDWIDTH == type_propagation);
 
     if (should_assign_type_information && (xtypes::TK_NONE != type_->type_identifiers().type_identifier1()._d()))
     {
         xtypes::TypeInformation type_info;
 
         if (RETCODE_OK ==
-            fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_information(
-                type_->type_identifiers(), type_info))
+                fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_information(
+                    type_->type_identifiers(), type_info))
         {
             switch (type_propagation)
             {
@@ -2261,7 +2261,7 @@ ReturnCode_t DataReaderImpl::get_subscription_builtin_topic_data(
     subscription_data.data_sharing = qos_.data_sharing();
 
     if (subscription_data.data_sharing.kind() != OFF &&
-        subscription_data.data_sharing.domain_ids().empty())
+            subscription_data.data_sharing.domain_ids().empty())
     {
         subscription_data.data_sharing.add_domain_id(utils::default_domain_id());
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -2198,7 +2198,8 @@ SubscriptionBuiltinTopicData DataReaderImpl::get_subscription_builtin_topic_data
 
     if (participant_is_valid)
     {
-        from_proxy_to_builtin(subscriber_->get_participant()->guid().guidPrefix, sub_builtin_data.participant_key.value);
+        from_proxy_to_builtin(subscriber_->get_participant()->guid().guidPrefix,
+                sub_builtin_data.participant_key.value);
     }
 
     if (topic_is_valid)

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -600,8 +600,6 @@ protected:
      */
     bool lifespan_expired();
 
-    fastdds::TopicAttributes topic_attributes() const;
-
     void subscriber_qos_updated();
 
     RequestedIncompatibleQosStatus& update_requested_incompatible_qos(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -375,9 +375,15 @@ public:
     std::recursive_mutex& get_conditions_mutex() const noexcept;
 
     /**
-     * @brief A method to retrieve the subscription data discovery information.
+     * Retrieve the subscription data discovery information.
+     *
+     * @param [out] subscription_data The subscription data discovery information.
+     *
+     * @return NOT_ENABLED if the reader has not been enabled.
+     * @return OK if the subscription data is returned.
      */
-    SubscriptionBuiltinTopicData get_subscription_builtin_topic_data() const;
+    ReturnCode_t get_subscription_builtin_topic_data(
+             SubscriptionBuiltinTopicData& subscription_data) const;
 
 protected:
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -383,7 +383,7 @@ public:
      * @return OK if the subscription data is returned.
      */
     ReturnCode_t get_subscription_builtin_topic_data(
-             SubscriptionBuiltinTopicData& subscription_data) const;
+            SubscriptionBuiltinTopicData& subscription_data) const;
 
 protected:
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -17,9 +17,8 @@
  *
  */
 
-#ifndef _FASTDDS_DATAREADERIMPL_HPP_
-#define _FASTDDS_DATAREADERIMPL_HPP_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#ifndef FASTDDS_SUBSCRIBER__DATAREADERIMPL_HPP
+#define FASTDDS_SUBSCRIBER__DATAREADERIMPL_HPP
 
 #include <mutex>
 
@@ -34,7 +33,6 @@
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/history/IPayloadPool.hpp>
@@ -46,6 +44,7 @@
 #include <fastdds/subscriber/DataReaderImpl/StateFilter.hpp>
 #include <fastdds/subscriber/history/DataReaderHistory.hpp>
 #include <fastdds/subscriber/SubscriberImpl.hpp>
+#include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <rtps/history/ITopicPayloadPool.h>
 
 namespace eprosima {
@@ -375,6 +374,11 @@ public:
 
     std::recursive_mutex& get_conditions_mutex() const noexcept;
 
+    /**
+     * @brief A method to retrieve the subscription data discovery information.
+     */
+    SubscriptionBuiltinTopicData get_subscription_builtin_topic_data() const;
+
 protected:
 
     //!Subscriber
@@ -652,5 +656,4 @@ private:
 } /* namespace fastdds */
 } /* namespace eprosima */
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_DATAREADERIMPL_HPP_*/
+#endif /* FASTDDS_SUBSCRIBER__DATAREADERIMPL_HPP*/

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -649,6 +649,7 @@ private:
     DataReaderQos get_datareader_qos_from_settings(
             const DataReaderQos& qos);
 
+    bool is_data_sharing_compatible_ = false;
 
 };
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -564,7 +564,7 @@ bool SubscriberImpl::type_in_use(
     {
         for (DataReaderImpl* reader : it.second)
         {
-            if (reader->topic_attributes().getTopicDataType() == type_name)
+            if (reader->get_topicdescription()->get_type_name() == type_name)
             {
                 return true; // Is in use
             }

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -231,7 +231,7 @@ void set_attributes_from_extended_qos(
 
 void set_qos_from_attributes(
         TopicQos& qos,
-        const TopicAttributes& attr)
+        const xmlparser::TopicAttributes& attr)
 {
     qos.history() = attr.historyQos;
     qos.resource_limits() = attr.resourceLimitsQos;

--- a/src/cpp/fastdds/utils/QosConverters.hpp
+++ b/src/cpp/fastdds/utils/QosConverters.hpp
@@ -28,13 +28,13 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 
 #include <xmlparser/attributes/ParticipantAttributes.hpp>
 #include <xmlparser/attributes/PublisherAttributes.hpp>
 #include <xmlparser/attributes/ReplierAttributes.hpp>
 #include <xmlparser/attributes/RequesterAttributes.hpp>
 #include <xmlparser/attributes/SubscriberAttributes.hpp>
+#include <xmlparser/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -125,7 +125,7 @@ void set_attributes_from_extended_qos(
  */
 void set_qos_from_attributes(
         TopicQos& qos,
-        const TopicAttributes& attr);
+        const xmlparser::TopicAttributes& attr);
 
 /**
  * Obtains the SubscriberQos from the SubscriberAttributes provided.

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -820,25 +820,6 @@ bool RTPSDomainImpl::set_library_settings(
     return true;
 }
 
-bool RTPSDomain::get_topic_attributes_from_profile(
-        const std::string& profile_name,
-        TopicAttributes& topic_attributes)
-{
-    return RTPSDomainImpl::get_topic_attributes_from_profile(profile_name, topic_attributes);
-}
-
-bool RTPSDomainImpl::get_topic_attributes_from_profile(
-        const std::string& profile_name,
-        TopicAttributes& topic_attributes)
-{
-    if (xmlparser::XMLP_ret::XML_OK ==
-            xmlparser::XMLProfileManager::fillTopicAttributes(profile_name, topic_attributes))
-    {
-        return true;
-    }
-    return false;
-}
-
 fastdds::dds::xtypes::ITypeObjectRegistry& RTPSDomainImpl::type_object_registry()
 {
     return get_instance()->type_object_registry_;

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -237,18 +237,6 @@ public:
             const fastdds::LibrarySettings& library_settings);
 
     /**
-     * @brief Get the TopicAttributes from XML profile.
-     *
-     * @param profile_name Topic profile name.
-     * @param topic_att TopicAttributes object where the attributes are returned.
-     * @return bool true if the profile exists.
-     *              false otherwise.
-     */
-    static bool get_topic_attributes_from_profile(
-            const std::string& profile_name,
-            TopicAttributes& topic_attributes);
-
-    /**
      * @brief Return the ITypeObjectRegistry member to access the interface for the public API.
      *
      * @return const xtypes::ITypeObjectRegistry reference.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -197,14 +197,13 @@ void BuiltinProtocols::filter_server_remote_locators(
 
 bool BuiltinProtocols::add_writer(
         RTPSWriter* rtps_writer,
-        const PublicationBuiltinTopicData& pub_builtin_data,
-        const fastdds::dds::WriterQos& wqos)
+        const PublicationBuiltinTopicData& pub_builtin_data)
 {
     bool ok = true;
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->get_edp()->new_writer_proxy_data(rtps_writer, pub_builtin_data, wqos);
+        ok = mp_PDP->get_edp()->new_writer_proxy_data(rtps_writer, pub_builtin_data);
 
         if (!ok)
         {
@@ -219,7 +218,7 @@ bool BuiltinProtocols::add_writer(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_writer(rtps_writer, wqos);
+        ok &= mp_WLP->add_local_writer(rtps_writer, pub_builtin_data.liveliness);
     }
     else
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -231,14 +231,15 @@ bool BuiltinProtocols::add_writer(
 
 bool BuiltinProtocols::add_reader(
         RTPSReader* rtps_reader,
-        const SubscriptionBuiltinTopicData& sub_builtin_data,
+        const TopicDescription& topic,
+        const fastdds::dds::ReaderQos& qos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
     bool ok = true;
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->get_edp()->new_reader_proxy_data(rtps_reader, sub_builtin_data, content_filter);
+        ok = mp_PDP->get_edp()->new_reader_proxy_data(rtps_reader, topic, qos, content_filter);
 
         if (!ok)
         {
@@ -253,7 +254,7 @@ bool BuiltinProtocols::add_reader(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_reader(rtps_reader, sub_builtin_data.liveliness);
+        ok &= mp_WLP->add_local_reader(rtps_reader, qos.m_liveliness);
     }
 
     return ok;

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -232,14 +232,13 @@ bool BuiltinProtocols::add_writer(
 bool BuiltinProtocols::add_reader(
         RTPSReader* rtps_reader,
         const SubscriptionBuiltinTopicData& sub_builtin_data,
-        const fastdds::dds::ReaderQos& rqos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
     bool ok = true;
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->get_edp()->new_reader_proxy_data(rtps_reader, sub_builtin_data, rqos, content_filter);
+        ok = mp_PDP->get_edp()->new_reader_proxy_data(rtps_reader, sub_builtin_data, content_filter);
 
         if (!ok)
         {
@@ -254,7 +253,7 @@ bool BuiltinProtocols::add_reader(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_reader(rtps_reader, rqos);
+        ok &= mp_WLP->add_local_reader(rtps_reader, sub_builtin_data.liveliness);
     }
 
     return ok;

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -229,9 +229,9 @@ bool BuiltinProtocols::add_writer(
     return ok;
 }
 
-bool BuiltinProtocols::addLocalReader(
-        RTPSReader* R,
-        const fastdds::TopicAttributes& topicAtt,
+bool BuiltinProtocols::add_reader(
+        RTPSReader* rtps_reader,
+        const SubscriptionBuiltinTopicData& sub_builtin_data,
         const fastdds::dds::ReaderQos& rqos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
@@ -239,7 +239,7 @@ bool BuiltinProtocols::addLocalReader(
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->getEDP()->newLocalReaderProxyData(R, topicAtt, rqos, content_filter);
+        ok = mp_PDP->get_edp()->new_reader_proxy_data(rtps_reader, sub_builtin_data, rqos, content_filter);
 
         if (!ok)
         {
@@ -254,7 +254,7 @@ bool BuiltinProtocols::addLocalReader(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_reader(R, rqos);
+        ok &= mp_WLP->add_local_reader(rtps_reader, rqos);
     }
 
     return ok;
@@ -272,16 +272,15 @@ bool BuiltinProtocols::update_writer(
     return ok;
 }
 
-bool BuiltinProtocols::updateLocalReader(
-        RTPSReader* R,
-        const TopicAttributes& topicAtt,
+bool BuiltinProtocols::update_reader(
+        RTPSReader* rtps_reader,
         const fastdds::dds::ReaderQos& rqos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
     bool ok = false;
-    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->get_edp()))
     {
-        ok = mp_PDP->getEDP()->updatedLocalReader(R, topicAtt, rqos, content_filter);
+        ok = mp_PDP->get_edp()->update_reader(rtps_reader, rqos, content_filter);
     }
     return ok;
 }
@@ -301,17 +300,17 @@ bool BuiltinProtocols::remove_writer(
     return ok;
 }
 
-bool BuiltinProtocols::removeLocalReader(
-        RTPSReader* R)
+bool BuiltinProtocols::remove_reader(
+        RTPSReader* rtps_reader)
 {
     bool ok = false;
     if (nullptr != mp_WLP)
     {
-        ok |= mp_WLP->remove_local_reader(R);
+        ok |= mp_WLP->remove_local_reader(rtps_reader);
     }
-    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->get_edp()))
     {
-        ok |= mp_PDP->getEDP()->removeLocalReader(R);
+        ok |= mp_PDP->get_edp()->remove_reader(rtps_reader);
     }
     return ok;
 }

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -195,16 +195,16 @@ void BuiltinProtocols::filter_server_remote_locators(
     m_DiscoveryServers.swap(allowed_locators);
 }
 
-bool BuiltinProtocols::addLocalWriter(
-        RTPSWriter* w,
-        const fastdds::TopicAttributes& topicAtt,
+bool BuiltinProtocols::add_writer(
+        RTPSWriter* rtps_writer,
+        const PublicationBuiltinTopicData& pub_builtin_data,
         const fastdds::dds::WriterQos& wqos)
 {
     bool ok = true;
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->getEDP()->newLocalWriterProxyData(w, topicAtt, wqos);
+        ok = mp_PDP->get_edp()->new_writer_proxy_data(rtps_writer, pub_builtin_data, wqos);
 
         if (!ok)
         {
@@ -219,7 +219,7 @@ bool BuiltinProtocols::addLocalWriter(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_writer(w, wqos);
+        ok &= mp_WLP->add_local_writer(rtps_writer, wqos);
     }
     else
     {
@@ -260,15 +260,14 @@ bool BuiltinProtocols::addLocalReader(
     return ok;
 }
 
-bool BuiltinProtocols::updateLocalWriter(
-        RTPSWriter* W,
-        const TopicAttributes& topicAtt,
+bool BuiltinProtocols::update_writer(
+        RTPSWriter* rtps_writer,
         const fastdds::dds::WriterQos& wqos)
 {
     bool ok = false;
-    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->get_edp()))
     {
-        ok = mp_PDP->getEDP()->updatedLocalWriter(W, topicAtt, wqos);
+        ok = mp_PDP->get_edp()->update_writer(rtps_writer, wqos);
     }
     return ok;
 }
@@ -287,17 +286,17 @@ bool BuiltinProtocols::updateLocalReader(
     return ok;
 }
 
-bool BuiltinProtocols::removeLocalWriter(
-        RTPSWriter* W)
+bool BuiltinProtocols::remove_writer(
+        RTPSWriter* rtps_writer)
 {
     bool ok = false;
     if (nullptr != mp_WLP)
     {
-        ok |= mp_WLP->remove_local_writer(W);
+        ok |= mp_WLP->remove_local_writer(rtps_writer);
     }
-    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->getEDP()))
+    if ((nullptr != mp_PDP) && (nullptr != mp_PDP->get_edp()))
     {
-        ok |= mp_PDP->getEDP()->removeLocalWriter(W);
+        ok |= mp_PDP->get_edp()->remove_writer(rtps_writer);
     }
     return ok;
 }

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -197,13 +197,14 @@ void BuiltinProtocols::filter_server_remote_locators(
 
 bool BuiltinProtocols::add_writer(
         RTPSWriter* rtps_writer,
-        const PublicationBuiltinTopicData& pub_builtin_data)
+        const TopicDescription& topic,
+        const fastdds::dds::WriterQos& qos)
 {
     bool ok = true;
 
     if (nullptr != mp_PDP)
     {
-        ok = mp_PDP->get_edp()->new_writer_proxy_data(rtps_writer, pub_builtin_data);
+        ok = mp_PDP->get_edp()->new_writer_proxy_data(rtps_writer, topic, qos);
 
         if (!ok)
         {
@@ -218,7 +219,7 @@ bool BuiltinProtocols::add_writer(
 
     if (nullptr != mp_WLP)
     {
-        ok &= mp_WLP->add_local_writer(rtps_writer, pub_builtin_data.liveliness);
+        ok &= mp_WLP->add_local_writer(rtps_writer, qos.m_liveliness);
     }
     else
     {

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -25,6 +25,7 @@
 
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 
 #include <utils/shared_mutex.hpp>
 
@@ -129,13 +130,17 @@ public:
 
     /**
      * Add a local writer to the BuiltinProtocols.
-     * @param writer            Pointer to the RTPSWriter
-     * @param pub_builtin_data  QoS policies dictated by the publisher
+     *
+     * @param writer  Pointer to the RTPSWriter
+     * @param topic   Information regarding the topic where the writer is registering
+     * @param wqos    QoS policies dictated by the publisher
+     *
      * @return True if correct.
      */
     bool add_writer(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data);
+            const TopicDescription& topic,
+            const fastdds::dds::WriterQos& qos);
     /**
      * Add a local reader to the BuiltinProtocols.
      * @param rtps_reader       Pointer to the RTPSReader.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -133,7 +133,7 @@ public:
      *
      * @param writer  Pointer to the RTPSWriter
      * @param topic   Information regarding the topic where the writer is registering
-     * @param wqos    QoS policies dictated by the publisher
+     * @param qos     QoS policies dictated by the publisher
      *
      * @return True if correct.
      */
@@ -143,14 +143,17 @@ public:
             const fastdds::dds::WriterQos& qos);
     /**
      * Add a local reader to the BuiltinProtocols.
-     * @param rtps_reader       Pointer to the RTPSReader.
-     * @param sub_builtin_data  QoS policies dictated by the subscriber
-     * @param content_filter    Optional content filtering information.
+     *
+     * @param rtps_reader     Pointer to the RTPSReader.
+     * @param topic           Information regarding the topic where the writer is registering
+     * @param qos             QoS policies dictated by the subscriber
+     * @param content_filter  Optional content filtering information.
      * @return True if correct.
      */
     bool add_reader(
             RTPSReader* rtps_reader,
-            const SubscriptionBuiltinTopicData& sub_builtin_data,
+            const TopicDescription& topic,
+            const fastdds::dds::ReaderQos& qos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -140,16 +140,14 @@ public:
             const fastdds::dds::WriterQos& wqos);
     /**
      * Add a local reader to the BuiltinProtocols.
-     * @param rtps_reader     Pointer to the RTPSReader.
-     * @param topicAtt        Attributes of the associated topic
-     * @param rqos            QoS policies dictated by the subscriber
-     * @param content_filter  Optional content filtering information.
+     * @param rtps_reader       Pointer to the RTPSReader.
+     * @param sub_builtin_data  QoS policies dictated by the subscriber
+     * @param content_filter    Optional content filtering information.
      * @return True if correct.
      */
     bool add_reader(
             RTPSReader* rtps_reader,
             const SubscriptionBuiltinTopicData& sub_builtin_data,
-            const fastdds::dds::ReaderQos& rqos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -129,15 +129,13 @@ public:
 
     /**
      * Add a local writer to the BuiltinProtocols.
-     * @param writer   Pointer to the RTPSWriter
-     * @param topicAtt Attributes of the associated topic
-     * @param wqos     QoS policies dictated by the publisher
+     * @param writer            Pointer to the RTPSWriter
+     * @param pub_builtin_data  QoS policies dictated by the publisher
      * @return True if correct.
      */
     bool add_writer(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data,
-            const fastdds::dds::WriterQos& wqos);
+            const PublicationBuiltinTopicData& pub_builtin_data);
     /**
      * Add a local reader to the BuiltinProtocols.
      * @param rtps_reader       Pointer to the RTPSReader.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -53,6 +53,7 @@ class RTPSParticipantImpl;
 class RTPSWriter;
 class RTPSReader;
 class NetworkFactory;
+struct PublicationBuiltinTopicData;
 
 /**
  * Class BuiltinProtocols that contains builtin endpoints implementing the discovery and liveliness protocols.
@@ -126,15 +127,15 @@ public:
     LocatorList_t m_DiscoveryServers;
 
     /**
-     * Add a local Writer to the BuiltinProtocols.
-     * @param w Pointer to the RTPSWriter
+     * Add a local writer to the BuiltinProtocols.
+     * @param writer   Pointer to the RTPSWriter
      * @param topicAtt Attributes of the associated topic
-     * @param wqos QoS policies dictated by the publisher
+     * @param wqos     QoS policies dictated by the publisher
      * @return True if correct.
      */
-    bool addLocalWriter(
-            RTPSWriter* w,
-            const TopicAttributes& topicAtt,
+    bool add_writer(
+            RTPSWriter* rtps_writer,
+            const PublicationBuiltinTopicData& pub_builtin_data,
             const fastdds::dds::WriterQos& wqos);
     /**
      * Add a local Reader to the BuiltinProtocols.
@@ -152,21 +153,18 @@ public:
 
     /**
      * Update a local Writer QOS
-     * @param W Writer to update
-     * @param topicAtt Attributes of the associated topic
-     * @param wqos New Writer QoS
+     * @param rtps_writer      Writer to update
+     * @param wqos             New Writer QoS
      * @return
      */
-    bool updateLocalWriter(
-            RTPSWriter* W,
-            const TopicAttributes& topicAtt,
+    bool update_writer(
+            RTPSWriter* rtps_writer,
             const fastdds::dds::WriterQos& wqos);
     /**
      * Update a local Reader QOS
-     * @param R               Reader to update
-     * @param topicAtt        Attributes of the associated topic
-     * @param qos             New Reader QoS
-     * @param content_filter  Optional content filtering information.
+     * @param rtps_reader      Reader to update
+     * @param rqos             New Reader QoS
+     * @param content_filter   Optional content filtering information.
      * @return
      */
     bool updateLocalReader(
@@ -179,8 +177,8 @@ public:
      * @param W Pointer to the writer.
      * @return True if correctly removed.
      */
-    bool removeLocalWriter(
-            RTPSWriter* W);
+    bool remove_writer(
+            RTPSWriter* rtps_writer);
     /**
      * Remove a local Reader from the builtinProtocols.
      * @param R Pointer to the reader.

--- a/src/cpp/rtps/builtin/BuiltinProtocols.h
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.h
@@ -54,6 +54,7 @@ class RTPSWriter;
 class RTPSReader;
 class NetworkFactory;
 struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 /**
  * Class BuiltinProtocols that contains builtin endpoints implementing the discovery and liveliness protocols.
@@ -138,16 +139,16 @@ public:
             const PublicationBuiltinTopicData& pub_builtin_data,
             const fastdds::dds::WriterQos& wqos);
     /**
-     * Add a local Reader to the BuiltinProtocols.
-     * @param R               Pointer to the RTPSReader.
+     * Add a local reader to the BuiltinProtocols.
+     * @param rtps_reader     Pointer to the RTPSReader.
      * @param topicAtt        Attributes of the associated topic
      * @param rqos            QoS policies dictated by the subscriber
      * @param content_filter  Optional content filtering information.
      * @return True if correct.
      */
-    bool addLocalReader(
-            RTPSReader* R,
-            const TopicAttributes& topicAtt,
+    bool add_reader(
+            RTPSReader* rtps_reader,
+            const SubscriptionBuiltinTopicData& sub_builtin_data,
             const fastdds::dds::ReaderQos& rqos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
 
@@ -167,10 +168,9 @@ public:
      * @param content_filter   Optional content filtering information.
      * @return
      */
-    bool updateLocalReader(
-            RTPSReader* R,
-            const TopicAttributes& topicAtt,
-            const fastdds::dds::ReaderQos& qos,
+    bool update_reader(
+            RTPSReader* rtps_reader,
+            const fastdds::dds::ReaderQos& rqos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * Remove a local Writer from the builtinProtocols.
@@ -184,8 +184,8 @@ public:
      * @param R Pointer to the reader.
      * @return True if correctly removed.
      */
-    bool removeLocalReader(
-            RTPSReader* R);
+    bool remove_reader(
+            RTPSReader* rtps_reader);
 
     //! Announce RTPSParticipantState (force the sending of a DPD message.)
     void announceRTPSParticipantState();

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -32,72 +32,11 @@
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
+#include <utils/BuiltinTopicKeyConversions.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace rtps {
-
-typedef uint32_t BuiltinTopicKeyValue[3];
-
-static void from_proxy_to_builtin(
-        const EntityId_t& entity_id,
-        BuiltinTopicKeyValue& builtin_key_value)
-{
-    builtin_key_value[0] = 0;
-    builtin_key_value[1] = 0;
-    builtin_key_value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
-            | static_cast<uint32_t>(entity_id.value[1]) << 16
-            | static_cast<uint32_t>(entity_id.value[2]) << 8
-            | static_cast<uint32_t>(entity_id.value[3]);
-}
-
-static void from_proxy_to_builtin(
-        const GuidPrefix_t& guid_prefix,
-        BuiltinTopicKeyValue& dds_key)
-{
-    dds_key[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[3]);
-    dds_key[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[7]);
-    dds_key[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[11]);
-}
-
-static void from_builtin_to_proxy(
-        const BuiltinTopicKeyValue& dds_key,
-        EntityId_t& entity_id)
-{
-    entity_id.value[0] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
-    entity_id.value[1] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
-    entity_id.value[2] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
-    entity_id.value[3] = static_cast<uint8_t>(dds_key[2] & 0xFF);
-}
-
-static void from_builtin_to_proxy(
-        const BuiltinTopicKeyValue& dds_key,
-        GuidPrefix_t& guid_prefix)
-{
-    guid_prefix.value[0] = static_cast<uint8_t>((dds_key[0] >> 24) & 0xFF);
-    guid_prefix.value[1] = static_cast<uint8_t>((dds_key[0] >> 16) & 0xFF);
-    guid_prefix.value[2] = static_cast<uint8_t>((dds_key[0] >> 8) & 0xFF);
-    guid_prefix.value[3] = static_cast<uint8_t>(dds_key[0] & 0xFF);
-
-    guid_prefix.value[4] = static_cast<uint8_t>((dds_key[1] >> 24) & 0xFF);
-    guid_prefix.value[5] = static_cast<uint8_t>((dds_key[1] >> 16) & 0xFF);
-    guid_prefix.value[6] = static_cast<uint8_t>((dds_key[1] >> 8) & 0xFF);
-    guid_prefix.value[7] = static_cast<uint8_t>(dds_key[1] & 0xFF);
-
-    guid_prefix.value[8] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
-    guid_prefix.value[9] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
-    guid_prefix.value[10] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
-    guid_prefix.value[11] = static_cast<uint8_t>(dds_key[2] & 0xFF);
-}
 
 void from_proxy_to_builtin(
         const ParticipantProxyData& proxy_data,

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -23,6 +23,8 @@
 #include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
+#include <fastdds/dds/subscriber/qos/ReaderQos.hpp>
+#include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
 #include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
@@ -203,78 +205,87 @@ void from_builtin_to_proxy(
         const PublicationBuiltinTopicData& builtin_data,
         WriterProxyData& proxy_data)
 {
+    fastdds::dds::WriterQos qos{};
+
     from_builtin_to_proxy(builtin_data.participant_key.value, proxy_data.guid().guidPrefix);
     from_builtin_to_proxy(builtin_data.key.value, proxy_data.guid().entityId);
 
     proxy_data.topicName(builtin_data.topic_name);
     proxy_data.typeName(builtin_data.type_name);
-    proxy_data.m_qos.m_durability = builtin_data.durability;
-    proxy_data.m_qos.m_durabilityService = builtin_data.durability_service;
-    proxy_data.m_qos.m_deadline = builtin_data.deadline;
-    proxy_data.m_qos.m_latencyBudget = builtin_data.latency_budget;
-    proxy_data.m_qos.m_liveliness = builtin_data.liveliness;
-    proxy_data.m_qos.m_reliability = builtin_data.reliability;
-    proxy_data.m_qos.m_lifespan = builtin_data.lifespan;
-    proxy_data.m_qos.m_userData = builtin_data.user_data;
-    proxy_data.m_qos.m_ownership = builtin_data.ownership;
-    proxy_data.m_qos.m_ownershipStrength = builtin_data.ownership_strength;
-    proxy_data.m_qos.m_destinationOrder = builtin_data.destination_order;
 
-    proxy_data.m_qos.m_presentation = builtin_data.presentation;
-    proxy_data.m_qos.m_partition = builtin_data.partition;
-    proxy_data.m_qos.m_topicData = builtin_data.topic_data;
-    proxy_data.m_qos.m_groupData = builtin_data.group_data;
+    qos.m_durability = builtin_data.durability;
+    qos.m_durabilityService = builtin_data.durability_service;
+    qos.m_deadline = builtin_data.deadline;
+    qos.m_latencyBudget = builtin_data.latency_budget;
+    qos.m_liveliness = builtin_data.liveliness;
+    qos.m_reliability = builtin_data.reliability;
+    qos.m_lifespan = builtin_data.lifespan;
+    qos.m_userData = builtin_data.user_data;
+    qos.m_ownership = builtin_data.ownership;
+    qos.m_ownershipStrength = builtin_data.ownership_strength;
+    qos.m_destinationOrder = builtin_data.destination_order;
+
+    qos.m_presentation = builtin_data.presentation;
+    qos.m_partition = builtin_data.partition;
+    qos.m_topicData = builtin_data.topic_data;
+    qos.m_groupData = builtin_data.group_data;
 
     proxy_data.type_information(builtin_data.type_information);
-    proxy_data.m_qos.representation = builtin_data.representation;
+    qos.representation = builtin_data.representation;
 
-    proxy_data.m_qos.m_disablePositiveACKs = builtin_data.disable_positive_acks;
-    proxy_data.m_qos.data_sharing = builtin_data.data_sharing;
+    qos.m_disablePositiveACKs = builtin_data.disable_positive_acks;
+    qos.data_sharing = builtin_data.data_sharing;
     proxy_data.guid(builtin_data.guid);
     proxy_data.persistence_guid(builtin_data.persistence_guid);
     proxy_data.RTPSParticipantKey(builtin_data.participant_guid);
     proxy_data.set_locators(builtin_data.remote_locators);
     proxy_data.typeMaxSerialized(builtin_data.max_serialized_size);
     proxy_data.networkConfiguration(builtin_data.loopback_transformation);
+
+    proxy_data.m_qos.setQos(qos, true);
 }
 
 void from_builtin_to_proxy(
         const SubscriptionBuiltinTopicData& builtin_data,
         ReaderProxyData& proxy_data)
 {
+    fastdds::dds::ReaderQos qos{};
+
     from_builtin_to_proxy(builtin_data.participant_key.value, proxy_data.guid().guidPrefix);
     from_builtin_to_proxy(builtin_data.key.value, proxy_data.guid().entityId);
 
     proxy_data.topicName(builtin_data.topic_name);
     proxy_data.typeName(builtin_data.type_name);
-    proxy_data.m_qos.m_durability = builtin_data.durability;
-    proxy_data.m_qos.m_deadline = builtin_data.deadline;
-    proxy_data.m_qos.m_latencyBudget = builtin_data.latency_budget;
-    proxy_data.m_qos.m_lifespan = builtin_data.lifespan;
-    proxy_data.m_qos.m_liveliness = builtin_data.liveliness;
-    proxy_data.m_qos.m_reliability = builtin_data.reliability;
-    proxy_data.m_qos.m_ownership = builtin_data.ownership;
-    proxy_data.m_qos.m_destinationOrder = builtin_data.destination_order;
-    proxy_data.m_qos.m_userData = builtin_data.user_data;
-    proxy_data.m_qos.m_timeBasedFilter = builtin_data.time_based_filter;
+    qos.m_durability = builtin_data.durability;
+    qos.m_deadline = builtin_data.deadline;
+    qos.m_latencyBudget = builtin_data.latency_budget;
+    qos.m_lifespan = builtin_data.lifespan;
+    qos.m_liveliness = builtin_data.liveliness;
+    qos.m_reliability = builtin_data.reliability;
+    qos.m_ownership = builtin_data.ownership;
+    qos.m_destinationOrder = builtin_data.destination_order;
+    qos.m_userData = builtin_data.user_data;
+    qos.m_timeBasedFilter = builtin_data.time_based_filter;
 
-    proxy_data.m_qos.m_presentation = builtin_data.presentation;
-    proxy_data.m_qos.m_partition = builtin_data.partition;
-    proxy_data.m_qos.m_topicData = builtin_data.topic_data;
-    proxy_data.m_qos.m_groupData = builtin_data.group_data;
+    qos.m_presentation = builtin_data.presentation;
+    qos.m_partition = builtin_data.partition;
+    qos.m_topicData = builtin_data.topic_data;
+    qos.m_groupData = builtin_data.group_data;
 
     proxy_data.type_information(builtin_data.type_information);
-    proxy_data.m_qos.representation = builtin_data.representation;
-    proxy_data.m_qos.type_consistency = builtin_data.type_consistency;
+    qos.representation = builtin_data.representation;
+    qos.type_consistency = builtin_data.type_consistency;
 
     proxy_data.content_filter(builtin_data.content_filter);
-    proxy_data.m_qos.m_disablePositiveACKs = builtin_data.disable_positive_acks;
-    proxy_data.m_qos.data_sharing = builtin_data.data_sharing;
+    qos.m_disablePositiveACKs = builtin_data.disable_positive_acks;
+    qos.data_sharing = builtin_data.data_sharing;
     proxy_data.guid(builtin_data.guid);
     proxy_data.RTPSParticipantKey(builtin_data.participant_guid);
     proxy_data.set_locators(builtin_data.remote_locators);
     proxy_data.networkConfiguration(builtin_data.loopback_transformation);
     proxy_data.m_expectsInlineQos = builtin_data.expects_inline_qos;
+
+    proxy_data.m_qos.setQos(qos, true);
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -39,6 +39,66 @@ namespace fastdds {
 namespace rtps {
 
 void from_proxy_to_builtin(
+        const EntityId_t& entity_id,
+        BuiltinTopicKeyValue& builtin_key_value)
+{
+    builtin_key_value[0] = 0;
+    builtin_key_value[1] = 0;
+    builtin_key_value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void from_proxy_to_builtin(
+        const GuidPrefix_t& guid_prefix,
+        BuiltinTopicKeyValue& dds_key)
+{
+    dds_key[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    dds_key[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    dds_key[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
+
+void from_builtin_to_proxy(
+        const BuiltinTopicKeyValue& dds_key,
+        EntityId_t& entity_id)
+{
+    entity_id.value[0] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
+    entity_id.value[1] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
+    entity_id.value[2] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
+    entity_id.value[3] = static_cast<uint8_t>(dds_key[2] & 0xFF);
+}
+
+void from_builtin_to_proxy(
+        const BuiltinTopicKeyValue& dds_key,
+        GuidPrefix_t& guid_prefix)
+{
+    guid_prefix.value[0] = static_cast<uint8_t>((dds_key[0] >> 24) & 0xFF);
+    guid_prefix.value[1] = static_cast<uint8_t>((dds_key[0] >> 16) & 0xFF);
+    guid_prefix.value[2] = static_cast<uint8_t>((dds_key[0] >> 8) & 0xFF);
+    guid_prefix.value[3] = static_cast<uint8_t>(dds_key[0] & 0xFF);
+
+    guid_prefix.value[4] = static_cast<uint8_t>((dds_key[1] >> 24) & 0xFF);
+    guid_prefix.value[5] = static_cast<uint8_t>((dds_key[1] >> 16) & 0xFF);
+    guid_prefix.value[6] = static_cast<uint8_t>((dds_key[1] >> 8) & 0xFF);
+    guid_prefix.value[7] = static_cast<uint8_t>(dds_key[1] & 0xFF);
+
+    guid_prefix.value[8] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
+    guid_prefix.value[9] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
+    guid_prefix.value[10] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
+    guid_prefix.value[11] = static_cast<uint8_t>(dds_key[2] & 0xFF);
+}
+
+void from_proxy_to_builtin(
         const ParticipantProxyData& proxy_data,
         ParticipantBuiltinTopicData& builtin_data)
 {

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
@@ -28,7 +28,6 @@
 #include <fastdds/rtps/builtin/data/ContentFilterProperty.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.hpp
@@ -23,7 +23,6 @@
 
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -35,6 +35,7 @@
 
 #include <fastdds/utils/TypePropagation.hpp>
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
+#include <rtps/builtin/data/ProxyDataConverters.hpp>
 #include <rtps/builtin/data/ProxyHashTables.hpp>
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
@@ -96,14 +97,13 @@ EDP::~EDP()
 bool EDP::new_reader_proxy_data(
         RTPSReader* rtps_reader,
         const SubscriptionBuiltinTopicData& sub_builtin_data,
-        const fastdds::dds::ReaderQos& rqos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
     EPROSIMA_LOG_INFO(RTPS_EDP,
             "Adding " << rtps_reader->getGuid().entityId << " in topic " <<
             sub_builtin_data.topic_name.to_string());
 
-    auto init_fun = [this, rtps_reader, &sub_builtin_data, &rqos, content_filter](
+    auto init_fun = [this, rtps_reader, &sub_builtin_data, content_filter](
         ReaderProxyData* rpd,
         bool updating,
         const ParticipantProxyData& participant_data)
@@ -118,6 +118,8 @@ bool EDP::new_reader_proxy_data(
 
                 const NetworkFactory& network = mp_RTPSParticipant->network_factory();
                 const auto& ratt = rtps_reader->getAttributes();
+
+                from_builtin_to_proxy(sub_builtin_data, *rpd);
 
                 rpd->isAlive(true);
                 rpd->m_expectsInlineQos = rtps_reader->expects_inline_qos();
@@ -175,7 +177,7 @@ bool EDP::new_reader_proxy_data(
                     }
                 }
 
-                rpd->m_qos.setQos(rqos, true);
+                rpd->m_qos.setQos(rpd->m_qos, true);
                 rpd->userDefinedId(ratt.getUserDefinedID());
                 if (nullptr != content_filter)
                 {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -240,14 +240,13 @@ bool EDP::new_reader_proxy_data(
 
 bool EDP::new_writer_proxy_data(
         RTPSWriter* rtps_writer,
-        const PublicationBuiltinTopicData& pub_builtin_data,
-        const fastdds::dds::WriterQos& wqos)
+        const PublicationBuiltinTopicData& pub_builtin_data)
 {
     EPROSIMA_LOG_INFO(RTPS_EDP,
             "Adding " << rtps_writer->getGuid().entityId << " in topic " <<
             pub_builtin_data.topic_name.to_string());
 
-    auto init_fun = [this, rtps_writer, &pub_builtin_data, &wqos](
+    auto init_fun = [this, rtps_writer, &pub_builtin_data](
         WriterProxyData* wpd,
         bool updating,
         const ParticipantProxyData& participant_data)
@@ -259,6 +258,8 @@ bool EDP::new_writer_proxy_data(
                                                               << pub_builtin_data.topic_name.to_string());
                     return false;
                 }
+
+                from_builtin_to_proxy(pub_builtin_data, *wpd);
 
                 const NetworkFactory& network = mp_RTPSParticipant->network_factory();
                 const auto& watt = rtps_writer->getAttributes();
@@ -320,7 +321,7 @@ bool EDP::new_writer_proxy_data(
                 BaseWriter* base_writer = BaseWriter::downcast(rtps_writer);
                 assert(base_writer->get_history() != nullptr);
                 wpd->typeMaxSerialized(base_writer->get_history()->getTypeMaxSerialized());
-                wpd->m_qos.setQos(wqos, true);
+                wpd->m_qos.setQos(wpd->m_qos, true);
                 wpd->userDefinedId(watt.getUserDefinedID());
                 wpd->persistence_guid(watt.persistence_guid);
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -99,7 +99,9 @@ bool EDP::new_reader_proxy_data(
         const fastdds::dds::ReaderQos& rqos,
         const fastdds::rtps::ContentFilterProperty* content_filter)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, "Adding " << rtps_reader->getGuid().entityId << " in topic " << sub_builtin_data.topic_name.to_string());
+    EPROSIMA_LOG_INFO(RTPS_EDP,
+            "Adding " << rtps_reader->getGuid().entityId << " in topic " <<
+            sub_builtin_data.topic_name.to_string());
 
     auto init_fun = [this, rtps_reader, &sub_builtin_data, &rqos, content_filter](
         ReaderProxyData* rpd,
@@ -239,7 +241,9 @@ bool EDP::new_writer_proxy_data(
         const PublicationBuiltinTopicData& pub_builtin_data,
         const fastdds::dds::WriterQos& wqos)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, "Adding " << rtps_writer->getGuid().entityId << " in topic " << pub_builtin_data.topic_name.to_string());
+    EPROSIMA_LOG_INFO(RTPS_EDP,
+            "Adding " << rtps_writer->getGuid().entityId << " in topic " <<
+            pub_builtin_data.topic_name.to_string());
 
     auto init_fun = [this, rtps_writer, &pub_builtin_data, &wqos](
         WriterProxyData* wpd,

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -179,15 +179,13 @@ public:
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * Create a new ReaderPD for a local Writer.
-     * @param rtps_writer      Pointer to the RTPSWriter.
-     * @param pub_builtin_data Publication data for the writer.
-     * @param qos              QoS policies dictated by the publisher.
+     * @param rtps_writer       Pointer to the RTPSWriter.
+     * @param pub_builtin_data  QoS policies dictated by the publisher.
      * @return True if correct.
      */
     bool new_writer_proxy_data(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data,
-            const fastdds::dds::WriterQos& qos);
+            const PublicationBuiltinTopicData& pub_builtin_data);
     /**
      * A previously created Reader has been updated
      * @param rtps_reader      Pointer to the RTPSReader.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -166,16 +166,16 @@ public:
 
     /**
      * Create a new ReaderPD for a local Reader.
-     * @param rtps_reader      Pointer to the RTPSReader.
-     * @param sub_builtin_data Subscription data for the reader.
-     * @param qos              QoS policies dictated by the subscriber.
-     * @param content_filter   Optional content filtering information.
+     *
+     * @param rtps_reader       Pointer to the RTPSReader.
+     * @param sub_builtin_data  Subscription data for the reader.
+     * @param content_filter    Optional content filtering information.
+     *
      * @return True if correct.
      */
     bool new_reader_proxy_data(
             RTPSReader* rtps_reader,
             const SubscriptionBuiltinTopicData& sub_builtin_data,
-            const fastdds::dds::ReaderQos& qos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * Create a new ReaderPD for a local Writer.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -44,7 +44,6 @@ class TypeIdentifier;
 } // namespace xtypes
 } // namespace dds
 
-class TopicAttributes;
 
 namespace rtps {
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -52,8 +52,6 @@ class RTPSWriter;
 class RTPSReader;
 class WriterProxyData;
 class RTPSParticipantImpl;
-struct PublicationBuiltinTopicData;
-struct SubscriptionBuiltinTopicData;
 struct TopicDescription;
 
 /**
@@ -168,15 +166,17 @@ public:
     /**
      * Create a new ReaderPD for a local Reader.
      *
-     * @param rtps_reader       Pointer to the RTPSReader.
-     * @param sub_builtin_data  Subscription data for the reader.
-     * @param content_filter    Optional content filtering information.
+     * @param rtps_reader     Pointer to the RTPSReader.
+     * @param topic           Information regarding the topic where the writer is registering.
+     * @param qos             QoS policies dictated by the subscriber.
+     * @param content_filter  Optional content filtering information.
      *
      * @return True if correct.
      */
     bool new_reader_proxy_data(
             RTPSReader* rtps_reader,
-            const SubscriptionBuiltinTopicData& sub_builtin_data,
+            const TopicDescription& topic,
+            const fastdds::dds::ReaderQos& qos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * Create a new WriterPD for a local Writer.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -54,6 +54,7 @@ class WriterProxyData;
 class RTPSParticipantImpl;
 struct PublicationBuiltinTopicData;
 struct SubscriptionBuiltinTopicData;
+struct TopicDescription;
 
 /**
  * Class EDP, base class for Endpoint Discovery Protocols. It contains generic methods used by the two EDP implemented (EDPSimple and EDPStatic), as well as abstract methods
@@ -178,14 +179,18 @@ public:
             const SubscriptionBuiltinTopicData& sub_builtin_data,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
-     * Create a new ReaderPD for a local Writer.
-     * @param rtps_writer       Pointer to the RTPSWriter.
-     * @param pub_builtin_data  QoS policies dictated by the publisher.
+     * Create a new WriterPD for a local Writer.
+     *
+     * @param rtps_writer  Pointer to the RTPSWriter.
+     * @param topic        Information regarding the topic where the writer is registering.
+     * @param qos          QoS policies dictated by the publisher.
+     *
      * @return True if correct.
      */
     bool new_writer_proxy_data(
             RTPSWriter* rtps_writer,
-            const PublicationBuiltinTopicData& pub_builtin_data);
+            const TopicDescription& topic,
+            const fastdds::dds::WriterQos& qos);
     /**
      * A previously created Reader has been updated
      * @param rtps_reader      Pointer to the RTPSReader.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -17,9 +17,8 @@
  *
  */
 
-#ifndef FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT_EDP_H
-#define FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT_EDP_H
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#ifndef FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDP_H
+#define FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDP_H
 
 #include <fastdds/dds/core/status/IncompatibleQosStatus.hpp>
 #include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
@@ -53,6 +52,8 @@ class RTPSWriter;
 class RTPSReader;
 class WriterProxyData;
 class RTPSParticipantImpl;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 /**
  * Class EDP, base class for Endpoint Discovery Protocols. It contains generic methods used by the two EDP implemented (EDPSimple and EDPStatic), as well as abstract methods
@@ -130,18 +131,18 @@ public:
 
     /**
      * Abstract method that removes a local Reader from the discovery method
-     * @param R Pointer to the Reader to remove.
+     * @param rtps_reader Pointer to the Reader to remove.
      * @return True if correctly removed.
      */
-    virtual bool removeLocalReader(
-            RTPSReader* R) = 0;
+    virtual bool remove_reader(
+            RTPSReader* rtps_reader) = 0;
     /**
      * Abstract method that removes a local Writer from the discovery method
-     * @param W Pointer to the Writer to remove.
+     * @param rtps_writer Pointer to the Writer to remove.
      * @return True if correctly removed.
      */
-    virtual bool removeLocalWriter(
-            RTPSWriter* W) = 0;
+    virtual bool remove_writer(
+            RTPSWriter* rtps_writer) = 0;
 
     /**
      * After a new local ReaderProxyData has been created some processing is needed (depends on the implementation).
@@ -149,7 +150,7 @@ public:
      * @param rdata Pointer to the ReaderProxyData object.
      * @return True if correct.
      */
-    virtual bool processLocalReaderProxyData(
+    virtual bool process_reader_proxy_data(
             RTPSReader* reader,
             ReaderProxyData* rdata) = 0;
 
@@ -159,57 +160,53 @@ public:
      * @param wdata Pointer to the Writer ProxyData object.
      * @return True if correct.
      */
-    virtual bool processLocalWriterProxyData(
+    virtual bool process_writer_proxy_data(
             RTPSWriter* writer,
             WriterProxyData* wdata) = 0;
 
     /**
      * Create a new ReaderPD for a local Reader.
-     * @param R               Pointer to the RTPSReader.
-     * @param att             Attributes of the associated topic
-     * @param qos             QoS policies dictated by the subscriber
-     * @param content_filter  Optional content filtering information.
+     * @param rtps_reader      Pointer to the RTPSReader.
+     * @param sub_builtin_data Subscription data for the reader.
+     * @param qos              QoS policies dictated by the subscriber.
+     * @param content_filter   Optional content filtering information.
      * @return True if correct.
      */
-    bool newLocalReaderProxyData(
-            RTPSReader* R,
-            const TopicAttributes& att,
+    bool new_reader_proxy_data(
+            RTPSReader* rtps_reader,
+            const SubscriptionBuiltinTopicData& sub_builtin_data,
             const fastdds::dds::ReaderQos& qos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * Create a new ReaderPD for a local Writer.
-     * @param W Pointer to the RTPSWriter.
-     * @param att Attributes of the associated topic
-     * @param qos QoS policies dictated by the publisher
+     * @param rtps_writer      Pointer to the RTPSWriter.
+     * @param pub_builtin_data Publication data for the writer.
+     * @param qos              QoS policies dictated by the publisher.
      * @return True if correct.
      */
-    bool newLocalWriterProxyData(
-            RTPSWriter* W,
-            const TopicAttributes& att,
+    bool new_writer_proxy_data(
+            RTPSWriter* rtps_writer,
+            const PublicationBuiltinTopicData& pub_builtin_data,
             const fastdds::dds::WriterQos& qos);
     /**
      * A previously created Reader has been updated
-     * @param R               Pointer to the reader
-     * @param att             Attributes of the associated topic
-     * @param qos             QoS policies dictated by the subscriber
-     * @param content_filter  Optional content filtering information.
+     * @param rtps_reader      Pointer to the RTPSReader.
+     * @param qos              QoS policies dictated by the subscriber.
+     * @param content_filter   Optional content filtering information.
      * @return True if correctly updated
      */
-    bool updatedLocalReader(
-            RTPSReader* R,
-            const TopicAttributes& att,
+    bool update_reader(
+            RTPSReader* rtps_reader,
             const fastdds::dds::ReaderQos& qos,
             const fastdds::rtps::ContentFilterProperty* content_filter = nullptr);
     /**
      * A previously created Writer has been updated
-     * @param W Pointer to the Writer
-     * @param att Attributes of the associated topic
-     * @param qos QoS policies dictated by the publisher
+     * @param rtps_writer      Pointer to the RTPSWriter.
+     * @param qos              QoS policies dictated by the publisher.
      * @return True if correctly updated
      */
-    bool updatedLocalWriter(
-            RTPSWriter* W,
-            const TopicAttributes& att,
+    bool update_writer(
+            RTPSWriter* rtps_writer,
             const fastdds::dds::WriterQos& qos);
 
     /**
@@ -391,5 +388,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif // FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT_EDP_H
+#endif // FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDP_H

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
@@ -38,7 +38,7 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-bool EDPClient::processLocalReaderProxyData(
+bool EDPClient::process_reader_proxy_data(
         RTPSReader* local_reader,
         ReaderProxyData* rdata)
 {
@@ -153,15 +153,15 @@ bool EDPClient::remove_writer(
     return mp_PDP->removeWriterProxyData(rtps_writer->getGuid());
 }
 
-bool EDPClient::removeLocalReader(
-        RTPSReader* R)
+bool EDPClient::remove_reader(
+        RTPSReader* rtps_reader)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, R->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, rtps_reader->getGuid().entityId);
 
     auto* writer = &subscriptions_writer_;
 
 #if HAVE_SECURITY
-    if (R->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_reader->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &subscriptions_secure_writer_;
     }
@@ -170,7 +170,7 @@ bool EDPClient::removeLocalReader(
     if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
-        iH = (R->getGuid());
+        iH = (rtps_reader->getGuid());
         CacheChange_t* change = EDPUtils::create_change(*writer, NOT_ALIVE_DISPOSED_UNREGISTERED, iH,
                         mp_PDP->builtin_attributes().writerPayloadSize);
         if (change != nullptr)
@@ -198,7 +198,7 @@ bool EDPClient::removeLocalReader(
             writer->second->add_change(change, wp);
         }
     }
-    return mp_PDP->removeReaderProxyData(R->getGuid());
+    return mp_PDP->removeReaderProxyData(rtps_reader->getGuid());
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.cpp
@@ -71,17 +71,17 @@ bool EDPClient::processLocalReaderProxyData(
     return ret_val;
 }
 
-bool EDPClient::processLocalWriterProxyData(
-        RTPSWriter* local_writer,
+bool EDPClient::process_writer_proxy_data(
+        RTPSWriter* rtps_writer,
         WriterProxyData* wdata)
 {
     EPROSIMA_LOG_INFO(RTPS_EDP, wdata->guid().entityId);
-    (void)local_writer;
+    (void)rtps_writer;
 
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if (local_writer->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_writer->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
@@ -104,15 +104,15 @@ bool EDPClient::processLocalWriterProxyData(
     return ret_val;
 }
 
-bool EDPClient::removeLocalWriter(
-        RTPSWriter* W)
+bool EDPClient::remove_writer(
+        RTPSWriter* rtps_writer)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, W->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, rtps_writer->getGuid().entityId);
 
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if (W->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_writer->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
@@ -121,7 +121,7 @@ bool EDPClient::removeLocalWriter(
     if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
-        iH = W->getGuid();
+        iH = rtps_writer->getGuid();
         CacheChange_t* change = EDPUtils::create_change(*writer, NOT_ALIVE_DISPOSED_UNREGISTERED, iH,
                         mp_PDP->builtin_attributes().writerPayloadSize);
         if (change != nullptr)
@@ -150,7 +150,7 @@ bool EDPClient::removeLocalWriter(
             writer->second->add_change(change, wp);
         }
     }
-    return mp_PDP->removeWriterProxyData(W->getGuid());
+    return mp_PDP->removeWriterProxyData(rtps_writer->getGuid());
 }
 
 bool EDPClient::removeLocalReader(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.h
@@ -49,12 +49,12 @@ public:
 
     /**
      * This method generates the corresponding change in the subscription writer and send it to all known remote endpoints.
-     * @param reader Pointer to the Reader object.
+     * @param rtps_reader Pointer to the Reader object.
      * @param rdata Pointer to the ReaderProxyData object.
      * @return true if correct.
      */
-    bool processLocalReaderProxyData(
-            RTPSReader* reader,
+    bool process_reader_proxy_data(
+            RTPSReader* rtps_reader,
             ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
@@ -67,11 +67,11 @@ public:
             WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
-     * @param R Pointer to the RTPSReader object.
+     * @param rtps_reader Pointer to the RTPSReader object.
      * @return True if correct.
      */
-    bool removeLocalReader(
-            RTPSReader* R) override;
+    bool remove_reader(
+            RTPSReader* rtps_reader) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param rtps_writer Pointer to the RTPSWriter object.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPClient.h
@@ -58,12 +58,12 @@ public:
             ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
-     * @param writer Pointer to the Writer object.
+     * @param rtps_writer Pointer to the Writer object.
      * @param wdata Pointer to the WriterProxyData object.
      * @return true if correct.
      */
-    bool processLocalWriterProxyData(
-            RTPSWriter* writer,
+    bool process_writer_proxy_data(
+            RTPSWriter* rtps_writer,
             WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
@@ -74,11 +74,11 @@ public:
             RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
-     * @param W Pointer to the RTPSWriter object.
+     * @param rtps_writer Pointer to the RTPSWriter object.
      * @return True if correct.
      */
-    bool removeLocalWriter(
-            RTPSWriter* W) override;
+    bool remove_writer(
+            RTPSWriter* rtps_writer) override;
 
 };
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -214,14 +214,14 @@ bool EDPServer::createSEDPEndpoints()
     return created;
 }
 
-bool EDPServer::removeLocalReader(
-        RTPSReader* R)
+bool EDPServer::remove_reader(
+        RTPSReader* rtps_reader)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, "Removing local reader: " << R->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, "Removing local reader: " << rtps_reader->getGuid().entityId);
 
     // Get subscriptions writer and reader guid
     auto* writer = &subscriptions_writer_;
-    GUID_t guid = R->getGuid();
+    GUID_t guid = rtps_reader->getGuid();
 
     // Recover reader information
     std::string topic_name;
@@ -375,7 +375,7 @@ bool EDPServer::process_writer_proxy_data(
     return false;
 }
 
-bool EDPServer::processLocalReaderProxyData(
+bool EDPServer::process_reader_proxy_data(
         RTPSReader* local_reader,
         ReaderProxyData* rdata)
 {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.cpp
@@ -269,14 +269,14 @@ bool EDPServer::removeLocalReader(
     return false;
 }
 
-bool EDPServer::removeLocalWriter(
-        RTPSWriter* W)
+bool EDPServer::remove_writer(
+        RTPSWriter* rtps_writer)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, "Removing local writer: " << W->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, "Removing local writer: " << rtps_writer->getGuid().entityId);
 
     // Get publications writer and writer guid
     auto* writer = &publications_writer_;
-    GUID_t guid = W->getGuid();
+    GUID_t guid = rtps_writer->getGuid();
 
     // Recover writer information
     std::string topic_name;
@@ -325,7 +325,7 @@ bool EDPServer::removeLocalWriter(
     return false;
 }
 
-bool EDPServer::processLocalWriterProxyData(
+bool EDPServer::process_writer_proxy_data(
         RTPSWriter* local_writer,
         WriterProxyData* wdata)
 {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -78,7 +78,7 @@ public:
      * @param rdata Pointer to the ReaderProxyData object.
      * @return true if correct.
      */
-    bool processLocalReaderProxyData(
+    bool process_reader_proxy_data(
             RTPSReader* reader,
             ReaderProxyData* rdata) override;
     /**
@@ -95,7 +95,7 @@ public:
      * @param R Pointer to the RTPSReader object.
      * @return True if correct.
      */
-    bool removeLocalReader(
+    bool remove_reader(
             RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPServer.hpp
@@ -87,7 +87,7 @@ public:
      * @param wdata Pointer to the WriterProxyData object.
      * @return true if correct.
      */
-    bool processLocalWriterProxyData(
+    bool process_writer_proxy_data(
             RTPSWriter* writer,
             WriterProxyData* wdata) override;
     /**
@@ -102,7 +102,7 @@ public:
      * @param W Pointer to the RTPSWriter object.
      * @return True if correct.
      */
-    bool removeLocalWriter(
+    bool remove_writer(
             RTPSWriter* W) override;
 
     /**

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -545,17 +545,17 @@ bool EDPSimple::processLocalReaderProxyData(
     return ret_val;
 }
 
-bool EDPSimple::processLocalWriterProxyData(
-        RTPSWriter* local_writer,
+bool EDPSimple::process_writer_proxy_data(
+        RTPSWriter* rtps_writer,
         WriterProxyData* wdata)
 {
     EPROSIMA_LOG_INFO(RTPS_EDP, wdata->guid().entityId);
-    (void)local_writer;
+    (void)rtps_writer;
 
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if (local_writer->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_writer->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
@@ -637,15 +637,15 @@ bool EDPSimple::serialize_proxy_data(
     return true;
 }
 
-bool EDPSimple::removeLocalWriter(
-        RTPSWriter* W)
+bool EDPSimple::remove_writer(
+        RTPSWriter* rtps_writer)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, W->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, rtps_writer->getGuid().entityId);
 
     auto* writer = &publications_writer_;
 
 #if HAVE_SECURITY
-    if (W->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_writer->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &publications_secure_writer_;
     }
@@ -654,7 +654,7 @@ bool EDPSimple::removeLocalWriter(
     if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
-        iH = W->getGuid();
+        iH = rtps_writer->getGuid();
         CacheChange_t* change = EDPUtils::create_change(*writer, NOT_ALIVE_DISPOSED_UNREGISTERED, iH,
                         mp_PDP->builtin_attributes().writerPayloadSize);
         if (change != nullptr)
@@ -680,11 +680,11 @@ bool EDPSimple::removeLocalWriter(
     // notify monitor service about the new local entity proxy update
     if (nullptr != this->mp_PDP->get_proxy_observer())
     {
-        this->mp_PDP->get_proxy_observer()->on_local_entity_change(W->getGuid(), false);
+        this->mp_PDP->get_proxy_observer()->on_local_entity_change(rtps_writer->getGuid(), false);
     }
 #endif //FASTDDS_STATISTICS
 
-    return mp_PDP->removeWriterProxyData(W->getGuid());
+    return mp_PDP->removeWriterProxyData(rtps_writer->getGuid());
 }
 
 bool EDPSimple::removeLocalReader(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -521,17 +521,17 @@ bool EDPSimple::create_sedp_secure_endpoints()
 
 #endif // if HAVE_SECURITY
 
-bool EDPSimple::processLocalReaderProxyData(
-        RTPSReader* local_reader,
+bool EDPSimple::process_reader_proxy_data(
+        RTPSReader* rtps_reader,
         ReaderProxyData* rdata)
 {
     EPROSIMA_LOG_INFO(RTPS_EDP, rdata->guid().entityId);
-    (void)local_reader;
+    (void)rtps_reader;
 
     auto* writer = &subscriptions_writer_;
 
 #if HAVE_SECURITY
-    if (local_reader->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_reader->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &subscriptions_secure_writer_;
     }
@@ -687,15 +687,15 @@ bool EDPSimple::remove_writer(
     return mp_PDP->removeWriterProxyData(rtps_writer->getGuid());
 }
 
-bool EDPSimple::removeLocalReader(
-        RTPSReader* R)
+bool EDPSimple::remove_reader(
+        RTPSReader* rtps_reader)
 {
-    EPROSIMA_LOG_INFO(RTPS_EDP, R->getGuid().entityId);
+    EPROSIMA_LOG_INFO(RTPS_EDP, rtps_reader->getGuid().entityId);
 
     auto* writer = &subscriptions_writer_;
 
 #if HAVE_SECURITY
-    if (R->getAttributes().security_attributes().is_discovery_protected)
+    if (rtps_reader->getAttributes().security_attributes().is_discovery_protected)
     {
         writer = &subscriptions_secure_writer_;
     }
@@ -704,7 +704,7 @@ bool EDPSimple::removeLocalReader(
     if (writer->first != nullptr)
     {
         InstanceHandle_t iH;
-        iH = (R->getGuid());
+        iH = (rtps_reader->getGuid());
         CacheChange_t* change = EDPUtils::create_change(*writer, NOT_ALIVE_DISPOSED_UNREGISTERED, iH,
                         mp_PDP->builtin_attributes().writerPayloadSize);
         if (change != nullptr)
@@ -729,11 +729,11 @@ bool EDPSimple::removeLocalReader(
     // notify monitor service about the new local entity proxy update
     if (nullptr != this->mp_PDP->get_proxy_observer())
     {
-        this->mp_PDP->get_proxy_observer()->on_local_entity_change(R->getGuid(), false);
+        this->mp_PDP->get_proxy_observer()->on_local_entity_change(rtps_reader->getGuid(), false);
     }
 #endif //FASTDDS_STATISTICS
 
-    return mp_PDP->removeReaderProxyData(R->getGuid());
+    return mp_PDP->removeReaderProxyData(rtps_reader->getGuid());
 }
 
 void EDPSimple::assignRemoteEndpoints(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -122,12 +122,12 @@ public:
 
     /**
      * This method generates the corresponding change in the subscription writer and send it to all known remote endpoints.
-     * @param reader Pointer to the Reader object.
-     * @param rdata Pointer to the ReaderProxyData object.
+     * @param rtps_reader Pointer to the Reader object.
+     * @param rdata       Pointer to the ReaderProxyData object.
      * @return true if correct.
      */
-    bool processLocalReaderProxyData(
-            RTPSReader* reader,
+    bool process_reader_proxy_data(
+            RTPSReader* rtps_reader,
             ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
@@ -140,11 +140,11 @@ public:
             WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
-     * @param R Pointer to the RTPSReader object.
+     * @param rtps_reader Pointer to the RTPSReader object.
      * @return True if correct.
      */
-    bool removeLocalReader(
-            RTPSReader* R) override;
+    bool remove_reader(
+            RTPSReader* rtps_reader) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
      * @param rtps_writer Pointer to the RTPSWriter object.

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.h
@@ -17,9 +17,8 @@
  *
  */
 
-#ifndef _FASTDDS_RTPS_EDPSIMPLE_H_
-#define _FASTDDS_RTPS_EDPSIMPLE_H_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#ifndef FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSIMPLE_H
+#define FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSIMPLE_H
 
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
@@ -132,12 +131,12 @@ public:
             ReaderProxyData* rdata) override;
     /**
      * This method generates the corresponding change in the publciations writer and send it to all known remote endpoints.
-     * @param writer Pointer to the Writer object.
-     * @param wdata Pointer to the WriterProxyData object.
+     * @param rtps_writer Pointer to the Writer object.
+     * @param wdata       Pointer to the WriterProxyData object.
      * @return true if correct.
      */
-    bool processLocalWriterProxyData(
-            RTPSWriter* writer,
+    bool process_writer_proxy_data(
+            RTPSWriter* rtps_writer,
             WriterProxyData* wdata) override;
     /**
      * This methods generates the change disposing of the local Reader and calls the unpairing and removal methods of the base class.
@@ -148,11 +147,11 @@ public:
             RTPSReader* R) override;
     /**
      * This methods generates the change disposing of the local Writer and calls the unpairing and removal methods of the base class.
-     * @param W Pointer to the RTPSWriter object.
+     * @param rtps_writer Pointer to the RTPSWriter object.
      * @return True if correct.
      */
-    bool removeLocalWriter(
-            RTPSWriter* W) override;
+    bool remove_writer(
+            RTPSWriter* rtps_writer) override;
 
 protected:
 
@@ -287,5 +286,4 @@ private:
 } /* namespace fastdds */
 } /* namespace eprosima */
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_EDPSIMPLE_H_ */
+#endif /* FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSIMPLE_H */

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -337,7 +337,7 @@ bool EDPStatic::processLocalReaderProxyData(
     return true;
 }
 
-bool EDPStatic::processLocalWriterProxyData(
+bool EDPStatic::process_writer_proxy_data(
         RTPSWriter*,
         WriterProxyData* wdata)
 {
@@ -379,8 +379,8 @@ bool EDPStatic::removeLocalReader(
     return false;
 }
 
-bool EDPStatic::removeLocalWriter(
-        RTPSWriter* W)
+bool EDPStatic::remove_writer(
+        RTPSWriter* rtps_writer)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_PDP->getMutex());
     ParticipantProxyData* localpdata = this->mp_PDP->getLocalParticipantProxyData();
@@ -390,10 +390,10 @@ bool EDPStatic::removeLocalWriter(
         EDPStaticProperty staticproperty;
         if (staticproperty.fromProperty((*pit).pair()))
         {
-            if (staticproperty.m_entityId == W->getGuid().entityId)
+            if (staticproperty.m_entityId == rtps_writer->getGuid().entityId)
             {
                 auto new_property = EDPStaticProperty::toProperty(exchange_format_, "Writer", "ENDED",
-                                W->getAttributes().getUserDefinedID(), W->getGuid().entityId);
+                                rtps_writer->getAttributes().getUserDefinedID(), rtps_writer->getGuid().entityId);
                 if (!pit->modify(new_property))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_EDP, "Failed to change property <"

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -322,7 +322,7 @@ bool EDPStaticProperty::fromProperty(
     return false;
 }
 
-bool EDPStatic::processLocalReaderProxyData(
+bool EDPStatic::process_reader_proxy_data(
         RTPSReader*,
         ReaderProxyData* rdata)
 {
@@ -352,8 +352,8 @@ bool EDPStatic::process_writer_proxy_data(
     return true;
 }
 
-bool EDPStatic::removeLocalReader(
-        RTPSReader* R)
+bool EDPStatic::remove_reader(
+        RTPSReader* rtps_reader)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_PDP->getMutex());
     ParticipantProxyData* localpdata = this->mp_PDP->getLocalParticipantProxyData();
@@ -363,10 +363,10 @@ bool EDPStatic::removeLocalReader(
         EDPStaticProperty staticproperty;
         if (staticproperty.fromProperty((*pit).pair()))
         {
-            if (staticproperty.m_entityId == R->getGuid().entityId)
+            if (staticproperty.m_entityId == rtps_reader->getGuid().entityId)
             {
                 auto new_property = EDPStaticProperty::toProperty(exchange_format_, "Reader", "ENDED",
-                                R->getAttributes().getUserDefinedID(), R->getGuid().entityId);
+                                rtps_reader->getAttributes().getUserDefinedID(), rtps_reader->getGuid().entityId);
                 if (!pit->modify(new_property))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_EDP, "Failed to change property <"

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.h
@@ -71,12 +71,12 @@ public:
             const ParticipantProxyData& pdata,
             bool assign_secure_endpoints) override;
     /**
-     * Abstract method that removes a local Reader from the discovery method
-     * @param R Pointer to the Reader to remove.
+     * Abstract method that removes a local reader from the discovery method
+     * @param rtps_reader Pointer to the Reader to remove.
      * @return True if correctly removed.
      */
-    bool removeLocalReader(
-            RTPSReader* R) override;
+    bool remove_reader(
+            RTPSReader* rtps_reader) override;
     /**
      * Abstract method that removes a local Writer from the discovery method
      * @param rtps_writer Pointer to the writer to remove.
@@ -87,12 +87,12 @@ public:
 
     /**
      * After a new local ReaderProxyData has been created some processing is needed (depends on the implementation).
-     * @param reader Pointer to the RTPSReader object.
-     * @param rdata Pointer to the ReaderProxyData object.
+     * @param rtps_reader Pointer to the RTPSReader object.
+     * @param rdata       Pointer to the ReaderProxyData object.
      * @return True if correct.
      */
-    bool processLocalReaderProxyData(
-            RTPSReader* reader,
+    bool process_reader_proxy_data(
+            RTPSReader* rtps_reader,
             ReaderProxyData* rdata) override;
     /**
      * After a new local WriterProxyData has been created some processing is needed (depends on the implementation).

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.h
@@ -17,9 +17,8 @@
  *
  */
 
-#ifndef _FASTDDS_RTPS_EDPSTATIC_H_
-#define _FASTDDS_RTPS_EDPSTATIC_H_
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
+#ifndef FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSTATIC_H
+#define FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSTATIC_H
 
 #include <rtps/builtin/discovery/endpoint/EDP.h>
 
@@ -80,11 +79,11 @@ public:
             RTPSReader* R) override;
     /**
      * Abstract method that removes a local Writer from the discovery method
-     * @param W Pointer to the Writer to remove.
+     * @param rtps_writer Pointer to the writer to remove.
      * @return True if correctly removed.
      */
-    bool removeLocalWriter(
-            RTPSWriter* W) override;
+    bool remove_writer(
+            RTPSWriter* rtps_writer) override;
 
     /**
      * After a new local ReaderProxyData has been created some processing is needed (depends on the implementation).
@@ -97,12 +96,12 @@ public:
             ReaderProxyData* rdata) override;
     /**
      * After a new local WriterProxyData has been created some processing is needed (depends on the implementation).
-     * @param writer Pointer to the RTPSWriter object.
-     * @param wdata Pointer to the Writer ProxyData object.
+     * @param rtps_writer Pointer to the RTPSWriter object.
+     * @param wdata       Pointer to the Writer ProxyData object.
      * @return True if correct.
      */
-    bool processLocalWriterProxyData(
-            RTPSWriter* writer,
+    bool process_writer_proxy_data(
+            RTPSWriter* rtps_writer,
             WriterProxyData* wdata) override;
 
     /**
@@ -162,5 +161,4 @@ private:
 } /* namespace rtps */
 } /* namespace eprosima */
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-#endif /* _FASTDDS_RTPS_EDPSTATIC_H_ */
+#endif /* FASTDDS_RTPS_BUILTIN_DISCOVERY_ENDPOINT__EDPSTATIC_H */

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -342,7 +342,7 @@ public:
      * Get a pointer to the EDP object.
      * @return pointer to the EDP object.
      */
-    inline EDP* getEDP()
+    inline EDP* get_edp()
     {
         return mp_EDP;
     }

--- a/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
@@ -43,7 +43,7 @@ DSClientEvent::DSClientEvent(
                 return event();
             }, interval)
     , mp_PDP(p_PDP)
-    , mp_EDP(static_cast<EDPClient*>(mp_PDP->getEDP()))
+    , mp_EDP(static_cast<EDPClient*>(mp_PDP->get_edp()))
 {
 }
 

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -832,13 +832,13 @@ bool WLP::remove_local_writer(
 
 bool WLP::add_local_reader(
         RTPSReader* reader,
-        const fastdds::dds::ReaderQos& rqos)
+        const fastdds::dds::LivelinessQosPolicy& qos)
 {
     auto base_reader = BaseReader::downcast(reader);
 
     std::lock_guard<std::recursive_mutex> guard(*mp_builtinProtocols->mp_PDP->getMutex());
 
-    if (rqos.m_liveliness.kind == dds::AUTOMATIC_LIVELINESS_QOS)
+    if (qos.kind == dds::AUTOMATIC_LIVELINESS_QOS)
     {
         automatic_readers_ = true;
     }

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -618,7 +618,7 @@ void WLP::removeRemoteEndpoints(
 
 bool WLP::add_local_writer(
         RTPSWriter* writer,
-        const fastdds::dds::WriterQos& wqos)
+        const fastdds::dds::LivelinessQosPolicy& qos)
 {
     std::lock_guard<std::recursive_mutex> guard(*mp_builtinProtocols->mp_PDP->getMutex());
 
@@ -626,10 +626,9 @@ bool WLP::add_local_writer(
 
     BaseWriter* base_writer = BaseWriter::downcast(writer);
 
-    double wAnnouncementPeriodMilliSec(fastdds::rtps::TimeConv::Duration_t2MilliSecondsDouble(wqos.m_liveliness.
-                    announcement_period));
+    double wAnnouncementPeriodMilliSec(TimeConv::Duration_t2MilliSecondsDouble(qos.announcement_period));
 
-    if (wqos.m_liveliness.kind == dds::AUTOMATIC_LIVELINESS_QOS )
+    if (qos.kind == dds::AUTOMATIC_LIVELINESS_QOS )
     {
         if (automatic_liveliness_assertion_ == nullptr)
         {
@@ -656,7 +655,7 @@ bool WLP::add_local_writer(
         }
         automatic_writers_.push_back(base_writer);
     }
-    else if (wqos.m_liveliness.kind == dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+    else if (qos.kind == dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
     {
         if (manual_liveliness_assertion_ == nullptr)
         {
@@ -685,21 +684,21 @@ bool WLP::add_local_writer(
 
         if (!pub_liveliness_manager_->add_writer(
                     writer->getGuid(),
-                    wqos.m_liveliness.kind,
-                    wqos.m_liveliness.lease_duration))
+                    qos.kind,
+                    qos.lease_duration))
         {
             EPROSIMA_LOG_ERROR(RTPS_LIVELINESS,
                     "Could not add writer " << writer->getGuid() << " to liveliness manager");
         }
     }
-    else if (wqos.m_liveliness.kind == dds::MANUAL_BY_TOPIC_LIVELINESS_QOS)
+    else if (qos.kind == dds::MANUAL_BY_TOPIC_LIVELINESS_QOS)
     {
         manual_by_topic_writers_.push_back(base_writer);
 
         if (!pub_liveliness_manager_->add_writer(
                     writer->getGuid(),
-                    wqos.m_liveliness.kind,
-                    wqos.m_liveliness.lease_duration))
+                    qos.kind,
+                    qos.lease_duration))
         {
             EPROSIMA_LOG_ERROR(RTPS_LIVELINESS,
                     "Could not add writer " << writer->getGuid() << " to liveliness manager");

--- a/src/cpp/rtps/builtin/liveliness/WLP.hpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.hpp
@@ -109,12 +109,12 @@ public:
     /**
      * Add a local writer to the liveliness protocol.
      * @param writer Pointer to the RTPSWriter.
-     * @param wqos Quality of service policies for the writer.
+     * @param qos Quality of service policies for the writer.
      * @return True if correct.
      */
     bool add_local_writer(
             RTPSWriter* writer,
-            const fastdds::dds::WriterQos& wqos);
+            const fastdds::dds::LivelinessQosPolicy& qos);
     /**
      * Remove a local writer from the liveliness protocol.
      * @param writer Pointer to the RTPSWriter.

--- a/src/cpp/rtps/builtin/liveliness/WLP.hpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.hpp
@@ -125,13 +125,13 @@ public:
 
     /**
      * @brief Adds a local reader to the liveliness protocol
-     * @param reader Pointer to the RTPS reader
-     * @param rqos Quality of service policies for the reader
+     * @param reader  Pointer to the RTPS reader
+     * @param qos     Quality of service policies for the reader
      * @return True if added successfully
      */
     bool add_local_reader(
             RTPSReader* reader,
-            const fastdds::dds::ReaderQos& rqos);
+            const fastdds::dds::LivelinessQosPolicy& qos);
 
     /**
      * @brief Removes a local reader from the livliness protocol

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -77,10 +77,9 @@ uint32_t RTPSParticipant::getRTPSParticipantID() const
 
 bool RTPSParticipant::register_writer(
         RTPSWriter* writer,
-        const PublicationBuiltinTopicData& pub_builtin_data,
-        const fastdds::dds::WriterQos& wqos)
+        const PublicationBuiltinTopicData& pub_builtin_data)
 {
-    return mp_impl->register_writer(writer, pub_builtin_data, wqos);
+    return mp_impl->register_writer(writer, pub_builtin_data);
 }
 
 bool RTPSParticipant::register_reader(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -86,10 +86,9 @@ bool RTPSParticipant::register_writer(
 bool RTPSParticipant::register_reader(
         RTPSReader* reader,
         const SubscriptionBuiltinTopicData& sub_builtin_data,
-        const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return mp_impl->register_reader(reader, sub_builtin_data, rqos, content_filter);
+    return mp_impl->register_reader(reader, sub_builtin_data, content_filter);
 }
 
 void RTPSParticipant::update_attributes(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -85,10 +85,11 @@ bool RTPSParticipant::register_writer(
 
 bool RTPSParticipant::register_reader(
         RTPSReader* reader,
-        const SubscriptionBuiltinTopicData& sub_builtin_data,
+        const TopicDescription& topic,
+        const fastdds::dds::ReaderQos& qos,
         const ContentFilterProperty* content_filter)
 {
-    return mp_impl->register_reader(reader, sub_builtin_data, content_filter);
+    return mp_impl->register_reader(reader, topic, qos, content_filter);
 }
 
 void RTPSParticipant::update_attributes(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -75,12 +75,12 @@ uint32_t RTPSParticipant::getRTPSParticipantID() const
     return mp_impl->getRTPSParticipantID();
 }
 
-bool RTPSParticipant::registerWriter(
-        RTPSWriter* Writer,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipant::register_writer(
+        RTPSWriter* writer,
+        const PublicationBuiltinTopicData& pub_builtin_data,
         const fastdds::dds::WriterQos& wqos)
 {
-    return mp_impl->registerWriter(Writer, topicAtt, wqos);
+    return mp_impl->register_writer(writer, pub_builtin_data, wqos);
 }
 
 bool RTPSParticipant::registerReader(
@@ -98,12 +98,11 @@ void RTPSParticipant::update_attributes(
     mp_impl->update_attributes(patt);
 }
 
-bool RTPSParticipant::updateWriter(
-        RTPSWriter* Writer,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipant::update_writer(
+        RTPSWriter* writer,
         const fastdds::dds::WriterQos& wqos)
 {
-    return mp_impl->updateLocalWriter(Writer, topicAtt, wqos);
+    return mp_impl->update_writer(writer, wqos);
 }
 
 bool RTPSParticipant::updateReader(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -77,9 +77,10 @@ uint32_t RTPSParticipant::getRTPSParticipantID() const
 
 bool RTPSParticipant::register_writer(
         RTPSWriter* writer,
-        const PublicationBuiltinTopicData& pub_builtin_data)
+        const TopicDescription& topic,
+        const fastdds::dds::WriterQos& qos)
 {
-    return mp_impl->register_writer(writer, pub_builtin_data);
+    return mp_impl->register_writer(writer, topic, qos);
 }
 
 bool RTPSParticipant::register_reader(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -83,13 +83,13 @@ bool RTPSParticipant::register_writer(
     return mp_impl->register_writer(writer, pub_builtin_data, wqos);
 }
 
-bool RTPSParticipant::registerReader(
-        RTPSReader* Reader,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipant::register_reader(
+        RTPSReader* reader,
+        const SubscriptionBuiltinTopicData& sub_builtin_data,
         const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return mp_impl->registerReader(Reader, topicAtt, rqos, content_filter);
+    return mp_impl->register_reader(reader, sub_builtin_data, rqos, content_filter);
 }
 
 void RTPSParticipant::update_attributes(
@@ -105,13 +105,12 @@ bool RTPSParticipant::update_writer(
     return mp_impl->update_writer(writer, wqos);
 }
 
-bool RTPSParticipant::updateReader(
-        RTPSReader* Reader,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipant::update_reader(
+        RTPSReader* reader,
         const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return mp_impl->updateLocalReader(Reader, topicAtt, rqos, content_filter);
+    return mp_impl->update_reader(reader, rqos, content_filter);
 }
 
 std::vector<std::string> RTPSParticipant::getParticipantNames() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1406,9 +1406,10 @@ void RTPSParticipantImpl::disableReader(
 
 bool RTPSParticipantImpl::register_writer(
         RTPSWriter* rtps_writer,
-        const PublicationBuiltinTopicData& pub_builtin_data)
+        const TopicDescription& topic,
+        const fastdds::dds::WriterQos& qos)
 {
-    return this->mp_builtinProtocols->add_writer(rtps_writer, pub_builtin_data);
+    return this->mp_builtinProtocols->add_writer(rtps_writer, topic, qos);
 }
 
 bool RTPSParticipantImpl::register_reader(
@@ -2876,9 +2877,10 @@ const fastdds::statistics::rtps::IStatusObserver* RTPSParticipantImpl::create_mo
                     return this->createWriter(WriterOut, param, hist, listen, entityId, isBuiltin);
                 },
                 [&](RTPSWriter* w,
-                const PublicationBuiltinTopicData& pub_builtin_data) -> bool
+                const TopicDescription& topic,
+                const fastdds::dds::WriterQos& qos) -> bool
                 {
-                    return this->register_writer(w, pub_builtin_data);
+                    return this->register_writer(w, topic, qos);
                 },
                 getEventResource()
                 ));

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1406,10 +1406,9 @@ void RTPSParticipantImpl::disableReader(
 
 bool RTPSParticipantImpl::register_writer(
         RTPSWriter* rtps_writer,
-        const PublicationBuiltinTopicData& pub_builtin_data,
-        const fastdds::dds::WriterQos& wqos)
+        const PublicationBuiltinTopicData& pub_builtin_data)
 {
-    return this->mp_builtinProtocols->add_writer(rtps_writer, pub_builtin_data, wqos);
+    return this->mp_builtinProtocols->add_writer(rtps_writer, pub_builtin_data);
 }
 
 bool RTPSParticipantImpl::register_reader(
@@ -2878,9 +2877,9 @@ const fastdds::statistics::rtps::IStatusObserver* RTPSParticipantImpl::create_mo
                 },
                 [&](RTPSWriter* w,
                 const PublicationBuiltinTopicData& pub_builtin_data,
-                const fastdds::dds::WriterQos& wqos) -> bool
+                const fastdds::dds::WriterQos& /*wqos*/) -> bool
                 {
-                    return this->register_writer(w, pub_builtin_data, wqos);
+                    return this->register_writer(w, pub_builtin_data);
                 },
                 getEventResource()
                 ));

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1415,10 +1415,9 @@ bool RTPSParticipantImpl::register_writer(
 bool RTPSParticipantImpl::register_reader(
         RTPSReader* rtps_reader,
         const SubscriptionBuiltinTopicData& sub_builtin_data,
-        const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return this->mp_builtinProtocols->add_reader(rtps_reader, sub_builtin_data, rqos, content_filter);
+    return this->mp_builtinProtocols->add_reader(rtps_reader, sub_builtin_data, content_filter);
 }
 
 void RTPSParticipantImpl::update_attributes(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2876,8 +2876,7 @@ const fastdds::statistics::rtps::IStatusObserver* RTPSParticipantImpl::create_mo
                     return this->createWriter(WriterOut, param, hist, listen, entityId, isBuiltin);
                 },
                 [&](RTPSWriter* w,
-                const PublicationBuiltinTopicData& pub_builtin_data,
-                const fastdds::dds::WriterQos& /*wqos*/) -> bool
+                const PublicationBuiltinTopicData& pub_builtin_data) -> bool
                 {
                     return this->register_writer(w, pub_builtin_data);
                 },

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1414,10 +1414,11 @@ bool RTPSParticipantImpl::register_writer(
 
 bool RTPSParticipantImpl::register_reader(
         RTPSReader* rtps_reader,
-        const SubscriptionBuiltinTopicData& sub_builtin_data,
+        const TopicDescription& topic,
+        const fastdds::dds::ReaderQos& qos,
         const ContentFilterProperty* content_filter)
 {
-    return this->mp_builtinProtocols->add_reader(rtps_reader, sub_builtin_data, content_filter);
+    return this->mp_builtinProtocols->add_reader(rtps_reader, topic, qos, content_filter);
 }
 
 void RTPSParticipantImpl::update_attributes(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1412,13 +1412,13 @@ bool RTPSParticipantImpl::register_writer(
     return this->mp_builtinProtocols->add_writer(rtps_writer, pub_builtin_data, wqos);
 }
 
-bool RTPSParticipantImpl::registerReader(
-        RTPSReader* reader,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipantImpl::register_reader(
+        RTPSReader* rtps_reader,
+        const SubscriptionBuiltinTopicData& sub_builtin_data,
         const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return this->mp_builtinProtocols->addLocalReader(reader, topicAtt, rqos, content_filter);
+    return this->mp_builtinProtocols->add_reader(rtps_reader, sub_builtin_data, rqos, content_filter);
 }
 
 void RTPSParticipantImpl::update_attributes(
@@ -1613,13 +1613,12 @@ bool RTPSParticipantImpl::update_writer(
     return this->mp_builtinProtocols->update_writer(rtps_writer, wqos);
 }
 
-bool RTPSParticipantImpl::updateLocalReader(
-        RTPSReader* reader,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipantImpl::update_reader(
+        RTPSReader* rtps_reader,
         const fastdds::dds::ReaderQos& rqos,
         const ContentFilterProperty* content_filter)
 {
-    return this->mp_builtinProtocols->updateLocalReader(reader, topicAtt, rqos, content_filter);
+    return this->mp_builtinProtocols->update_reader(rtps_reader, rqos, content_filter);
 }
 
 /*
@@ -2014,7 +2013,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
     {
         if (found_in_users)
         {
-            mp_builtinProtocols->removeLocalReader(static_cast<RTPSReader*>(p_endpoint));
+            mp_builtinProtocols->remove_reader(static_cast<RTPSReader*>(p_endpoint));
         }
 
 #if HAVE_SECURITY
@@ -2090,7 +2089,7 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
             {
                 return kind == WRITER
                        ? mp_builtinProtocols->remove_writer((RTPSWriter*)p)
-                       : mp_builtinProtocols->removeLocalReader((RTPSReader*)p);
+                       : mp_builtinProtocols->remove_reader((RTPSReader*)p);
             };
 
 #if HAVE_SECURITY

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1404,12 +1404,12 @@ void RTPSParticipantImpl::disableReader(
     m_receiverResourcelistMutex.unlock();
 }
 
-bool RTPSParticipantImpl::registerWriter(
-        RTPSWriter* Writer,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipantImpl::register_writer(
+        RTPSWriter* rtps_writer,
+        const PublicationBuiltinTopicData& pub_builtin_data,
         const fastdds::dds::WriterQos& wqos)
 {
-    return this->mp_builtinProtocols->addLocalWriter(Writer, topicAtt, wqos);
+    return this->mp_builtinProtocols->add_writer(rtps_writer, pub_builtin_data, wqos);
 }
 
 bool RTPSParticipantImpl::registerReader(
@@ -1606,12 +1606,11 @@ void RTPSParticipantImpl::update_attributes(
     }
 }
 
-bool RTPSParticipantImpl::updateLocalWriter(
-        RTPSWriter* Writer,
-        const TopicAttributes& topicAtt,
+bool RTPSParticipantImpl::update_writer(
+        RTPSWriter* rtps_writer,
         const fastdds::dds::WriterQos& wqos)
 {
-    return this->mp_builtinProtocols->updateLocalWriter(Writer, topicAtt, wqos);
+    return this->mp_builtinProtocols->update_writer(rtps_writer, wqos);
 }
 
 bool RTPSParticipantImpl::updateLocalReader(
@@ -2000,7 +1999,7 @@ bool RTPSParticipantImpl::deleteUserEndpoint(
     {
         if (found_in_users)
         {
-            mp_builtinProtocols->removeLocalWriter(static_cast<RTPSWriter*>(p_endpoint));
+            mp_builtinProtocols->remove_writer(static_cast<RTPSWriter*>(p_endpoint));
         }
 
 #if HAVE_SECURITY
@@ -2090,7 +2089,7 @@ void RTPSParticipantImpl::deleteAllUserEndpoints()
     auto removeEndpoint = [this](EndpointKind_t kind, Endpoint* p)
             {
                 return kind == WRITER
-                       ? mp_builtinProtocols->removeLocalWriter((RTPSWriter*)p)
+                       ? mp_builtinProtocols->remove_writer((RTPSWriter*)p)
                        : mp_builtinProtocols->removeLocalReader((RTPSReader*)p);
             };
 
@@ -2880,10 +2879,10 @@ const fastdds::statistics::rtps::IStatusObserver* RTPSParticipantImpl::create_mo
                     return this->createWriter(WriterOut, param, hist, listen, entityId, isBuiltin);
                 },
                 [&](RTPSWriter* w,
-                const fastdds::TopicAttributes& topicAtt,
+                const PublicationBuiltinTopicData& pub_builtin_data,
                 const fastdds::dds::WriterQos& wqos) -> bool
                 {
-                    return this->registerWriter(w, topicAtt, wqos);
+                    return this->register_writer(w, pub_builtin_data, wqos);
                 },
                 getEventResource()
                 ));

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -113,6 +113,7 @@ class MessageReceiver;
 namespace rtps {
 
 struct PublicationBuiltinTopicData;
+struct TopicDescription;
 class RTPSParticipant;
 class RTPSParticipantListener;
 class BuiltinProtocols;
@@ -895,13 +896,17 @@ public:
 
     /**
      * Register a Writer in the BuiltinProtocols.
-     * @param Writer Pointer to the RTPSWriter.
-     * @param pub_builtin_data Contains the discovery information of the writer.
+     *
+     * @param Writer  Pointer to the RTPSWriter.
+     * @param topic   Information regarding the topic where the writer is registering.
+     * @param qos     Qos policies of the writer.
+     *
      * @return True if correctly registered.
      */
     bool register_writer(
             RTPSWriter* Writer,
-            const PublicationBuiltinTopicData& pub_builtin_data);
+            const TopicDescription& topic,
+            const fastdds::dds::WriterQos& qos);
 
     /**
      * Register a Reader in the BuiltinProtocols.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -910,14 +910,18 @@ public:
 
     /**
      * Register a Reader in the BuiltinProtocols.
-     * @param Reader           Pointer to the RTPSReader.
-     * @param sub_builtin_data Contains the discovery information of the reader.
-     * @param content_filter   Optional content filtering information.
+     *
+     * @param Reader          Pointer to the RTPSReader.
+     * @param topic           Information regarding the topic where the reader is registering.
+     * @param qos             Qos policies of the reader.
+     * @param content_filter  Optional content filtering information.
+     *
      * @return True if correctly registered.
      */
     bool register_reader(
             RTPSReader* Reader,
-            const SubscriptionBuiltinTopicData& sub_builtin_data,
+            const TopicDescription& topic,
+            const fastdds::dds::ReaderQos& qos,
             const ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -897,13 +897,11 @@ public:
      * Register a Writer in the BuiltinProtocols.
      * @param Writer Pointer to the RTPSWriter.
      * @param pub_builtin_data Contains the discovery information of the writer.
-     * @param wqos WriterQos.
      * @return True if correctly registered.
      */
     bool register_writer(
             RTPSWriter* Writer,
-            const PublicationBuiltinTopicData& pub_builtin_data,
-            const fastdds::dds::WriterQos& wqos);
+            const PublicationBuiltinTopicData& pub_builtin_data);
 
     /**
      * Register a Reader in the BuiltinProtocols.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -108,7 +108,6 @@ class TypeLookupManager;
 
 namespace fastdds {
 
-class TopicAttributes;
 class MessageReceiver;
 
 namespace rtps {
@@ -897,59 +896,55 @@ public:
     /**
      * Register a Writer in the BuiltinProtocols.
      * @param Writer Pointer to the RTPSWriter.
-     * @param topicAtt TopicAttributes of the Writer.
+     * @param pub_builtin_data Contains the discovery information of the writer.
      * @param wqos WriterQos.
      * @return True if correctly registered.
      */
-    bool registerWriter(
+    bool register_writer(
             RTPSWriter* Writer,
-            const TopicAttributes& topicAtt,
+            const PublicationBuiltinTopicData& pub_builtin_data,
             const fastdds::dds::WriterQos& wqos);
 
     /**
      * Register a Reader in the BuiltinProtocols.
-     * @param Reader          Pointer to the RTPSReader.
-     * @param topicAtt        TopicAttributes of the Reader.
-     * @param rqos            ReaderQos.
-     * @param content_filter  Optional content filtering information.
+     * @param Reader           Pointer to the RTPSReader.
+     * @param sub_builtin_data Contains the discovery information of the reader.
+     * @param rqos             ReaderQos.
+     * @param content_filter   Optional content filtering information.
      * @return True if correctly registered.
      */
-    bool registerReader(
+    bool register_reader(
             RTPSReader* Reader,
-            const TopicAttributes& topicAtt,
+            const SubscriptionBuiltinTopicData& sub_builtin_data,
             const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 
     /**
      * Update participant attributes.
      * @param patt New participant attributes.
-     * @return True on success, false otherwise.
      */
     void update_attributes(
             const RTPSParticipantAttributes& patt);
 
     /**
      * Update local writer QoS
-     * @param Writer Writer to update
-     * @param wqos New QoS for the writer
+     * @param rtps_writer Writer to update.
+     * @param wqos        New QoS for the writer.
      * @return True on success
      */
-    bool updateLocalWriter(
-            RTPSWriter* Writer,
-            const TopicAttributes& topicAtt,
+    bool update_writer(
+            RTPSWriter* rtps_writer,
             const fastdds::dds::WriterQos& wqos);
 
     /**
      * Update local reader QoS
-     * @param Reader          Reader to update
-     * @param topicAtt        TopicAttributes of the Reader.
-     * @param rqos            New QoS for the reader
-     * @param content_filter  Optional content filtering information.
+     * @param rtps_reader      Reader to update.
+     * @param rqos             New QoS for the reader.
+     * @param content_filter   Optional content filtering information.
      * @return True on success
      */
-    bool updateLocalReader(
-            RTPSReader* Reader,
-            const TopicAttributes& topicAtt,
+    bool update_reader(
+            RTPSReader* rtps_reader,
             const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -909,14 +909,12 @@ public:
      * Register a Reader in the BuiltinProtocols.
      * @param Reader           Pointer to the RTPSReader.
      * @param sub_builtin_data Contains the discovery information of the reader.
-     * @param rqos             ReaderQos.
      * @param content_filter   Optional content filtering information.
      * @return True if correctly registered.
      */
     bool register_reader(
             RTPSReader* Reader,
             const SubscriptionBuiltinTopicData& sub_builtin_data,
-            const fastdds::dds::ReaderQos& rqos,
             const ContentFilterProperty* content_filter = nullptr);
 
     /**

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -4069,13 +4069,13 @@ bool SecurityManager::participant_authorized(
 
         for (auto& remote_reader : temp_readers)
         {
-            participant_->pdp()->getEDP()->pairing_reader_proxy_with_local_writer(remote_reader.second,
+            participant_->pdp()->get_edp()->pairing_reader_proxy_with_local_writer(remote_reader.second,
                     participant_data.m_guid, remote_reader.first);
         }
 
         for (auto& remote_writer : temp_writers)
         {
-            participant_->pdp()->getEDP()->pairing_writer_proxy_with_local_reader(remote_writer.second,
+            participant_->pdp()->get_edp()->pairing_writer_proxy_with_local_reader(remote_writer.second,
                     participant_data.m_guid, remote_writer.first);
         }
 

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
@@ -18,6 +18,8 @@
 
 #include <statistics/rtps/monitor-service/MonitorService.hpp>
 
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
+
 #include <fastdds/publisher/DataWriterHistory.hpp>
 #include <fastdds/statistics/topic_names.hpp>
 
@@ -482,14 +484,17 @@ bool MonitorService::create_endpoint()
     {
         status_writer_ = dynamic_cast<StatefulWriter*>(tmp_writer);
 
-        // Register the writer in the participant
-        PublicationBuiltinTopicData pub_builtin_data;
-        pub_builtin_data.reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        pub_builtin_data.durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-        pub_builtin_data.topic_name = MONITOR_SERVICE_TOPIC;
-        pub_builtin_data.type_name = type_.get_name();
+        //! Register the writer in the participant
+        fastdds::dds::WriterQos wqos;
 
-        endpoint_registrator_(status_writer_, pub_builtin_data);
+        wqos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        wqos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+
+        TopicDescription topic_desc;
+        topic_desc.topic_name = MONITOR_SERVICE_TOPIC;
+        topic_desc.type_name = type_.get_name();
+
+        endpoint_registrator_(status_writer_, topic_desc, wqos);
     }
     else
     {

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
@@ -482,17 +482,14 @@ bool MonitorService::create_endpoint()
     {
         status_writer_ = dynamic_cast<StatefulWriter*>(tmp_writer);
 
-        //! Register the writer in the participant
-        fastdds::dds::WriterQos wqos;
-
-        wqos.m_reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
-        wqos.m_durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
-
+        // Register the writer in the participant
         PublicationBuiltinTopicData pub_builtin_data;
+        pub_builtin_data.reliability.kind = dds::RELIABLE_RELIABILITY_QOS;
+        pub_builtin_data.durability.kind = dds::TRANSIENT_LOCAL_DURABILITY_QOS;
         pub_builtin_data.topic_name = MONITOR_SERVICE_TOPIC;
         pub_builtin_data.type_name = type_.get_name();
 
-        endpoint_registrator_(status_writer_, pub_builtin_data, wqos);
+        endpoint_registrator_(status_writer_, pub_builtin_data);
     }
     else
     {

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -82,8 +82,7 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
-                        const fastdds::dds::WriterQos&)>;
+                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&)>;
 
     MonitorService(
             const fastdds::rtps::GUID_t& guid,

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
+#include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 
@@ -81,7 +82,7 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const fastdds::TopicAttributes&,
+                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
                         const fastdds::dds::WriterQos&)>;
 
     MonitorService(

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
-#include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 
@@ -82,7 +82,8 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&)>;
+                        const eprosima::fastdds::rtps::TopicDescription&,
+                        const eprosima::fastdds::dds::WriterQos&)>;
 
     MonitorService(
             const fastdds::rtps::GUID_t& guid,

--- a/src/cpp/utils/BuiltinTopicKeyConversions.hpp
+++ b/src/cpp/utils/BuiltinTopicKeyConversions.hpp
@@ -26,65 +26,21 @@ namespace rtps {
 
 typedef uint32_t BuiltinTopicKeyValue[3];
 
-inline void from_proxy_to_builtin(
+void from_proxy_to_builtin(
         const EntityId_t& entity_id,
-        BuiltinTopicKeyValue& builtin_key_value)
-{
-    builtin_key_value[0] = 0;
-    builtin_key_value[1] = 0;
-    builtin_key_value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
-            | static_cast<uint32_t>(entity_id.value[1]) << 16
-            | static_cast<uint32_t>(entity_id.value[2]) << 8
-            | static_cast<uint32_t>(entity_id.value[3]);
-}
+        BuiltinTopicKeyValue& builtin_key_value);
 
-inline void from_proxy_to_builtin(
+void from_proxy_to_builtin(
         const GuidPrefix_t& guid_prefix,
-        BuiltinTopicKeyValue& dds_key)
-{
-    dds_key[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[3]);
-    dds_key[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[7]);
-    dds_key[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[11]);
-}
+        BuiltinTopicKeyValue& dds_key);
 
-inline void from_builtin_to_proxy(
+void from_builtin_to_proxy(
         const BuiltinTopicKeyValue& dds_key,
-        EntityId_t& entity_id)
-{
-    entity_id.value[0] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
-    entity_id.value[1] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
-    entity_id.value[2] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
-    entity_id.value[3] = static_cast<uint8_t>(dds_key[2] & 0xFF);
-}
+        EntityId_t& entity_id);
 
-inline void from_builtin_to_proxy(
+void from_builtin_to_proxy(
         const BuiltinTopicKeyValue& dds_key,
-        GuidPrefix_t& guid_prefix)
-{
-    guid_prefix.value[0] = static_cast<uint8_t>((dds_key[0] >> 24) & 0xFF);
-    guid_prefix.value[1] = static_cast<uint8_t>((dds_key[0] >> 16) & 0xFF);
-    guid_prefix.value[2] = static_cast<uint8_t>((dds_key[0] >> 8) & 0xFF);
-    guid_prefix.value[3] = static_cast<uint8_t>(dds_key[0] & 0xFF);
-
-    guid_prefix.value[4] = static_cast<uint8_t>((dds_key[1] >> 24) & 0xFF);
-    guid_prefix.value[5] = static_cast<uint8_t>((dds_key[1] >> 16) & 0xFF);
-    guid_prefix.value[6] = static_cast<uint8_t>((dds_key[1] >> 8) & 0xFF);
-    guid_prefix.value[7] = static_cast<uint8_t>(dds_key[1] & 0xFF);
-
-    guid_prefix.value[8] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
-    guid_prefix.value[9] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
-    guid_prefix.value[10] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
-    guid_prefix.value[11] = static_cast<uint8_t>(dds_key[2] & 0xFF);
-}
+        GuidPrefix_t& guid_prefix);
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/utils/BuiltinTopicKeyConversions.hpp
+++ b/src/cpp/utils/BuiltinTopicKeyConversions.hpp
@@ -1,0 +1,91 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file BuiltinTopicKeyConversions.hpp
+ */
+
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/GuidPrefix_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+typedef uint32_t BuiltinTopicKeyValue[3];
+
+inline void from_proxy_to_builtin(
+        const EntityId_t& entity_id,
+        BuiltinTopicKeyValue& builtin_key_value)
+{
+    builtin_key_value[0] = 0;
+    builtin_key_value[1] = 0;
+    builtin_key_value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+inline void from_proxy_to_builtin(
+        const GuidPrefix_t& guid_prefix,
+        BuiltinTopicKeyValue& dds_key)
+{
+    dds_key[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    dds_key[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    dds_key[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
+
+inline void from_builtin_to_proxy(
+        const BuiltinTopicKeyValue& dds_key,
+        EntityId_t& entity_id)
+{
+    entity_id.value[0] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
+    entity_id.value[1] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
+    entity_id.value[2] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
+    entity_id.value[3] = static_cast<uint8_t>(dds_key[2] & 0xFF);
+}
+
+inline void from_builtin_to_proxy(
+        const BuiltinTopicKeyValue& dds_key,
+        GuidPrefix_t& guid_prefix)
+{
+    guid_prefix.value[0] = static_cast<uint8_t>((dds_key[0] >> 24) & 0xFF);
+    guid_prefix.value[1] = static_cast<uint8_t>((dds_key[0] >> 16) & 0xFF);
+    guid_prefix.value[2] = static_cast<uint8_t>((dds_key[0] >> 8) & 0xFF);
+    guid_prefix.value[3] = static_cast<uint8_t>(dds_key[0] & 0xFF);
+
+    guid_prefix.value[4] = static_cast<uint8_t>((dds_key[1] >> 24) & 0xFF);
+    guid_prefix.value[5] = static_cast<uint8_t>((dds_key[1] >> 16) & 0xFF);
+    guid_prefix.value[6] = static_cast<uint8_t>((dds_key[1] >> 8) & 0xFF);
+    guid_prefix.value[7] = static_cast<uint8_t>(dds_key[1] & 0xFF);
+
+    guid_prefix.value[8] = static_cast<uint8_t>((dds_key[2] >> 24) & 0xFF);
+    guid_prefix.value[9] = static_cast<uint8_t>((dds_key[2] >> 16) & 0xFF);
+    guid_prefix.value[10] = static_cast<uint8_t>((dds_key[2] >> 8) & 0xFF);
+    guid_prefix.value[11] = static_cast<uint8_t>(dds_key[2] & 0xFF);
+}
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima

--- a/src/cpp/xmlparser/XMLProfileManager.h
+++ b/src/cpp/xmlparser/XMLProfileManager.h
@@ -27,6 +27,7 @@
 #include <xmlparser/attributes/ParticipantAttributes.hpp>
 #include <xmlparser/attributes/PublisherAttributes.hpp>
 #include <xmlparser/attributes/SubscriberAttributes.hpp>
+#include <xmlparser/attributes/TopicAttributes.hpp>
 #include <xmlparser/XMLParser.h>
 #include <xmlparser/XMLParserCommon.h>
 

--- a/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
@@ -24,10 +24,11 @@
 #include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
 #include <fastdds/rtps/common/Locator.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
+
+#include <xmlparser/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -61,7 +62,7 @@ public:
     }
 
     //! Topic Attributes for the Publisher
-    fastdds::TopicAttributes topic;
+    fastdds::xmlparser::TopicAttributes topic;
 
     //! QOS for the Publisher
     dds::WriterQos qos;

--- a/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
@@ -24,9 +24,10 @@
 #include <fastdds/rtps/attributes/PropertyPolicy.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/Locator.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
+
+#include <xmlparser/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -41,7 +42,7 @@ class SubscriberAttributes
 public:
 
     //! Topic Attributes
-    fastdds::TopicAttributes topic;
+    fastdds::xmlparser::TopicAttributes topic;
 
     //! Reader QOs.
     dds::ReaderQos qos;

--- a/src/cpp/xmlparser/attributes/TopicAttributes.cpp
+++ b/src/cpp/xmlparser/attributes/TopicAttributes.cpp
@@ -16,11 +16,13 @@
  * @file TopicAttributes.cpp
  */
 
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/dds/log/Log.hpp>
+
+#include <xmlparser/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {
+namespace xmlparser {
 
 bool TopicAttributes::checkQos() const
 {
@@ -72,5 +74,6 @@ bool TopicAttributes::checkQos() const
     return true;
 }
 
+}  // namespave xmlparser
 }  // namespace fastdds
 }  // namespace eprosima

--- a/src/cpp/xmlparser/attributes/TopicAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/TopicAttributes.hpp
@@ -16,8 +16,8 @@
  * @file TopicAttributes.hpp
  */
 
-#ifndef FASTDDS_RTPS_ATTRIBUTES__TOPICATTRIBUTES_HPP
-#define FASTDDS_RTPS_ATTRIBUTES__TOPICATTRIBUTES_HPP
+#ifndef FASTDDS_XMLPARSER_ATTRIBUTES__TOPICATTRIBUTES_HPP
+#define FASTDDS_XMLPARSER_ATTRIBUTES__TOPICATTRIBUTES_HPP
 
 #include <string>
 
@@ -26,9 +26,10 @@
 
 namespace eprosima {
 namespace fastdds {
+namespace xmlparser {
 
 /**
- * Class TopicAttributes, used by the user to define the attributes of the topic associated with a Publisher or Subscriber.
+ * Class TopicAttributes, used to define the attributes of the topic associated with a Publisher or Subscriber.
  * @ingroup FASTDDS_ATTRIBUTES_MODULE
  */
 class TopicAttributes
@@ -120,8 +121,6 @@ public:
     bool checkQos() const;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-
 /**
  * Check if two topic attributes are not equal
  * @param t1 First instance of TopicAttributes to compare
@@ -143,9 +142,8 @@ bool inline operator !=(
     return false;
 }
 
-#endif // ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
-
+} // namespace xmlparser
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // FASTDDS_RTPS_ATTRIBUTES__TOPICATTRIBUTES_HPP
+#endif // FASTDDS_XMLPARSER_ATTRIBUTES__TOPICATTRIBUTES_HPP

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -807,7 +807,6 @@ TEST(RTPS, MultithreadedWriterCreation)
                 /* Create writer history */
                 eprosima::fastdds::rtps::HistoryAttributes hattr;
                 eprosima::fastdds::rtps::WriterHistory* history = new eprosima::fastdds::rtps::WriterHistory(hattr);
-                eprosima::fastdds::TopicAttributes topic_attr;
 
                 /* Create writer with a flow controller */
                 eprosima::fastdds::rtps::WriterAttributes writer_attr;
@@ -816,9 +815,12 @@ TEST(RTPS, MultithreadedWriterCreation)
                 eprosima::fastdds::rtps::RTPSWriter*  writer = eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter(
                     rtps_participant, writer_attr, history, nullptr);
 
+                PublicationBuiltinTopicData pub_builtin_data;
+                pub_builtin_data.type_name = "string";
+                pub_builtin_data.topic_name = "test_topic";
                 /* Register writer in participant */
                 eprosima::fastdds::dds::WriterQos writer_qos;
-                ASSERT_EQ(rtps_participant->registerWriter(writer, topic_attr, writer_qos), true);
+                ASSERT_EQ(rtps_participant->register_writer(writer, pub_builtin_data, writer_qos), true);
 
                 {
                     /* Wait for test completion request */

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -819,8 +819,7 @@ TEST(RTPS, MultithreadedWriterCreation)
                 pub_builtin_data.type_name = "string";
                 pub_builtin_data.topic_name = "test_topic";
                 /* Register writer in participant */
-                eprosima::fastdds::dds::WriterQos writer_qos;
-                ASSERT_EQ(rtps_participant->register_writer(writer, pub_builtin_data, writer_qos), true);
+                ASSERT_EQ(rtps_participant->register_writer(writer, pub_builtin_data), true);
 
                 {
                     /* Wait for test completion request */

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -21,6 +21,7 @@
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/LibrarySettings.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/common/CDRMessage_t.hpp>
 #include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
 #include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
@@ -815,11 +816,12 @@ TEST(RTPS, MultithreadedWriterCreation)
                 eprosima::fastdds::rtps::RTPSWriter*  writer = eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter(
                     rtps_participant, writer_attr, history, nullptr);
 
-                PublicationBuiltinTopicData pub_builtin_data;
-                pub_builtin_data.type_name = "string";
-                pub_builtin_data.topic_name = "test_topic";
+                TopicDescription topic_desc;
+                topic_desc.type_name = "string";
+                topic_desc.topic_name = "test_topic";
                 /* Register writer in participant */
-                ASSERT_EQ(rtps_participant->register_writer(writer, pub_builtin_data), true);
+                eprosima::fastdds::dds::WriterQos writer_qos;
+                ASSERT_EQ(rtps_participant->register_writer(writer, topic_desc, writer_qos), true);
 
                 {
                     /* Wait for test completion request */

--- a/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
@@ -433,7 +433,7 @@ TEST_P(RTPSDiscovery, WriterListenerOnReaderDiscoveryIncompatibleQoS)
 }
 
 /*!
- * \test RTPS-CFT-RRR-01 Tests a good `ContentFilterProperty` passed to `registerReader()` and `updateReader()` is
+ * \test RTPS-CFT-RRR-01 Tests a good `ContentFilterProperty` passed to `register_reader()` and `update_reader()` is
  * propagated successfully through discovery.
  */
 TEST_P(RTPSDiscovery, ContentFilterRegistration)
@@ -528,7 +528,7 @@ TEST_P(RTPSDiscovery, ContentFilterRegistration)
 }
 
 /*!
- * \test RTPS-CFT-RRR-02 Tests a wrong `ContentFilterProperty` passed to `registerReader()` makes the function fail.
+ * \test RTPS-CFT-RRR-02 Tests a wrong `ContentFilterProperty` passed to `register_reader()` makes the function fail.
  */
 TEST_P(RTPSDiscovery, ContentFilterWrongRegistration)
 {
@@ -630,7 +630,7 @@ TEST_P(RTPSDiscovery, ContentFilterWrongRegistration)
 }
 
 /*!
- * \test RTPS-CFT-RRR-03 Tests a wrong `ContentFilterProperty` passed to `updateReader()` makes the function fail.
+ * \test RTPS-CFT-RRR-03 Tests a wrong `ContentFilterProperty` passed to `update_reader()` makes the function fail.
  */
 TEST_P(RTPSDiscovery, ContentFilterWrongUpdate)
 {
@@ -747,7 +747,7 @@ TEST_P(RTPSDiscovery, ContentFilterWrongUpdate)
 }
 
 /*!
- * \test RTPS-CFT-RRR-04 Tests `registerReader()` and `updateReader()` works successfully when the pointer to
+ * \test RTPS-CFT-RRR-04 Tests `register_reader()` and `update_reader()` works successfully when the pointer to
  * `ContentFilterProperty` is `nullptr`.
  */
 TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFP)
@@ -830,8 +830,8 @@ TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFP)
 }
 
 /*!
- * \test RTPS-CFT-RRR_05 Tests ``updateReader()` works successfully when a `ContentFilterProperty` is added for first
- * time, because `registerReader()` passed a `nullptr`.
+ * \test RTPS-CFT-RRR_05 Tests ``update_reader()` works successfully when a `ContentFilterProperty` is added for first
+ * time, because `register_reader()` passed a `nullptr`.
  */
 TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFPButUpdate)
 {

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -193,7 +193,7 @@ public:
             return;
         }
 
-        initialized_ = participant_->register_reader(reader_, sub_builtin_data_, reader_qos_, content_filter_property_);
+        initialized_ = participant_->register_reader(reader_, sub_builtin_data_, content_filter_property_);
     }
 
     void update()

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -448,6 +448,7 @@ public:
         {
             reader_qos_.m_reliability.kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;
         }
+        sub_builtin_data_.reliability = reader_qos_.m_reliability;
 
         return *this;
     }
@@ -457,6 +458,7 @@ public:
     {
         reader_attr_.endpoint.durabilityKind = kind;
         reader_qos_.m_durability.durabilityKind(kind);
+        sub_builtin_data_.durability = reader_qos_.m_durability;
 
         return *this;
     }
@@ -518,6 +520,7 @@ public:
             const std::vector<eprosima::fastdds::rtps::octet>& user_data)
     {
         reader_qos_.m_userData = user_data;
+        sub_builtin_data_.user_data = reader_qos_.m_userData;
         return *this;
     }
 
@@ -532,6 +535,7 @@ public:
             std::vector<std::string>& partitions)
     {
         reader_qos_.m_partition.setNames(partitions);
+        sub_builtin_data_.partition = reader_qos_.m_partition;
         return *this;
     }
 

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -193,7 +193,11 @@ public:
             return;
         }
 
-        initialized_ = participant_->register_reader(reader_, sub_builtin_data_, content_filter_property_);
+        eprosima::fastdds::rtps::TopicDescription topic_desc;
+        topic_desc.topic_name = sub_builtin_data_.topic_name;
+        topic_desc.type_name = sub_builtin_data_.type_name;
+
+        initialized_ = participant_->register_reader(reader_, topic_desc, reader_qos_, content_filter_property_);
     }
 
     void update()

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -35,6 +35,7 @@
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/reader/ReaderListener.hpp>

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -34,7 +34,7 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
+#include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/reader/ReaderListener.hpp>
@@ -140,11 +140,11 @@ public:
         , receiving_(false)
         , matched_(0)
     {
-        topic_attr_.topicDataType = type_.get_name();
+        sub_builtin_data_.type_name = type_.get_name();
         // Generate topic name
         std::ostringstream t;
         t << topic_name << "_" << asio::ip::host_name() << "_" << GET_PID();
-        topic_attr_.topicName = t.str();
+        sub_builtin_data_.topic_name = t.str();
 
         // By default, heartbeat period delay is 100 milliseconds.
         reader_attr_.times.heartbeat_response_delay.seconds = 0;
@@ -193,7 +193,7 @@ public:
             return;
         }
 
-        initialized_ = participant_->registerReader(reader_, topic_attr_, reader_qos_, content_filter_property_);
+        initialized_ = participant_->register_reader(reader_, sub_builtin_data_, reader_qos_, content_filter_property_);
     }
 
     void update()
@@ -203,7 +203,7 @@ public:
             return;
         }
 
-        initialized_ = participant_->updateReader(reader_, topic_attr_, reader_qos_, content_filter_property_);
+        initialized_ = participant_->update_reader(reader_, reader_qos_, content_filter_property_);
     }
 
     bool isInitialized() const
@@ -430,7 +430,8 @@ public:
     RTPSWithRegistrationReader& history_depth(
             const int32_t depth)
     {
-        topic_attr_.historyQos.depth = depth;
+        hattr_.maximumReservedCaches = depth;
+        hattr_.initialReservedCaches = std::min(hattr_.initialReservedCaches, depth);
         return *this;
     }
 
@@ -627,7 +628,7 @@ private:
     bool destroy_participant_{false};
     eprosima::fastdds::rtps::RTPSReader* reader_;
     eprosima::fastdds::rtps::ReaderAttributes reader_attr_;
-    eprosima::fastdds::TopicAttributes topic_attr_;
+    eprosima::fastdds::rtps::SubscriptionBuiltinTopicData sub_builtin_data_;
     eprosima::fastdds::dds::ReaderQos reader_qos_;
     eprosima::fastdds::rtps::ReaderHistory* history_;
     eprosima::fastdds::rtps::HistoryAttributes hattr_;

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -182,7 +182,7 @@ public:
             return;
         }
 
-        TopicDescription topic_desc;
+        eprosima::fastdds::rtps::TopicDescription topic_desc;
         topic_desc.type_name = type_.get_name();
         topic_desc.topic_name = pub_builtin_data_.topic_name;
         ASSERT_EQ(participant_->register_writer(writer_, topic_desc, writer_qos_), true);

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -178,7 +178,7 @@ public:
             return;
         }
 
-        ASSERT_EQ(participant_->register_writer(writer_, pub_builtin_data_, writer_qos_), true);
+        ASSERT_EQ(participant_->register_writer(writer_, pub_builtin_data_), true);
 
         initialized_ = true;
     }

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -130,6 +130,9 @@ public:
         t << topic_name << "_" << asio::ip::host_name() << "_" << GET_PID();
         pub_builtin_data_.topic_name = t.str();
 
+        // The tests are assuming a default durability of TRANSIENT_LOCAL, which is not the default mandated by the DDS standard.
+        pub_builtin_data_.durability.kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+
         // By default, heartbeat period and nack response delay are 100 milliseconds.
         writer_attr_.times.heartbeat_period.seconds = 0;
         writer_attr_.times.heartbeat_period.nanosec = 100000000;
@@ -393,6 +396,7 @@ public:
         {
             writer_qos_.m_reliability.kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
         }
+        pub_builtin_data_.reliability = writer_qos_.m_reliability;
 
         return *this;
     }
@@ -402,6 +406,7 @@ public:
     {
         writer_attr_.endpoint.durabilityKind = kind;
         writer_qos_.m_durability.durabilityKind(kind);
+        pub_builtin_data_.durability = writer_qos_.m_durability;
 
         return *this;
     }
@@ -517,6 +522,7 @@ public:
             const std::vector<eprosima::fastdds::rtps::octet>& user_data)
     {
         writer_qos_.m_userData = user_data;
+        pub_builtin_data_.user_data = writer_qos_.m_userData;
         return *this;
     }
 
@@ -531,6 +537,7 @@ public:
             std::vector<std::string>& partitions)
     {
         writer_qos_.m_partition.setNames(partitions);
+        pub_builtin_data_.partition = writer_qos_.m_partition;
         return *this;
     }
 

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -34,6 +34,7 @@
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
 #include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 #include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
@@ -181,7 +182,10 @@ public:
             return;
         }
 
-        ASSERT_EQ(participant_->register_writer(writer_, pub_builtin_data_), true);
+        TopicDescription topic_desc;
+        topic_desc.type_name = type_.get_name();
+        topic_desc.topic_name = pub_builtin_data_.topic_name;
+        ASSERT_EQ(participant_->register_writer(writer_, topic_desc, writer_qos_), true);
 
         initialized_ = true;
     }

--- a/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -45,11 +45,11 @@ class DataWriterHistory : public WriterHistory
 public:
 
     static HistoryAttributes to_history_attributes(
-        const HistoryQosPolicy& history_qos,
-        const ResourceLimitsQosPolicy& resource_limits_qos,
-        const rtps::TopicKind_t& topic_kind,
-        uint32_t payloadMaxSize,
-        MemoryManagementPolicy_t mempolicy)
+            const HistoryQosPolicy& history_qos,
+            const ResourceLimitsQosPolicy& resource_limits_qos,
+            const rtps::TopicKind_t& topic_kind,
+            uint32_t payloadMaxSize,
+            MemoryManagementPolicy_t mempolicy)
     {
         auto initial_samples = resource_limits_qos.allocated_samples;
         auto max_samples = resource_limits_qos.max_samples;
@@ -78,7 +78,8 @@ public:
             uint32_t payloadMaxSize,
             MemoryManagementPolicy_t mempolicy,
             std::function<void (const fastdds::rtps::InstanceHandle_t&)> unack_sample_remove_functor)
-        : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
+        : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize,
+                mempolicy), payload_pool, change_pool)
         , history_qos_(history_qos)
         , resource_limited_qos_(resource_limits_qos)
         , topic_kind_(topic_kind)

--- a/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -22,7 +22,6 @@
 
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/CacheChange.hpp>
 #include <fastdds/rtps/common/ChangeKind_t.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
@@ -31,6 +30,7 @@
 #include <fastdds/rtps/common/Types.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 #include <fastdds/utils/TimedMutex.hpp>
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
 
 #include <fastdds/publisher/history/DataWriterInstance.hpp>
 
@@ -45,20 +45,22 @@ class DataWriterHistory : public WriterHistory
 public:
 
     static HistoryAttributes to_history_attributes(
-            const TopicAttributes& topic_att,
-            uint32_t payloadMaxSize,
-            MemoryManagementPolicy_t mempolicy)
+        const HistoryQosPolicy& history_qos,
+        const ResourceLimitsQosPolicy& resource_limits_qos,
+        const rtps::TopicKind_t& topic_kind,
+        uint32_t payloadMaxSize,
+        MemoryManagementPolicy_t mempolicy)
     {
-        auto initial_samples = topic_att.resourceLimitsQos.allocated_samples;
-        auto max_samples = topic_att.resourceLimitsQos.max_samples;
-        auto extra_samples = topic_att.resourceLimitsQos.extra_samples;
+        auto initial_samples = resource_limits_qos.allocated_samples;
+        auto max_samples = resource_limits_qos.max_samples;
+        auto extra_samples = resource_limits_qos.extra_samples;
 
-        if (topic_att.historyQos.kind != KEEP_ALL_HISTORY_QOS)
+        if (history_qos.kind != KEEP_ALL_HISTORY_QOS)
         {
-            max_samples = topic_att.historyQos.depth;
-            if (topic_att.getTopicKind() != NO_KEY)
+            max_samples = history_qos.depth;
+            if (topic_kind != NO_KEY)
             {
-                max_samples *= topic_att.resourceLimitsQos.max_instances;
+                max_samples *= resource_limits_qos.max_instances;
             }
 
             initial_samples = std::min(initial_samples, max_samples);
@@ -70,14 +72,16 @@ public:
     DataWriterHistory(
             const std::shared_ptr<IPayloadPool>& payload_pool,
             const std::shared_ptr<IChangePool>& change_pool,
-            const TopicAttributes& topic_att,
+            const HistoryQosPolicy& history_qos,
+            const ResourceLimitsQosPolicy& resource_limits_qos,
+            const rtps::TopicKind_t& topic_kind,
             uint32_t payloadMaxSize,
             MemoryManagementPolicy_t mempolicy,
-            std::function<void (const InstanceHandle_t&)> unack_sample_remove_functor)
-        : WriterHistory(to_history_attributes(topic_att, payloadMaxSize, mempolicy), payload_pool, change_pool)
-        , history_qos_(topic_att.historyQos)
-        , resource_limited_qos_(topic_att.resourceLimitsQos)
-        , topic_att_(topic_att)
+            std::function<void (const fastdds::rtps::InstanceHandle_t&)> unack_sample_remove_functor)
+        : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
+        , history_qos_(history_qos)
+        , resource_limited_qos_(resource_limits_qos)
+        , topic_kind_(topic_kind)
         , unacknowledged_sample_removed_functor_(unack_sample_remove_functor)
     {
         if (resource_limited_qos_.max_samples <= 0)
@@ -122,7 +126,7 @@ public:
         payload = nullptr;
 
         /// Preconditions
-        if (topic_att_.getTopicKind() == NO_KEY)
+        if (topic_kind_ == NO_KEY)
         {
             return false;
         }
@@ -184,8 +188,8 @@ public:
         bool returnedValue = false;
 
         // For NO_KEY we can directly add the change
-        bool add = (topic_att_.getTopicKind() == NO_KEY);
-        if (topic_att_.getTopicKind() == WITH_KEY)
+        bool add = (topic_kind_ == NO_KEY);
+        if (topic_kind_ == WITH_KEY)
         {
             t_m_Inst_Caches::iterator vit;
 
@@ -258,7 +262,7 @@ public:
         }
 
         std::lock_guard<RecursiveTimedMutex> guard(*this->mp_mutex);
-        if (topic_att_.getTopicKind() == NO_KEY)
+        if (topic_kind_ == NO_KEY)
         {
             if (remove_change(change))
             {
@@ -303,7 +307,7 @@ private:
     //!ResourceLimitsQosPolicy values.
     ResourceLimitsQosPolicy resource_limited_qos_;
     //!Topic Attributes
-    TopicAttributes topic_att_;
+    TopicKind_t topic_kind_;
 
     //! Unacknowledged sample removed functor
     std::function<void (const fastdds::rtps::InstanceHandle_t&)> unacknowledged_sample_removed_functor_;

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -712,6 +712,14 @@ public:
         return id_counter_;
     }
 
+    bool fill_type_information(
+            const TypeSupport& /*type*/,
+            xtypes::TypeInformationParameter& /*type_information*/)
+    {
+        return false;
+    }
+
+
 protected:
 
     DomainId_t domain_id_;

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -719,7 +719,6 @@ public:
         return false;
     }
 
-
 protected:
 
     DomainId_t domain_id_;

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -36,7 +36,6 @@
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/publisher/PublisherImpl.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/InstanceHandle.hpp>
 #include <fastdds/rtps/common/Types.hpp>
@@ -87,7 +86,7 @@ protected:
         participant_->impl_ = this;
 
         guid_.guidPrefix.value[11] = 1;
-        eprosima::fastdds::TopicAttributes top_attr;
+        eprosima::fastdds::xmlparser::TopicAttributes top_attr;
         eprosima::fastdds::xmlparser::XMLProfileManager::getDefaultTopicAttributes(top_attr);
         default_topic_qos_.history() = top_attr.historyQos;
         default_topic_qos_.resource_limits() = top_attr.resourceLimitsQos;

--- a/test/mock/rtps/EDP/rtps/builtin/discovery/endpoint/EDP.h
+++ b/test/mock/rtps/EDP/rtps/builtin/discovery/endpoint/EDP.h
@@ -63,7 +63,7 @@ public:
         return true;
     }
 
-    virtual bool removeLocalWriter(
+    virtual bool remove_writer(
             eprosima::fastdds::rtps::RTPSWriter*)
     {
         return true;
@@ -83,7 +83,7 @@ public:
         return true;
     }
 
-    virtual bool processLocalWriterProxyData(
+    virtual bool process_writer_proxy_data(
             eprosima::fastdds::rtps::RTPSWriter*,
             eprosima::fastdds::rtps::WriterProxyData*)
     {

--- a/test/mock/rtps/EDP/rtps/builtin/discovery/endpoint/EDP.h
+++ b/test/mock/rtps/EDP/rtps/builtin/discovery/endpoint/EDP.h
@@ -57,7 +57,7 @@ public:
         return true;
     }
 
-    virtual bool removeLocalReader(
+    virtual bool remove_reader(
             eprosima::fastdds::rtps::RTPSReader*)
     {
         return true;
@@ -76,7 +76,7 @@ public:
 
     }
 
-    virtual bool processLocalReaderProxyData(
+    virtual bool process_reader_proxy_data(
             eprosima::fastdds::rtps::RTPSReader*,
             eprosima::fastdds::rtps::ReaderProxyData*)
     {

--- a/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.h
+++ b/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.h
@@ -106,6 +106,11 @@ public:
         return {};
     }
 
+    NetworkConfigSet_t network_configuration() const
+    {
+        return NetworkConfigSet_t{};
+    }
+
 };
 
 } // namespace rtps

--- a/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
@@ -60,7 +60,7 @@ public:
 
     MOCK_METHOD0(createPDPEndpoints, bool());
 
-    MOCK_METHOD0(getEDP, EDP*());
+    MOCK_METHOD0(get_edp, EDP*());
 
 #ifdef FASTDDS_STATISTICS
     MOCK_METHOD0(get_proxy_observer, const fastdds::statistics::rtps::IProxyObserver*());

--- a/test/mock/rtps/PDPSimple/rtps/builtin/discovery/participant/PDPSimple.h
+++ b/test/mock/rtps/PDPSimple/rtps/builtin/discovery/participant/PDPSimple.h
@@ -38,7 +38,7 @@ public:
 
     MOCK_METHOD1(get_participant_proxy_data_serialized, CDRMessage_t(Endianness_t));
 
-    EDP* getEDP()
+    EDP* get_edp()
     {
         return &edp_;
     }

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -185,14 +185,13 @@ public:
 
     MOCK_CONST_METHOD0(typelookup_manager, fastdds::dds::builtin::TypeLookupManager* ());
 
-    MOCK_METHOD3(registerWriter, bool(
+    MOCK_METHOD3(register_writer, bool(
                 RTPSWriter * Writer,
-                const TopicAttributes& topicAtt,
+                const PublicationBuiltinTopicData& pub_builtin_data,
                 const fastdds::dds::WriterQos& wqos));
 
-    MOCK_METHOD3(updateWriter, bool(
+    MOCK_METHOD2(update_writer, bool(
                 RTPSWriter * Writer,
-                const TopicAttributes& topicAtt,
                 const fastdds::dds::WriterQos& wqos));
 
     MOCK_METHOD3(registerReader, bool(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -185,10 +185,9 @@ public:
 
     MOCK_CONST_METHOD0(typelookup_manager, fastdds::dds::builtin::TypeLookupManager* ());
 
-    MOCK_METHOD3(register_writer, bool(
+    MOCK_METHOD2(register_writer, bool(
                 RTPSWriter * Writer,
-                const PublicationBuiltinTopicData& pub_builtin_data,
-                const fastdds::dds::WriterQos& wqos));
+                const PublicationBuiltinTopicData& pub_builtin_data));
 
     MOCK_METHOD2(update_writer, bool(
                 RTPSWriter * Writer,

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -58,8 +58,6 @@ class TypeLookupManager;
 } // namespace builtin
 } // namespace dds
 
-class TopicAttributes;
-
 namespace rtps {
 
 struct PublicationBuiltinTopicData;

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -195,9 +195,10 @@ public:
                 RTPSWriter * Writer,
                 const fastdds::dds::WriterQos& wqos));
 
-    MOCK_METHOD3(register_reader, bool(
+    MOCK_METHOD4(register_reader, bool(
                 RTPSReader * Reader,
-                const SubscriptionBuiltinTopicData& sub_builtin_data,
+                const fastdds::rtps::TopicDescription& topic,
+                const fastdds::dds::ReaderQos& qos,
                 const fastdds::rtps::ContentFilterProperty* content_filter));
 
     MOCK_METHOD3(update_reader, bool(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -194,30 +194,19 @@ public:
                 RTPSWriter * Writer,
                 const fastdds::dds::WriterQos& wqos));
 
-    MOCK_METHOD3(registerReader, bool(
+    MOCK_METHOD4(register_reader, bool(
                 RTPSReader * Reader,
-                const TopicAttributes& topicAtt,
-                const fastdds::dds::ReaderQos& rqos));
-
-    MOCK_METHOD4(registerReader, bool(
-                RTPSReader * Reader,
-                const TopicAttributes& topicAtt,
+                const SubscriptionBuiltinTopicData& sub_builtin_data,
                 const fastdds::dds::ReaderQos& rqos,
                 const fastdds::rtps::ContentFilterProperty* content_filter));
 
-    MOCK_METHOD3(updateReader, bool(
+    MOCK_METHOD3(update_reader, bool(
                 RTPSReader * Reader,
-                const TopicAttributes& topicAtt,
-                const fastdds::dds::ReaderQos& rqos));
+                const fastdds::dds::ReaderQos& rqos,
+                const fastdds::rtps::ContentFilterProperty* content_filter));
 
     MOCK_METHOD1(ignore_participant, bool(
                 const GuidPrefix_t& participant_guid));
-
-    MOCK_METHOD4(updateReader, bool(
-                RTPSReader * Reader,
-                const TopicAttributes& topicAtt,
-                const fastdds::dds::ReaderQos& rqos,
-                const fastdds::rtps::ContentFilterProperty* content_filter));
 
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const
     {

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -194,10 +194,9 @@ public:
                 RTPSWriter * Writer,
                 const fastdds::dds::WriterQos& wqos));
 
-    MOCK_METHOD4(register_reader, bool(
+    MOCK_METHOD3(register_reader, bool(
                 RTPSReader * Reader,
                 const SubscriptionBuiltinTopicData& sub_builtin_data,
-                const fastdds::dds::ReaderQos& rqos,
                 const fastdds::rtps::ContentFilterProperty* content_filter));
 
     MOCK_METHOD3(update_reader, bool(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -66,6 +66,7 @@ class RTPSParticipantListener;
 class RTPSWriter;
 class RTPSReader;
 struct SubscriptionBuiltinTopicData;
+struct TopicDescription;
 class ResourceEvent;
 class WLP;
 
@@ -185,9 +186,10 @@ public:
 
     MOCK_CONST_METHOD0(typelookup_manager, fastdds::dds::builtin::TypeLookupManager* ());
 
-    MOCK_METHOD2(register_writer, bool(
+    MOCK_METHOD3(register_writer, bool(
                 RTPSWriter * Writer,
-                const PublicationBuiltinTopicData& pub_builtin_data));
+                const fastdds::rtps::TopicDescription& topic,
+                const fastdds::dds::WriterQos& qos));
 
     MOCK_METHOD2(update_writer, bool(
                 RTPSWriter * Writer,

--- a/test/mock/rtps/RTPSWriter/rtps/writer/BaseWriter.hpp
+++ b/test/mock/rtps/RTPSWriter/rtps/writer/BaseWriter.hpp
@@ -76,10 +76,13 @@ public:
         return static_cast<BaseWriter*>(endpoint);
     }
 
+    RTPSParticipantImpl* get_participant_impl()
+    {
+        return nullptr;
+    }
+
     // *INDENT-OFF* Uncrustify makes a mess with MOCK_METHOD macros
     MOCK_METHOD0(get_max_allowed_payload_size, uint32_t());
-
-    MOCK_METHOD0(get_participant_impl, RTPSParticipantImpl* ());
 
     MOCK_METHOD4(deliver_sample_nts, DeliveryRetCode(
             CacheChange_t*,

--- a/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
+++ b/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
@@ -324,23 +324,6 @@ public:
         return content_filter_;
     }
 
-    void networkConfiguration(
-            const NetworkConfigSet_t& networkConfiguration)
-    {
-        m_networkConfiguration = networkConfiguration;
-    }
-
-    void networkConfiguration(
-            NetworkConfigSet_t&& networkConfiguration)
-    {
-        m_networkConfiguration = std::move(networkConfiguration);
-    }
-
-    const NetworkConfigSet_t& networkConfiguration() const
-    {
-        return m_networkConfiguration;
-    }
-
     void copy(
             ReaderProxyData* /*rdat*/)
     {
@@ -368,7 +351,6 @@ private:
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
     fastdds::rtps::ContentFilterProperty content_filter_;
-    NetworkConfigSet_t m_networkConfiguration;
     bool has_type_info_ {false};
 
 };

--- a/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
+++ b/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
@@ -324,6 +324,23 @@ public:
         return content_filter_;
     }
 
+    void networkConfiguration(
+            const NetworkConfigSet_t& networkConfiguration)
+    {
+        m_networkConfiguration = networkConfiguration;
+    }
+
+    void networkConfiguration(
+            NetworkConfigSet_t&& networkConfiguration)
+    {
+        m_networkConfiguration = std::move(networkConfiguration);
+    }
+
+    const NetworkConfigSet_t& networkConfiguration() const
+    {
+        return m_networkConfiguration;
+    }
+
     void copy(
             ReaderProxyData* /*rdat*/)
     {
@@ -351,6 +368,7 @@ private:
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
     fastdds::rtps::ContentFilterProperty content_filter_;
+    NetworkConfigSet_t m_networkConfiguration;
     bool has_type_info_ {false};
 
 };

--- a/test/mock/rtps/WriterProxyData/rtps/builtin/data/WriterProxyData.hpp
+++ b/test/mock/rtps/WriterProxyData/rtps/builtin/data/WriterProxyData.hpp
@@ -297,28 +297,6 @@ public:
         return m_userDefinedId;
     }
 
-    void networkConfiguration(
-            const NetworkConfigSet_t& networkConfiguration)
-    {
-        m_networkConfiguration = networkConfiguration;
-    }
-
-    void networkConfiguration(
-            NetworkConfigSet_t&& networkConfiguration)
-    {
-        m_networkConfiguration = std::move(networkConfiguration);
-    }
-
-    const NetworkConfigSet_t& networkConfiguration() const
-    {
-        return m_networkConfiguration;
-    }
-
-    NetworkConfigSet_t& networkConfiguration()
-    {
-        return m_networkConfiguration;
-    }
-
     void copy(
             WriterProxyData* /*wdat*/)
     {
@@ -345,7 +323,6 @@ private:
     InstanceHandle_t m_key;
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
-    NetworkConfigSet_t m_networkConfiguration;
     bool has_type_info_ {false};
 };
 

--- a/test/mock/rtps/WriterProxyData/rtps/builtin/data/WriterProxyData.hpp
+++ b/test/mock/rtps/WriterProxyData/rtps/builtin/data/WriterProxyData.hpp
@@ -297,6 +297,28 @@ public:
         return m_userDefinedId;
     }
 
+    void networkConfiguration(
+            const NetworkConfigSet_t& networkConfiguration)
+    {
+        m_networkConfiguration = networkConfiguration;
+    }
+
+    void networkConfiguration(
+            NetworkConfigSet_t&& networkConfiguration)
+    {
+        m_networkConfiguration = std::move(networkConfiguration);
+    }
+
+    const NetworkConfigSet_t& networkConfiguration() const
+    {
+        return m_networkConfiguration;
+    }
+
+    NetworkConfigSet_t& networkConfiguration()
+    {
+        return m_networkConfiguration;
+    }
+
     void copy(
             WriterProxyData* /*wdat*/)
     {
@@ -323,6 +345,7 @@ private:
     InstanceHandle_t m_key;
     InstanceHandle_t m_RTPSParticipantKey;
     uint16_t m_userDefinedId;
+    NetworkConfigSet_t m_networkConfiguration;
     bool has_type_info_ {false};
 };
 

--- a/test/unittest/dds/status/CMakeLists.txt
+++ b/test/unittest/dds/status/CMakeLists.txt
@@ -58,6 +58,10 @@ set(LISTENERTESTS_SOURCE ListenerTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/utils/TypePropagation.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/GuidPrefix_t.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/LocatorWithMask.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/SerializedPayload.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -585,7 +585,7 @@ protected:
         ASSERT_NE(subscriber_, nullptr);
 
         EXPECT_CALL(participant_mock_,
-                registerReader(&reader_mock_, ::testing::_, ::testing::_, nullptr)).WillRepeatedly(
+                register_reader(&reader_mock_, ::testing::_, ::testing::_, nullptr)).WillRepeatedly(
             ::testing::Return(true));
 
         datareader_ =

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -585,7 +585,7 @@ protected:
         ASSERT_NE(subscriber_, nullptr);
 
         EXPECT_CALL(participant_mock_,
-                register_reader(&reader_mock_, ::testing::_, ::testing::_, nullptr)).WillRepeatedly(
+                register_reader(&reader_mock_, ::testing::_, nullptr)).WillRepeatedly(
             ::testing::Return(true));
 
         datareader_ =

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -585,7 +585,7 @@ protected:
         ASSERT_NE(subscriber_, nullptr);
 
         EXPECT_CALL(participant_mock_,
-                register_reader(&reader_mock_, ::testing::_, nullptr)).WillRepeatedly(
+                register_reader(&reader_mock_, ::testing::_, ::testing::_, nullptr)).WillRepeatedly(
             ::testing::Return(true));
 
         datareader_ =

--- a/test/unittest/dds/topic/TopicTests.cpp
+++ b/test/unittest/dds/topic/TopicTests.cpp
@@ -22,7 +22,6 @@
 #include <fastdds/dds/topic/qos/TopicQos.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TopicListener.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -21,6 +21,7 @@ set(EDPTESTS_SOURCE EdpTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/EndpointSecurityAttributes.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/LocatorWithMask.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/SerializedPayload.cpp

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -21,7 +21,6 @@ set(EDPTESTS_SOURCE EdpTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/EndpointSecurityAttributes.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
-    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/LocatorWithMask.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/SerializedPayload.cpp

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -66,7 +66,7 @@ public:
         return true;
     }
 
-    bool removeLocalWriter(
+    bool remove_writer(
             RTPSWriter* /*W*/) override
     {
         return true;
@@ -79,7 +79,7 @@ public:
         return true;
     }
 
-    bool processLocalWriterProxyData(
+    bool process_writer_proxy_data(
             RTPSWriter* /*writer*/,
             WriterProxyData* /*wdata*/) override
     {

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -60,7 +60,7 @@ public:
     {
     }
 
-    bool removeLocalReader(
+    bool remove_reader(
             RTPSReader* /*R*/) override
     {
         return true;
@@ -72,7 +72,7 @@ public:
         return true;
     }
 
-    bool processLocalReaderProxyData(
+    bool process_reader_proxy_data(
             RTPSReader* /*reader*/,
             ReaderProxyData* /*rdata*/) override
     {

--- a/test/unittest/rtps/domain/RTPSDomainTests.cpp
+++ b/test/unittest/rtps/domain/RTPSDomainTests.cpp
@@ -56,48 +56,6 @@ TEST(RTPSDomainTests, library_settings_test)
     eprosima::fastdds::rtps::RTPSDomain::stopAll();
 }
 
-/**
- * This test checks get_topic_attributes_from_profile API.
- */
-TEST(RTPSDomainTests, get_topic_attributes_from_profile_test)
-{
-    std::string profile_name = "test_profile_name";
-    eprosima::fastdds::TopicAttributes topic_att;
-    EXPECT_FALSE(eprosima::fastdds::rtps::RTPSDomain::get_topic_attributes_from_profile(profile_name, topic_att));
-
-    const std::string xml =
-            R"(<profiles>
-    <topic profile_name="test_profile_name">
-        <name>Test</name>
-        <dataType>DataTest</dataType>
-        <historyQos>
-            <kind>KEEP_LAST</kind>
-            <depth>20</depth>
-        </historyQos>
-        <resourceLimitsQos>
-            <max_samples>5</max_samples>
-            <max_instances>2</max_instances>
-            <max_samples_per_instance>1</max_samples_per_instance>
-            <allocated_samples>20</allocated_samples>
-            <extra_samples>10</extra_samples>
-        </resourceLimitsQos>
-    </topic>
-</profiles>)";
-
-    EXPECT_EQ(eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->load_XML_profiles_string(xml.c_str(),
-            xml.length()), eprosima::fastdds::dds::RETCODE_OK);
-    EXPECT_TRUE(eprosima::fastdds::rtps::RTPSDomain::get_topic_attributes_from_profile(profile_name, topic_att));
-    EXPECT_EQ(topic_att.topicName, "Test");
-    EXPECT_EQ(topic_att.topicDataType, "DataTest");
-    EXPECT_EQ(topic_att.historyQos.kind, eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS);
-    EXPECT_EQ(topic_att.historyQos.depth, 20);
-    EXPECT_EQ(topic_att.resourceLimitsQos.max_samples, 5);
-    EXPECT_EQ(topic_att.resourceLimitsQos.max_instances, 2);
-    EXPECT_EQ(topic_att.resourceLimitsQos.max_samples_per_instance, 1);
-    EXPECT_EQ(topic_att.resourceLimitsQos.allocated_samples, 20);
-    EXPECT_EQ(topic_att.resourceLimitsQos.extra_samples, 10);
-}
-
 int main(
         int argc,
         char** argv)

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -26,6 +26,7 @@
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/SequenceNumber.hpp>
 #include <fastdds/rtps/common/Types.hpp>
@@ -93,11 +94,11 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     SubscriptionBuiltinTopicData sub_builtin_data;
     sub_builtin_data.type_name = "string";
     sub_builtin_data.topic_name = "topic";
-    PublicationBuiltinTopicData pub_builtin_data;
-    pub_builtin_data.type_name = "string";
-    pub_builtin_data.topic_name = "topic";
+    TopicDescription topic_desc;
+    topic_desc.type_name = "string";
+    topic_desc.topic_name = "topic";
     part->register_reader(reader, sub_builtin_data);
-    part->register_writer(writer, pub_builtin_data);
+    part->register_writer(writer, topic_desc, {});
 
     // After registration, the writer should be matched
     auto writer_guid = writer->getGuid();

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -96,7 +96,7 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     PublicationBuiltinTopicData pub_builtin_data;
     pub_builtin_data.type_name = "string";
     pub_builtin_data.topic_name = "topic";
-    part->register_reader(reader, sub_builtin_data, {});
+    part->register_reader(reader, sub_builtin_data);
     part->register_writer(writer, pub_builtin_data, {});
 
     // After registration, the writer should be matched

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -90,12 +90,10 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     ASSERT_NE(writer, nullptr);
 
     // Register both endpoints
-    TopicAttributes topic_att;
-    topic_att.topicKind = NO_KEY;
-    topic_att.topicDataType = "string";
-    topic_att.topicName = "topic";
-    part->registerReader(reader, topic_att, {});
-    part->registerWriter(writer, topic_att, {});
+    PublicationBuiltinTopicData pub_builtin_data;
+    pub_builtin_data.type_name = "string";
+    pub_builtin_data.topic_name = "topic";
+    part->register_writer(writer, pub_builtin_data, {});
 
     // After registration, the writer should be matched
     auto writer_guid = writer->getGuid();

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -90,9 +90,13 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     ASSERT_NE(writer, nullptr);
 
     // Register both endpoints
+    SubscriptionBuiltinTopicData sub_builtin_data;
+    sub_builtin_data.type_name = "string";
+    sub_builtin_data.topic_name = "topic";
     PublicationBuiltinTopicData pub_builtin_data;
     pub_builtin_data.type_name = "string";
     pub_builtin_data.topic_name = "topic";
+    part->register_reader(reader, sub_builtin_data, {});
     part->register_writer(writer, pub_builtin_data, {});
 
     // After registration, the writer should be matched

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -91,13 +91,10 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     ASSERT_NE(writer, nullptr);
 
     // Register both endpoints
-    SubscriptionBuiltinTopicData sub_builtin_data;
-    sub_builtin_data.type_name = "string";
-    sub_builtin_data.topic_name = "topic";
     TopicDescription topic_desc;
     topic_desc.type_name = "string";
     topic_desc.topic_name = "topic";
-    part->register_reader(reader, sub_builtin_data);
+    part->register_reader(reader, topic_desc, {});
     part->register_writer(writer, topic_desc, {});
 
     // After registration, the writer should be matched

--- a/test/unittest/rtps/reader/StatefulReaderTests.cpp
+++ b/test/unittest/rtps/reader/StatefulReaderTests.cpp
@@ -97,7 +97,7 @@ TEST(StatefulReaderTests, RTPSCorrectGAPProcessing)
     pub_builtin_data.type_name = "string";
     pub_builtin_data.topic_name = "topic";
     part->register_reader(reader, sub_builtin_data);
-    part->register_writer(writer, pub_builtin_data, {});
+    part->register_writer(writer, pub_builtin_data);
 
     // After registration, the writer should be matched
     auto writer_guid = writer->getGuid();

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -395,9 +395,11 @@ public:
         }
     }
 
-    inline PublicationBuiltinTopicData get_publication_builtin_topic_data() const
+    inline ReturnCode_t get_publication_builtin_topic_data(
+            PublicationBuiltinTopicData& publication_data) const
     {
-        return PublicationBuiltinTopicData();
+        publication_data = PublicationBuiltinTopicData{};
+        return RETCODE_OK;
     }
 
     static ReturnCode_t check_qos(

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -395,6 +395,11 @@ public:
         }
     }
 
+    inline PublicationBuiltinTopicData get_publication_builtin_topic_data() const
+    {
+        return PublicationBuiltinTopicData();
+    }
+
     static ReturnCode_t check_qos(
             const ::eprosima::fastdds::dds::DataWriterQos&)
     {

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -130,7 +130,9 @@ public:
         history_.reset(new DataWriterHistory(
                     payload_pool,
                     change_pool,
-                    atts_,
+                    qos_.history(),
+                    qos_.resource_limits(),
+                    topic_kind_,
                     500,
                     fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
                     [](const InstanceHandle_t&)
@@ -428,7 +430,8 @@ public:
     OfferedIncompatibleQosStatus offered_incompatible_qos_status_;
     std::chrono::duration<double, std::ratio<1, 1000000>> lifespan_duration_us_;
     std::unique_ptr<DataWriterHistory> history_;
-    fastdds::TopicAttributes atts_;
+
+    rtps::TopicKind_t topic_kind_;
 
 };
 

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -78,7 +78,7 @@ public:
             },
             [&](
                 fastdds::rtps::RTPSWriter*,
-                const fastdds::TopicAttributes&,
+                const ::eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
                 const fastdds::dds::WriterQos&)->bool
             {
                 return true;

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -78,7 +78,8 @@ public:
             },
             [&](
                 fastdds::rtps::RTPSWriter*,
-                const ::eprosima::fastdds::rtps::PublicationBuiltinTopicData&)->bool
+                const ::eprosima::fastdds::rtps::TopicDescription&,
+                const ::eprosima::fastdds::dds::WriterQos&)->bool
             {
                 return true;
             },

--- a/test/unittest/statistics/rtps/MonitorServiceTests.cpp
+++ b/test/unittest/statistics/rtps/MonitorServiceTests.cpp
@@ -78,8 +78,7 @@ public:
             },
             [&](
                 fastdds::rtps::RTPSWriter*,
-                const ::eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
-                const fastdds::dds::WriterQos&)->bool
+                const ::eprosima::fastdds::rtps::PublicationBuiltinTopicData&)->bool
             {
                 return true;
             },

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -362,9 +362,15 @@ public:
         pub_builtin_data.type_name = data_type;
         pub_builtin_data.topic_name = topic_name;
 
+        auto& ratt = writer_->getAttributes();
         SubscriptionBuiltinTopicData sub_builtin_data;
         sub_builtin_data.type_name = data_type;
         sub_builtin_data.topic_name = topic_name;
+        sub_builtin_data.durability.durabilityKind(ratt.durabilityKind);
+        sub_builtin_data.reliability.kind =
+                RELIABLE ==
+                ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
+
 
         dds::WriterQos Wqos;
         auto& watt = writer_->getAttributes();
@@ -373,15 +379,8 @@ public:
                 RELIABLE ==
                 watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
-        dds::ReaderQos Rqos;
-        auto& ratt = writer_->getAttributes();
-        Rqos.m_durability.durabilityKind(ratt.durabilityKind);
-        Rqos.m_reliability.kind =
-                RELIABLE ==
-                ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
-
         participant_->register_writer(writer_, pub_builtin_data, Wqos);
-        participant_->register_reader(reader_, sub_builtin_data, Rqos);
+        participant_->register_reader(reader_, sub_builtin_data);
     }
 
     void destroy_endpoints()

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -32,6 +32,7 @@
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
+#include <fastdds/rtps/builtin/data/TopicDescription.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
@@ -358,14 +359,9 @@ public:
         using namespace fastdds;
         using namespace fastdds::rtps;
 
-        auto& watt = writer_->getAttributes();
-        PublicationBuiltinTopicData pub_builtin_data;
-        pub_builtin_data.type_name = data_type;
-        pub_builtin_data.topic_name = topic_name;
-        pub_builtin_data.durability.durabilityKind(watt.durabilityKind);
-        pub_builtin_data.reliability.kind =
-                RELIABLE ==
-                watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
+        TopicDescription topic_desc;
+        topic_desc.type_name = data_type;
+        topic_desc.topic_name = topic_name;
 
         auto& ratt = writer_->getAttributes();
         SubscriptionBuiltinTopicData sub_builtin_data;
@@ -376,7 +372,15 @@ public:
                 RELIABLE ==
                 ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
-        participant_->register_writer(writer_, pub_builtin_data);
+
+        dds::WriterQos Wqos;
+        auto& watt = writer_->getAttributes();
+        Wqos.m_durability.durabilityKind(watt.durabilityKind);
+        Wqos.m_reliability.kind =
+                RELIABLE ==
+                watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
+
+        participant_->register_writer(writer_, topic_desc, Wqos);
         participant_->register_reader(reader_, sub_builtin_data);
     }
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -358,9 +358,14 @@ public:
         using namespace fastdds;
         using namespace fastdds::rtps;
 
+        auto& watt = writer_->getAttributes();
         PublicationBuiltinTopicData pub_builtin_data;
         pub_builtin_data.type_name = data_type;
         pub_builtin_data.topic_name = topic_name;
+        pub_builtin_data.durability.durabilityKind(watt.durabilityKind);
+        pub_builtin_data.reliability.kind =
+                RELIABLE ==
+                watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
         auto& ratt = writer_->getAttributes();
         SubscriptionBuiltinTopicData sub_builtin_data;
@@ -371,15 +376,7 @@ public:
                 RELIABLE ==
                 ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
-
-        dds::WriterQos Wqos;
-        auto& watt = writer_->getAttributes();
-        Wqos.m_durability.durabilityKind(watt.durabilityKind);
-        Wqos.m_reliability.kind =
-                RELIABLE ==
-                watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
-
-        participant_->register_writer(writer_, pub_builtin_data, Wqos);
+        participant_->register_writer(writer_, pub_builtin_data);
         participant_->register_reader(reader_, sub_builtin_data);
     }
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -352,17 +352,16 @@ public:
     }
 
     void match_endpoints(
-            bool key,
+            bool /* key */,
             fastcdr::string_255 data_type,
             fastcdr::string_255 topic_name)
     {
         using namespace fastdds;
         using namespace fastdds::rtps;
 
-        TopicAttributes Tatt;
-        Tatt.topicKind = key ? TopicKind_t::WITH_KEY : TopicKind_t::NO_KEY;
-        Tatt.topicDataType = data_type;
-        Tatt.topicName = topic_name;
+        PublicationBuiltinTopicData pub_builtin_data;
+        pub_builtin_data.type_name = data_type;
+        pub_builtin_data.topic_name = topic_name;
 
         dds::WriterQos Wqos;
         auto& watt = writer_->getAttributes();
@@ -378,7 +377,7 @@ public:
                 RELIABLE ==
                 ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
-        participant_->registerWriter(writer_, Tatt, Wqos);
+        participant_->register_writer(writer_, pub_builtin_data, Wqos);
         participant_->registerReader(reader_, Tatt, Rqos);
     }
 

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -31,7 +31,6 @@
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
-#include <fastdds/rtps/attributes/TopicAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
@@ -363,6 +362,10 @@ public:
         pub_builtin_data.type_name = data_type;
         pub_builtin_data.topic_name = topic_name;
 
+        SubscriptionBuiltinTopicData sub_builtin_data;
+        sub_builtin_data.type_name = data_type;
+        sub_builtin_data.topic_name = topic_name;
+
         dds::WriterQos Wqos;
         auto& watt = writer_->getAttributes();
         Wqos.m_durability.durabilityKind(watt.durabilityKind);
@@ -378,7 +381,7 @@ public:
                 ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
         participant_->register_writer(writer_, pub_builtin_data, Wqos);
-        participant_->registerReader(reader_, Tatt, Rqos);
+        participant_->register_reader(reader_, sub_builtin_data, Rqos);
     }
 
     void destroy_endpoints()

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -363,16 +363,6 @@ public:
         topic_desc.type_name = data_type;
         topic_desc.topic_name = topic_name;
 
-        auto& ratt = writer_->getAttributes();
-        SubscriptionBuiltinTopicData sub_builtin_data;
-        sub_builtin_data.type_name = data_type;
-        sub_builtin_data.topic_name = topic_name;
-        sub_builtin_data.durability.durabilityKind(ratt.durabilityKind);
-        sub_builtin_data.reliability.kind =
-                RELIABLE ==
-                ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
-
-
         dds::WriterQos Wqos;
         auto& watt = writer_->getAttributes();
         Wqos.m_durability.durabilityKind(watt.durabilityKind);
@@ -380,8 +370,15 @@ public:
                 RELIABLE ==
                 watt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
 
+        dds::ReaderQos Rqos;
+        auto& ratt = writer_->getAttributes();
+        Rqos.m_durability.durabilityKind(ratt.durabilityKind);
+        Rqos.m_reliability.kind =
+                RELIABLE ==
+                ratt.reliabilityKind ? dds::RELIABLE_RELIABILITY_QOS : dds::BEST_EFFORT_RELIABILITY_QOS;
+
         participant_->register_writer(writer_, topic_desc, Wqos);
-        participant_->register_reader(reader_, sub_builtin_data);
+        participant_->register_reader(reader_, topic_desc, Rqos);
     }
 
     void destroy_endpoints()

--- a/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
@@ -21,17 +21,15 @@
 
 #include <gmock/gmock.h>
 
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
+#include <fastdds/rtps/history/IChangePool.hpp>
+#include <fastdds/rtps/history/IPayloadPool.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 #include <fastdds/utils/TimedMutex.hpp>
-#include <fastdds/rtps/history/IPayloadPool.hpp>
-#include <fastdds/rtps/history/IChangePool.hpp>
 
 namespace eprosima {
 namespace fastdds {
-
-class TopicAttributes;
-
 namespace rtps {
 
 class WriteParams;
@@ -48,9 +46,11 @@ class Topic;
 
 
 static fastdds::rtps::HistoryAttributes to_history_attributes(
-        const fastdds::TopicAttributes&,
+        const HistoryQosPolicy&,
+        const ResourceLimitsQosPolicy&,
+        const rtps::TopicKind_t&,
         uint32_t,
-        fastdds::rtps::MemoryManagementPolicy_t)
+        rtps::MemoryManagementPolicy_t)
 {
 
     return fastdds::rtps::HistoryAttributes();
@@ -60,14 +60,16 @@ class DataWriterHistory : public fastdds::rtps::WriterHistory
 {
 public:
 
-    DataWriterHistory(
-            const std::shared_ptr<rtps::IPayloadPool>& payload_pool,
-            const std::shared_ptr<rtps::IChangePool>& change_pool,
-            const TopicAttributes& topic_att,
-            uint32_t payloadMaxSize,
-            rtps::MemoryManagementPolicy_t mempolicy,
-            std::function<void (const rtps::InstanceHandle_t&)>)
-        : WriterHistory(to_history_attributes(topic_att, payloadMaxSize, mempolicy), payload_pool, change_pool)
+DataWriterHistory(
+        const std::shared_ptr<rtps::IPayloadPool>& payload_pool,
+        const std::shared_ptr<rtps::IChangePool>& change_pool,
+        const HistoryQosPolicy& history_qos,
+        const ResourceLimitsQosPolicy& resource_limits_qos,
+        const rtps::TopicKind_t& topic_kind,
+        uint32_t payloadMaxSize,
+        rtps::MemoryManagementPolicy_t mempolicy,
+        std::function<void (const fastdds::rtps::InstanceHandle_t&)>)
+    : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
     {
     }
 

--- a/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/unittest/statistics/rtps/mock/Publisher/fastdds/publisher/DataWriterHistory.hpp
@@ -60,16 +60,17 @@ class DataWriterHistory : public fastdds::rtps::WriterHistory
 {
 public:
 
-DataWriterHistory(
-        const std::shared_ptr<rtps::IPayloadPool>& payload_pool,
-        const std::shared_ptr<rtps::IChangePool>& change_pool,
-        const HistoryQosPolicy& history_qos,
-        const ResourceLimitsQosPolicy& resource_limits_qos,
-        const rtps::TopicKind_t& topic_kind,
-        uint32_t payloadMaxSize,
-        rtps::MemoryManagementPolicy_t mempolicy,
-        std::function<void (const fastdds::rtps::InstanceHandle_t&)>)
-    : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize, mempolicy), payload_pool, change_pool)
+    DataWriterHistory(
+            const std::shared_ptr<rtps::IPayloadPool>& payload_pool,
+            const std::shared_ptr<rtps::IChangePool>& change_pool,
+            const HistoryQosPolicy& history_qos,
+            const ResourceLimitsQosPolicy& resource_limits_qos,
+            const rtps::TopicKind_t& topic_kind,
+            uint32_t payloadMaxSize,
+            rtps::MemoryManagementPolicy_t mempolicy,
+            std::function<void (const fastdds::rtps::InstanceHandle_t&)>)
+        : WriterHistory(to_history_attributes(history_qos, resource_limits_qos, topic_kind, payloadMaxSize,
+                mempolicy), payload_pool, change_pool)
     {
     }
 

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -45,7 +45,7 @@ namespace fastdds {
 
 namespace rtps {
 
-struct PublicationBuiltinTopicData;
+struct TopicDescription;
 
 } // namespace rtps
 
@@ -69,7 +69,8 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&)>;
+                        const eprosima::fastdds::rtps::TopicDescription&,
+                        const eprosima::fastdds::dds::WriterQos&)>;
 
     MonitorService(
             const fastdds::rtps::GUID_t& guid,

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -69,8 +69,7 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
-                        const fastdds::dds::WriterQos&)>;
+                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&)>;
 
     MonitorService(
             const fastdds::rtps::GUID_t& guid,

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -29,6 +29,7 @@
 
 #include <fastdds/dds/publisher/qos/WriterQos.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/rtps/history/WriterHistory.hpp>
 
 #include <rtps/history/ITopicPayloadPool.h>
@@ -41,6 +42,13 @@
 
 namespace eprosima {
 namespace fastdds {
+
+namespace rtps {
+
+struct PublicationBuiltinTopicData;
+
+} // namespace rtps
+
 namespace statistics {
 namespace rtps {
 
@@ -61,7 +69,7 @@ public:
 
     using endpoint_registrator_t = std::function<bool (
                         fastdds::rtps::RTPSWriter*,
-                        const fastdds::TopicAttributes&,
+                        const eprosima::fastdds::rtps::PublicationBuiltinTopicData&,
                         const fastdds::dds::WriterQos&)>;
 
     MonitorService(

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -2089,7 +2089,7 @@ TEST_F(XMLParserTests, getXMLFlowControllerDescriptorList_NegativeClauses)
 TEST_F(XMLParserTests, getXMLTopicAttributes_NegativeClauses)
 {
     uint8_t ident = 1;
-    TopicAttributes topic;
+    xmlparser::TopicAttributes topic;
     tinyxml2::XMLDocument xml_doc;
     tinyxml2::XMLElement* titleElement;
 

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -851,7 +851,7 @@ TEST_P(XMLProfileParserTests, XMLParserPublisher)
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
             xmlparser::XMLProfileManager::fillPublisherAttributes(publisher_profile, publisher_atts));
 
-    TopicAttributes& pub_topic = publisher_atts.topic;
+    xmlparser::TopicAttributes& pub_topic = publisher_atts.topic;
     dds::WriterQos& pub_qos = publisher_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -925,7 +925,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserPublisherDeprecated)
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
             xmlparser::XMLProfileManager::fillPublisherAttributes(publisher_profile, publisher_atts));
 
-    TopicAttributes& pub_topic = publisher_atts.topic;
+    xmlparser::TopicAttributes& pub_topic = publisher_atts.topic;
     dds::WriterQos& pub_qos = publisher_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -997,7 +997,7 @@ TEST_P(XMLProfileParserTests, XMLParserDefaultPublisherProfile)
             xmlparser::XMLProfileManager::loadXMLFile(xml_filename_));
     xmlparser::XMLProfileManager::getDefaultPublisherAttributes(publisher_atts);
 
-    TopicAttributes& pub_topic = publisher_atts.topic;
+    xmlparser::TopicAttributes& pub_topic = publisher_atts.topic;
     dds::WriterQos& pub_qos = publisher_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -1069,7 +1069,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserDefaultPublisherProfileDeprecated)
             xmlparser::XMLProfileManager::loadXMLFile("test_xml_deprecated.xml"));
     xmlparser::XMLProfileManager::getDefaultPublisherAttributes(publisher_atts);
 
-    TopicAttributes& pub_topic = publisher_atts.topic;
+    xmlparser::TopicAttributes& pub_topic = publisher_atts.topic;
     dds::WriterQos& pub_qos = publisher_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -1143,7 +1143,7 @@ TEST_P(XMLProfileParserTests, XMLParserSubscriber)
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
             xmlparser::XMLProfileManager::fillSubscriberAttributes(subscriber_profile, subscriber_atts));
 
-    TopicAttributes& sub_topic = subscriber_atts.topic;
+    xmlparser::TopicAttributes& sub_topic = subscriber_atts.topic;
     dds::ReaderQos& sub_qos = subscriber_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -1215,7 +1215,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserSubscriberDeprecated)
     EXPECT_EQ(  xmlparser::XMLP_ret::XML_OK,
             xmlparser::XMLProfileManager::fillSubscriberAttributes(subscriber_profile, subscriber_atts));
 
-    TopicAttributes& sub_topic = subscriber_atts.topic;
+    xmlparser::TopicAttributes& sub_topic = subscriber_atts.topic;
     dds::ReaderQos& sub_qos = subscriber_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -1285,7 +1285,7 @@ TEST_P(XMLProfileParserTests, XMLParserDefaultSubscriberProfile)
             xmlparser::XMLProfileManager::loadXMLFile(xml_filename_));
     xmlparser::XMLProfileManager::getDefaultSubscriberAttributes(subscriber_atts);
 
-    TopicAttributes& sub_topic = subscriber_atts.topic;
+    xmlparser::TopicAttributes& sub_topic = subscriber_atts.topic;
     dds::ReaderQos& sub_qos = subscriber_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;
@@ -1355,7 +1355,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserDefaultSubscriberProfileDeprecated)
             xmlparser::XMLProfileManager::loadXMLFile("test_xml_deprecated.xml"));
     xmlparser::XMLProfileManager::getDefaultSubscriberAttributes(subscriber_atts);
 
-    TopicAttributes& sub_topic = subscriber_atts.topic;
+    xmlparser::TopicAttributes& sub_topic = subscriber_atts.topic;
     dds::ReaderQos& sub_qos = subscriber_atts.qos;
     Locator_t locator;
     LocatorListIterator loc_list_it;

--- a/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
+++ b/test/unittest/xmlparser/wrapper/XMLParserTest.hpp
@@ -239,7 +239,7 @@ public:
 
     static XMLP_ret getXMLTopicAttributes_wrapper(
             tinyxml2::XMLElement* elem,
-            TopicAttributes& topic,
+            xmlparser::TopicAttributes& topic,
             uint8_t ident)
     {
         return getXMLTopicAttributes(elem, topic, ident);
@@ -522,7 +522,7 @@ public:
 
     static XMLP_ret fillDataNode_wrapper(
             tinyxml2::XMLElement* p_profile,
-            DataNode<TopicAttributes>& topic_node)
+            DataNode<xmlparser::TopicAttributes>& topic_node)
     {
         return fillDataNode(p_profile, topic_node);
     }

--- a/versions.md
+++ b/versions.md
@@ -19,10 +19,14 @@ Forthcoming
   * RTPSParticipant:
     * Some methods changed to `snake_case`: `register_reader`, `register_writer`, `update_reader`, `update_writer`.
 	* Register methods take a `TopicDescription` instead of `TopicAttributes`.
+	* Update methods no longer take `TopicAttributes`.
 * Discovery callbacks refactor:
   * on_participant_discovery now receives a `ParticipantDiscoveryStatus` and a `ParticipantBuiltinTopicData` instead of a `ParticipantDiscoveryInfo`
   * on_data_reader_discovery now receives a `ReaderDiscoveryStatus` and a `SubscriptionBuiltinTopicData` instead of a `ReaderDiscoveryInfo`
   * on_data_writer_discovery now receives a `WriterDiscoveryStatus` and a `PublicationBuiltinTopicData` instead of a `WriterDiscoveryInfo`
+* New methods to get local discovery information:
+  * `DataWriter::get_publication_builtin_topic_data`
+  * `DataReader::get_subscription_builtin_topic_data`
 * Public API that is no longer public:
   * XML Parser API no longer public.
   * ReaderProxyData

--- a/versions.md
+++ b/versions.md
@@ -16,6 +16,9 @@ Forthcoming
     * Several methods that were meant for internal use have been removed from public API
     * All public methods now have `snake_case` names
     * All public attributes now have `snake_case` names
+  * RTPSParticipant:
+    * Some methods changed to `snake_case`: `register_reader`, `register_writer`, `update_reader`, `update_writer`.
+	* Register methods take a `TopicDescription` instead of `TopicAttributes`.
 * Discovery callbacks refactor:
   * on_participant_discovery now receives a `ParticipantDiscoveryStatus` and a `ParticipantBuiltinTopicData` instead of a `ParticipantDiscoveryInfo`
   * on_data_reader_discovery now receives a `ReaderDiscoveryStatus` and a `SubscriptionBuiltinTopicData` instead of a `ReaderDiscoveryInfo`
@@ -33,6 +36,7 @@ Forthcoming
   * RequesterAttributes
   * PublisherAttributes
   * SubscriberAttributes
+  * TopicAttributes
   * All discovery implementation related API
   * ProxyPool
   * Semaphore


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR:

* Removes `TopicAttributes` from public APIs in DDS and RTPS making usage of the new `PublicationBuiltinTopicData` and `SubscriptionBuiltinTopicData`.
* Moves `TopicAttributes` to the private folder and namespace `eprosima::fastdds::xmlparser`.
* Includes new `get_*_buitin_topic_data()` methods in `DataReader` and `DataWriter`
* Refactors some internal APIs (EDP, BuiltinProtocols,...) so they match the naming chain in snake_case.
* Includes an improvement in the discover server test to make it more resilient.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _NO_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _NO_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - [X] Related Discovery Server PR: https://github.com/eProsima/Discovery-Server/pull/100
    - Related documentation PR: `NOT NEEDED`
    - Related Python PR: `NOT NEEDED`
    - Related Shapes Demo PR: `NOT NEEDED`
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
