### PR TITLE
[21393] Add new tests for testing new key hash calculation according to DDS-XTypes 1.3

### DIFF
--- a/examples/cpp/configuration/ConfigurationCdrAux.ipp
+++ b/examples/cpp/configuration/ConfigurationCdrAux.ipp
@@ -121,8 +121,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Configuration& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
+                        scdr << data.data();
+
 }
 
 

--- a/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
+++ b/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ConfigurationPubSubType::compute_key(
             Configuration_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Configuration_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/content_filter/HelloWorldCdrAux.ipp
+++ b/examples/cpp/content_filter/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/custom_payload_pool/HelloWorldCdrAux.ipp
+++ b/examples/cpp/custom_payload_pool/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/delivery_mechanisms/DeliveryMechanismsCdrAux.ipp
+++ b/examples/cpp/delivery_mechanisms/DeliveryMechanismsCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DeliveryMechanisms& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
+++ b/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool DeliveryMechanismsPubSubType::compute_key(
             DeliveryMechanisms_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DeliveryMechanisms_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/discovery_server/HelloWorldCdrAux.ipp
+++ b/examples/cpp/discovery_server/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/flow_control/FlowControlCdrAux.ipp
+++ b/examples/cpp/flow_control/FlowControlCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FlowControl& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
+++ b/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool FlowControlPubSubType::compute_key(
             FlowControl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FlowControl_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/hello_world/HelloWorldCdrAux.ipp
+++ b/examples/cpp/hello_world/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/request_reply/types/CalculatorCdrAux.ipp
+++ b/examples/cpp/request_reply/types/CalculatorCdrAux.ipp
@@ -129,9 +129,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CalculatorRequestType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.client_id();
+                        scdr << data.client_id();
 
 
 
@@ -218,9 +219,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CalculatorReplyType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.client_id();
+                        scdr << data.client_id();
 
 
 }

--- a/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
+++ b/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool CalculatorRequestTypePubSubType::compute_key(
             CalculatorRequestType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CalculatorRequestType_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool CalculatorReplyTypePubSubType::compute_key(
             CalculatorReplyType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CalculatorReplyType_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/security/HelloWorldCdrAux.ipp
+++ b/examples/cpp/security/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/security/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/security/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/static_edp_discovery/HelloWorldCdrAux.ipp
+++ b/examples/cpp/static_edp_discovery/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/examples/cpp/topic_instances/ShapeTypeCdrAux.ipp
+++ b/examples/cpp/topic_instances/ShapeTypeCdrAux.ipp
@@ -50,17 +50,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.color(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.color(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.x(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.x(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.y(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.y(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.shapesize(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.shapesize(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -84,7 +84,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.x()
         << eprosima::fastcdr::MemberId(2) << data.y()
         << eprosima::fastcdr::MemberId(3) << data.shapesize()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -101,21 +101,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.color();
-                        break;
+                                        case 0:
+                                                dcdr >> data.color();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.x();
-                        break;
+                                        case 1:
+                                                dcdr >> data.x();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.y();
-                        break;
+                                        case 2:
+                                                dcdr >> data.y();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.shapesize();
-                        break;
+                                        case 3:
+                                                dcdr >> data.shapesize();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -132,12 +132,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.color();
+                        scdr << data.color();
 
 
 
 
 }
+
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/examples/cpp/topic_instances/ShapeTypeCdrAux.ipp
+++ b/examples/cpp/topic_instances/ShapeTypeCdrAux.ipp
@@ -50,17 +50,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.color(), current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.color(), current_alignment);
 
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.x(), current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.x(), current_alignment);
 
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.y(), current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.y(), current_alignment);
 
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.shapesize(), current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.shapesize(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -84,7 +84,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.x()
         << eprosima::fastcdr::MemberId(2) << data.y()
         << eprosima::fastcdr::MemberId(3) << data.shapesize()
-;
+    ;
     scdr.end_serialize_type(current_state);
 }
 
@@ -101,21 +101,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.color();
-                                            break;
+                    case 0:
+                        dcdr >> data.color();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.x();
-                                            break;
+                    case 1:
+                        dcdr >> data.x();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.y();
-                                            break;
+                    case 2:
+                        dcdr >> data.y();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.shapesize();
-                                            break;
+                    case 3:
+                        dcdr >> data.shapesize();
+                        break;
 
                     default:
                         ret_value = false;
@@ -129,16 +129,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ShapeType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.color();
+    scdr << data.color();
 
 
 
 
 }
-
-
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
+++ b/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ShapeTypePubSubType::compute_key(
             ShapeType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ShapeType_max_key_cdr_typesize > 16)
     {

--- a/include/fastdds/rtps/common/InstanceHandle.hpp
+++ b/include/fastdds/rtps/common/InstanceHandle.hpp
@@ -29,7 +29,9 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-using KeyHash_t = std::array<octet, 16>;
+constexpr const uint8_t RTPS_KEY_HASH_SIZE = 16;
+
+using KeyHash_t = std::array<octet, RTPS_KEY_HASH_SIZE>;
 
 struct FASTDDS_EXPORTED_API InstanceHandleValue_t
 {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.ipp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.ipp
@@ -115,6 +115,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.type_ids();
+
 }
 
 
@@ -207,6 +209,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.types();
+
+                        scdr << data.complete_to_minimal();
+
 }
 
 
@@ -414,6 +420,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.continuation_point();
+
+                        scdr << data.type_ids();
+
 }
 
 
@@ -506,6 +516,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.continuation_point();
+
+                        scdr << data.dependent_typeids();
+
 }
 
 
@@ -846,9 +860,18 @@ void serialize_key(
         const eprosima::fastdds::dds::builtin::TypeLookup_Request& data)
 {
     using namespace eprosima::fastdds::dds::builtin;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::rpc::RequestHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.data();
+
 }
 
 
@@ -1074,9 +1097,18 @@ void serialize_key(
         const eprosima::fastdds::dds::builtin::TypeLookup_Reply& data)
 {
     using namespace eprosima::fastdds::dds::builtin;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::rpc::ReplyHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.return_value();
+
 }
 
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
@@ -190,7 +190,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_getTypes_In_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_getTypes_In_max_key_cdr_typesize > 16)
         {
@@ -371,7 +372,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_getTypes_Out_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_getTypes_Out_max_key_cdr_typesize > 16)
         {
@@ -553,7 +555,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_getTypeDependencies_In_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_getTypeDependencies_In_max_key_cdr_typesize > 16)
         {
@@ -734,7 +737,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_getTypeDependencies_Out_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_getTypeDependencies_Out_max_key_cdr_typesize > 16)
         {
@@ -917,7 +921,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_Request_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_Request_max_key_cdr_typesize > 16)
         {
@@ -1099,7 +1104,8 @@ namespace builtin {
                 eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_builtin_TypeLookup_Reply_max_key_cdr_typesize > 16)
         {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.ipp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesCdrAux.ipp
@@ -123,6 +123,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.entityKey();
+
+                        scdr << data.entityKind();
+
 }
 
 
@@ -212,9 +216,17 @@ void serialize_key(
         const eprosima::fastdds::dds::GUID_t& data)
 {
     using namespace eprosima::fastdds::dds;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::EntityId_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.guidPrefix();
+
+                        serialize_key(scdr, data.entityId());
+
 }
 
 
@@ -307,6 +319,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.high();
+
+                        scdr << data.low();
+
 }
 
 
@@ -396,9 +412,21 @@ void serialize_key(
         const eprosima::fastdds::dds::SampleIdentity& data)
 {
     using namespace eprosima::fastdds::dds;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::GUID_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::SequenceNumber_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.writer_guid());
+
+                        serialize_key(scdr, data.sequence_number());
+
 }
 
 
@@ -488,9 +516,18 @@ void serialize_key(
         const eprosima::fastdds::dds::rpc::RequestHeader& data)
 {
     using namespace eprosima::fastdds::dds::rpc;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::SampleIdentity& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.requestId());
+
+                        scdr << data.instanceName();
+
 }
 
 
@@ -580,9 +617,18 @@ void serialize_key(
         const eprosima::fastdds::dds::rpc::ReplyHeader& data)
 {
     using namespace eprosima::fastdds::dds::rpc;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::SampleIdentity& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.relatedRequestId());
+
+                        scdr << data.remoteEx();
+
 }
 
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
@@ -189,7 +189,8 @@ bool EntityId_tPubSubType::compute_key(
             eprosima_fastdds_dds_EntityId_t_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_EntityId_t_max_key_cdr_typesize > 16)
     {
@@ -370,7 +371,8 @@ bool GUID_tPubSubType::compute_key(
             eprosima_fastdds_dds_GUID_t_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_GUID_t_max_key_cdr_typesize > 16)
     {
@@ -551,7 +553,8 @@ bool SequenceNumber_tPubSubType::compute_key(
             eprosima_fastdds_dds_SequenceNumber_t_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_SequenceNumber_t_max_key_cdr_typesize > 16)
     {
@@ -732,7 +735,8 @@ bool SampleIdentityPubSubType::compute_key(
             eprosima_fastdds_dds_SampleIdentity_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_SampleIdentity_max_key_cdr_typesize > 16)
     {
@@ -914,7 +918,8 @@ namespace rpc {
                 eprosima_fastdds_dds_rpc_RequestHeader_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_rpc_RequestHeader_max_key_cdr_typesize > 16)
         {
@@ -1095,7 +1100,8 @@ namespace rpc {
                 eprosima_fastdds_dds_rpc_ReplyHeader_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || eprosima_fastdds_dds_rpc_ReplyHeader_max_key_cdr_typesize > 16)
         {

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
@@ -829,22 +829,15 @@ void TypeObjectUtils::add_complete_struct_member(
         {
             throw InvalidArgumentError("Sequence has another member with same name");
         }
-    }
-#endif // !defined(NDEBUG)
-    auto it = member_seq.begin();
-    for (; it != member_seq.end(); ++it)
-    {
-        // Ordered by the member_index
-        if (it->common().member_id() > member.common().member_id())
-        {
-            break;
-        }
-        else if (it->common().member_id() == member.common().member_id())
+
+        if (struct_member.common().member_id() == member.common().member_id())
         {
             throw InvalidArgumentError("Sequence has another member with same ID");
         }
     }
-    member_seq.emplace(it, member);
+#endif // !defined(NDEBUG)
+    // Ordered by the member_index
+    member_seq.emplace_back(member);
 }
 
 const AppliedBuiltinTypeAnnotations TypeObjectUtils::build_applied_builtin_type_annotations(
@@ -999,6 +992,10 @@ void TypeObjectUtils::add_complete_union_member(
         {
             throw InvalidArgumentError("Sequence has another member with same name");
         }
+        if (union_member.common().member_id() == member.common().member_id())
+        {
+            throw InvalidArgumentError("Sequence has another member with same ID");
+        }
         if (member.common().member_flags() & MemberFlagBits::IS_DEFAULT &&
                 union_member.common().member_flags() & MemberFlagBits::IS_DEFAULT)
         {
@@ -1013,20 +1010,8 @@ void TypeObjectUtils::add_complete_union_member(
         }
     }
 #endif // !defined(NDEBUG)
-    auto it = complete_union_member_seq.begin();
-    for (; it != complete_union_member_seq.end(); ++it)
-    {
-        // Ordered by member_index
-        if (it->common().member_id() > member.common().member_id())
-        {
-            break;
-        }
-        else if (it->common().member_id() == member.common().member_id())
-        {
-            throw InvalidArgumentError("Sequence has another member with same ID");
-        }
-    }
-    complete_union_member_seq.emplace(it, member);
+    // Ordered by the member_index
+    complete_union_member_seq.emplace_back(member);
 }
 
 const CommonDiscriminatorMember TypeObjectUtils::build_common_discriminator_member(

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp
@@ -823,6 +823,7 @@ void TypeObjectUtils::add_complete_struct_member(
 {
 #if !defined(NDEBUG)
     complete_struct_member_consistency(member);
+#endif // !defined(NDEBUG)
     for (const CompleteStructMember& struct_member : member_seq)
     {
         if (struct_member.detail().name() == member.detail().name())
@@ -835,7 +836,6 @@ void TypeObjectUtils::add_complete_struct_member(
             throw InvalidArgumentError("Sequence has another member with same ID");
         }
     }
-#endif // !defined(NDEBUG)
     // Ordered by the member_index
     member_seq.emplace_back(member);
 }
@@ -980,6 +980,7 @@ void TypeObjectUtils::add_complete_union_member(
     }
 #if !defined(NDEBUG)
     complete_union_member_consistency(member);
+#endif // !defined(NDEBUG)
     std::set<int32_t> case_labels;
     // New member labels are ensured to be unique (complete_union_member_consistency)
     for (int32_t label : member.common().label_seq())
@@ -1009,7 +1010,6 @@ void TypeObjectUtils::add_complete_union_member(
             }
         }
     }
-#endif // !defined(NDEBUG)
     // Ordered by the member_index
     complete_union_member_seq.emplace_back(member);
 }
@@ -1222,7 +1222,7 @@ const CompleteAliasType TypeObjectUtils::build_complete_alias_type(
 #if !defined(NDEBUG)
     complete_alias_header_consistency(header);
     complete_alias_body_consistency(body);
-#endif // !defined(NDEBUF)
+#endif // !defined(NDEBUG)
     CompleteAliasType complete_alias_type;
     complete_alias_type.alias_flags(alias_flags);
     complete_alias_type.header(header);

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
@@ -256,6 +256,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bound();
+
 }
 
 
@@ -340,6 +342,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bound();
+
 }
 
 
@@ -432,6 +436,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.equiv_kind();
+
+                        scdr << data.element_flags();
+
 }
 
 
@@ -529,9 +537,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainSequenceSElemDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.bound();
+
+                        scdr << data.element_identifier();
+
 }
 
 
@@ -629,9 +649,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainSequenceLElemDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.bound();
+
+                        scdr << data.element_identifier();
+
 }
 
 
@@ -729,9 +761,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainArraySElemDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.array_bound_seq();
+
+                        scdr << data.element_identifier();
+
 }
 
 
@@ -829,9 +873,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainArrayLElemDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.array_bound_seq();
+
+                        scdr << data.element_identifier();
+
 }
 
 
@@ -945,9 +1001,27 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainMapSTypeDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.bound();
+
+                        scdr << data.element_identifier();
+
+                        scdr << data.key_flags();
+
+                        scdr << data.key_identifier();
+
 }
 
 
@@ -1061,9 +1135,27 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::PlainMapLTypeDefn& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::PlainCollectionHeader& data);
+
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.bound();
+
+                        scdr << data.element_identifier();
+
+                        scdr << data.key_flags();
+
+                        scdr << data.key_identifier();
+
 }
 
 
@@ -1164,6 +1256,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.sc_component_id();
+
+                        scdr << data.scc_length();
+
+                        scdr << data.scc_index();
+
 }
 
 
@@ -2369,6 +2467,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.paramname_hash();
+
+                        scdr << data.value();
+
 }
 
 
@@ -2462,6 +2564,13 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.annotation_typeid();
+
+                        if (data.param_seq().has_value())
+                        {
+                            scdr << data.param_seq().value();
+                        }
+
 }
 
 
@@ -2563,6 +2672,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.placement();
+
+                        scdr << data.language();
+
+                        scdr << data.text();
+
 }
 
 
@@ -2671,6 +2786,26 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.unit().has_value())
+                        {
+                            scdr << data.unit().value();
+                        }
+
+                        if (data.min().has_value())
+                        {
+                            scdr << data.min().value();
+                        }
+
+                        if (data.max().has_value())
+                        {
+                            scdr << data.max().value();
+                        }
+
+                        if (data.hash_id().has_value())
+                        {
+                            scdr << data.hash_id().value();
+                        }
+
 }
 
 
@@ -2771,6 +2906,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.member_id();
+
+                        scdr << data.member_flags();
+
+                        scdr << data.member_type_id();
+
 }
 
 
@@ -2868,9 +3009,26 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedBuiltinMemberAnnotations& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.name();
+
+                        if (data.ann_builtin().has_value())
+                        {
+                            serialize_key(scdr, data.ann_builtin().value());
+                        }
+
+                        if (data.ann_custom().has_value())
+                        {
+                            scdr << data.ann_custom().value();
+                        }
+
 }
 
 
@@ -2955,6 +3113,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.name_hash();
+
 }
 
 
@@ -3044,9 +3204,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteStructMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonStructMember& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -3137,9 +3309,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalStructMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonStructMember& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -3222,9 +3406,18 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::AppliedBuiltinTypeAnnotations& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedVerbatimAnnotation& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.verbatim().has_value())
+                        {
+                            serialize_key(scdr, data.verbatim().value());
+                        }
+
 }
 
 
@@ -3394,9 +3587,27 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedBuiltinTypeAnnotations& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.ann_builtin().has_value())
+                        {
+                            serialize_key(scdr, data.ann_builtin().value());
+                        }
+
+                        if (data.ann_custom().has_value())
+                        {
+                            scdr << data.ann_custom().value();
+                        }
+
+                        scdr << data.type_name();
+
 }
 
 
@@ -3486,9 +3697,17 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteStructHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.base_type();
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -3578,9 +3797,17 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalStructHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.base_type();
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -3678,9 +3905,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteStructType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteStructHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.struct_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -3778,9 +4016,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalStructType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalStructHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.struct_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -3890,6 +4139,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.member_id();
+
+                        scdr << data.member_flags();
+
+                        scdr << data.type_id();
+
+                        scdr << data.label_seq();
+
 }
 
 
@@ -3979,9 +4236,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteUnionMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonUnionMember& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -4072,9 +4341,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalUnionMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonUnionMember& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -4168,6 +4449,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.member_flags();
+
+                        scdr << data.type_id();
+
 }
 
 
@@ -4265,9 +4550,30 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteDiscriminatorMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonDiscriminatorMember& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedBuiltinTypeAnnotations& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        if (data.ann_builtin().has_value())
+                        {
+                            serialize_key(scdr, data.ann_builtin().value());
+                        }
+
+                        if (data.ann_custom().has_value())
+                        {
+                            scdr << data.ann_custom().value();
+                        }
+
 }
 
 
@@ -4349,9 +4655,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalDiscriminatorMember& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonDiscriminatorMember& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -4433,9 +4745,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteUnionHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -4517,9 +4835,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalUnionHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -4625,9 +4949,26 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteUnionType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteUnionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteDiscriminatorMember& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.union_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.discriminator());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -4733,9 +5074,26 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalUnionType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalUnionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalDiscriminatorMember& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.union_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.discriminator());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -4828,6 +5186,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.member_flags();
+
+                        scdr << data.member_type_id();
+
 }
 
 
@@ -4925,9 +5287,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteAnnotationParameter& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonAnnotationParameter& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        scdr << data.name();
+
+                        scdr << data.default_value();
+
 }
 
 
@@ -5026,9 +5400,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalAnnotationParameter& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonAnnotationParameter& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        scdr << data.name_hash();
+
+                        scdr << data.default_value();
+
 }
 
 
@@ -5114,6 +5500,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.annotation_name();
+
 }
 
 
@@ -5283,9 +5671,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteAnnotationType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteAnnotationHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.annotation_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -5383,9 +5782,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalAnnotationType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalAnnotationHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.annotation_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.member_seq();
+
 }
 
 
@@ -5478,6 +5888,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.related_flags();
+
+                        scdr << data.related_type();
+
 }
 
 
@@ -5575,9 +5989,30 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteAliasBody& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonAliasBody& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedBuiltinMemberAnnotations& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        if (data.ann_builtin().has_value())
+                        {
+                            serialize_key(scdr, data.ann_builtin().value());
+                        }
+
+                        if (data.ann_custom().has_value())
+                        {
+                            scdr << data.ann_custom().value();
+                        }
+
 }
 
 
@@ -5659,9 +6094,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalAliasBody& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonAliasBody& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -5743,9 +6184,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteAliasHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -5915,9 +6362,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteAliasType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteAliasHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteAliasBody& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.alias_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.body());
+
 }
 
 
@@ -6015,9 +6476,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalAliasType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalAliasHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalAliasBody& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.alias_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.body());
+
 }
 
 
@@ -6107,9 +6582,24 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteElementDetail& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::AppliedBuiltinMemberAnnotations& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.ann_builtin().has_value())
+                        {
+                            serialize_key(scdr, data.ann_builtin().value());
+                        }
+
+                        if (data.ann_custom().has_value())
+                        {
+                            scdr << data.ann_custom().value();
+                        }
+
 }
 
 
@@ -6202,6 +6692,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.element_flags();
+
+                        scdr << data.type();
+
 }
 
 
@@ -6291,9 +6785,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteCollectionElement& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonCollectionElement& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteElementDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -6375,9 +6881,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalCollectionElement& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -6462,6 +6974,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bound();
+
 }
 
 
@@ -6551,9 +7065,24 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonCollectionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        if (data.detail().has_value())
+                        {
+                            serialize_key(scdr, data.detail().value());
+                        }
+
 }
 
 
@@ -6635,9 +7164,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalCollectionHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonCollectionHeader& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -6735,9 +7270,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteSequenceType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -6835,9 +7384,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalSequenceType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -6922,6 +7485,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bound_seq();
+
 }
 
 
@@ -7011,9 +7576,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteArrayHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonArrayHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -7095,9 +7672,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalArrayHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonArrayHeader& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -7195,9 +7778,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteArrayType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteArrayHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -7295,9 +7892,23 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalArrayType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalArrayHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -7403,9 +8014,29 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteMapType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionElement& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.key());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -7511,9 +8142,29 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalMapType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionElement& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalCollectionElement& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.collection_flag();
+
+                        serialize_key(scdr, data.header());
+
+                        serialize_key(scdr, data.key());
+
+                        serialize_key(scdr, data.element());
+
 }
 
 
@@ -7607,6 +8258,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
+                        scdr << data.flags();
+
 }
 
 
@@ -7696,9 +8351,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteEnumeratedLiteral& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonEnumeratedLiteral& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -7789,9 +8456,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalEnumeratedLiteral& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonEnumeratedLiteral& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -7877,6 +8556,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bit_bound();
+
 }
 
 
@@ -7966,9 +8647,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteEnumeratedHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonEnumeratedHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -8050,9 +8743,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalEnumeratedHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonEnumeratedHeader& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
 }
 
 
@@ -8150,9 +8849,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteEnumeratedType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteEnumeratedHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.enum_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.literal_seq();
+
 }
 
 
@@ -8250,9 +8960,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalEnumeratedType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalEnumeratedHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.enum_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.literal_seq();
+
 }
 
 
@@ -8345,6 +9066,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.position();
+
+                        scdr << data.flags();
+
 }
 
 
@@ -8434,9 +9159,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteBitflag& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonBitflag& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -8527,9 +9264,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalBitflag& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonBitflag& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -8615,6 +9364,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bit_bound();
+
 }
 
 
@@ -8717,6 +9468,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bitmask_flags();
+
+                        scdr << data.header();
+
+                        scdr << data.flag_seq();
+
 }
 
 
@@ -8817,6 +9574,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bitmask_flags();
+
+                        scdr << data.header();
+
+                        scdr << data.flag_seq();
+
 }
 
 
@@ -8925,6 +9688,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.position();
+
+                        scdr << data.flags();
+
+                        scdr << data.bitcount();
+
+                        scdr << data.holder_type();
+
 }
 
 
@@ -9014,9 +9785,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteBitfield& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonBitfield& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteMemberDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -9107,9 +9890,18 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalBitfield& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CommonBitfield& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.common());
+
+                        scdr << data.name_hash();
+
 }
 
 
@@ -9192,9 +9984,15 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteBitsetHeader& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteTypeDetail& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.detail());
+
 }
 
 
@@ -9364,9 +10162,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::CompleteBitsetType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::CompleteBitsetHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bitset_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.field_seq();
+
 }
 
 
@@ -9464,9 +10273,20 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::MinimalBitsetType& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::MinimalBitsetHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.bitset_flags();
+
+                        serialize_key(scdr, data.header());
+
+                        scdr << data.field_seq();
+
 }
 
 
@@ -10473,6 +11293,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.type_identifier();
+
+                        scdr << data.type_object();
+
 }
 
 
@@ -10566,6 +11390,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.type_identifier1();
+
+                        scdr << data.type_identifier2();
+
 }
 
 
@@ -10659,6 +11487,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.type_id();
+
+                        scdr << data.typeobject_serialized_size();
+
 }
 
 
@@ -10757,9 +11589,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::TypeIdentifierWithDependencies& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::TypeIdentfierWithSize& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.typeid_with_size());
+
+                        scdr << data.dependent_typeid_count();
+
+                        scdr << data.dependent_typeids();
+
 }
 
 
@@ -10850,9 +11694,21 @@ void serialize_key(
         const eprosima::fastdds::dds::xtypes::TypeInformation& data)
 {
     using namespace eprosima::fastdds::dds::xtypes;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::TypeIdentifierWithDependencies& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::dds::xtypes::TypeIdentifierWithDependencies& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.minimal());
+
+                        serialize_key(scdr, data.complete());
+
 }
 
 

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
@@ -192,7 +192,8 @@ bool StringSTypeDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_StringSTypeDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_StringSTypeDefn_max_key_cdr_typesize > 16)
     {
@@ -373,7 +374,8 @@ bool StringLTypeDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_StringLTypeDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_StringLTypeDefn_max_key_cdr_typesize > 16)
     {
@@ -554,7 +556,8 @@ bool PlainCollectionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainCollectionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainCollectionHeader_max_key_cdr_typesize > 16)
     {
@@ -735,7 +738,8 @@ bool PlainSequenceSElemDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainSequenceSElemDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainSequenceSElemDefn_max_key_cdr_typesize > 16)
     {
@@ -916,7 +920,8 @@ bool PlainSequenceLElemDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainSequenceLElemDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainSequenceLElemDefn_max_key_cdr_typesize > 16)
     {
@@ -1097,7 +1102,8 @@ bool PlainArraySElemDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainArraySElemDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainArraySElemDefn_max_key_cdr_typesize > 16)
     {
@@ -1278,7 +1284,8 @@ bool PlainArrayLElemDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainArrayLElemDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainArrayLElemDefn_max_key_cdr_typesize > 16)
     {
@@ -1459,7 +1466,8 @@ bool PlainMapSTypeDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainMapSTypeDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainMapSTypeDefn_max_key_cdr_typesize > 16)
     {
@@ -1640,7 +1648,8 @@ bool PlainMapLTypeDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_PlainMapLTypeDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_PlainMapLTypeDefn_max_key_cdr_typesize > 16)
     {
@@ -1821,7 +1830,8 @@ bool StronglyConnectedComponentIdPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_StronglyConnectedComponentId_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_StronglyConnectedComponentId_max_key_cdr_typesize > 16)
     {
@@ -2002,7 +2012,8 @@ bool ExtendedTypeDefnPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_ExtendedTypeDefn_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_ExtendedTypeDefn_max_key_cdr_typesize > 16)
     {
@@ -2183,7 +2194,8 @@ bool DummyPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_Dummy_max_key_cdr_typesize > 16)
     {
@@ -2369,7 +2381,8 @@ bool ExtendedAnnotationParameterValuePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_ExtendedAnnotationParameterValue_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_ExtendedAnnotationParameterValue_max_key_cdr_typesize > 16)
     {
@@ -2551,7 +2564,8 @@ bool AppliedAnnotationParameterPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_AppliedAnnotationParameter_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_AppliedAnnotationParameter_max_key_cdr_typesize > 16)
     {
@@ -2733,7 +2747,8 @@ bool AppliedAnnotationPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_AppliedAnnotation_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_AppliedAnnotation_max_key_cdr_typesize > 16)
     {
@@ -2915,7 +2930,8 @@ bool AppliedVerbatimAnnotationPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_AppliedVerbatimAnnotation_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_AppliedVerbatimAnnotation_max_key_cdr_typesize > 16)
     {
@@ -3096,7 +3112,8 @@ bool AppliedBuiltinMemberAnnotationsPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_AppliedBuiltinMemberAnnotations_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_AppliedBuiltinMemberAnnotations_max_key_cdr_typesize > 16)
     {
@@ -3277,7 +3294,8 @@ bool CommonStructMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonStructMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonStructMember_max_key_cdr_typesize > 16)
     {
@@ -3458,7 +3476,8 @@ bool CompleteMemberDetailPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteMemberDetail_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteMemberDetail_max_key_cdr_typesize > 16)
     {
@@ -3639,7 +3658,8 @@ bool MinimalMemberDetailPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalMemberDetail_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalMemberDetail_max_key_cdr_typesize > 16)
     {
@@ -3820,7 +3840,8 @@ bool CompleteStructMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteStructMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteStructMember_max_key_cdr_typesize > 16)
     {
@@ -4002,7 +4023,8 @@ bool MinimalStructMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalStructMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalStructMember_max_key_cdr_typesize > 16)
     {
@@ -4184,7 +4206,8 @@ bool AppliedBuiltinTypeAnnotationsPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_AppliedBuiltinTypeAnnotations_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_AppliedBuiltinTypeAnnotations_max_key_cdr_typesize > 16)
     {
@@ -4365,7 +4388,8 @@ bool MinimalTypeDetailPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalTypeDetail_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalTypeDetail_max_key_cdr_typesize > 16)
     {
@@ -4546,7 +4570,8 @@ bool CompleteTypeDetailPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteTypeDetail_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteTypeDetail_max_key_cdr_typesize > 16)
     {
@@ -4727,7 +4752,8 @@ bool CompleteStructHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteStructHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteStructHeader_max_key_cdr_typesize > 16)
     {
@@ -4908,7 +4934,8 @@ bool MinimalStructHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalStructHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalStructHeader_max_key_cdr_typesize > 16)
     {
@@ -5089,7 +5116,8 @@ bool CompleteStructTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteStructType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteStructType_max_key_cdr_typesize > 16)
     {
@@ -5270,7 +5298,8 @@ bool MinimalStructTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalStructType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalStructType_max_key_cdr_typesize > 16)
     {
@@ -5452,7 +5481,8 @@ bool CommonUnionMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonUnionMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonUnionMember_max_key_cdr_typesize > 16)
     {
@@ -5633,7 +5663,8 @@ bool CompleteUnionMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteUnionMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteUnionMember_max_key_cdr_typesize > 16)
     {
@@ -5815,7 +5846,8 @@ bool MinimalUnionMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalUnionMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalUnionMember_max_key_cdr_typesize > 16)
     {
@@ -5997,7 +6029,8 @@ bool CommonDiscriminatorMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonDiscriminatorMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonDiscriminatorMember_max_key_cdr_typesize > 16)
     {
@@ -6178,7 +6211,8 @@ bool CompleteDiscriminatorMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteDiscriminatorMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteDiscriminatorMember_max_key_cdr_typesize > 16)
     {
@@ -6359,7 +6393,8 @@ bool MinimalDiscriminatorMemberPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalDiscriminatorMember_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalDiscriminatorMember_max_key_cdr_typesize > 16)
     {
@@ -6540,7 +6575,8 @@ bool CompleteUnionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteUnionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteUnionHeader_max_key_cdr_typesize > 16)
     {
@@ -6721,7 +6757,8 @@ bool MinimalUnionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalUnionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalUnionHeader_max_key_cdr_typesize > 16)
     {
@@ -6902,7 +6939,8 @@ bool CompleteUnionTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteUnionType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteUnionType_max_key_cdr_typesize > 16)
     {
@@ -7083,7 +7121,8 @@ bool MinimalUnionTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalUnionType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalUnionType_max_key_cdr_typesize > 16)
     {
@@ -7264,7 +7303,8 @@ bool CommonAnnotationParameterPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonAnnotationParameter_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonAnnotationParameter_max_key_cdr_typesize > 16)
     {
@@ -7445,7 +7485,8 @@ bool CompleteAnnotationParameterPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAnnotationParameter_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAnnotationParameter_max_key_cdr_typesize > 16)
     {
@@ -7627,7 +7668,8 @@ bool MinimalAnnotationParameterPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAnnotationParameter_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAnnotationParameter_max_key_cdr_typesize > 16)
     {
@@ -7809,7 +7851,8 @@ bool CompleteAnnotationHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAnnotationHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAnnotationHeader_max_key_cdr_typesize > 16)
     {
@@ -7990,7 +8033,8 @@ bool MinimalAnnotationHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAnnotationHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAnnotationHeader_max_key_cdr_typesize > 16)
     {
@@ -8171,7 +8215,8 @@ bool CompleteAnnotationTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAnnotationType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAnnotationType_max_key_cdr_typesize > 16)
     {
@@ -8352,7 +8397,8 @@ bool MinimalAnnotationTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAnnotationType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAnnotationType_max_key_cdr_typesize > 16)
     {
@@ -8533,7 +8579,8 @@ bool CommonAliasBodyPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonAliasBody_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonAliasBody_max_key_cdr_typesize > 16)
     {
@@ -8714,7 +8761,8 @@ bool CompleteAliasBodyPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAliasBody_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAliasBody_max_key_cdr_typesize > 16)
     {
@@ -8895,7 +8943,8 @@ bool MinimalAliasBodyPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAliasBody_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAliasBody_max_key_cdr_typesize > 16)
     {
@@ -9076,7 +9125,8 @@ bool CompleteAliasHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAliasHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAliasHeader_max_key_cdr_typesize > 16)
     {
@@ -9257,7 +9307,8 @@ bool MinimalAliasHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAliasHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAliasHeader_max_key_cdr_typesize > 16)
     {
@@ -9438,7 +9489,8 @@ bool CompleteAliasTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteAliasType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteAliasType_max_key_cdr_typesize > 16)
     {
@@ -9619,7 +9671,8 @@ bool MinimalAliasTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalAliasType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalAliasType_max_key_cdr_typesize > 16)
     {
@@ -9800,7 +9853,8 @@ bool CompleteElementDetailPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteElementDetail_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteElementDetail_max_key_cdr_typesize > 16)
     {
@@ -9981,7 +10035,8 @@ bool CommonCollectionElementPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonCollectionElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonCollectionElement_max_key_cdr_typesize > 16)
     {
@@ -10162,7 +10217,8 @@ bool CompleteCollectionElementPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteCollectionElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteCollectionElement_max_key_cdr_typesize > 16)
     {
@@ -10343,7 +10399,8 @@ bool MinimalCollectionElementPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalCollectionElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalCollectionElement_max_key_cdr_typesize > 16)
     {
@@ -10524,7 +10581,8 @@ bool CommonCollectionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonCollectionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonCollectionHeader_max_key_cdr_typesize > 16)
     {
@@ -10705,7 +10763,8 @@ bool CompleteCollectionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteCollectionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteCollectionHeader_max_key_cdr_typesize > 16)
     {
@@ -10886,7 +10945,8 @@ bool MinimalCollectionHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalCollectionHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalCollectionHeader_max_key_cdr_typesize > 16)
     {
@@ -11067,7 +11127,8 @@ bool CompleteSequenceTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteSequenceType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteSequenceType_max_key_cdr_typesize > 16)
     {
@@ -11248,7 +11309,8 @@ bool MinimalSequenceTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalSequenceType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalSequenceType_max_key_cdr_typesize > 16)
     {
@@ -11429,7 +11491,8 @@ bool CommonArrayHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonArrayHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonArrayHeader_max_key_cdr_typesize > 16)
     {
@@ -11610,7 +11673,8 @@ bool CompleteArrayHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteArrayHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteArrayHeader_max_key_cdr_typesize > 16)
     {
@@ -11791,7 +11855,8 @@ bool MinimalArrayHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalArrayHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalArrayHeader_max_key_cdr_typesize > 16)
     {
@@ -11972,7 +12037,8 @@ bool CompleteArrayTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteArrayType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteArrayType_max_key_cdr_typesize > 16)
     {
@@ -12153,7 +12219,8 @@ bool MinimalArrayTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalArrayType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalArrayType_max_key_cdr_typesize > 16)
     {
@@ -12334,7 +12401,8 @@ bool CompleteMapTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteMapType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteMapType_max_key_cdr_typesize > 16)
     {
@@ -12515,7 +12583,8 @@ bool MinimalMapTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalMapType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalMapType_max_key_cdr_typesize > 16)
     {
@@ -12697,7 +12766,8 @@ bool CommonEnumeratedLiteralPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonEnumeratedLiteral_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonEnumeratedLiteral_max_key_cdr_typesize > 16)
     {
@@ -12878,7 +12948,8 @@ bool CompleteEnumeratedLiteralPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteEnumeratedLiteral_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteEnumeratedLiteral_max_key_cdr_typesize > 16)
     {
@@ -13060,7 +13131,8 @@ bool MinimalEnumeratedLiteralPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalEnumeratedLiteral_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalEnumeratedLiteral_max_key_cdr_typesize > 16)
     {
@@ -13242,7 +13314,8 @@ bool CommonEnumeratedHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonEnumeratedHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonEnumeratedHeader_max_key_cdr_typesize > 16)
     {
@@ -13423,7 +13496,8 @@ bool CompleteEnumeratedHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteEnumeratedHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteEnumeratedHeader_max_key_cdr_typesize > 16)
     {
@@ -13604,7 +13678,8 @@ bool MinimalEnumeratedHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalEnumeratedHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalEnumeratedHeader_max_key_cdr_typesize > 16)
     {
@@ -13785,7 +13860,8 @@ bool CompleteEnumeratedTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteEnumeratedType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteEnumeratedType_max_key_cdr_typesize > 16)
     {
@@ -13966,7 +14042,8 @@ bool MinimalEnumeratedTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalEnumeratedType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalEnumeratedType_max_key_cdr_typesize > 16)
     {
@@ -14147,7 +14224,8 @@ bool CommonBitflagPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonBitflag_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonBitflag_max_key_cdr_typesize > 16)
     {
@@ -14328,7 +14406,8 @@ bool CompleteBitflagPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteBitflag_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteBitflag_max_key_cdr_typesize > 16)
     {
@@ -14510,7 +14589,8 @@ bool MinimalBitflagPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalBitflag_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalBitflag_max_key_cdr_typesize > 16)
     {
@@ -14692,7 +14772,8 @@ bool CommonBitmaskHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonBitmaskHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonBitmaskHeader_max_key_cdr_typesize > 16)
     {
@@ -14875,7 +14956,8 @@ bool CompleteBitmaskTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteBitmaskType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteBitmaskType_max_key_cdr_typesize > 16)
     {
@@ -15056,7 +15138,8 @@ bool MinimalBitmaskTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalBitmaskType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalBitmaskType_max_key_cdr_typesize > 16)
     {
@@ -15237,7 +15320,8 @@ bool CommonBitfieldPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CommonBitfield_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CommonBitfield_max_key_cdr_typesize > 16)
     {
@@ -15418,7 +15502,8 @@ bool CompleteBitfieldPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteBitfield_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteBitfield_max_key_cdr_typesize > 16)
     {
@@ -15600,7 +15685,8 @@ bool MinimalBitfieldPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalBitfield_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalBitfield_max_key_cdr_typesize > 16)
     {
@@ -15782,7 +15868,8 @@ bool CompleteBitsetHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteBitsetHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteBitsetHeader_max_key_cdr_typesize > 16)
     {
@@ -15963,7 +16050,8 @@ bool MinimalBitsetHeaderPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalBitsetHeader_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalBitsetHeader_max_key_cdr_typesize > 16)
     {
@@ -16144,7 +16232,8 @@ bool CompleteBitsetTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteBitsetType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteBitsetType_max_key_cdr_typesize > 16)
     {
@@ -16325,7 +16414,8 @@ bool MinimalBitsetTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalBitsetType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalBitsetType_max_key_cdr_typesize > 16)
     {
@@ -16506,7 +16596,8 @@ bool CompleteExtendedTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_CompleteExtendedType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_CompleteExtendedType_max_key_cdr_typesize > 16)
     {
@@ -16688,7 +16779,8 @@ bool MinimalExtendedTypePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_MinimalExtendedType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_MinimalExtendedType_max_key_cdr_typesize > 16)
     {
@@ -16873,7 +16965,8 @@ bool TypeIdentifierTypeObjectPairPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_TypeIdentifierTypeObjectPair_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_TypeIdentifierTypeObjectPair_max_key_cdr_typesize > 16)
     {
@@ -17055,7 +17148,8 @@ bool TypeIdentifierPairPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_TypeIdentifierPair_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_TypeIdentifierPair_max_key_cdr_typesize > 16)
     {
@@ -17237,7 +17331,8 @@ bool TypeIdentfierWithSizePubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_TypeIdentfierWithSize_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_TypeIdentfierWithSize_max_key_cdr_typesize > 16)
     {
@@ -17419,7 +17514,8 @@ bool TypeIdentifierWithDependenciesPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_TypeIdentifierWithDependencies_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_TypeIdentifierWithDependencies_max_key_cdr_typesize > 16)
     {
@@ -17601,7 +17697,8 @@ bool TypeInformationPubSubType::compute_key(
             eprosima_fastdds_dds_xtypes_TypeInformation_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || eprosima_fastdds_dds_xtypes_TypeInformation_max_key_cdr_typesize > 16)
     {

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
@@ -136,9 +136,23 @@ void serialize_key(
         const eprosima::fastdds::statistics::Connection& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.mode();
+
+                        serialize_key(scdr, data.guid());
+
+                        scdr << data.announced_locators();
+
+                        scdr << data.used_locators();
+
 }
 
 
@@ -231,6 +245,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.policy_id();
+
+                        scdr << data.count();
+
 }
 
 
@@ -315,6 +333,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
 }
 
 
@@ -416,6 +436,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
+                        scdr << data.last_policy_id();
+
+                        scdr << data.policies();
+
 }
 
 
@@ -516,6 +542,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.alive_count();
+
+                        scdr << data.not_alive_count();
+
+                        scdr << data.last_publication_handle();
+
 }
 
 
@@ -608,6 +640,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
+                        scdr << data.last_instance_handle();
+
 }
 
 
@@ -992,12 +1028,18 @@ void serialize_key(
         const eprosima::fastdds::statistics::MonitorServiceStatusData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.local_entity();
+                        serialize_key(scdr, data.local_entity());
 
-                            scdr << data.status_kind();
+                        scdr << data.status_kind();
 
 
 }

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -187,7 +187,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Connection_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Connection_max_key_cdr_typesize > 16)
                 {
@@ -367,7 +368,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_QosPolicyCount_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_QosPolicyCount_s_max_key_cdr_typesize > 16)
                 {
@@ -547,7 +549,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -728,7 +731,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_IncompatibleQoSStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_IncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -908,7 +912,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_LivelinessChangedStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_LivelinessChangedStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -1088,7 +1093,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -1275,7 +1281,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_MonitorServiceStatusData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_MonitorServiceStatusData_max_key_cdr_typesize > 16)
                 {

--- a/src/cpp/statistics/types/typesCdrAux.ipp
+++ b/src/cpp/statistics/types/typesCdrAux.ipp
@@ -115,6 +115,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -199,6 +201,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -288,9 +292,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::detail::GUID_s& data)
 {
     using namespace eprosima::fastdds::statistics::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GuidPrefix_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::EntityId_s& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.guidPrefix());
+
+                        serialize_key(scdr, data.entityId());
+
 }
 
 
@@ -383,6 +399,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.high();
+
+                        scdr << data.low();
+
 }
 
 
@@ -472,9 +492,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::detail::SampleIdentity_s& data)
 {
     using namespace eprosima::fastdds::statistics::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::SequenceNumber_s& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.writer_guid());
+
+                        serialize_key(scdr, data.sequence_number());
+
 }
 
 
@@ -575,6 +607,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.kind();
+
+                        scdr << data.port();
+
+                        scdr << data.address();
+
 }
 
 
@@ -696,12 +734,24 @@ void serialize_key(
         const eprosima::fastdds::statistics::DiscoveryTime& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.local_participant_guid();
+                        serialize_key(scdr, data.local_participant_guid());
 
-                                scdr << data.remote_entity_guid();
+                        serialize_key(scdr, data.remote_entity_guid());
 
 
 
@@ -796,10 +846,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::EntityCount& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.guid();
+                        serialize_key(scdr, data.guid());
 
 
 }
@@ -891,10 +946,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::SampleIdentityCount& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::SampleIdentity_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.sample_id();
+                        serialize_key(scdr, data.sample_id());
 
 
 }
@@ -1010,12 +1070,23 @@ void serialize_key(
         const eprosima::fastdds::statistics::Entity2LocatorTraffic& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.src_guid();
+                        serialize_key(scdr, data.src_guid());
 
-                                scdr << data.dst_locator();
+                        serialize_key(scdr, data.dst_locator());
 
 
 
@@ -1117,12 +1188,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::WriterReaderData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.writer_guid();
+                        serialize_key(scdr, data.writer_guid());
 
-                                scdr << data.reader_guid();
+                        serialize_key(scdr, data.reader_guid());
 
 
 }
@@ -1222,12 +1302,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::Locator2LocatorData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.src_locator();
+                        serialize_key(scdr, data.src_locator());
 
-                                scdr << data.dst_locator();
+                        serialize_key(scdr, data.dst_locator());
 
 
 }
@@ -1319,10 +1408,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::EntityData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.guid();
+                        serialize_key(scdr, data.guid());
 
 
 }
@@ -1430,10 +1524,17 @@ void serialize_key(
         const eprosima::fastdds::statistics::PhysicalData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.participant_guid();
+                        serialize_key(scdr, data.participant_guid());
 
 
 

--- a/src/cpp/statistics/types/typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/typesPubSubTypes.cxx
@@ -188,7 +188,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_EntityId_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_EntityId_s_max_key_cdr_typesize > 16)
                     {
@@ -368,7 +369,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_GuidPrefix_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_GuidPrefix_s_max_key_cdr_typesize > 16)
                     {
@@ -548,7 +550,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_GUID_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_GUID_s_max_key_cdr_typesize > 16)
                     {
@@ -728,7 +731,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_SequenceNumber_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_SequenceNumber_s_max_key_cdr_typesize > 16)
                     {
@@ -908,7 +912,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_SampleIdentity_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_SampleIdentity_s_max_key_cdr_typesize > 16)
                     {
@@ -1088,7 +1093,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_Locator_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_Locator_s_max_key_cdr_typesize > 16)
                     {
@@ -1270,7 +1276,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_DiscoveryTime_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_DiscoveryTime_max_key_cdr_typesize > 16)
                 {
@@ -1450,7 +1457,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_EntityCount_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_EntityCount_max_key_cdr_typesize > 16)
                 {
@@ -1630,7 +1638,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_SampleIdentityCount_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_SampleIdentityCount_max_key_cdr_typesize > 16)
                 {
@@ -1810,7 +1819,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Entity2LocatorTraffic_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Entity2LocatorTraffic_max_key_cdr_typesize > 16)
                 {
@@ -1990,7 +2000,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_WriterReaderData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_WriterReaderData_max_key_cdr_typesize > 16)
                 {
@@ -2170,7 +2181,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Locator2LocatorData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Locator2LocatorData_max_key_cdr_typesize > 16)
                 {
@@ -2350,7 +2362,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_EntityData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_EntityData_max_key_cdr_typesize > 16)
                 {
@@ -2530,7 +2543,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_PhysicalData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_PhysicalData_max_key_cdr_typesize > 16)
                 {

--- a/test/blackbox/types/Data1mbCdrAux.ipp
+++ b/test/blackbox/types/Data1mbCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Data1mb& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.data();
+
 }
 
 

--- a/test/blackbox/types/Data1mbPubSubTypes.cxx
+++ b/test/blackbox/types/Data1mbPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool Data1mbPubSubType::compute_key(
             Data1mb_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Data1mb_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/Data64kbCdrAux.ipp
+++ b/test/blackbox/types/Data64kbCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Data64kb& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.data();
+
 }
 
 

--- a/test/blackbox/types/Data64kbPubSubTypes.cxx
+++ b/test/blackbox/types/Data64kbPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool Data64kbPubSubType::compute_key(
             Data64kb_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Data64kb_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/FixedSizedCdrAux.ipp
+++ b/test/blackbox/types/FixedSizedCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixedSized& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
 }
 
 

--- a/test/blackbox/types/FixedSizedPubSubTypes.cxx
+++ b/test/blackbox/types/FixedSizedPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool FixedSizedPubSubType::compute_key(
             FixedSized_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixedSized_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/HelloWorldCdrAux.ipp
+++ b/test/blackbox/types/HelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/test/blackbox/types/HelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/HelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool HelloWorldPubSubType::compute_key(
             HelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HelloWorld_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/KeyedData1mbCdrAux.ipp
+++ b/test/blackbox/types/KeyedData1mbCdrAux.ipp
@@ -113,9 +113,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedData1mb& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key();
+                        scdr << data.key();
 
 
 }

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool KeyedData1mbPubSubType::compute_key(
             KeyedData1mb_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedData1mb_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/KeyedHelloWorldCdrAux.ipp
+++ b/test/blackbox/types/KeyedHelloWorldCdrAux.ipp
@@ -121,9 +121,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedHelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key();
+                        scdr << data.key();
 
 
 

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool KeyedHelloWorldPubSubType::compute_key(
             KeyedHelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedHelloWorld_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/StringTestCdrAux.ipp
+++ b/test/blackbox/types/StringTestCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StringTest& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.message();
+
 }
 
 

--- a/test/blackbox/types/StringTestPubSubTypes.cxx
+++ b/test/blackbox/types/StringTestPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool StringTestPubSubType::compute_key(
             StringTest_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StringTest_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/TestRegression3361CdrAux.ipp
+++ b/test/blackbox/types/TestRegression3361CdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const TestRegression3361& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.uuid();
+
 }
 
 

--- a/test/blackbox/types/TestRegression3361PubSubTypes.cxx
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.cxx
@@ -184,7 +184,8 @@ bool TestRegression3361PubSubType::compute_key(
             TestRegression3361_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TestRegression3361_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/UnboundedHelloWorldCdrAux.ipp
+++ b/test/blackbox/types/UnboundedHelloWorldCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnboundedHelloWorld& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        scdr << data.message();
+
 }
 
 

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool UnboundedHelloWorldPubSubType::compute_key(
             UnboundedHelloWorld_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnboundedHelloWorld_max_key_cdr_typesize > 16)
     {

--- a/test/blackbox/types/core/core_typesCdrAux.ipp
+++ b/test/blackbox/types/core/core_typesCdrAux.ipp
@@ -115,6 +115,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -207,6 +209,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.major();
+
+                        scdr << data.minor();
+
 }
 
 
@@ -291,6 +297,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.vendorId();
+
 }
 
 
@@ -375,6 +383,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -464,9 +474,21 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::detail::GUID_t& data)
 {
     using namespace eprosima::fastdds::rtps::core::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::GuidPrefix_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::EntityId_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.guidPrefix());
+
+                        serialize_key(scdr, data.entityId());
+
 }
 
 
@@ -559,6 +581,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.high();
+
+                        scdr << data.low();
+
 }
 
 
@@ -643,6 +669,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -735,6 +763,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.seconds();
+
+                        scdr << data.fraction();
+
 }
 
 
@@ -833,9 +865,21 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::detail::SequenceNumberSet& data)
 {
     using namespace eprosima::fastdds::rtps::core::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::SequenceNumber_t& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.bitmapBase());
+
+                        scdr << data.numBits();
+
+                        scdr << data.bitmap();
+
 }
 
 
@@ -936,6 +980,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.kind();
+
+                        scdr << data.port();
+
+                        scdr << data.address();
+
 }
 
 
@@ -1028,6 +1078,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.seconds();
+
+                        scdr << data.fraction();
+
 }
 
 
@@ -1114,6 +1168,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1198,6 +1254,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1282,6 +1340,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.name();
+
 }
 
 
@@ -1387,9 +1447,29 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::Header& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::ProtocolVersion_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::VendorId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::GuidPrefix_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.prefix();
+
+                        serialize_key(scdr, data.version());
+
+                        serialize_key(scdr, data.vendorId());
+
+                        serialize_key(scdr, data.guidPrefix());
+
 }
 
 
@@ -1490,6 +1570,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.submessageId();
+
+                        scdr << data.flags();
+
+                        scdr << data.submessageLength();
+
 }
 
 
@@ -1604,9 +1690,39 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::AckNackSubmessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::SubmessageHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::EntityId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::EntityId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::SequenceNumberSet& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::Count_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.submsgHeader());
+
+                        serialize_key(scdr, data.readerId());
+
+                        serialize_key(scdr, data.writerId());
+
+                        serialize_key(scdr, data.readerSNState());
+
+                        serialize_key(scdr, data.count());
+
 }
 
 
@@ -1728,9 +1844,45 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::HeartBeatSubmessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::SubmessageHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::EntityId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::EntityId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::SequenceNumber_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::SequenceNumber_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::Count_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.submsgHeader());
+
+                        serialize_key(scdr, data.readerId());
+
+                        serialize_key(scdr, data.writerId());
+
+                        serialize_key(scdr, data.firstSN());
+
+                        serialize_key(scdr, data.lastSN());
+
+                        serialize_key(scdr, data.count());
+
 }
 
 
@@ -1820,9 +1972,21 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::InfoDestinationSubmessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::SubmessageHeader& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::GuidPrefix_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.submsgHeader());
+
+                        serialize_key(scdr, data.guidPrefix());
+
 }
 
 
@@ -1936,9 +2100,36 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::InfoSourceSubmessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::SubmessageHeader& data);
+
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::ProtocolVersion_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::VendorId_t& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::detail::GuidPrefix_t& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.submsgHeader());
+
+                        scdr << data.unused();
+
+                        serialize_key(scdr, data.version());
+
+                        serialize_key(scdr, data.vendorId());
+
+                        serialize_key(scdr, data.guidPrefix());
+
 }
 
 
@@ -2028,9 +2219,18 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::InfoTimestampSubmessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::SubmessageHeader& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.submsgHeader());
+
+                        scdr << data.timestamp();
+
 }
 
 
@@ -2310,9 +2510,18 @@ void serialize_key(
         const eprosima::fastdds::rtps::core::RTPSMessage& data)
 {
     using namespace eprosima::fastdds::rtps::core;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::rtps::core::Header& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.msg_header());
+
+                        scdr << data.submessages();
+
 }
 
 

--- a/test/blackbox/types/core/core_typesPubSubTypes.cxx
+++ b/test/blackbox/types/core/core_typesPubSubTypes.cxx
@@ -189,7 +189,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_EntityId_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_EntityId_t_max_key_cdr_typesize > 16)
                         {
@@ -369,7 +370,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_ProtocolVersion_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_ProtocolVersion_t_max_key_cdr_typesize > 16)
                         {
@@ -549,7 +551,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_VendorId_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_VendorId_t_max_key_cdr_typesize > 16)
                         {
@@ -729,7 +732,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_GuidPrefix_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_GuidPrefix_t_max_key_cdr_typesize > 16)
                         {
@@ -909,7 +913,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_GUID_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_GUID_t_max_key_cdr_typesize > 16)
                         {
@@ -1089,7 +1094,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_SequenceNumber_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_SequenceNumber_t_max_key_cdr_typesize > 16)
                         {
@@ -1269,7 +1275,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_Count_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_Count_t_max_key_cdr_typesize > 16)
                         {
@@ -1449,7 +1456,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_Time_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_Time_t_max_key_cdr_typesize > 16)
                         {
@@ -1630,7 +1638,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_SequenceNumberSet_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_SequenceNumberSet_max_key_cdr_typesize > 16)
                         {
@@ -1810,7 +1819,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_Locator_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_Locator_t_max_key_cdr_typesize > 16)
                         {
@@ -1990,7 +2000,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_Duration_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_Duration_t_max_key_cdr_typesize > 16)
                         {
@@ -2172,7 +2183,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_StatusInfo_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_StatusInfo_t_max_key_cdr_typesize > 16)
                         {
@@ -2352,7 +2364,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_KeyHash_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_KeyHash_t_max_key_cdr_typesize > 16)
                         {
@@ -2532,7 +2545,8 @@ namespace eprosima {
                                 eprosima_fastdds_rtps_core_detail_EntityName_t_max_key_cdr_typesize);
 
                         // Object that serializes the data.
-                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                         eprosima::fastcdr::serialize_key(ser, *p_type);
                         if (force_md5 || eprosima_fastdds_rtps_core_detail_EntityName_t_max_key_cdr_typesize > 16)
                         {
@@ -2714,7 +2728,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_Header_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_Header_max_key_cdr_typesize > 16)
                     {
@@ -2894,7 +2909,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_SubmessageHeader_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_SubmessageHeader_max_key_cdr_typesize > 16)
                     {
@@ -3077,7 +3093,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_AckNackSubmessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_AckNackSubmessage_max_key_cdr_typesize > 16)
                     {
@@ -3257,7 +3274,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_HeartBeatSubmessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_HeartBeatSubmessage_max_key_cdr_typesize > 16)
                     {
@@ -3437,7 +3455,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_InfoDestinationSubmessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_InfoDestinationSubmessage_max_key_cdr_typesize > 16)
                     {
@@ -3617,7 +3636,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_InfoSourceSubmessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_InfoSourceSubmessage_max_key_cdr_typesize > 16)
                     {
@@ -3797,7 +3817,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_InfoTimestampSubmessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_InfoTimestampSubmessage_max_key_cdr_typesize > 16)
                     {
@@ -3978,7 +3999,8 @@ namespace eprosima {
                             eprosima_fastdds_rtps_core_RTPSMessage_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_rtps_core_RTPSMessage_max_key_cdr_typesize > 16)
                     {

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
@@ -136,9 +136,23 @@ void serialize_key(
         const eprosima::fastdds::statistics::Connection& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.mode();
+
+                        serialize_key(scdr, data.guid());
+
+                        scdr << data.announced_locators();
+
+                        scdr << data.used_locators();
+
 }
 
 
@@ -231,6 +245,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.policy_id();
+
+                        scdr << data.count();
+
 }
 
 
@@ -315,6 +333,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
 }
 
 
@@ -416,6 +436,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
+                        scdr << data.last_policy_id();
+
+                        scdr << data.policies();
+
 }
 
 
@@ -516,6 +542,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.alive_count();
+
+                        scdr << data.not_alive_count();
+
+                        scdr << data.last_publication_handle();
+
 }
 
 
@@ -608,6 +640,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.total_count();
+
+                        scdr << data.last_instance_handle();
+
 }
 
 
@@ -992,12 +1028,18 @@ void serialize_key(
         const eprosima::fastdds::statistics::MonitorServiceStatusData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.local_entity();
+                        serialize_key(scdr, data.local_entity());
 
-                            scdr << data.status_kind();
+                        scdr << data.status_kind();
 
 
 }

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -187,7 +187,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Connection_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Connection_max_key_cdr_typesize > 16)
                 {
@@ -367,7 +368,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_QosPolicyCount_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_QosPolicyCount_s_max_key_cdr_typesize > 16)
                 {
@@ -547,7 +549,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -728,7 +731,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_IncompatibleQoSStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_IncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -908,7 +912,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_LivelinessChangedStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_LivelinessChangedStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -1088,7 +1093,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize > 16)
                 {
@@ -1275,7 +1281,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_MonitorServiceStatusData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_MonitorServiceStatusData_max_key_cdr_typesize > 16)
                 {

--- a/test/blackbox/types/statistics/typesCdrAux.ipp
+++ b/test/blackbox/types/statistics/typesCdrAux.ipp
@@ -115,6 +115,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -199,6 +201,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -288,9 +292,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::detail::GUID_s& data)
 {
     using namespace eprosima::fastdds::statistics::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GuidPrefix_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::EntityId_s& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.guidPrefix());
+
+                        serialize_key(scdr, data.entityId());
+
 }
 
 
@@ -383,6 +399,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.high();
+
+                        scdr << data.low();
+
 }
 
 
@@ -472,9 +492,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::detail::SampleIdentity_s& data)
 {
     using namespace eprosima::fastdds::statistics::detail;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::SequenceNumber_s& data);
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.writer_guid());
+
+                        serialize_key(scdr, data.sequence_number());
+
 }
 
 
@@ -575,6 +607,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.kind();
+
+                        scdr << data.port();
+
+                        scdr << data.address();
+
 }
 
 
@@ -696,12 +734,24 @@ void serialize_key(
         const eprosima::fastdds::statistics::DiscoveryTime& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.local_participant_guid();
+                        serialize_key(scdr, data.local_participant_guid());
 
-                                scdr << data.remote_entity_guid();
+                        serialize_key(scdr, data.remote_entity_guid());
 
 
 
@@ -796,10 +846,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::EntityCount& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.guid();
+                        serialize_key(scdr, data.guid());
 
 
 }
@@ -891,10 +946,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::SampleIdentityCount& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::SampleIdentity_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.sample_id();
+                        serialize_key(scdr, data.sample_id());
 
 
 }
@@ -1010,12 +1070,23 @@ void serialize_key(
         const eprosima::fastdds::statistics::Entity2LocatorTraffic& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.src_guid();
+                        serialize_key(scdr, data.src_guid());
 
-                                scdr << data.dst_locator();
+                        serialize_key(scdr, data.dst_locator());
 
 
 
@@ -1117,12 +1188,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::WriterReaderData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.writer_guid();
+                        serialize_key(scdr, data.writer_guid());
 
-                                scdr << data.reader_guid();
+                        serialize_key(scdr, data.reader_guid());
 
 
 }
@@ -1222,12 +1302,21 @@ void serialize_key(
         const eprosima::fastdds::statistics::Locator2LocatorData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::Locator_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.src_locator();
+                        serialize_key(scdr, data.src_locator());
 
-                                scdr << data.dst_locator();
+                        serialize_key(scdr, data.dst_locator());
 
 
 }
@@ -1319,10 +1408,15 @@ void serialize_key(
         const eprosima::fastdds::statistics::EntityData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.guid();
+                        serialize_key(scdr, data.guid());
 
 
 }
@@ -1430,10 +1524,17 @@ void serialize_key(
         const eprosima::fastdds::statistics::PhysicalData& data)
 {
     using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                                scdr << data.participant_guid();
+                        serialize_key(scdr, data.participant_guid());
 
 
 

--- a/test/blackbox/types/statistics/typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/typesPubSubTypes.cxx
@@ -188,7 +188,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_EntityId_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_EntityId_s_max_key_cdr_typesize > 16)
                     {
@@ -368,7 +369,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_GuidPrefix_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_GuidPrefix_s_max_key_cdr_typesize > 16)
                     {
@@ -548,7 +550,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_GUID_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_GUID_s_max_key_cdr_typesize > 16)
                     {
@@ -728,7 +731,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_SequenceNumber_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_SequenceNumber_s_max_key_cdr_typesize > 16)
                     {
@@ -908,7 +912,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_SampleIdentity_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_SampleIdentity_s_max_key_cdr_typesize > 16)
                     {
@@ -1088,7 +1093,8 @@ namespace eprosima {
                             eprosima_fastdds_statistics_detail_Locator_s_max_key_cdr_typesize);
 
                     // Object that serializes the data.
-                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                     eprosima::fastcdr::serialize_key(ser, *p_type);
                     if (force_md5 || eprosima_fastdds_statistics_detail_Locator_s_max_key_cdr_typesize > 16)
                     {
@@ -1270,7 +1276,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_DiscoveryTime_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_DiscoveryTime_max_key_cdr_typesize > 16)
                 {
@@ -1450,7 +1457,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_EntityCount_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_EntityCount_max_key_cdr_typesize > 16)
                 {
@@ -1630,7 +1638,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_SampleIdentityCount_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_SampleIdentityCount_max_key_cdr_typesize > 16)
                 {
@@ -1810,7 +1819,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Entity2LocatorTraffic_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Entity2LocatorTraffic_max_key_cdr_typesize > 16)
                 {
@@ -1990,7 +2000,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_WriterReaderData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_WriterReaderData_max_key_cdr_typesize > 16)
                 {
@@ -2170,7 +2181,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_Locator2LocatorData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_Locator2LocatorData_max_key_cdr_typesize > 16)
                 {
@@ -2350,7 +2362,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_EntityData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_EntityData_max_key_cdr_typesize > 16)
                 {
@@ -2530,7 +2543,8 @@ namespace eprosima {
                         eprosima_fastdds_statistics_PhysicalData_max_key_cdr_typesize);
 
                 // Object that serializes the data.
-                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
                 eprosima::fastcdr::serialize_key(ser, *p_type);
                 if (force_md5 || eprosima_fastdds_statistics_PhysicalData_max_key_cdr_typesize > 16)
                 {

--- a/test/dds-types-test/aliasesCdrAux.ipp
+++ b/test/dds-types-test/aliasesCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasInt16& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasUint16& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasInt32& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasUInt32& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasInt64& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasUInt64& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasFloat32& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasFloat64& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasFloat128& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasBool& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasChar8& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasChar16& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasString8& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasString16& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasBitmask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasMultiArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1701,8 +1764,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1777,8 +1843,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1853,8 +1922,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1929,8 +2001,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 

--- a/test/dds-types-test/aliasesPubSubTypes.cxx
+++ b/test/dds-types-test/aliasesPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool AliasInt16PubSubType::compute_key(
             AliasInt16_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasInt16_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool AliasUint16PubSubType::compute_key(
             AliasUint16_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasUint16_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool AliasInt32PubSubType::compute_key(
             AliasInt32_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasInt32_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool AliasUInt32PubSubType::compute_key(
             AliasUInt32_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasUInt32_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool AliasInt64PubSubType::compute_key(
             AliasInt64_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasInt64_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool AliasUInt64PubSubType::compute_key(
             AliasUInt64_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasUInt64_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool AliasFloat32PubSubType::compute_key(
             AliasFloat32_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasFloat32_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool AliasFloat64PubSubType::compute_key(
             AliasFloat64_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasFloat64_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool AliasFloat128PubSubType::compute_key(
             AliasFloat128_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasFloat128_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool AliasBoolPubSubType::compute_key(
             AliasBool_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasBool_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool AliasOctetPubSubType::compute_key(
             AliasOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool AliasChar8PubSubType::compute_key(
             AliasChar8_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasChar8_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool AliasChar16PubSubType::compute_key(
             AliasChar16_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasChar16_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool AliasString8PubSubType::compute_key(
             AliasString8_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasString8_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool AliasString16PubSubType::compute_key(
             AliasString16_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasString16_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool AliasEnumPubSubType::compute_key(
             AliasEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasEnum_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool AliasBitmaskPubSubType::compute_key(
             AliasBitmask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasBitmask_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool AliasAliasPubSubType::compute_key(
             AliasAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasAlias_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool AliasArrayPubSubType::compute_key(
             AliasArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasArray_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool AliasMultiArrayPubSubType::compute_key(
             AliasMultiArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasMultiArray_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool AliasSequencePubSubType::compute_key(
             AliasSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasSequence_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool AliasMapPubSubType::compute_key(
             AliasMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasMap_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool AliasUnionPubSubType::compute_key(
             AliasUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasUnion_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool AliasStructPubSubType::compute_key(
             AliasStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasStruct_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool AliasBitsetPubSubType::compute_key(
             AliasBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasBitset_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/annotationsCdrAux.ipp
+++ b/test/dds-types-test/annotationsCdrAux.ipp
@@ -93,6 +93,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AnnotatedStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -157,6 +158,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const EmptyAnnotatedStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -234,8 +236,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BasicAnnotationsStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.basic_annotations_member();
+
 }
 
 

--- a/test/dds-types-test/annotationsPubSubTypes.cxx
+++ b/test/dds-types-test/annotationsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool AnnotatedStructPubSubType::compute_key(
             AnnotatedStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AnnotatedStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool EmptyAnnotatedStructPubSubType::compute_key(
             EmptyAnnotatedStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || EmptyAnnotatedStruct_max_key_cdr_typesize > 16)
     {
@@ -545,7 +547,8 @@ bool BasicAnnotationsStructPubSubType::compute_key(
             BasicAnnotationsStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BasicAnnotationsStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/appendableCdrAux.ipp
+++ b/test/dds-types-test/appendableCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableUShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableULongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableLongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableULongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableFloatStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableLongDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableBooleanStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableOctetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char8();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableWCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char16();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableUnionStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union();
+
 }
 
 
@@ -1157,6 +1199,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1233,8 +1276,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableEmptyInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1317,8 +1363,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1393,6 +1442,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableInheritanceEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1477,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableExtensibilityInheritance& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 

--- a/test/dds-types-test/appendableCdrAux.ipp
+++ b/test/dds-types-test/appendableCdrAux.ipp
@@ -1276,11 +1276,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableEmptyInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const AppendableEmptyStruct& data);
+    serialize_key(scdr, static_cast<const AppendableEmptyStruct&>(data));
 }
 
 
@@ -1363,11 +1362,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const AppendableShortStruct& data);
+    serialize_key(scdr, static_cast<const AppendableShortStruct&>(data));
 }
 
 
@@ -1442,9 +1440,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableInheritanceEmptyStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const AppendableShortStruct& data);
+    serialize_key(scdr, static_cast<const AppendableShortStruct&>(data));
 }
 
 
@@ -1527,11 +1526,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableExtensibilityInheritance& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_long();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const AppendableShortStruct& data);
+    serialize_key(scdr, static_cast<const AppendableShortStruct&>(data));
 }
 
 

--- a/test/dds-types-test/appendablePubSubTypes.cxx
+++ b/test/dds-types-test/appendablePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool AppendableShortStructPubSubType::compute_key(
             AppendableShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableShortStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool AppendableUShortStructPubSubType::compute_key(
             AppendableUShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableUShortStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool AppendableLongStructPubSubType::compute_key(
             AppendableLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableLongStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool AppendableULongStructPubSubType::compute_key(
             AppendableULongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableULongStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool AppendableLongLongStructPubSubType::compute_key(
             AppendableLongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableLongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool AppendableULongLongStructPubSubType::compute_key(
             AppendableULongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableULongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool AppendableFloatStructPubSubType::compute_key(
             AppendableFloatStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableFloatStruct_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool AppendableDoubleStructPubSubType::compute_key(
             AppendableDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool AppendableLongDoubleStructPubSubType::compute_key(
             AppendableLongDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableLongDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool AppendableBooleanStructPubSubType::compute_key(
             AppendableBooleanStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableBooleanStruct_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool AppendableOctetStructPubSubType::compute_key(
             AppendableOctetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableOctetStruct_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool AppendableCharStructPubSubType::compute_key(
             AppendableCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool AppendableWCharStructPubSubType::compute_key(
             AppendableWCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableWCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool AppendableUnionStructPubSubType::compute_key(
             AppendableUnionStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableUnionStruct_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool AppendableEmptyStructPubSubType::compute_key(
             AppendableEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool AppendableEmptyInheritanceStructPubSubType::compute_key(
             AppendableEmptyInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableEmptyInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool AppendableInheritanceStructPubSubType::compute_key(
             AppendableInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool AppendableInheritanceEmptyStructPubSubType::compute_key(
             AppendableInheritanceEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableInheritanceEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool AppendableExtensibilityInheritancePubSubType::compute_key(
             AppendableExtensibilityInheritance_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableExtensibilityInheritance_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/arraysCdrAux.ipp
+++ b/test/dds-types-test/arraysCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_char();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wchar();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_string();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wstring();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_string();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_wstring();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_enum();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitmask();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_alias();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayShortArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short_array();
+
 }
 
 
@@ -1701,8 +1764,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_sequence();
+
 }
 
 
@@ -1777,8 +1843,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_map();
+
 }
 
 
@@ -1853,8 +1922,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_union();
+
 }
 
 
@@ -1929,8 +2001,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_structure();
+
 }
 
 
@@ -2005,8 +2080,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitset();
+
 }
 
 
@@ -2081,8 +2159,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short();
+
 }
 
 
@@ -2157,8 +2238,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ushort();
+
 }
 
 
@@ -2233,8 +2317,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_long();
+
 }
 
 
@@ -2309,8 +2396,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulong();
+
 }
 
 
@@ -2385,8 +2475,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longlong();
+
 }
 
 
@@ -2461,8 +2554,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulonglong();
+
 }
 
 
@@ -2537,8 +2633,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_float();
+
 }
 
 
@@ -2613,8 +2712,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_double();
+
 }
 
 
@@ -2689,8 +2791,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longdouble();
+
 }
 
 
@@ -2765,8 +2870,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_boolean();
+
 }
 
 
@@ -2841,8 +2949,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_octet();
+
 }
 
 
@@ -2917,8 +3028,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_char();
+
 }
 
 
@@ -2993,8 +3107,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wchar();
+
 }
 
 
@@ -3069,8 +3186,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_string();
+
 }
 
 
@@ -3145,8 +3265,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wstring();
+
 }
 
 
@@ -3221,8 +3344,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_string();
+
 }
 
 
@@ -3297,8 +3423,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_wstring();
+
 }
 
 
@@ -3373,8 +3502,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_enum();
+
 }
 
 
@@ -3449,8 +3581,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitmask();
+
 }
 
 
@@ -3525,8 +3660,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_alias();
+
 }
 
 
@@ -3601,8 +3739,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_sequence();
+
 }
 
 
@@ -3677,8 +3818,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_map();
+
 }
 
 
@@ -3753,8 +3897,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_union();
+
 }
 
 
@@ -3829,8 +3976,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_structure();
+
 }
 
 
@@ -3905,8 +4055,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitset();
+
 }
 
 
@@ -3983,8 +4136,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short();
+
 }
 
 
@@ -4059,8 +4215,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsUnsignedShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ushort();
+
 }
 
 
@@ -4135,8 +4294,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_long();
+
 }
 
 
@@ -4211,8 +4373,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsUnsignedLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulong();
+
 }
 
 
@@ -4287,8 +4452,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longlong();
+
 }
 
 
@@ -4363,8 +4531,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsUnsignedLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulonglong();
+
 }
 
 
@@ -4439,8 +4610,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_float();
+
 }
 
 
@@ -4515,8 +4689,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_double();
+
 }
 
 
@@ -4591,8 +4768,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longdouble();
+
 }
 
 
@@ -4667,8 +4847,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_boolean();
+
 }
 
 
@@ -4743,8 +4926,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_octet();
+
 }
 
 
@@ -4819,8 +5005,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_char();
+
 }
 
 
@@ -4895,8 +5084,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wchar();
+
 }
 
 
@@ -4971,8 +5163,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_string();
+
 }
 
 
@@ -5047,8 +5242,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wstring();
+
 }
 
 
@@ -5123,8 +5321,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_string();
+
 }
 
 
@@ -5199,8 +5400,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_wstring();
+
 }
 
 
@@ -5275,8 +5479,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_enum();
+
 }
 
 
@@ -5351,8 +5558,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitmask();
+
 }
 
 
@@ -5427,8 +5637,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_alias();
+
 }
 
 
@@ -5503,8 +5716,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsShortArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short_array();
+
 }
 
 
@@ -5579,8 +5795,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_sequence();
+
 }
 
 
@@ -5655,8 +5874,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_map();
+
 }
 
 
@@ -5731,8 +5953,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_union();
+
 }
 
 
@@ -5807,8 +6032,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_structure();
+
 }
 
 
@@ -5883,8 +6111,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArraySingleDimensionLiteralsBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitset();
+
 }
 
 
@@ -5959,8 +6190,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short();
+
 }
 
 
@@ -6035,8 +6269,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ushort();
+
 }
 
 
@@ -6111,8 +6348,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_long();
+
 }
 
 
@@ -6187,8 +6427,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulong();
+
 }
 
 
@@ -6263,8 +6506,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longlong();
+
 }
 
 
@@ -6339,8 +6585,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_ulonglong();
+
 }
 
 
@@ -6415,8 +6664,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_float();
+
 }
 
 
@@ -6491,8 +6743,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_double();
+
 }
 
 
@@ -6567,8 +6822,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_longdouble();
+
 }
 
 
@@ -6643,8 +6901,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_boolean();
+
 }
 
 
@@ -6719,8 +6980,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_octet();
+
 }
 
 
@@ -6795,8 +7059,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_char();
+
 }
 
 
@@ -6871,8 +7138,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wchar();
+
 }
 
 
@@ -6947,8 +7217,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_string();
+
 }
 
 
@@ -7023,8 +7296,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_wstring();
+
 }
 
 
@@ -7099,8 +7375,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_string();
+
 }
 
 
@@ -7175,8 +7454,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bounded_wstring();
+
 }
 
 
@@ -7251,8 +7533,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_enum();
+
 }
 
 
@@ -7327,8 +7612,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitmask();
+
 }
 
 
@@ -7403,8 +7691,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_alias();
+
 }
 
 
@@ -7479,8 +7770,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_sequence();
+
 }
 
 
@@ -7555,8 +7849,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_map();
+
 }
 
 
@@ -7631,8 +7928,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_union();
+
 }
 
 
@@ -7707,8 +8007,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_structure();
+
 }
 
 
@@ -7783,8 +8086,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayMultiDimensionLiteralsBitSet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_bitset();
+
 }
 
 
@@ -7859,8 +8165,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedSmallArrays& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_small();
+
 }
 
 
@@ -7935,8 +8244,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedBigArrays& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_big();
+
 }
 
 

--- a/test/dds-types-test/arraysPubSubTypes.cxx
+++ b/test/dds-types-test/arraysPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ArrayShortPubSubType::compute_key(
             ArrayShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayShort_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ArrayUShortPubSubType::compute_key(
             ArrayUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayUShort_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool ArrayLongPubSubType::compute_key(
             ArrayLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayLong_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool ArrayULongPubSubType::compute_key(
             ArrayULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayULong_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool ArrayLongLongPubSubType::compute_key(
             ArrayLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayLongLong_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool ArrayULongLongPubSubType::compute_key(
             ArrayULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayULongLong_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool ArrayFloatPubSubType::compute_key(
             ArrayFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayFloat_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool ArrayDoublePubSubType::compute_key(
             ArrayDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayDouble_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool ArrayLongDoublePubSubType::compute_key(
             ArrayLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayLongDouble_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool ArrayBooleanPubSubType::compute_key(
             ArrayBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayBoolean_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool ArrayOctetPubSubType::compute_key(
             ArrayOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool ArrayCharPubSubType::compute_key(
             ArrayChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayChar_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool ArrayWCharPubSubType::compute_key(
             ArrayWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayWChar_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool ArrayStringPubSubType::compute_key(
             ArrayString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayString_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool ArrayWStringPubSubType::compute_key(
             ArrayWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayWString_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool ArrayBoundedStringPubSubType::compute_key(
             ArrayBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayBoundedString_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool ArrayBoundedWStringPubSubType::compute_key(
             ArrayBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool ArrayEnumPubSubType::compute_key(
             ArrayEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayEnum_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool ArrayBitMaskPubSubType::compute_key(
             ArrayBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayBitMask_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool ArrayAliasPubSubType::compute_key(
             ArrayAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayAlias_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool ArrayShortArrayPubSubType::compute_key(
             ArrayShortArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayShortArray_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool ArraySequencePubSubType::compute_key(
             ArraySequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySequence_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool ArrayMapPubSubType::compute_key(
             ArrayMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMap_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool ArrayUnionPubSubType::compute_key(
             ArrayUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayUnion_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool ArrayStructurePubSubType::compute_key(
             ArrayStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayStructure_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool ArrayBitsetPubSubType::compute_key(
             ArrayBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayBitset_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool ArrayMultiDimensionShortPubSubType::compute_key(
             ArrayMultiDimensionShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionShort_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool ArrayMultiDimensionUShortPubSubType::compute_key(
             ArrayMultiDimensionUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionUShort_max_key_cdr_typesize > 16)
     {
@@ -5224,7 +5252,8 @@ bool ArrayMultiDimensionLongPubSubType::compute_key(
             ArrayMultiDimensionLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLong_max_key_cdr_typesize > 16)
     {
@@ -5404,7 +5433,8 @@ bool ArrayMultiDimensionULongPubSubType::compute_key(
             ArrayMultiDimensionULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionULong_max_key_cdr_typesize > 16)
     {
@@ -5584,7 +5614,8 @@ bool ArrayMultiDimensionLongLongPubSubType::compute_key(
             ArrayMultiDimensionLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLongLong_max_key_cdr_typesize > 16)
     {
@@ -5764,7 +5795,8 @@ bool ArrayMultiDimensionULongLongPubSubType::compute_key(
             ArrayMultiDimensionULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionULongLong_max_key_cdr_typesize > 16)
     {
@@ -5944,7 +5976,8 @@ bool ArrayMultiDimensionFloatPubSubType::compute_key(
             ArrayMultiDimensionFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionFloat_max_key_cdr_typesize > 16)
     {
@@ -6124,7 +6157,8 @@ bool ArrayMultiDimensionDoublePubSubType::compute_key(
             ArrayMultiDimensionDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionDouble_max_key_cdr_typesize > 16)
     {
@@ -6304,7 +6338,8 @@ bool ArrayMultiDimensionLongDoublePubSubType::compute_key(
             ArrayMultiDimensionLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLongDouble_max_key_cdr_typesize > 16)
     {
@@ -6484,7 +6519,8 @@ bool ArrayMultiDimensionBooleanPubSubType::compute_key(
             ArrayMultiDimensionBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionBoolean_max_key_cdr_typesize > 16)
     {
@@ -6664,7 +6700,8 @@ bool ArrayMultiDimensionOctetPubSubType::compute_key(
             ArrayMultiDimensionOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionOctet_max_key_cdr_typesize > 16)
     {
@@ -6844,7 +6881,8 @@ bool ArrayMultiDimensionCharPubSubType::compute_key(
             ArrayMultiDimensionChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionChar_max_key_cdr_typesize > 16)
     {
@@ -7024,7 +7062,8 @@ bool ArrayMultiDimensionWCharPubSubType::compute_key(
             ArrayMultiDimensionWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionWChar_max_key_cdr_typesize > 16)
     {
@@ -7204,7 +7243,8 @@ bool ArrayMultiDimensionStringPubSubType::compute_key(
             ArrayMultiDimensionString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionString_max_key_cdr_typesize > 16)
     {
@@ -7384,7 +7424,8 @@ bool ArrayMultiDimensionWStringPubSubType::compute_key(
             ArrayMultiDimensionWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionWString_max_key_cdr_typesize > 16)
     {
@@ -7564,7 +7605,8 @@ bool ArrayMultiDimensionBoundedStringPubSubType::compute_key(
             ArrayMultiDimensionBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionBoundedString_max_key_cdr_typesize > 16)
     {
@@ -7744,7 +7786,8 @@ bool ArrayMultiDimensionBoundedWStringPubSubType::compute_key(
             ArrayMultiDimensionBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -7924,7 +7967,8 @@ bool ArrayMultiDimensionEnumPubSubType::compute_key(
             ArrayMultiDimensionEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionEnum_max_key_cdr_typesize > 16)
     {
@@ -8104,7 +8148,8 @@ bool ArrayMultiDimensionBitMaskPubSubType::compute_key(
             ArrayMultiDimensionBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionBitMask_max_key_cdr_typesize > 16)
     {
@@ -8284,7 +8329,8 @@ bool ArrayMultiDimensionAliasPubSubType::compute_key(
             ArrayMultiDimensionAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionAlias_max_key_cdr_typesize > 16)
     {
@@ -8464,7 +8510,8 @@ bool ArrayMultiDimensionSequencePubSubType::compute_key(
             ArrayMultiDimensionSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionSequence_max_key_cdr_typesize > 16)
     {
@@ -8644,7 +8691,8 @@ bool ArrayMultiDimensionMapPubSubType::compute_key(
             ArrayMultiDimensionMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionMap_max_key_cdr_typesize > 16)
     {
@@ -8824,7 +8872,8 @@ bool ArrayMultiDimensionUnionPubSubType::compute_key(
             ArrayMultiDimensionUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionUnion_max_key_cdr_typesize > 16)
     {
@@ -9004,7 +9053,8 @@ bool ArrayMultiDimensionStructurePubSubType::compute_key(
             ArrayMultiDimensionStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionStructure_max_key_cdr_typesize > 16)
     {
@@ -9184,7 +9234,8 @@ bool ArrayMultiDimensionBitsetPubSubType::compute_key(
             ArrayMultiDimensionBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionBitset_max_key_cdr_typesize > 16)
     {
@@ -9366,7 +9417,8 @@ bool ArraySingleDimensionLiteralsShortPubSubType::compute_key(
             ArraySingleDimensionLiteralsShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsShort_max_key_cdr_typesize > 16)
     {
@@ -9546,7 +9598,8 @@ bool ArraySingleDimensionLiteralsUnsignedShortPubSubType::compute_key(
             ArraySingleDimensionLiteralsUnsignedShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsUnsignedShort_max_key_cdr_typesize > 16)
     {
@@ -9726,7 +9779,8 @@ bool ArraySingleDimensionLiteralsLongPubSubType::compute_key(
             ArraySingleDimensionLiteralsLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsLong_max_key_cdr_typesize > 16)
     {
@@ -9906,7 +9960,8 @@ bool ArraySingleDimensionLiteralsUnsignedLongPubSubType::compute_key(
             ArraySingleDimensionLiteralsUnsignedLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsUnsignedLong_max_key_cdr_typesize > 16)
     {
@@ -10086,7 +10141,8 @@ bool ArraySingleDimensionLiteralsLongLongPubSubType::compute_key(
             ArraySingleDimensionLiteralsLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsLongLong_max_key_cdr_typesize > 16)
     {
@@ -10266,7 +10322,8 @@ bool ArraySingleDimensionLiteralsUnsignedLongLongPubSubType::compute_key(
             ArraySingleDimensionLiteralsUnsignedLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsUnsignedLongLong_max_key_cdr_typesize > 16)
     {
@@ -10446,7 +10503,8 @@ bool ArraySingleDimensionLiteralsFloatPubSubType::compute_key(
             ArraySingleDimensionLiteralsFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsFloat_max_key_cdr_typesize > 16)
     {
@@ -10626,7 +10684,8 @@ bool ArraySingleDimensionLiteralsDoublePubSubType::compute_key(
             ArraySingleDimensionLiteralsDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsDouble_max_key_cdr_typesize > 16)
     {
@@ -10806,7 +10865,8 @@ bool ArraySingleDimensionLiteralsLongDoublePubSubType::compute_key(
             ArraySingleDimensionLiteralsLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsLongDouble_max_key_cdr_typesize > 16)
     {
@@ -10986,7 +11046,8 @@ bool ArraySingleDimensionLiteralsBooleanPubSubType::compute_key(
             ArraySingleDimensionLiteralsBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsBoolean_max_key_cdr_typesize > 16)
     {
@@ -11166,7 +11227,8 @@ bool ArraySingleDimensionLiteralsOctetPubSubType::compute_key(
             ArraySingleDimensionLiteralsOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsOctet_max_key_cdr_typesize > 16)
     {
@@ -11346,7 +11408,8 @@ bool ArraySingleDimensionLiteralsCharPubSubType::compute_key(
             ArraySingleDimensionLiteralsChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsChar_max_key_cdr_typesize > 16)
     {
@@ -11526,7 +11589,8 @@ bool ArraySingleDimensionLiteralsWCharPubSubType::compute_key(
             ArraySingleDimensionLiteralsWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsWChar_max_key_cdr_typesize > 16)
     {
@@ -11706,7 +11770,8 @@ bool ArraySingleDimensionLiteralsStringPubSubType::compute_key(
             ArraySingleDimensionLiteralsString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsString_max_key_cdr_typesize > 16)
     {
@@ -11886,7 +11951,8 @@ bool ArraySingleDimensionLiteralsWStringPubSubType::compute_key(
             ArraySingleDimensionLiteralsWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsWString_max_key_cdr_typesize > 16)
     {
@@ -12066,7 +12132,8 @@ bool ArraySingleDimensionLiteralsBoundedStringPubSubType::compute_key(
             ArraySingleDimensionLiteralsBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsBoundedString_max_key_cdr_typesize > 16)
     {
@@ -12246,7 +12313,8 @@ bool ArraySingleDimensionLiteralsBoundedWStringPubSubType::compute_key(
             ArraySingleDimensionLiteralsBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -12426,7 +12494,8 @@ bool ArraySingleDimensionLiteralsEnumPubSubType::compute_key(
             ArraySingleDimensionLiteralsEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsEnum_max_key_cdr_typesize > 16)
     {
@@ -12606,7 +12675,8 @@ bool ArraySingleDimensionLiteralsBitMaskPubSubType::compute_key(
             ArraySingleDimensionLiteralsBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsBitMask_max_key_cdr_typesize > 16)
     {
@@ -12786,7 +12856,8 @@ bool ArraySingleDimensionLiteralsAliasPubSubType::compute_key(
             ArraySingleDimensionLiteralsAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsAlias_max_key_cdr_typesize > 16)
     {
@@ -12966,7 +13037,8 @@ bool ArraySingleDimensionLiteralsShortArrayPubSubType::compute_key(
             ArraySingleDimensionLiteralsShortArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsShortArray_max_key_cdr_typesize > 16)
     {
@@ -13146,7 +13218,8 @@ bool ArraySingleDimensionLiteralsSequencePubSubType::compute_key(
             ArraySingleDimensionLiteralsSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsSequence_max_key_cdr_typesize > 16)
     {
@@ -13326,7 +13399,8 @@ bool ArraySingleDimensionLiteralsMapPubSubType::compute_key(
             ArraySingleDimensionLiteralsMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsMap_max_key_cdr_typesize > 16)
     {
@@ -13506,7 +13580,8 @@ bool ArraySingleDimensionLiteralsUnionPubSubType::compute_key(
             ArraySingleDimensionLiteralsUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsUnion_max_key_cdr_typesize > 16)
     {
@@ -13686,7 +13761,8 @@ bool ArraySingleDimensionLiteralsStructurePubSubType::compute_key(
             ArraySingleDimensionLiteralsStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsStructure_max_key_cdr_typesize > 16)
     {
@@ -13866,7 +13942,8 @@ bool ArraySingleDimensionLiteralsBitsetPubSubType::compute_key(
             ArraySingleDimensionLiteralsBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArraySingleDimensionLiteralsBitset_max_key_cdr_typesize > 16)
     {
@@ -14046,7 +14123,8 @@ bool ArrayMultiDimensionLiteralsShortPubSubType::compute_key(
             ArrayMultiDimensionLiteralsShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsShort_max_key_cdr_typesize > 16)
     {
@@ -14226,7 +14304,8 @@ bool ArrayMultiDimensionLiteralsUShortPubSubType::compute_key(
             ArrayMultiDimensionLiteralsUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsUShort_max_key_cdr_typesize > 16)
     {
@@ -14406,7 +14485,8 @@ bool ArrayMultiDimensionLiteralsLongPubSubType::compute_key(
             ArrayMultiDimensionLiteralsLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsLong_max_key_cdr_typesize > 16)
     {
@@ -14586,7 +14666,8 @@ bool ArrayMultiDimensionLiteralsULongPubSubType::compute_key(
             ArrayMultiDimensionLiteralsULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsULong_max_key_cdr_typesize > 16)
     {
@@ -14766,7 +14847,8 @@ bool ArrayMultiDimensionLiteralsLongLongPubSubType::compute_key(
             ArrayMultiDimensionLiteralsLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsLongLong_max_key_cdr_typesize > 16)
     {
@@ -14946,7 +15028,8 @@ bool ArrayMultiDimensionLiteralsULongLongPubSubType::compute_key(
             ArrayMultiDimensionLiteralsULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsULongLong_max_key_cdr_typesize > 16)
     {
@@ -15126,7 +15209,8 @@ bool ArrayMultiDimensionLiteralsFloatPubSubType::compute_key(
             ArrayMultiDimensionLiteralsFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsFloat_max_key_cdr_typesize > 16)
     {
@@ -15306,7 +15390,8 @@ bool ArrayMultiDimensionLiteralsDoublePubSubType::compute_key(
             ArrayMultiDimensionLiteralsDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsDouble_max_key_cdr_typesize > 16)
     {
@@ -15486,7 +15571,8 @@ bool ArrayMultiDimensionLiteralsLongDoublePubSubType::compute_key(
             ArrayMultiDimensionLiteralsLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsLongDouble_max_key_cdr_typesize > 16)
     {
@@ -15666,7 +15752,8 @@ bool ArrayMultiDimensionLiteralsBooleanPubSubType::compute_key(
             ArrayMultiDimensionLiteralsBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsBoolean_max_key_cdr_typesize > 16)
     {
@@ -15846,7 +15933,8 @@ bool ArrayMultiDimensionLiteralsOctetPubSubType::compute_key(
             ArrayMultiDimensionLiteralsOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsOctet_max_key_cdr_typesize > 16)
     {
@@ -16026,7 +16114,8 @@ bool ArrayMultiDimensionLiteralsCharPubSubType::compute_key(
             ArrayMultiDimensionLiteralsChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsChar_max_key_cdr_typesize > 16)
     {
@@ -16206,7 +16295,8 @@ bool ArrayMultiDimensionLiteralsWCharPubSubType::compute_key(
             ArrayMultiDimensionLiteralsWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsWChar_max_key_cdr_typesize > 16)
     {
@@ -16386,7 +16476,8 @@ bool ArrayMultiDimensionLiteralsStringPubSubType::compute_key(
             ArrayMultiDimensionLiteralsString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsString_max_key_cdr_typesize > 16)
     {
@@ -16566,7 +16657,8 @@ bool ArrayMultiDimensionLiteralsWStringPubSubType::compute_key(
             ArrayMultiDimensionLiteralsWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsWString_max_key_cdr_typesize > 16)
     {
@@ -16746,7 +16838,8 @@ bool ArrayMultiDimensionLiteralsBoundedStringPubSubType::compute_key(
             ArrayMultiDimensionLiteralsBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsBoundedString_max_key_cdr_typesize > 16)
     {
@@ -16926,7 +17019,8 @@ bool ArrayMultiDimensionLiteralsBoundedWStringPubSubType::compute_key(
             ArrayMultiDimensionLiteralsBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -17106,7 +17200,8 @@ bool ArrayMultiDimensionLiteralsEnumPubSubType::compute_key(
             ArrayMultiDimensionLiteralsEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsEnum_max_key_cdr_typesize > 16)
     {
@@ -17286,7 +17381,8 @@ bool ArrayMultiDimensionLiteralsBitMaskPubSubType::compute_key(
             ArrayMultiDimensionLiteralsBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsBitMask_max_key_cdr_typesize > 16)
     {
@@ -17466,7 +17562,8 @@ bool ArrayMultiDimensionLiteralsAliasPubSubType::compute_key(
             ArrayMultiDimensionLiteralsAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsAlias_max_key_cdr_typesize > 16)
     {
@@ -17646,7 +17743,8 @@ bool ArrayMultiDimensionLiteralsSequencePubSubType::compute_key(
             ArrayMultiDimensionLiteralsSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsSequence_max_key_cdr_typesize > 16)
     {
@@ -17826,7 +17924,8 @@ bool ArrayMultiDimensionLiteralsMapPubSubType::compute_key(
             ArrayMultiDimensionLiteralsMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsMap_max_key_cdr_typesize > 16)
     {
@@ -18006,7 +18105,8 @@ bool ArrayMultiDimensionLiteralsUnionPubSubType::compute_key(
             ArrayMultiDimensionLiteralsUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsUnion_max_key_cdr_typesize > 16)
     {
@@ -18186,7 +18286,8 @@ bool ArrayMultiDimensionLiteralsStructurePubSubType::compute_key(
             ArrayMultiDimensionLiteralsStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsStructure_max_key_cdr_typesize > 16)
     {
@@ -18366,7 +18467,8 @@ bool ArrayMultiDimensionLiteralsBitSetPubSubType::compute_key(
             ArrayMultiDimensionLiteralsBitSet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayMultiDimensionLiteralsBitSet_max_key_cdr_typesize > 16)
     {
@@ -18546,7 +18648,8 @@ bool BoundedSmallArraysPubSubType::compute_key(
             BoundedSmallArrays_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedSmallArrays_max_key_cdr_typesize > 16)
     {
@@ -18726,7 +18829,8 @@ bool BoundedBigArraysPubSubType::compute_key(
             BoundedBigArrays_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedBigArrays_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/bitsetsCdrAux.ipp
+++ b/test/dds-types-test/bitsetsCdrAux.ipp
@@ -317,8 +317,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BitsetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_InnerBitsetHelper();
+
+                        scdr << data.var_InnerTypedBitsetHelper();
+
+                        scdr << data.var_InnerTypedBitsetHelper2();
+
+                        scdr << data.var_InnerTypedBitsetHelper3();
+
+                        scdr << data.var_InnerTypedBitsetHelper4();
+
 }
 
 

--- a/test/dds-types-test/bitsetsPubSubTypes.cxx
+++ b/test/dds-types-test/bitsetsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool BitsetStructPubSubType::compute_key(
             BitsetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BitsetStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/constantsCdrAux.ipp
+++ b/test/dds-types-test/constantsCdrAux.ipp
@@ -139,6 +139,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.module1_array_literal_const_moduled();
+
+                        scdr << data.module1_array_literal_const_alias_const_moduled();
+
+                        scdr << data.var1();
+
+                        scdr << data.var2();
+
 }
 
 
@@ -247,6 +255,14 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.module2_array_literal_const_moduled();
+
+                        scdr << data.module2_array_literal_const_alias_const_moduled();
+
+                        scdr << data.module2_array_literal_const_scoped_moduled();
+
+                        scdr << data.module2_array_literal_module1_const_moduled();
+
 }
 
 
@@ -537,8 +553,65 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ConstsLiteralsStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.array_literal_const_short();
+
+                        scdr << data.array_literal_const_ushort();
+
+                        scdr << data.array_literal_const_long();
+
+                        scdr << data.array_literal_const_ulong();
+
+                        scdr << data.array_literal_const_longlong();
+
+                        scdr << data.array_literal_const_ulonglong();
+
+                        scdr << data.array_literal_const_int8();
+
+                        scdr << data.array_literal_const_uint8();
+
+                        scdr << data.array_literal_const_int16();
+
+                        scdr << data.array_literal_const_uint16();
+
+                        scdr << data.array_literal_const_int32();
+
+                        scdr << data.array_literal_const_uint32();
+
+                        scdr << data.array_literal_const_int64();
+
+                        scdr << data.array_literal_const_uint64();
+
+                        scdr << data.array_literals_operations1_const();
+
+                        scdr << data.array_literals_operations2_const();
+
+                        scdr << data.array_literals_operations3_const();
+
+                        scdr << data.array_literals_operations4_const();
+
+                        scdr << data.array_literals_operations5_const();
+
+                        scdr << data.array_literals_operations6_const();
+
+                        scdr << data.array_literals_operations7_const();
+
+                        scdr << data.array_literals_operations8_const();
+
+                        scdr << data.array_literal_const_inner_const_helper();
+
+                        scdr << data.array_moduled1_literal_const();
+
+                        scdr << data.array_moduled2_literal_const();
+
+                        scdr << data.array_literal_const_alias_const();
+
+                        scdr << data.array_moduled1_literal_alias_const_moduled();
+
+                        scdr << data.array_moduled2_literal_alias_const_moduled();
+
 }
 
 

--- a/test/dds-types-test/constantsPubSubTypes.cxx
+++ b/test/dds-types-test/constantsPubSubTypes.cxx
@@ -185,7 +185,8 @@ namespace const_module1 {
                 const_module1_ModuleConstsLiteralsStruct_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || const_module1_ModuleConstsLiteralsStruct_max_key_cdr_typesize > 16)
         {
@@ -368,7 +369,8 @@ namespace const_module2 {
                 const_module2_Module2ConstsLiteralsStruct_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || const_module2_Module2ConstsLiteralsStruct_max_key_cdr_typesize > 16)
         {
@@ -550,7 +552,8 @@ bool ConstsLiteralsStructPubSubType::compute_key(
             ConstsLiteralsStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ConstsLiteralsStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/declarationsCdrAux.ipp
+++ b/test/dds-types-test/declarationsCdrAux.ipp
@@ -129,8 +129,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ForwardDeclarationsRecursiveStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_RecursiveUnboundedSeqForwardStruct();
+
+                        scdr << data.var_RecursiveBoundedSeqForwardStruct();
+
+                        scdr << data.var_RecursiveUnboundedSeqForwardUnion();
+
+                        scdr << data.var_RecursiveBoundedSeqForwardUnion();
+
 }
 
 
@@ -343,8 +352,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ForwardStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
+                        scdr << data.var_long();
+
 }
 
 
@@ -429,6 +443,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_u_long_long();
+
 }
 
 
@@ -527,8 +543,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ModuledForwardDeclarationsRecursiveStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ModuledRecursiveUnboundedSeqForwardStruct();
+
+                        scdr << data.var_ModuledRecursiveBoundedSeqForwardStruct();
+
+                        scdr << data.var_ModuledRecursiveUnboundedSeqForwardUnion();
+
+                        scdr << data.var_ModuledRecursiveBoundedSeqForwardUnion();
+
 }
 
 
@@ -621,6 +646,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
+                        scdr << data.var_long();
+
 }
 
 
@@ -840,8 +869,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ModuledCommonNameStructure& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const ForwardStruct& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const declarations_module::ForwardStruct& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.global_struct());
+
+                        serialize_key(scdr, data.namespaced_struct());
+
 }
 
 

--- a/test/dds-types-test/declarationsPubSubTypes.cxx
+++ b/test/dds-types-test/declarationsPubSubTypes.cxx
@@ -182,7 +182,8 @@ bool ForwardDeclarationsRecursiveStructPubSubType::compute_key(
             ForwardDeclarationsRecursiveStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ForwardDeclarationsRecursiveStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ForwardStructPubSubType::compute_key(
             ForwardStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ForwardStruct_max_key_cdr_typesize > 16)
     {
@@ -546,7 +548,8 @@ namespace declarations_module {
                 declarations_module_ForwardStruct_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || declarations_module_ForwardStruct_max_key_cdr_typesize > 16)
         {
@@ -729,7 +732,8 @@ bool ModuledForwardDeclarationsRecursiveStructPubSubType::compute_key(
             ModuledForwardDeclarationsRecursiveStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ModuledForwardDeclarationsRecursiveStruct_max_key_cdr_typesize > 16)
     {
@@ -911,7 +915,8 @@ namespace declarations_module {
                 declarations_module_ModuledForwardStruct_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || declarations_module_ModuledForwardStruct_max_key_cdr_typesize > 16)
         {
@@ -1096,7 +1101,8 @@ bool ModuledCommonNameStructurePubSubType::compute_key(
             ModuledCommonNameStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ModuledCommonNameStructure_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/enumerationsCdrAux.ipp
+++ b/test/dds-types-test/enumerationsCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const EnumStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_InnerEnumHelper();
+
+                        scdr << data.var_scoped_InnerEnumHelper();
+
 }
 
 
@@ -189,8 +194,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BitMaskStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_InnerBitMaskHelper();
+
 }
 
 
@@ -265,8 +273,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedBitMaskStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_InnerBoundedBitMaskHelper();
+
 }
 
 

--- a/test/dds-types-test/enumerationsPubSubTypes.cxx
+++ b/test/dds-types-test/enumerationsPubSubTypes.cxx
@@ -187,7 +187,8 @@ bool EnumStructurePubSubType::compute_key(
             EnumStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || EnumStructure_max_key_cdr_typesize > 16)
     {
@@ -367,7 +368,8 @@ bool BitMaskStructurePubSubType::compute_key(
             BitMaskStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BitMaskStructure_max_key_cdr_typesize > 16)
     {
@@ -547,7 +549,8 @@ bool BoundedBitMaskStructurePubSubType::compute_key(
             BoundedBitMaskStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedBitMaskStructure_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/externalCdrAux.ipp
+++ b/test/dds-types-test/externalCdrAux.ipp
@@ -1534,7 +1534,7 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                        serialize_key(scdr, data.value());
+                        serialize_key(scdr, *data.value());
 
 }
 
@@ -1789,7 +1789,7 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-                        serialize_key(scdr, data.value());
+                        serialize_key(scdr, *data.value());
 
 }
 
@@ -1874,7 +1874,7 @@ void serialize_key(
     static_cast<void>(data);
                         if (data.value().has_value())
                         {
-                            serialize_key(scdr, data.value().value());
+                            serialize_key(scdr, *data.value().value());
                         }
 
 }

--- a/test/dds-types-test/externalCdrAux.ipp
+++ b/test/dds-types-test/externalCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const short_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ushort_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const long_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulong_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longlong_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulonglong_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const float_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const double_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longdouble_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const boolean_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const octet_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const char_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const wchar_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const sequence_short_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_unbounded_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_bounded_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const map_short_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const array_short_external& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -1473,8 +1527,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_external& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.value());
+
 }
 
 
@@ -1557,8 +1618,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructExternal& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.s();
+
+                        scdr << data.l();
+
 }
 
 
@@ -1633,8 +1699,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ext_struct_external& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructExternal& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.value());
+
 }
 
 
@@ -1709,8 +1782,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ext_and_inner_struct_external& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructExternal& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.value());
+
 }
 
 
@@ -1785,8 +1865,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_external_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -1870,8 +1960,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const recursive_union_container& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.l();
+
+                        scdr << data.ext();
+
 }
 
 
@@ -2105,8 +2200,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const recursive_test_1& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.s();
+
+                        scdr << data.u();
+
 }
 
 
@@ -2341,8 +2441,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const recursive_structure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.s();
+
+                        scdr << data.c();
+
 }
 
 
@@ -2425,8 +2530,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const recursive_test_2& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const recursive_structure& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        serialize_key(scdr, data.s());
+
 }
 
 

--- a/test/dds-types-test/externalPubSubTypes.cxx
+++ b/test/dds-types-test/externalPubSubTypes.cxx
@@ -182,7 +182,8 @@ bool short_externalPubSubType::compute_key(
             short_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || short_external_max_key_cdr_typesize > 16)
     {
@@ -363,7 +364,8 @@ bool ushort_externalPubSubType::compute_key(
             ushort_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ushort_external_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool long_externalPubSubType::compute_key(
             long_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || long_external_max_key_cdr_typesize > 16)
     {
@@ -725,7 +728,8 @@ bool ulong_externalPubSubType::compute_key(
             ulong_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulong_external_max_key_cdr_typesize > 16)
     {
@@ -906,7 +910,8 @@ bool longlong_externalPubSubType::compute_key(
             longlong_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longlong_external_max_key_cdr_typesize > 16)
     {
@@ -1087,7 +1092,8 @@ bool ulonglong_externalPubSubType::compute_key(
             ulonglong_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulonglong_external_max_key_cdr_typesize > 16)
     {
@@ -1268,7 +1274,8 @@ bool float_externalPubSubType::compute_key(
             float_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || float_external_max_key_cdr_typesize > 16)
     {
@@ -1449,7 +1456,8 @@ bool double_externalPubSubType::compute_key(
             double_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || double_external_max_key_cdr_typesize > 16)
     {
@@ -1630,7 +1638,8 @@ bool longdouble_externalPubSubType::compute_key(
             longdouble_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longdouble_external_max_key_cdr_typesize > 16)
     {
@@ -1811,7 +1820,8 @@ bool boolean_externalPubSubType::compute_key(
             boolean_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || boolean_external_max_key_cdr_typesize > 16)
     {
@@ -1992,7 +2002,8 @@ bool octet_externalPubSubType::compute_key(
             octet_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || octet_external_max_key_cdr_typesize > 16)
     {
@@ -2173,7 +2184,8 @@ bool char_externalPubSubType::compute_key(
             char_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || char_external_max_key_cdr_typesize > 16)
     {
@@ -2354,7 +2366,8 @@ bool wchar_externalPubSubType::compute_key(
             wchar_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || wchar_external_max_key_cdr_typesize > 16)
     {
@@ -2535,7 +2548,8 @@ bool sequence_short_externalPubSubType::compute_key(
             sequence_short_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || sequence_short_external_max_key_cdr_typesize > 16)
     {
@@ -2716,7 +2730,8 @@ bool string_unbounded_externalPubSubType::compute_key(
             string_unbounded_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_unbounded_external_max_key_cdr_typesize > 16)
     {
@@ -2897,7 +2912,8 @@ bool string_bounded_externalPubSubType::compute_key(
             string_bounded_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_bounded_external_max_key_cdr_typesize > 16)
     {
@@ -3078,7 +3094,8 @@ bool map_short_externalPubSubType::compute_key(
             map_short_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || map_short_external_max_key_cdr_typesize > 16)
     {
@@ -3259,7 +3276,8 @@ bool array_short_externalPubSubType::compute_key(
             array_short_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || array_short_external_max_key_cdr_typesize > 16)
     {
@@ -3440,7 +3458,8 @@ bool struct_externalPubSubType::compute_key(
             struct_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_external_max_key_cdr_typesize > 16)
     {
@@ -3621,7 +3640,8 @@ bool InnerStructExternalPubSubType::compute_key(
             InnerStructExternal_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructExternal_max_key_cdr_typesize > 16)
     {
@@ -3802,7 +3822,8 @@ bool ext_struct_externalPubSubType::compute_key(
             ext_struct_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ext_struct_external_max_key_cdr_typesize > 16)
     {
@@ -3983,7 +4004,8 @@ bool ext_and_inner_struct_externalPubSubType::compute_key(
             ext_and_inner_struct_external_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ext_and_inner_struct_external_max_key_cdr_typesize > 16)
     {
@@ -4164,7 +4186,8 @@ bool struct_external_optionalPubSubType::compute_key(
             struct_external_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_external_optional_max_key_cdr_typesize > 16)
     {
@@ -4346,7 +4369,8 @@ bool recursive_union_containerPubSubType::compute_key(
             recursive_union_container_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || recursive_union_container_max_key_cdr_typesize > 16)
     {
@@ -4528,7 +4552,8 @@ bool recursive_test_1PubSubType::compute_key(
             recursive_test_1_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || recursive_test_1_max_key_cdr_typesize > 16)
     {
@@ -4711,7 +4736,8 @@ bool recursive_structurePubSubType::compute_key(
             recursive_structure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || recursive_structure_max_key_cdr_typesize > 16)
     {
@@ -4892,7 +4918,8 @@ bool recursive_test_2PubSubType::compute_key(
             recursive_test_2_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || recursive_test_2_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/finalCdrAux.ipp
+++ b/test/dds-types-test/finalCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalUShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalULongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalLongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalULongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalFloatStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalLongDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalBooleanStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalOctetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char8();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalWCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char16();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalUnionStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union();
+
 }
 
 
@@ -1157,6 +1199,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1233,8 +1276,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalEmptyInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1317,8 +1363,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1393,6 +1442,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InheritanceEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1477,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalExtensibilityInheritance& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 

--- a/test/dds-types-test/finalCdrAux.ipp
+++ b/test/dds-types-test/finalCdrAux.ipp
@@ -1276,11 +1276,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalEmptyInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const FinalEmptyStruct& data);
+    serialize_key(scdr, static_cast<const FinalEmptyStruct&>(data));
 }
 
 
@@ -1363,11 +1362,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const FinalShortStruct& data);
+    serialize_key(scdr, static_cast<const FinalShortStruct&>(data));
 }
 
 
@@ -1442,9 +1440,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InheritanceEmptyStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const FinalShortStruct& data);
+    serialize_key(scdr, static_cast<const FinalShortStruct&>(data));
 }
 
 
@@ -1527,11 +1526,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalExtensibilityInheritance& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_long();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const FinalShortStruct& data);
+    serialize_key(scdr, static_cast<const FinalShortStruct&>(data));
 }
 
 

--- a/test/dds-types-test/finalPubSubTypes.cxx
+++ b/test/dds-types-test/finalPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool FinalShortStructPubSubType::compute_key(
             FinalShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalShortStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool FinalUShortStructPubSubType::compute_key(
             FinalUShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalUShortStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool FinalLongStructPubSubType::compute_key(
             FinalLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalLongStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool FinalULongStructPubSubType::compute_key(
             FinalULongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalULongStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool FinalLongLongStructPubSubType::compute_key(
             FinalLongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalLongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool FinalULongLongStructPubSubType::compute_key(
             FinalULongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalULongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool FinalFloatStructPubSubType::compute_key(
             FinalFloatStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalFloatStruct_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool FinalDoubleStructPubSubType::compute_key(
             FinalDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool FinalLongDoubleStructPubSubType::compute_key(
             FinalLongDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalLongDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool FinalBooleanStructPubSubType::compute_key(
             FinalBooleanStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalBooleanStruct_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool FinalOctetStructPubSubType::compute_key(
             FinalOctetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalOctetStruct_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool FinalCharStructPubSubType::compute_key(
             FinalCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool FinalWCharStructPubSubType::compute_key(
             FinalWCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalWCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool FinalUnionStructPubSubType::compute_key(
             FinalUnionStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalUnionStruct_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool FinalEmptyStructPubSubType::compute_key(
             FinalEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool FinalEmptyInheritanceStructPubSubType::compute_key(
             FinalEmptyInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalEmptyInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool FinalInheritanceStructPubSubType::compute_key(
             FinalInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool InheritanceEmptyStructPubSubType::compute_key(
             InheritanceEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InheritanceEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool FinalExtensibilityInheritancePubSubType::compute_key(
             FinalExtensibilityInheritance_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalExtensibilityInheritance_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/helpers/basic_inner_typesCdrAux.ipp
+++ b/test/dds-types-test/helpers/basic_inner_typesCdrAux.ipp
@@ -113,8 +113,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.field1();
+
+                        scdr << data.field2();
+
 }
 
 
@@ -177,6 +182,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerEmptyStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }

--- a/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.cxx
+++ b/test/dds-types-test/helpers/basic_inner_typesPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool InnerStructureHelperPubSubType::compute_key(
             InnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool InnerEmptyStructureHelperPubSubType::compute_key(
             InnerEmptyStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerEmptyStructureHelper_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/inheritanceCdrAux.ipp
+++ b/test/dds-types-test/inheritanceCdrAux.ipp
@@ -129,13 +129,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperChild& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_child_longlong();
-
-                        scdr << data.var_child_ulonglong();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const InnerStructureHelper& data);
+    serialize_key(scdr, static_cast<const InnerStructureHelper&>(data));
 }
 
 
@@ -250,13 +247,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperChildChild& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_child_childlonglong2();
-
-                        scdr << data.var_childchild_ulonglong2();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const InnerStructureHelperChild& data);
+    serialize_key(scdr, static_cast<const InnerStructureHelperChild&>(data));
 }
 
 
@@ -339,9 +333,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperEmptyChild& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const InnerStructureHelper& data);
+    serialize_key(scdr, static_cast<const InnerStructureHelper&>(data));
 }
 
 
@@ -432,11 +427,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperEmptyChildChild& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_char();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const InnerStructureHelperEmptyChild& data);
+    serialize_key(scdr, static_cast<const InnerStructureHelperEmptyChild&>(data));
 }
 
 
@@ -519,13 +513,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerEmptyStructureHelperChild& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_child_longlong();
-
-                        scdr << data.var_child_ulonglong();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const InnerEmptyStructureHelper& data);
+    serialize_key(scdr, static_cast<const InnerEmptyStructureHelper&>(data));
 }
 
 
@@ -616,11 +607,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructAliasInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.new_member();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const inner_structure_helper_alias& data);
+    serialize_key(scdr, static_cast<const inner_structure_helper_alias&>(data));
 }
 
 

--- a/test/dds-types-test/inheritanceCdrAux.ipp
+++ b/test/dds-types-test/inheritanceCdrAux.ipp
@@ -129,8 +129,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperChild& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_child_longlong();
+
+                        scdr << data.var_child_ulonglong();
+
 }
 
 
@@ -245,8 +250,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperChildChild& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_child_childlonglong2();
+
+                        scdr << data.var_childchild_ulonglong2();
+
 }
 
 
@@ -329,6 +339,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperEmptyChild& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -421,8 +432,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructureHelperEmptyChildChild& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char();
+
 }
 
 
@@ -505,8 +519,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerEmptyStructureHelperChild& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_child_longlong();
+
+                        scdr << data.var_child_ulonglong();
+
 }
 
 
@@ -597,8 +616,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructAliasInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.new_member();
+
 }
 
 
@@ -713,8 +735,45 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructuresInheritanceStruct& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelperChild& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelperChildChild& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelperEmptyChild& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelperEmptyChildChild& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerEmptyStructureHelperChild& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructAliasInheritanceStruct& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.var_InnerStructureHelperChild());
+
+                        serialize_key(scdr, data.var_InnerStructureHelperChildChild());
+
+                        serialize_key(scdr, data.var_InnerStructureHelperEmptyChild());
+
+                        serialize_key(scdr, data.var_InnerStructureHelperEmptyChildChild());
+
+                        serialize_key(scdr, data.var_InnerEmptyStructureHelperChild());
+
+                        serialize_key(scdr, data.var_StructAliasInheritanceStruct());
+
 }
 
 
@@ -1015,8 +1074,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BitsetsChildInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_InnerBitsetHelperChild();
+
+                        scdr << data.var_InnerBitsetHelperChildChild();
+
+                        scdr << data.var_BitsetAliasInheritanceBitset();
+
 }
 
 

--- a/test/dds-types-test/inheritancePubSubTypes.cxx
+++ b/test/dds-types-test/inheritancePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool InnerStructureHelperChildPubSubType::compute_key(
             InnerStructureHelperChild_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructureHelperChild_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool InnerStructureHelperChildChildPubSubType::compute_key(
             InnerStructureHelperChildChild_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructureHelperChildChild_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool InnerStructureHelperEmptyChildPubSubType::compute_key(
             InnerStructureHelperEmptyChild_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructureHelperEmptyChild_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool InnerStructureHelperEmptyChildChildPubSubType::compute_key(
             InnerStructureHelperEmptyChildChild_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructureHelperEmptyChildChild_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool InnerEmptyStructureHelperChildPubSubType::compute_key(
             InnerEmptyStructureHelperChild_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerEmptyStructureHelperChild_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool StructAliasInheritanceStructPubSubType::compute_key(
             StructAliasInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructAliasInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool StructuresInheritanceStructPubSubType::compute_key(
             StructuresInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructuresInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -1447,7 +1454,8 @@ bool BitsetsChildInheritanceStructPubSubType::compute_key(
             BitsetsChildInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BitsetsChildInheritanceStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/key.hpp
+++ b/test/dds-types-test/key.hpp
@@ -2739,6 +2739,627 @@ private:
 
 
 };
+/*!
+ * @brief This class represents the structure KeyedFinal defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedFinal
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport KeyedFinal()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~KeyedFinal()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object KeyedFinal that will be copied.
+     */
+    eProsima_user_DllExport KeyedFinal(
+            const KeyedFinal& x)
+    {
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object KeyedFinal that will be copied.
+     */
+    eProsima_user_DllExport KeyedFinal(
+            KeyedFinal&& x) noexcept
+    {
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object KeyedFinal that will be copied.
+     */
+    eProsima_user_DllExport KeyedFinal& operator =(
+            const KeyedFinal& x)
+    {
+
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object KeyedFinal that will be copied.
+     */
+    eProsima_user_DllExport KeyedFinal& operator =(
+            KeyedFinal&& x) noexcept
+    {
+
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedFinal object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const KeyedFinal& x) const
+    {
+        return (m_key_long == x.m_key_long &&
+           m_key_short == x.m_key_short &&
+           m_key_string == x.m_key_string);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedFinal object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const KeyedFinal& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets a value in member key_long
+     * @param _key_long New value for member key_long
+     */
+    eProsima_user_DllExport void key_long(
+            int32_t _key_long)
+    {
+        m_key_long = _key_long;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_long
+     * @return Value of member key_long
+     */
+    eProsima_user_DllExport int32_t key_long() const
+    {
+        return m_key_long;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_long
+     * @return Reference to member key_long
+     */
+    eProsima_user_DllExport int32_t& key_long()
+    {
+        return m_key_long;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member key_short
+     * @param _key_short New value for member key_short
+     */
+    eProsima_user_DllExport void key_short(
+            int16_t _key_short)
+    {
+        m_key_short = _key_short;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_short
+     * @return Value of member key_short
+     */
+    eProsima_user_DllExport int16_t key_short() const
+    {
+        return m_key_short;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_short
+     * @return Reference to member key_short
+     */
+    eProsima_user_DllExport int16_t& key_short()
+    {
+        return m_key_short;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member key_string
+     * @param _key_string New value to be copied in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            const std::string& _key_string)
+    {
+        m_key_string = _key_string;
+    }
+
+    /*!
+     * @brief This function moves the value in member key_string
+     * @param _key_string New value to be moved in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            std::string&& _key_string)
+    {
+        m_key_string = std::move(_key_string);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member key_string
+     * @return Constant reference to member key_string
+     */
+    eProsima_user_DllExport const std::string& key_string() const
+    {
+        return m_key_string;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_string
+     * @return Reference to member key_string
+     */
+    eProsima_user_DllExport std::string& key_string()
+    {
+        return m_key_string;
+    }
+
+
+
+private:
+
+    int32_t m_key_long{0};
+    int16_t m_key_short{0};
+    std::string m_key_string;
+
+};
+/*!
+ * @brief This class represents the structure KeyedAppendable defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedAppendable
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport KeyedAppendable()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~KeyedAppendable()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object KeyedAppendable that will be copied.
+     */
+    eProsima_user_DllExport KeyedAppendable(
+            const KeyedAppendable& x)
+    {
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object KeyedAppendable that will be copied.
+     */
+    eProsima_user_DllExport KeyedAppendable(
+            KeyedAppendable&& x) noexcept
+    {
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object KeyedAppendable that will be copied.
+     */
+    eProsima_user_DllExport KeyedAppendable& operator =(
+            const KeyedAppendable& x)
+    {
+
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object KeyedAppendable that will be copied.
+     */
+    eProsima_user_DllExport KeyedAppendable& operator =(
+            KeyedAppendable&& x) noexcept
+    {
+
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedAppendable object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const KeyedAppendable& x) const
+    {
+        return (m_key_long == x.m_key_long &&
+           m_key_short == x.m_key_short &&
+           m_key_string == x.m_key_string);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedAppendable object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const KeyedAppendable& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets a value in member key_long
+     * @param _key_long New value for member key_long
+     */
+    eProsima_user_DllExport void key_long(
+            int32_t _key_long)
+    {
+        m_key_long = _key_long;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_long
+     * @return Value of member key_long
+     */
+    eProsima_user_DllExport int32_t key_long() const
+    {
+        return m_key_long;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_long
+     * @return Reference to member key_long
+     */
+    eProsima_user_DllExport int32_t& key_long()
+    {
+        return m_key_long;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member key_short
+     * @param _key_short New value for member key_short
+     */
+    eProsima_user_DllExport void key_short(
+            int16_t _key_short)
+    {
+        m_key_short = _key_short;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_short
+     * @return Value of member key_short
+     */
+    eProsima_user_DllExport int16_t key_short() const
+    {
+        return m_key_short;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_short
+     * @return Reference to member key_short
+     */
+    eProsima_user_DllExport int16_t& key_short()
+    {
+        return m_key_short;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member key_string
+     * @param _key_string New value to be copied in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            const std::string& _key_string)
+    {
+        m_key_string = _key_string;
+    }
+
+    /*!
+     * @brief This function moves the value in member key_string
+     * @param _key_string New value to be moved in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            std::string&& _key_string)
+    {
+        m_key_string = std::move(_key_string);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member key_string
+     * @return Constant reference to member key_string
+     */
+    eProsima_user_DllExport const std::string& key_string() const
+    {
+        return m_key_string;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_string
+     * @return Reference to member key_string
+     */
+    eProsima_user_DllExport std::string& key_string()
+    {
+        return m_key_string;
+    }
+
+
+
+private:
+
+    int32_t m_key_long{0};
+    int16_t m_key_short{0};
+    std::string m_key_string;
+
+};
+/*!
+ * @brief This class represents the structure KeyedMutable defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedMutable
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport KeyedMutable()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~KeyedMutable()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object KeyedMutable that will be copied.
+     */
+    eProsima_user_DllExport KeyedMutable(
+            const KeyedMutable& x)
+    {
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object KeyedMutable that will be copied.
+     */
+    eProsima_user_DllExport KeyedMutable(
+            KeyedMutable&& x) noexcept
+    {
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object KeyedMutable that will be copied.
+     */
+    eProsima_user_DllExport KeyedMutable& operator =(
+            const KeyedMutable& x)
+    {
+
+                    m_key_long = x.m_key_long;
+
+                    m_key_short = x.m_key_short;
+
+                    m_key_string = x.m_key_string;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object KeyedMutable that will be copied.
+     */
+    eProsima_user_DllExport KeyedMutable& operator =(
+            KeyedMutable&& x) noexcept
+    {
+
+        m_key_long = x.m_key_long;
+        m_key_short = x.m_key_short;
+        m_key_string = std::move(x.m_key_string);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedMutable object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const KeyedMutable& x) const
+    {
+        return (m_key_long == x.m_key_long &&
+           m_key_short == x.m_key_short &&
+           m_key_string == x.m_key_string);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x KeyedMutable object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const KeyedMutable& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets a value in member key_long
+     * @param _key_long New value for member key_long
+     */
+    eProsima_user_DllExport void key_long(
+            int32_t _key_long)
+    {
+        m_key_long = _key_long;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_long
+     * @return Value of member key_long
+     */
+    eProsima_user_DllExport int32_t key_long() const
+    {
+        return m_key_long;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_long
+     * @return Reference to member key_long
+     */
+    eProsima_user_DllExport int32_t& key_long()
+    {
+        return m_key_long;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member key_short
+     * @param _key_short New value for member key_short
+     */
+    eProsima_user_DllExport void key_short(
+            int16_t _key_short)
+    {
+        m_key_short = _key_short;
+    }
+
+    /*!
+     * @brief This function returns the value of member key_short
+     * @return Value of member key_short
+     */
+    eProsima_user_DllExport int16_t key_short() const
+    {
+        return m_key_short;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_short
+     * @return Reference to member key_short
+     */
+    eProsima_user_DllExport int16_t& key_short()
+    {
+        return m_key_short;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member key_string
+     * @param _key_string New value to be copied in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            const std::string& _key_string)
+    {
+        m_key_string = _key_string;
+    }
+
+    /*!
+     * @brief This function moves the value in member key_string
+     * @param _key_string New value to be moved in member key_string
+     */
+    eProsima_user_DllExport void key_string(
+            std::string&& _key_string)
+    {
+        m_key_string = std::move(_key_string);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member key_string
+     * @return Constant reference to member key_string
+     */
+    eProsima_user_DllExport const std::string& key_string() const
+    {
+        return m_key_string;
+    }
+
+    /*!
+     * @brief This function returns a reference to member key_string
+     * @return Reference to member key_string
+     */
+    eProsima_user_DllExport std::string& key_string()
+    {
+        return m_key_string;
+    }
+
+
+
+private:
+
+    int32_t m_key_long{0};
+    int16_t m_key_short{0};
+    std::string m_key_string;
+
+};
 
 #endif // _FAST_DDS_GENERATED_KEY_HPP_
 

--- a/test/dds-types-test/keyCdrAux.hpp
+++ b/test/dds-types-test/keyCdrAux.hpp
@@ -24,6 +24,9 @@
 
 #include "key.hpp"
 
+constexpr uint32_t KeyedMutable_max_cdr_typesize {292UL};
+constexpr uint32_t KeyedMutable_max_key_cdr_typesize {268UL};
+
 constexpr uint32_t KeyedShortStruct_max_cdr_typesize {8UL};
 constexpr uint32_t KeyedShortStruct_max_key_cdr_typesize {2UL};
 
@@ -36,11 +39,17 @@ constexpr uint32_t KeyedULongLongStruct_max_key_cdr_typesize {8UL};
 constexpr uint32_t KeyedDoubleStruct_max_cdr_typesize {24UL};
 constexpr uint32_t KeyedDoubleStruct_max_key_cdr_typesize {8UL};
 
+constexpr uint32_t KeyedAppendable_max_cdr_typesize {272UL};
+constexpr uint32_t KeyedAppendable_max_key_cdr_typesize {268UL};
+
 constexpr uint32_t KeyedBooleanStruct_max_cdr_typesize {6UL};
 constexpr uint32_t KeyedBooleanStruct_max_key_cdr_typesize {1UL};
 
 constexpr uint32_t KeyedWCharStruct_max_cdr_typesize {8UL};
 constexpr uint32_t KeyedWCharStruct_max_key_cdr_typesize {2UL};
+
+constexpr uint32_t KeyedFinal_max_cdr_typesize {268UL};
+constexpr uint32_t KeyedFinal_max_key_cdr_typesize {268UL};
 
 constexpr uint32_t KeyedInheritanceStruct_max_cdr_typesize {528UL};
 constexpr uint32_t KeyedInheritanceStruct_max_key_cdr_typesize {2UL};
@@ -149,6 +158,18 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InheritanceKeyedEmptyStruct& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedFinal& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedAppendable& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedMutable& data);
 
 
 } // namespace fastcdr

--- a/test/dds-types-test/keyCdrAux.ipp
+++ b/test/dds-types-test/keyCdrAux.ipp
@@ -113,9 +113,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_short();
+                        scdr << data.key_short();
 
 
 }
@@ -200,9 +201,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedUShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_ushort();
+                        scdr << data.key_ushort();
 
 
 }
@@ -287,9 +289,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_long();
+                        scdr << data.key_long();
 
 
 }
@@ -374,9 +377,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedULongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_ulong();
+                        scdr << data.key_ulong();
 
 
 }
@@ -461,9 +465,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedLongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_longlong();
+                        scdr << data.key_longlong();
 
 
 }
@@ -548,9 +553,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedULongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_ulonglong();
+                        scdr << data.key_ulonglong();
 
 
 }
@@ -635,9 +641,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedFloatStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_float();
+                        scdr << data.key_float();
 
 
 }
@@ -722,9 +729,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_double();
+                        scdr << data.key_double();
 
 
 }
@@ -809,9 +817,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedLongDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_longdouble();
+                        scdr << data.key_longdouble();
 
 
 }
@@ -896,9 +905,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedBooleanStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_boolean();
+                        scdr << data.key_boolean();
 
 
 }
@@ -983,9 +993,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedOctetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_octet();
+                        scdr << data.key_octet();
 
 
 }
@@ -1070,9 +1081,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_char8();
+                        scdr << data.key_char8();
 
 
 }
@@ -1157,9 +1169,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedWCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_char16();
+                        scdr << data.key_char16();
 
 
 }
@@ -1236,9 +1249,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.key_short();
+                        scdr << data.key_short();
 
 }
 
@@ -1330,6 +1344,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedEmptyInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1430,6 +1445,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1514,8 +1530,306 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InheritanceKeyedEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const KeyedFinal& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.key_long(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.key_short(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.key_string(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedFinal& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.key_long()
+        << eprosima::fastcdr::MemberId(1) << data.key_short()
+        << eprosima::fastcdr::MemberId(2) << data.key_string()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        KeyedFinal& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.key_long();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.key_short();
+                                            break;
+
+                                        case 2:
+                                                dcdr >> data.key_string();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedFinal& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.key_string();
+
+                        scdr << data.key_short();
+
+                        scdr << data.key_long();
+
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const KeyedAppendable& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.key_long(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.key_short(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.key_string(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedAppendable& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.key_long()
+        << eprosima::fastcdr::MemberId(1) << data.key_short()
+        << eprosima::fastcdr::MemberId(2) << data.key_string()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        KeyedAppendable& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.key_long();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.key_short();
+                                            break;
+
+                                        case 2:
+                                                dcdr >> data.key_string();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedAppendable& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.key_string();
+
+                        scdr << data.key_short();
+
+                        scdr << data.key_long();
+
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const KeyedMutable& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0x00000002),
+                data.key_long(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0x00000001),
+                data.key_short(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0x00000000),
+                data.key_string(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedMutable& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0x00000002) << data.key_long()
+        << eprosima::fastcdr::MemberId(0x00000001) << data.key_short()
+        << eprosima::fastcdr::MemberId(0x00000000) << data.key_string()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        KeyedMutable& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0x00000002:
+                                                dcdr >> data.key_long();
+                                            break;
+
+                                        case 0x00000001:
+                                                dcdr >> data.key_short();
+                                            break;
+
+                                        case 0x00000000:
+                                                dcdr >> data.key_string();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const KeyedMutable& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.key_string();
+
+                        scdr << data.key_short();
+
+                        scdr << data.key_long();
+
 }
 
 

--- a/test/dds-types-test/keyCdrAux.ipp
+++ b/test/dds-types-test/keyCdrAux.ipp
@@ -1344,9 +1344,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedEmptyInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const KeyedEmptyStruct& data);
+    serialize_key(scdr, static_cast<const KeyedEmptyStruct&>(data));
 }
 
 
@@ -1445,9 +1446,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyedInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const KeyedShortStruct& data);
+    serialize_key(scdr, static_cast<const KeyedShortStruct&>(data));
 }
 
 
@@ -1530,9 +1532,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InheritanceKeyedEmptyStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const KeyedShortStruct& data);
+    serialize_key(scdr, static_cast<const KeyedShortStruct&>(data));
 }
 
 

--- a/test/dds-types-test/keyPubSubTypes.cxx
+++ b/test/dds-types-test/keyPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool KeyedShortStructPubSubType::compute_key(
             KeyedShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedShortStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool KeyedUShortStructPubSubType::compute_key(
             KeyedUShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedUShortStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool KeyedLongStructPubSubType::compute_key(
             KeyedLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedLongStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool KeyedULongStructPubSubType::compute_key(
             KeyedULongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedULongStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool KeyedLongLongStructPubSubType::compute_key(
             KeyedLongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedLongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool KeyedULongLongStructPubSubType::compute_key(
             KeyedULongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedULongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool KeyedFloatStructPubSubType::compute_key(
             KeyedFloatStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedFloatStruct_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool KeyedDoubleStructPubSubType::compute_key(
             KeyedDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool KeyedLongDoubleStructPubSubType::compute_key(
             KeyedLongDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedLongDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool KeyedBooleanStructPubSubType::compute_key(
             KeyedBooleanStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedBooleanStruct_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool KeyedOctetStructPubSubType::compute_key(
             KeyedOctetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedOctetStruct_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool KeyedCharStructPubSubType::compute_key(
             KeyedCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool KeyedWCharStructPubSubType::compute_key(
             KeyedWCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedWCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool KeyedEmptyStructPubSubType::compute_key(
             KeyedEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool KeyedEmptyInheritanceStructPubSubType::compute_key(
             KeyedEmptyInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedEmptyInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool KeyedInheritanceStructPubSubType::compute_key(
             KeyedInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyedInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool InheritanceKeyedEmptyStructPubSubType::compute_key(
             InheritanceKeyedEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InheritanceKeyedEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -3089,6 +3106,549 @@ bool InheritanceKeyedEmptyStructPubSubType::compute_key(
 void InheritanceKeyedEmptyStructPubSubType::register_type_object_representation()
 {
     register_InheritanceKeyedEmptyStruct_type_identifier(type_identifiers_);
+}
+
+KeyedFinalPubSubType::KeyedFinalPubSubType()
+{
+    set_name("KeyedFinal");
+    uint32_t type_size = KeyedFinal_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = true;
+    uint32_t key_length = KeyedFinal_max_key_cdr_typesize > 16 ? KeyedFinal_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+KeyedFinalPubSubType::~KeyedFinalPubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool KeyedFinalPubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const KeyedFinal* p_type = static_cast<const KeyedFinal*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool KeyedFinalPubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        KeyedFinal* p_type = static_cast<KeyedFinal*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t KeyedFinalPubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const KeyedFinal*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* KeyedFinalPubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new KeyedFinal());
+}
+
+void KeyedFinalPubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<KeyedFinal*>(data));
+}
+
+bool KeyedFinalPubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    KeyedFinal data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool KeyedFinalPubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const KeyedFinal* p_type = static_cast<const KeyedFinal*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            KeyedFinal_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || KeyedFinal_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void KeyedFinalPubSubType::register_type_object_representation()
+{
+    register_KeyedFinal_type_identifier(type_identifiers_);
+}
+
+KeyedAppendablePubSubType::KeyedAppendablePubSubType()
+{
+    set_name("KeyedAppendable");
+    uint32_t type_size = KeyedAppendable_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = true;
+    uint32_t key_length = KeyedAppendable_max_key_cdr_typesize > 16 ? KeyedAppendable_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+KeyedAppendablePubSubType::~KeyedAppendablePubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool KeyedAppendablePubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const KeyedAppendable* p_type = static_cast<const KeyedAppendable*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool KeyedAppendablePubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        KeyedAppendable* p_type = static_cast<KeyedAppendable*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t KeyedAppendablePubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const KeyedAppendable*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* KeyedAppendablePubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new KeyedAppendable());
+}
+
+void KeyedAppendablePubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<KeyedAppendable*>(data));
+}
+
+bool KeyedAppendablePubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    KeyedAppendable data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool KeyedAppendablePubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const KeyedAppendable* p_type = static_cast<const KeyedAppendable*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            KeyedAppendable_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || KeyedAppendable_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void KeyedAppendablePubSubType::register_type_object_representation()
+{
+    register_KeyedAppendable_type_identifier(type_identifiers_);
+}
+
+KeyedMutablePubSubType::KeyedMutablePubSubType()
+{
+    set_name("KeyedMutable");
+    uint32_t type_size = KeyedMutable_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = true;
+    uint32_t key_length = KeyedMutable_max_key_cdr_typesize > 16 ? KeyedMutable_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+KeyedMutablePubSubType::~KeyedMutablePubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool KeyedMutablePubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const KeyedMutable* p_type = static_cast<const KeyedMutable*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR :
+        eprosima::fastcdr::EncodingAlgorithmFlag::PL_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool KeyedMutablePubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        KeyedMutable* p_type = static_cast<KeyedMutable*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t KeyedMutablePubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const KeyedMutable*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* KeyedMutablePubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new KeyedMutable());
+}
+
+void KeyedMutablePubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<KeyedMutable*>(data));
+}
+
+bool KeyedMutablePubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    KeyedMutable data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool KeyedMutablePubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const KeyedMutable* p_type = static_cast<const KeyedMutable*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            KeyedMutable_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || KeyedMutable_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void KeyedMutablePubSubType::register_type_object_representation()
+{
+    register_KeyedMutable_type_identifier(type_identifiers_);
 }
 
 

--- a/test/dds-types-test/keyPubSubTypes.hpp
+++ b/test/dds-types-test/keyPubSubTypes.hpp
@@ -1415,5 +1415,248 @@ private:
 
 };
 
+/*!
+ * @brief This class represents the TopicDataType of the type KeyedFinal defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedFinalPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef KeyedFinal type;
+
+    eProsima_user_DllExport KeyedFinalPubSubType();
+
+    eProsima_user_DllExport ~KeyedFinalPubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
+/*!
+ * @brief This class represents the TopicDataType of the type KeyedAppendable defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedAppendablePubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef KeyedAppendable type;
+
+    eProsima_user_DllExport KeyedAppendablePubSubType();
+
+    eProsima_user_DllExport ~KeyedAppendablePubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
+/*!
+ * @brief This class represents the TopicDataType of the type KeyedMutable defined by the user in the IDL file.
+ * @ingroup key
+ */
+class KeyedMutablePubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef KeyedMutable type;
+
+    eProsima_user_DllExport KeyedMutablePubSubType();
+
+    eProsima_user_DllExport ~KeyedMutablePubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
 #endif // FAST_DDS_GENERATED__KEY_PUBSUBTYPES_HPP
 

--- a/test/dds-types-test/keyTypeObjectSupport.cxx
+++ b/test/dds-types-test/keyTypeObjectSupport.cxx
@@ -1738,4 +1738,523 @@ void register_InheritanceKeyedEmptyStruct_type_identifier(
         }
     }
 }
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_KeyedFinal_type_identifier(
+        TypeIdentifierPair& type_ids_KeyedFinal)
+{
+
+    ReturnCode_t return_code_KeyedFinal {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_KeyedFinal =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "KeyedFinal", type_ids_KeyedFinal);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_KeyedFinal)
+    {
+        StructTypeFlag struct_flags_KeyedFinal = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+                false, false);
+        QualifiedTypeName type_name_KeyedFinal = "KeyedFinal";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_KeyedFinal;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_KeyedFinal;
+        AppliedAnnotationSeq tmp_ann_custom_KeyedFinal;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_KeyedFinal;
+        if (!tmp_ann_custom_KeyedFinal.empty())
+        {
+            ann_custom_KeyedFinal = tmp_ann_custom_KeyedFinal;
+        }
+
+        CompleteTypeDetail detail_KeyedFinal = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_KeyedFinal, ann_custom_KeyedFinal, type_name_KeyedFinal.to_string());
+        CompleteStructHeader header_KeyedFinal;
+        header_KeyedFinal = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_KeyedFinal);
+        CompleteStructMemberSeq member_seq_KeyedFinal;
+        {
+            TypeIdentifierPair type_ids_key_long;
+            ReturnCode_t return_code_key_long {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_long =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_key_long);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_long)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_long Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_long = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_long = 0x00000002;
+            bool common_key_long_ec {false};
+            CommonStructMember common_key_long {TypeObjectUtils::build_common_struct_member(member_id_key_long, member_flags_key_long, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_long, common_key_long_ec))};
+            if (!common_key_long_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_long member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_long = "key_long";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_long;
+            ann_custom_KeyedFinal.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_long;
+            eprosima::fastcdr::optional<std::string> unit_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_long;
+            eprosima::fastcdr::optional<std::string> hash_id_key_long;
+            if (unit_key_long.has_value() || min_key_long.has_value() || max_key_long.has_value() || hash_id_key_long.has_value())
+            {
+                member_ann_builtin_key_long = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_long, min_key_long, max_key_long, hash_id_key_long);
+            }
+            if (!tmp_ann_custom_key_long.empty())
+            {
+                ann_custom_KeyedFinal = tmp_ann_custom_key_long;
+            }
+            CompleteMemberDetail detail_key_long = TypeObjectUtils::build_complete_member_detail(name_key_long, member_ann_builtin_key_long, ann_custom_KeyedFinal);
+            CompleteStructMember member_key_long = TypeObjectUtils::build_complete_struct_member(common_key_long, detail_key_long);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedFinal, member_key_long);
+        }
+        {
+            TypeIdentifierPair type_ids_key_short;
+            ReturnCode_t return_code_key_short {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_short =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int16_t", type_ids_key_short);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_short)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_short Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_short = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_short = 0x00000001;
+            bool common_key_short_ec {false};
+            CommonStructMember common_key_short {TypeObjectUtils::build_common_struct_member(member_id_key_short, member_flags_key_short, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_short, common_key_short_ec))};
+            if (!common_key_short_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_short member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_short = "key_short";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_short;
+            ann_custom_KeyedFinal.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_short;
+            eprosima::fastcdr::optional<std::string> unit_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_short;
+            eprosima::fastcdr::optional<std::string> hash_id_key_short;
+            if (unit_key_short.has_value() || min_key_short.has_value() || max_key_short.has_value() || hash_id_key_short.has_value())
+            {
+                member_ann_builtin_key_short = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_short, min_key_short, max_key_short, hash_id_key_short);
+            }
+            if (!tmp_ann_custom_key_short.empty())
+            {
+                ann_custom_KeyedFinal = tmp_ann_custom_key_short;
+            }
+            CompleteMemberDetail detail_key_short = TypeObjectUtils::build_complete_member_detail(name_key_short, member_ann_builtin_key_short, ann_custom_KeyedFinal);
+            CompleteStructMember member_key_short = TypeObjectUtils::build_complete_struct_member(common_key_short, detail_key_short);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedFinal, member_key_short);
+        }
+        {
+            TypeIdentifierPair type_ids_key_string;
+            ReturnCode_t return_code_key_string {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_string =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_key_string);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_string)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_key_string))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_key_string = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_string = 0x00000000;
+            bool common_key_string_ec {false};
+            CommonStructMember common_key_string {TypeObjectUtils::build_common_struct_member(member_id_key_string, member_flags_key_string, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_string, common_key_string_ec))};
+            if (!common_key_string_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_string member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_string = "key_string";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_string;
+            ann_custom_KeyedFinal.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_string;
+            eprosima::fastcdr::optional<std::string> unit_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_string;
+            eprosima::fastcdr::optional<std::string> hash_id_key_string;
+            if (unit_key_string.has_value() || min_key_string.has_value() || max_key_string.has_value() || hash_id_key_string.has_value())
+            {
+                member_ann_builtin_key_string = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_string, min_key_string, max_key_string, hash_id_key_string);
+            }
+            if (!tmp_ann_custom_key_string.empty())
+            {
+                ann_custom_KeyedFinal = tmp_ann_custom_key_string;
+            }
+            CompleteMemberDetail detail_key_string = TypeObjectUtils::build_complete_member_detail(name_key_string, member_ann_builtin_key_string, ann_custom_KeyedFinal);
+            CompleteStructMember member_key_string = TypeObjectUtils::build_complete_struct_member(common_key_string, detail_key_string);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedFinal, member_key_string);
+        }
+        CompleteStructType struct_type_KeyedFinal = TypeObjectUtils::build_complete_struct_type(struct_flags_KeyedFinal, header_KeyedFinal, member_seq_KeyedFinal);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_KeyedFinal, type_name_KeyedFinal.to_string(), type_ids_KeyedFinal))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "KeyedFinal already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_KeyedAppendable_type_identifier(
+        TypeIdentifierPair& type_ids_KeyedAppendable)
+{
+
+    ReturnCode_t return_code_KeyedAppendable {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_KeyedAppendable =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "KeyedAppendable", type_ids_KeyedAppendable);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_KeyedAppendable)
+    {
+        StructTypeFlag struct_flags_KeyedAppendable = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_KeyedAppendable = "KeyedAppendable";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_KeyedAppendable;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_KeyedAppendable;
+        AppliedAnnotationSeq tmp_ann_custom_KeyedAppendable;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_KeyedAppendable;
+        if (!tmp_ann_custom_KeyedAppendable.empty())
+        {
+            ann_custom_KeyedAppendable = tmp_ann_custom_KeyedAppendable;
+        }
+
+        CompleteTypeDetail detail_KeyedAppendable = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_KeyedAppendable, ann_custom_KeyedAppendable, type_name_KeyedAppendable.to_string());
+        CompleteStructHeader header_KeyedAppendable;
+        header_KeyedAppendable = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_KeyedAppendable);
+        CompleteStructMemberSeq member_seq_KeyedAppendable;
+        {
+            TypeIdentifierPair type_ids_key_long;
+            ReturnCode_t return_code_key_long {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_long =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_key_long);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_long)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_long Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_long = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_long = 0x00000002;
+            bool common_key_long_ec {false};
+            CommonStructMember common_key_long {TypeObjectUtils::build_common_struct_member(member_id_key_long, member_flags_key_long, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_long, common_key_long_ec))};
+            if (!common_key_long_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_long member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_long = "key_long";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_long;
+            ann_custom_KeyedAppendable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_long;
+            eprosima::fastcdr::optional<std::string> unit_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_long;
+            eprosima::fastcdr::optional<std::string> hash_id_key_long;
+            if (unit_key_long.has_value() || min_key_long.has_value() || max_key_long.has_value() || hash_id_key_long.has_value())
+            {
+                member_ann_builtin_key_long = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_long, min_key_long, max_key_long, hash_id_key_long);
+            }
+            if (!tmp_ann_custom_key_long.empty())
+            {
+                ann_custom_KeyedAppendable = tmp_ann_custom_key_long;
+            }
+            CompleteMemberDetail detail_key_long = TypeObjectUtils::build_complete_member_detail(name_key_long, member_ann_builtin_key_long, ann_custom_KeyedAppendable);
+            CompleteStructMember member_key_long = TypeObjectUtils::build_complete_struct_member(common_key_long, detail_key_long);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedAppendable, member_key_long);
+        }
+        {
+            TypeIdentifierPair type_ids_key_short;
+            ReturnCode_t return_code_key_short {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_short =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int16_t", type_ids_key_short);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_short)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_short Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_short = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_short = 0x00000001;
+            bool common_key_short_ec {false};
+            CommonStructMember common_key_short {TypeObjectUtils::build_common_struct_member(member_id_key_short, member_flags_key_short, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_short, common_key_short_ec))};
+            if (!common_key_short_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_short member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_short = "key_short";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_short;
+            ann_custom_KeyedAppendable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_short;
+            eprosima::fastcdr::optional<std::string> unit_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_short;
+            eprosima::fastcdr::optional<std::string> hash_id_key_short;
+            if (unit_key_short.has_value() || min_key_short.has_value() || max_key_short.has_value() || hash_id_key_short.has_value())
+            {
+                member_ann_builtin_key_short = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_short, min_key_short, max_key_short, hash_id_key_short);
+            }
+            if (!tmp_ann_custom_key_short.empty())
+            {
+                ann_custom_KeyedAppendable = tmp_ann_custom_key_short;
+            }
+            CompleteMemberDetail detail_key_short = TypeObjectUtils::build_complete_member_detail(name_key_short, member_ann_builtin_key_short, ann_custom_KeyedAppendable);
+            CompleteStructMember member_key_short = TypeObjectUtils::build_complete_struct_member(common_key_short, detail_key_short);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedAppendable, member_key_short);
+        }
+        {
+            TypeIdentifierPair type_ids_key_string;
+            ReturnCode_t return_code_key_string {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_string =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_key_string);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_string)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_key_string))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_key_string = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_string = 0x00000000;
+            bool common_key_string_ec {false};
+            CommonStructMember common_key_string {TypeObjectUtils::build_common_struct_member(member_id_key_string, member_flags_key_string, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_string, common_key_string_ec))};
+            if (!common_key_string_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_string member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_string = "key_string";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_string;
+            ann_custom_KeyedAppendable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_string;
+            eprosima::fastcdr::optional<std::string> unit_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_string;
+            eprosima::fastcdr::optional<std::string> hash_id_key_string;
+            if (unit_key_string.has_value() || min_key_string.has_value() || max_key_string.has_value() || hash_id_key_string.has_value())
+            {
+                member_ann_builtin_key_string = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_string, min_key_string, max_key_string, hash_id_key_string);
+            }
+            if (!tmp_ann_custom_key_string.empty())
+            {
+                ann_custom_KeyedAppendable = tmp_ann_custom_key_string;
+            }
+            CompleteMemberDetail detail_key_string = TypeObjectUtils::build_complete_member_detail(name_key_string, member_ann_builtin_key_string, ann_custom_KeyedAppendable);
+            CompleteStructMember member_key_string = TypeObjectUtils::build_complete_struct_member(common_key_string, detail_key_string);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedAppendable, member_key_string);
+        }
+        CompleteStructType struct_type_KeyedAppendable = TypeObjectUtils::build_complete_struct_type(struct_flags_KeyedAppendable, header_KeyedAppendable, member_seq_KeyedAppendable);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_KeyedAppendable, type_name_KeyedAppendable.to_string(), type_ids_KeyedAppendable))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "KeyedAppendable already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_KeyedMutable_type_identifier(
+        TypeIdentifierPair& type_ids_KeyedMutable)
+{
+
+    ReturnCode_t return_code_KeyedMutable {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_KeyedMutable =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "KeyedMutable", type_ids_KeyedMutable);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_KeyedMutable)
+    {
+        StructTypeFlag struct_flags_KeyedMutable = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::MUTABLE,
+                false, false);
+        QualifiedTypeName type_name_KeyedMutable = "KeyedMutable";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_KeyedMutable;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_KeyedMutable;
+        AppliedAnnotationSeq tmp_ann_custom_KeyedMutable;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_KeyedMutable;
+        if (!tmp_ann_custom_KeyedMutable.empty())
+        {
+            ann_custom_KeyedMutable = tmp_ann_custom_KeyedMutable;
+        }
+
+        CompleteTypeDetail detail_KeyedMutable = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_KeyedMutable, ann_custom_KeyedMutable, type_name_KeyedMutable.to_string());
+        CompleteStructHeader header_KeyedMutable;
+        header_KeyedMutable = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_KeyedMutable);
+        CompleteStructMemberSeq member_seq_KeyedMutable;
+        {
+            TypeIdentifierPair type_ids_key_long;
+            ReturnCode_t return_code_key_long {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_long =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_key_long);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_long)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_long Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_long = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_long = 0x00000002;
+            bool common_key_long_ec {false};
+            CommonStructMember common_key_long {TypeObjectUtils::build_common_struct_member(member_id_key_long, member_flags_key_long, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_long, common_key_long_ec))};
+            if (!common_key_long_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_long member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_long = "key_long";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_long;
+            ann_custom_KeyedMutable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_long;
+            eprosima::fastcdr::optional<std::string> unit_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_long;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_long;
+            eprosima::fastcdr::optional<std::string> hash_id_key_long;
+            if (unit_key_long.has_value() || min_key_long.has_value() || max_key_long.has_value() || hash_id_key_long.has_value())
+            {
+                member_ann_builtin_key_long = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_long, min_key_long, max_key_long, hash_id_key_long);
+            }
+            if (!tmp_ann_custom_key_long.empty())
+            {
+                ann_custom_KeyedMutable = tmp_ann_custom_key_long;
+            }
+            CompleteMemberDetail detail_key_long = TypeObjectUtils::build_complete_member_detail(name_key_long, member_ann_builtin_key_long, ann_custom_KeyedMutable);
+            CompleteStructMember member_key_long = TypeObjectUtils::build_complete_struct_member(common_key_long, detail_key_long);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedMutable, member_key_long);
+        }
+        {
+            TypeIdentifierPair type_ids_key_short;
+            ReturnCode_t return_code_key_short {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_short =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int16_t", type_ids_key_short);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_short)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "key_short Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_key_short = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_short = 0x00000001;
+            bool common_key_short_ec {false};
+            CommonStructMember common_key_short {TypeObjectUtils::build_common_struct_member(member_id_key_short, member_flags_key_short, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_short, common_key_short_ec))};
+            if (!common_key_short_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_short member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_short = "key_short";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_short;
+            ann_custom_KeyedMutable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_short;
+            eprosima::fastcdr::optional<std::string> unit_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_short;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_short;
+            eprosima::fastcdr::optional<std::string> hash_id_key_short;
+            if (unit_key_short.has_value() || min_key_short.has_value() || max_key_short.has_value() || hash_id_key_short.has_value())
+            {
+                member_ann_builtin_key_short = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_short, min_key_short, max_key_short, hash_id_key_short);
+            }
+            if (!tmp_ann_custom_key_short.empty())
+            {
+                ann_custom_KeyedMutable = tmp_ann_custom_key_short;
+            }
+            CompleteMemberDetail detail_key_short = TypeObjectUtils::build_complete_member_detail(name_key_short, member_ann_builtin_key_short, ann_custom_KeyedMutable);
+            CompleteStructMember member_key_short = TypeObjectUtils::build_complete_struct_member(common_key_short, detail_key_short);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedMutable, member_key_short);
+        }
+        {
+            TypeIdentifierPair type_ids_key_string;
+            ReturnCode_t return_code_key_string {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_key_string =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_key_string);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_key_string)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_key_string))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_key_string = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_key_string = 0x00000000;
+            bool common_key_string_ec {false};
+            CommonStructMember common_key_string {TypeObjectUtils::build_common_struct_member(member_id_key_string, member_flags_key_string, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_key_string, common_key_string_ec))};
+            if (!common_key_string_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure key_string member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_key_string = "key_string";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_key_string;
+            ann_custom_KeyedMutable.reset();
+            AppliedAnnotationSeq tmp_ann_custom_key_string;
+            eprosima::fastcdr::optional<std::string> unit_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_key_string;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_key_string;
+            eprosima::fastcdr::optional<std::string> hash_id_key_string;
+            if (unit_key_string.has_value() || min_key_string.has_value() || max_key_string.has_value() || hash_id_key_string.has_value())
+            {
+                member_ann_builtin_key_string = TypeObjectUtils::build_applied_builtin_member_annotations(unit_key_string, min_key_string, max_key_string, hash_id_key_string);
+            }
+            if (!tmp_ann_custom_key_string.empty())
+            {
+                ann_custom_KeyedMutable = tmp_ann_custom_key_string;
+            }
+            CompleteMemberDetail detail_key_string = TypeObjectUtils::build_complete_member_detail(name_key_string, member_ann_builtin_key_string, ann_custom_KeyedMutable);
+            CompleteStructMember member_key_string = TypeObjectUtils::build_complete_struct_member(common_key_string, detail_key_string);
+            TypeObjectUtils::add_complete_struct_member(member_seq_KeyedMutable, member_key_string);
+        }
+        CompleteStructType struct_type_KeyedMutable = TypeObjectUtils::build_complete_struct_type(struct_flags_KeyedMutable, header_KeyedMutable, member_seq_KeyedMutable);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_KeyedMutable, type_name_KeyedMutable.to_string(), type_ids_KeyedMutable))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "KeyedMutable already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
 

--- a/test/dds-types-test/keyTypeObjectSupport.hpp
+++ b/test/dds-types-test/keyTypeObjectSupport.hpp
@@ -241,6 +241,42 @@ eProsima_user_DllExport void register_KeyedInheritanceStruct_type_identifier(
  */
 eProsima_user_DllExport void register_InheritanceKeyedEmptyStruct_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register KeyedFinal related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_KeyedFinal_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register KeyedAppendable related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_KeyedAppendable_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register KeyedMutable related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_KeyedMutable_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/test/dds-types-test/mapsCdrAux.ipp
+++ b/test/dds-types-test/mapsCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_char();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_wchar();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_string();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_wstring();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliasboundedstringhelper();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_innerenumhelper();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_innerbitmaskhelper();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliashelper();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliasarrayhelper();
+
 }
 
 
@@ -1701,8 +1764,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliassequencehelper();
+
 }
 
 
@@ -1777,8 +1843,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_inneraliasmaphelper();
+
 }
 
 
@@ -1853,8 +1922,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_innerunionhelper();
+
 }
 
 
@@ -1929,8 +2001,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_innerstructurehelper();
+
 }
 
 
@@ -2005,8 +2080,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapShortInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_short_innerbitsethelper();
+
 }
 
 
@@ -2081,8 +2159,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_short();
+
 }
 
 
@@ -2157,8 +2238,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_ushort();
+
 }
 
 
@@ -2233,8 +2317,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_long();
+
 }
 
 
@@ -2309,8 +2396,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_ulong();
+
 }
 
 
@@ -2385,8 +2475,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_longlong();
+
 }
 
 
@@ -2461,8 +2554,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_ulonglong();
+
 }
 
 
@@ -2537,8 +2633,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_float();
+
 }
 
 
@@ -2613,8 +2712,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_double();
+
 }
 
 
@@ -2689,8 +2791,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_longdouble();
+
 }
 
 
@@ -2765,8 +2870,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_boolean();
+
 }
 
 
@@ -2841,8 +2949,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_octet();
+
 }
 
 
@@ -2917,8 +3028,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_char();
+
 }
 
 
@@ -2993,8 +3107,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_wchar();
+
 }
 
 
@@ -3069,8 +3186,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_string();
+
 }
 
 
@@ -3145,8 +3265,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_wstring();
+
 }
 
 
@@ -3221,8 +3344,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliasboundedstringhelper();
+
 }
 
 
@@ -3297,8 +3423,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -3373,8 +3502,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_innerenumhelper();
+
 }
 
 
@@ -3449,8 +3581,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_innerbitmaskhelper();
+
 }
 
 
@@ -3525,8 +3660,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliashelper();
+
 }
 
 
@@ -3601,8 +3739,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliasarrayhelper();
+
 }
 
 
@@ -3677,8 +3818,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliassequencehelper();
+
 }
 
 
@@ -3753,8 +3897,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_inneraliasmaphelper();
+
 }
 
 
@@ -3829,8 +3976,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_innerunionhelper();
+
 }
 
 
@@ -3905,8 +4055,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_innerstructurehelper();
+
 }
 
 
@@ -3981,8 +4134,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapUShortInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ushort_innerbitsethelper();
+
 }
 
 
@@ -4057,8 +4213,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_short();
+
 }
 
 
@@ -4133,8 +4292,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_ushort();
+
 }
 
 
@@ -4209,8 +4371,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_long();
+
 }
 
 
@@ -4285,8 +4450,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_ulong();
+
 }
 
 
@@ -4361,8 +4529,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongKeyLongLongValue& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_longlong();
+
 }
 
 
@@ -4437,8 +4608,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_ulonglong();
+
 }
 
 
@@ -4513,8 +4687,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_float();
+
 }
 
 
@@ -4589,8 +4766,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_double();
+
 }
 
 
@@ -4665,8 +4845,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongKeyLongDoubleValue& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_longdouble();
+
 }
 
 
@@ -4741,8 +4924,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_boolean();
+
 }
 
 
@@ -4817,8 +5003,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_octet();
+
 }
 
 
@@ -4893,8 +5082,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_char();
+
 }
 
 
@@ -4969,8 +5161,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_wchar();
+
 }
 
 
@@ -5045,8 +5240,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_string();
+
 }
 
 
@@ -5121,8 +5319,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_wstring();
+
 }
 
 
@@ -5197,8 +5398,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliasboundedstringhelper();
+
 }
 
 
@@ -5273,8 +5477,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -5349,8 +5556,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_innerenumhelper();
+
 }
 
 
@@ -5425,8 +5635,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_innerbitmaskhelper();
+
 }
 
 
@@ -5501,8 +5714,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliashelper();
+
 }
 
 
@@ -5577,8 +5793,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliasarrayhelper();
+
 }
 
 
@@ -5653,8 +5872,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliassequencehelper();
+
 }
 
 
@@ -5729,8 +5951,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_inneraliasmaphelper();
+
 }
 
 
@@ -5805,8 +6030,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_innerunionhelper();
+
 }
 
 
@@ -5881,8 +6109,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_innerstructurehelper();
+
 }
 
 
@@ -5957,8 +6188,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_long_innerbitsethelper();
+
 }
 
 
@@ -6033,8 +6267,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_short();
+
 }
 
 
@@ -6109,8 +6346,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_ushort();
+
 }
 
 
@@ -6185,8 +6425,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_long();
+
 }
 
 
@@ -6261,8 +6504,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_ulong();
+
 }
 
 
@@ -6337,8 +6583,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapKeyULongValueLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_longlong();
+
 }
 
 
@@ -6413,8 +6662,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_ulonglong();
+
 }
 
 
@@ -6489,8 +6741,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_float();
+
 }
 
 
@@ -6565,8 +6820,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_double();
+
 }
 
 
@@ -6641,8 +6899,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapKeyULongValueLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_longdouble();
+
 }
 
 
@@ -6717,8 +6978,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_boolean();
+
 }
 
 
@@ -6793,8 +7057,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_octet();
+
 }
 
 
@@ -6869,8 +7136,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_char();
+
 }
 
 
@@ -6945,8 +7215,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_wchar();
+
 }
 
 
@@ -7021,8 +7294,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_string();
+
 }
 
 
@@ -7097,8 +7373,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_wstring();
+
 }
 
 
@@ -7173,8 +7452,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliasboundedstringhelper();
+
 }
 
 
@@ -7249,8 +7531,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -7325,8 +7610,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_innerenumhelper();
+
 }
 
 
@@ -7401,8 +7689,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_innerbitmaskhelper();
+
 }
 
 
@@ -7477,8 +7768,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliashelper();
+
 }
 
 
@@ -7553,8 +7847,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliasarrayhelper();
+
 }
 
 
@@ -7629,8 +7926,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliassequencehelper();
+
 }
 
 
@@ -7705,8 +8005,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_inneraliasmaphelper();
+
 }
 
 
@@ -7781,8 +8084,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_innerunionhelper();
+
 }
 
 
@@ -7857,8 +8163,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_innerstructurehelper();
+
 }
 
 
@@ -7933,8 +8242,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_ulong_innerbitsethelper();
+
 }
 
 
@@ -8009,8 +8321,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_short();
+
 }
 
 
@@ -8085,8 +8400,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_ushort();
+
 }
 
 
@@ -8161,8 +8479,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongKeyLongValue& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_long();
+
 }
 
 
@@ -8237,8 +8558,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_ulong();
+
 }
 
 
@@ -8313,8 +8637,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_longlong();
+
 }
 
 
@@ -8389,8 +8716,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_ulonglong();
+
 }
 
 
@@ -8465,8 +8795,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_float();
+
 }
 
 
@@ -8541,8 +8874,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongKeyDoubleValue& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_double();
+
 }
 
 
@@ -8617,8 +8953,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_longdouble();
+
 }
 
 
@@ -8693,8 +9032,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_boolean();
+
 }
 
 
@@ -8769,8 +9111,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_octet();
+
 }
 
 
@@ -8845,8 +9190,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_char();
+
 }
 
 
@@ -8921,8 +9269,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_wchar();
+
 }
 
 
@@ -8997,8 +9348,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_string();
+
 }
 
 
@@ -9073,8 +9427,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_wstring();
+
 }
 
 
@@ -9149,8 +9506,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliasboundedstringhelper();
+
 }
 
 
@@ -9225,8 +9585,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -9301,8 +9664,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_innerenumhelper();
+
 }
 
 
@@ -9377,8 +9743,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_innerbitmaskhelper();
+
 }
 
 
@@ -9453,8 +9822,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliashelper();
+
 }
 
 
@@ -9529,8 +9901,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliasarrayhelper();
+
 }
 
 
@@ -9605,8 +9980,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliassequencehelper();
+
 }
 
 
@@ -9681,8 +10059,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_inneraliasmaphelper();
+
 }
 
 
@@ -9757,8 +10138,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_innerunionhelper();
+
 }
 
 
@@ -9833,8 +10217,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_innerstructurehelper();
+
 }
 
 
@@ -9909,8 +10296,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapLongLongInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_longlong_innerbitsethelper();
+
 }
 
 
@@ -9985,8 +10375,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_short();
+
 }
 
 
@@ -10061,8 +10454,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_u_short();
+
 }
 
 
@@ -10137,8 +10533,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_long();
+
 }
 
 
@@ -10213,8 +10612,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_u_long();
+
 }
 
 
@@ -10289,8 +10691,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_long_long();
+
 }
 
 
@@ -10365,8 +10770,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_u_long_long();
+
 }
 
 
@@ -10441,8 +10849,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_float();
+
 }
 
 
@@ -10517,8 +10928,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapKeyULongLongValueDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_double();
+
 }
 
 
@@ -10593,8 +11007,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_long_double();
+
 }
 
 
@@ -10669,8 +11086,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_boolean();
+
 }
 
 
@@ -10745,8 +11165,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_octet();
+
 }
 
 
@@ -10821,8 +11244,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_char();
+
 }
 
 
@@ -10897,8 +11323,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_wchar();
+
 }
 
 
@@ -10973,8 +11402,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_string();
+
 }
 
 
@@ -11049,8 +11481,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_wstring();
+
 }
 
 
@@ -11125,8 +11560,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_bounded_string_helper();
+
 }
 
 
@@ -11201,8 +11639,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_bounded_wstring_helper();
+
 }
 
 
@@ -11277,8 +11718,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_enum_helper();
+
 }
 
 
@@ -11353,8 +11797,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_bit_mask_helper();
+
 }
 
 
@@ -11429,8 +11876,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_helper();
+
 }
 
 
@@ -11505,8 +11955,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_array_helper();
+
 }
 
 
@@ -11581,8 +12034,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_sequence_helper();
+
 }
 
 
@@ -11657,8 +12113,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_alias_map_helper();
+
 }
 
 
@@ -11733,8 +12192,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_union_helper();
+
 }
 
 
@@ -11809,8 +12271,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_structure_helper();
+
 }
 
 
@@ -11885,8 +12350,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapULongLongInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_u_long_long_inner_bitset_helper();
+
 }
 
 
@@ -11961,8 +12429,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_short();
+
 }
 
 
@@ -12037,8 +12508,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_ushort();
+
 }
 
 
@@ -12113,8 +12587,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_long();
+
 }
 
 
@@ -12189,8 +12666,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_ulong();
+
 }
 
 
@@ -12265,8 +12745,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_longlong();
+
 }
 
 
@@ -12341,8 +12824,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_ulonglong();
+
 }
 
 
@@ -12417,8 +12903,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_float();
+
 }
 
 
@@ -12493,8 +12982,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_double();
+
 }
 
 
@@ -12569,8 +13061,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_longdouble();
+
 }
 
 
@@ -12645,8 +13140,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_boolean();
+
 }
 
 
@@ -12721,8 +13219,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_octet();
+
 }
 
 
@@ -12797,8 +13298,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_char();
+
 }
 
 
@@ -12873,8 +13377,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_wchar();
+
 }
 
 
@@ -12949,8 +13456,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_string();
+
 }
 
 
@@ -13025,8 +13535,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_wstring();
+
 }
 
 
@@ -13101,8 +13614,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliasboundedstringhelper();
+
 }
 
 
@@ -13177,8 +13693,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -13253,8 +13772,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_innerenumhelper();
+
 }
 
 
@@ -13329,8 +13851,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_innerbitmaskhelper();
+
 }
 
 
@@ -13405,8 +13930,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliashelper();
+
 }
 
 
@@ -13481,8 +14009,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliasarrayhelper();
+
 }
 
 
@@ -13557,8 +14088,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliassequencehelper();
+
 }
 
 
@@ -13633,8 +14167,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_inneraliasmaphelper();
+
 }
 
 
@@ -13709,8 +14246,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_innerunionhelper();
+
 }
 
 
@@ -13785,8 +14325,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_innerstructurehelper();
+
 }
 
 
@@ -13861,8 +14404,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStringInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_string_innerbitsethelper();
+
 }
 
 
@@ -13937,8 +14483,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_short();
+
 }
 
 
@@ -14013,8 +14562,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_ushort();
+
 }
 
 
@@ -14089,8 +14641,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_long();
+
 }
 
 
@@ -14165,8 +14720,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_ulong();
+
 }
 
 
@@ -14241,8 +14799,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_longlong();
+
 }
 
 
@@ -14317,8 +14878,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_ulonglong();
+
 }
 
 
@@ -14393,8 +14957,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_float();
+
 }
 
 
@@ -14469,8 +15036,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_double();
+
 }
 
 
@@ -14545,8 +15115,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_longdouble();
+
 }
 
 
@@ -14621,8 +15194,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_boolean();
+
 }
 
 
@@ -14697,8 +15273,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_octet();
+
 }
 
 
@@ -14773,8 +15352,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_char();
+
 }
 
 
@@ -14849,8 +15431,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_wchar();
+
 }
 
 
@@ -14925,8 +15510,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_string();
+
 }
 
 
@@ -15001,8 +15589,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_wstring();
+
 }
 
 
@@ -15077,8 +15668,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliasboundedstringhelper();
+
 }
 
 
@@ -15153,8 +15747,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -15229,8 +15826,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_innerenumhelper();
+
 }
 
 
@@ -15305,8 +15905,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_innerbitmaskhelper();
+
 }
 
 
@@ -15381,8 +15984,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliashelper();
+
 }
 
 
@@ -15457,8 +16063,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliasarrayhelper();
+
 }
 
 
@@ -15533,8 +16142,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliassequencehelper();
+
 }
 
 
@@ -15609,8 +16221,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_inneraliasmaphelper();
+
 }
 
 
@@ -15685,8 +16300,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_innerunionhelper();
+
 }
 
 
@@ -15761,8 +16379,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_innerstructurehelper();
+
 }
 
 
@@ -15837,8 +16458,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapWStringInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_wstring_innerbitsethelper();
+
 }
 
 
@@ -15913,8 +16537,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_short();
+
 }
 
 
@@ -15989,8 +16616,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_ushort();
+
 }
 
 
@@ -16065,8 +16695,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_long();
+
 }
 
 
@@ -16141,8 +16774,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_ulong();
+
 }
 
 
@@ -16217,8 +16853,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_longlong();
+
 }
 
 
@@ -16293,8 +16932,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_ulonglong();
+
 }
 
 
@@ -16369,8 +17011,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_float();
+
 }
 
 
@@ -16445,8 +17090,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_double();
+
 }
 
 
@@ -16521,8 +17169,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_longdouble();
+
 }
 
 
@@ -16597,8 +17248,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_boolean();
+
 }
 
 
@@ -16673,8 +17327,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_octet();
+
 }
 
 
@@ -16749,8 +17406,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_char();
+
 }
 
 
@@ -16825,8 +17485,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_wchar();
+
 }
 
 
@@ -16901,8 +17564,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_string();
+
 }
 
 
@@ -16977,8 +17643,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_wstring();
+
 }
 
 
@@ -17053,8 +17722,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliasboundedstringhelper();
+
 }
 
 
@@ -17129,8 +17801,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -17205,8 +17880,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_innerenumhelper();
+
 }
 
 
@@ -17281,8 +17959,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_innerbitmaskhelper();
+
 }
 
 
@@ -17357,8 +18038,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliashelper();
+
 }
 
 
@@ -17433,8 +18117,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliasarrayhelper();
+
 }
 
 
@@ -17509,8 +18196,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliassequencehelper();
+
 }
 
 
@@ -17585,8 +18275,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_inneraliasmaphelper();
+
 }
 
 
@@ -17661,8 +18354,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_innerunionhelper();
+
 }
 
 
@@ -17737,8 +18433,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_innerstructurehelper();
+
 }
 
 
@@ -17813,8 +18512,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedStringHelperInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedstringhelper_innerbitsethelper();
+
 }
 
 
@@ -17889,8 +18591,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_short();
+
 }
 
 
@@ -17965,8 +18670,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_ushort();
+
 }
 
 
@@ -18041,8 +18749,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_long();
+
 }
 
 
@@ -18117,8 +18828,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_ulong();
+
 }
 
 
@@ -18193,8 +18907,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_longlong();
+
 }
 
 
@@ -18269,8 +18986,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_ulonglong();
+
 }
 
 
@@ -18345,8 +19065,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_float();
+
 }
 
 
@@ -18421,8 +19144,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_double();
+
 }
 
 
@@ -18497,8 +19223,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_longdouble();
+
 }
 
 
@@ -18573,8 +19302,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_boolean();
+
 }
 
 
@@ -18649,8 +19381,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_octet();
+
 }
 
 
@@ -18725,8 +19460,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_char();
+
 }
 
 
@@ -18801,8 +19539,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_wchar();
+
 }
 
 
@@ -18877,8 +19618,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_string();
+
 }
 
 
@@ -18953,8 +19697,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_wstring();
+
 }
 
 
@@ -19029,8 +19776,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliasboundedstringhelper();
+
 }
 
 
@@ -19105,8 +19855,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliasboundedwstringhelper();
+
 }
 
 
@@ -19181,8 +19934,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_innerenumhelper();
+
 }
 
 
@@ -19257,8 +20013,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_innerbitmaskhelper();
+
 }
 
 
@@ -19333,8 +20092,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliashelper();
+
 }
 
 
@@ -19409,8 +20171,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliasarrayhelper();
+
 }
 
 
@@ -19485,8 +20250,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliassequencehelper();
+
 }
 
 
@@ -19561,8 +20329,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerAliasMapHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_inneraliasmaphelper();
+
 }
 
 
@@ -19637,8 +20408,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_innerunionhelper();
+
 }
 
 
@@ -19713,8 +20487,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_innerstructurehelper();
+
 }
 
 
@@ -19789,8 +20566,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapInnerAliasBoundedWStringHelperInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map_inneraliasboundedwstringhelper_innerbitsethelper();
+
 }
 
 
@@ -19881,8 +20661,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedSmallMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_small_map();
+
+                        scdr << data.var_unbounded_string_long_bounded_small_map();
+
+                        scdr << data.var_long_unbounded_string_bounded_small_map();
+
 }
 
 
@@ -19973,8 +20760,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedLargeMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_large_map();
+
+                        scdr << data.var_unbounded_string_long_bounded_large_map();
+
+                        scdr << data.var_long_unbounded_string_bounded_large_map();
+
 }
 
 

--- a/test/dds-types-test/mapsPubSubTypes.cxx
+++ b/test/dds-types-test/mapsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool MapShortShortPubSubType::compute_key(
             MapShortShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortShort_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool MapShortUShortPubSubType::compute_key(
             MapShortUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortUShort_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool MapShortLongPubSubType::compute_key(
             MapShortLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortLong_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool MapShortULongPubSubType::compute_key(
             MapShortULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortULong_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool MapShortLongLongPubSubType::compute_key(
             MapShortLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortLongLong_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool MapShortULongLongPubSubType::compute_key(
             MapShortULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortULongLong_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool MapShortFloatPubSubType::compute_key(
             MapShortFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortFloat_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool MapShortDoublePubSubType::compute_key(
             MapShortDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortDouble_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool MapShortLongDoublePubSubType::compute_key(
             MapShortLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortLongDouble_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool MapShortBooleanPubSubType::compute_key(
             MapShortBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortBoolean_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool MapShortOctetPubSubType::compute_key(
             MapShortOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool MapShortCharPubSubType::compute_key(
             MapShortChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortChar_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool MapShortWCharPubSubType::compute_key(
             MapShortWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortWChar_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool MapShortStringPubSubType::compute_key(
             MapShortString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortString_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool MapShortWStringPubSubType::compute_key(
             MapShortWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortWString_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool MapShortInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapShortInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool MapShortInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapShortInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool MapShortInnerEnumHelperPubSubType::compute_key(
             MapShortInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool MapShortInnerBitMaskHelperPubSubType::compute_key(
             MapShortInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool MapShortInnerAliasHelperPubSubType::compute_key(
             MapShortInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool MapShortInnerAliasArrayHelperPubSubType::compute_key(
             MapShortInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool MapShortInnerAliasSequenceHelperPubSubType::compute_key(
             MapShortInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool MapShortInnerAliasMapHelperPubSubType::compute_key(
             MapShortInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool MapShortInnerUnionHelperPubSubType::compute_key(
             MapShortInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool MapShortInnerStructureHelperPubSubType::compute_key(
             MapShortInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool MapShortInnerBitsetHelperPubSubType::compute_key(
             MapShortInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapShortInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool MapUShortShortPubSubType::compute_key(
             MapUShortShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortShort_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool MapUShortUShortPubSubType::compute_key(
             MapUShortUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortUShort_max_key_cdr_typesize > 16)
     {
@@ -5224,7 +5252,8 @@ bool MapUShortLongPubSubType::compute_key(
             MapUShortLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortLong_max_key_cdr_typesize > 16)
     {
@@ -5404,7 +5433,8 @@ bool MapUShortULongPubSubType::compute_key(
             MapUShortULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortULong_max_key_cdr_typesize > 16)
     {
@@ -5584,7 +5614,8 @@ bool MapUShortLongLongPubSubType::compute_key(
             MapUShortLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortLongLong_max_key_cdr_typesize > 16)
     {
@@ -5764,7 +5795,8 @@ bool MapUShortULongLongPubSubType::compute_key(
             MapUShortULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortULongLong_max_key_cdr_typesize > 16)
     {
@@ -5944,7 +5976,8 @@ bool MapUShortFloatPubSubType::compute_key(
             MapUShortFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortFloat_max_key_cdr_typesize > 16)
     {
@@ -6124,7 +6157,8 @@ bool MapUShortDoublePubSubType::compute_key(
             MapUShortDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortDouble_max_key_cdr_typesize > 16)
     {
@@ -6304,7 +6338,8 @@ bool MapUShortLongDoublePubSubType::compute_key(
             MapUShortLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortLongDouble_max_key_cdr_typesize > 16)
     {
@@ -6484,7 +6519,8 @@ bool MapUShortBooleanPubSubType::compute_key(
             MapUShortBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortBoolean_max_key_cdr_typesize > 16)
     {
@@ -6664,7 +6700,8 @@ bool MapUShortOctetPubSubType::compute_key(
             MapUShortOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortOctet_max_key_cdr_typesize > 16)
     {
@@ -6844,7 +6881,8 @@ bool MapUShortCharPubSubType::compute_key(
             MapUShortChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortChar_max_key_cdr_typesize > 16)
     {
@@ -7024,7 +7062,8 @@ bool MapUShortWCharPubSubType::compute_key(
             MapUShortWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortWChar_max_key_cdr_typesize > 16)
     {
@@ -7204,7 +7243,8 @@ bool MapUShortStringPubSubType::compute_key(
             MapUShortString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortString_max_key_cdr_typesize > 16)
     {
@@ -7384,7 +7424,8 @@ bool MapUShortWStringPubSubType::compute_key(
             MapUShortWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortWString_max_key_cdr_typesize > 16)
     {
@@ -7564,7 +7605,8 @@ bool MapUShortInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapUShortInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -7744,7 +7786,8 @@ bool MapUShortInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapUShortInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -7924,7 +7967,8 @@ bool MapUShortInnerEnumHelperPubSubType::compute_key(
             MapUShortInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -8104,7 +8148,8 @@ bool MapUShortInnerBitMaskHelperPubSubType::compute_key(
             MapUShortInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -8284,7 +8329,8 @@ bool MapUShortInnerAliasHelperPubSubType::compute_key(
             MapUShortInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -8464,7 +8510,8 @@ bool MapUShortInnerAliasArrayHelperPubSubType::compute_key(
             MapUShortInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -8644,7 +8691,8 @@ bool MapUShortInnerAliasSequenceHelperPubSubType::compute_key(
             MapUShortInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -8824,7 +8872,8 @@ bool MapUShortInnerAliasMapHelperPubSubType::compute_key(
             MapUShortInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -9004,7 +9053,8 @@ bool MapUShortInnerUnionHelperPubSubType::compute_key(
             MapUShortInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -9184,7 +9234,8 @@ bool MapUShortInnerStructureHelperPubSubType::compute_key(
             MapUShortInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -9364,7 +9415,8 @@ bool MapUShortInnerBitsetHelperPubSubType::compute_key(
             MapUShortInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapUShortInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -9544,7 +9596,8 @@ bool MapLongShortPubSubType::compute_key(
             MapLongShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongShort_max_key_cdr_typesize > 16)
     {
@@ -9724,7 +9777,8 @@ bool MapLongUShortPubSubType::compute_key(
             MapLongUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongUShort_max_key_cdr_typesize > 16)
     {
@@ -9904,7 +9958,8 @@ bool MapLongLongPubSubType::compute_key(
             MapLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLong_max_key_cdr_typesize > 16)
     {
@@ -10084,7 +10139,8 @@ bool MapLongULongPubSubType::compute_key(
             MapLongULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongULong_max_key_cdr_typesize > 16)
     {
@@ -10264,7 +10320,8 @@ bool MapLongKeyLongLongValuePubSubType::compute_key(
             MapLongKeyLongLongValue_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongKeyLongLongValue_max_key_cdr_typesize > 16)
     {
@@ -10444,7 +10501,8 @@ bool MapLongULongLongPubSubType::compute_key(
             MapLongULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongULongLong_max_key_cdr_typesize > 16)
     {
@@ -10624,7 +10682,8 @@ bool MapLongFloatPubSubType::compute_key(
             MapLongFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongFloat_max_key_cdr_typesize > 16)
     {
@@ -10804,7 +10863,8 @@ bool MapLongDoublePubSubType::compute_key(
             MapLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongDouble_max_key_cdr_typesize > 16)
     {
@@ -10984,7 +11044,8 @@ bool MapLongKeyLongDoubleValuePubSubType::compute_key(
             MapLongKeyLongDoubleValue_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongKeyLongDoubleValue_max_key_cdr_typesize > 16)
     {
@@ -11164,7 +11225,8 @@ bool MapLongBooleanPubSubType::compute_key(
             MapLongBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongBoolean_max_key_cdr_typesize > 16)
     {
@@ -11344,7 +11406,8 @@ bool MapLongOctetPubSubType::compute_key(
             MapLongOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongOctet_max_key_cdr_typesize > 16)
     {
@@ -11524,7 +11587,8 @@ bool MapLongCharPubSubType::compute_key(
             MapLongChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongChar_max_key_cdr_typesize > 16)
     {
@@ -11704,7 +11768,8 @@ bool MapLongWCharPubSubType::compute_key(
             MapLongWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongWChar_max_key_cdr_typesize > 16)
     {
@@ -11884,7 +11949,8 @@ bool MapLongStringPubSubType::compute_key(
             MapLongString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongString_max_key_cdr_typesize > 16)
     {
@@ -12064,7 +12130,8 @@ bool MapLongWStringPubSubType::compute_key(
             MapLongWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongWString_max_key_cdr_typesize > 16)
     {
@@ -12244,7 +12311,8 @@ bool MapLongInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapLongInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -12424,7 +12492,8 @@ bool MapLongInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -12604,7 +12673,8 @@ bool MapLongInnerEnumHelperPubSubType::compute_key(
             MapLongInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -12784,7 +12854,8 @@ bool MapLongInnerBitMaskHelperPubSubType::compute_key(
             MapLongInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -12964,7 +13035,8 @@ bool MapLongInnerAliasHelperPubSubType::compute_key(
             MapLongInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -13144,7 +13216,8 @@ bool MapLongInnerAliasArrayHelperPubSubType::compute_key(
             MapLongInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -13324,7 +13397,8 @@ bool MapLongInnerAliasSequenceHelperPubSubType::compute_key(
             MapLongInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -13504,7 +13578,8 @@ bool MapLongInnerAliasMapHelperPubSubType::compute_key(
             MapLongInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -13684,7 +13759,8 @@ bool MapLongInnerUnionHelperPubSubType::compute_key(
             MapLongInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -13864,7 +13940,8 @@ bool MapLongInnerStructureHelperPubSubType::compute_key(
             MapLongInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -14044,7 +14121,8 @@ bool MapLongInnerBitsetHelperPubSubType::compute_key(
             MapLongInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -14224,7 +14302,8 @@ bool MapULongShortPubSubType::compute_key(
             MapULongShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongShort_max_key_cdr_typesize > 16)
     {
@@ -14404,7 +14483,8 @@ bool MapULongUShortPubSubType::compute_key(
             MapULongUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongUShort_max_key_cdr_typesize > 16)
     {
@@ -14584,7 +14664,8 @@ bool MapULongLongPubSubType::compute_key(
             MapULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLong_max_key_cdr_typesize > 16)
     {
@@ -14764,7 +14845,8 @@ bool MapULongULongPubSubType::compute_key(
             MapULongULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongULong_max_key_cdr_typesize > 16)
     {
@@ -14944,7 +15026,8 @@ bool MapKeyULongValueLongLongPubSubType::compute_key(
             MapKeyULongValueLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapKeyULongValueLongLong_max_key_cdr_typesize > 16)
     {
@@ -15124,7 +15207,8 @@ bool MapULongULongLongPubSubType::compute_key(
             MapULongULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongULongLong_max_key_cdr_typesize > 16)
     {
@@ -15304,7 +15388,8 @@ bool MapULongFloatPubSubType::compute_key(
             MapULongFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongFloat_max_key_cdr_typesize > 16)
     {
@@ -15484,7 +15569,8 @@ bool MapULongDoublePubSubType::compute_key(
             MapULongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongDouble_max_key_cdr_typesize > 16)
     {
@@ -15664,7 +15750,8 @@ bool MapKeyULongValueLongDoublePubSubType::compute_key(
             MapKeyULongValueLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapKeyULongValueLongDouble_max_key_cdr_typesize > 16)
     {
@@ -15844,7 +15931,8 @@ bool MapULongBooleanPubSubType::compute_key(
             MapULongBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongBoolean_max_key_cdr_typesize > 16)
     {
@@ -16024,7 +16112,8 @@ bool MapULongOctetPubSubType::compute_key(
             MapULongOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongOctet_max_key_cdr_typesize > 16)
     {
@@ -16204,7 +16293,8 @@ bool MapULongCharPubSubType::compute_key(
             MapULongChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongChar_max_key_cdr_typesize > 16)
     {
@@ -16384,7 +16474,8 @@ bool MapULongWCharPubSubType::compute_key(
             MapULongWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongWChar_max_key_cdr_typesize > 16)
     {
@@ -16564,7 +16655,8 @@ bool MapULongStringPubSubType::compute_key(
             MapULongString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongString_max_key_cdr_typesize > 16)
     {
@@ -16744,7 +16836,8 @@ bool MapULongWStringPubSubType::compute_key(
             MapULongWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongWString_max_key_cdr_typesize > 16)
     {
@@ -16924,7 +17017,8 @@ bool MapULongInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapULongInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -17104,7 +17198,8 @@ bool MapULongInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapULongInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -17284,7 +17379,8 @@ bool MapULongInnerEnumHelperPubSubType::compute_key(
             MapULongInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -17464,7 +17560,8 @@ bool MapULongInnerBitMaskHelperPubSubType::compute_key(
             MapULongInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -17644,7 +17741,8 @@ bool MapULongInnerAliasHelperPubSubType::compute_key(
             MapULongInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -17824,7 +17922,8 @@ bool MapULongInnerAliasArrayHelperPubSubType::compute_key(
             MapULongInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -18004,7 +18103,8 @@ bool MapULongInnerAliasSequenceHelperPubSubType::compute_key(
             MapULongInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -18184,7 +18284,8 @@ bool MapULongInnerAliasMapHelperPubSubType::compute_key(
             MapULongInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -18364,7 +18465,8 @@ bool MapULongInnerUnionHelperPubSubType::compute_key(
             MapULongInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -18544,7 +18646,8 @@ bool MapULongInnerStructureHelperPubSubType::compute_key(
             MapULongInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -18724,7 +18827,8 @@ bool MapULongInnerBitsetHelperPubSubType::compute_key(
             MapULongInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -18904,7 +19008,8 @@ bool MapLongLongShortPubSubType::compute_key(
             MapLongLongShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongShort_max_key_cdr_typesize > 16)
     {
@@ -19084,7 +19189,8 @@ bool MapLongLongUShortPubSubType::compute_key(
             MapLongLongUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongUShort_max_key_cdr_typesize > 16)
     {
@@ -19264,7 +19370,8 @@ bool MapLongLongKeyLongValuePubSubType::compute_key(
             MapLongLongKeyLongValue_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongKeyLongValue_max_key_cdr_typesize > 16)
     {
@@ -19444,7 +19551,8 @@ bool MapLongLongULongPubSubType::compute_key(
             MapLongLongULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongULong_max_key_cdr_typesize > 16)
     {
@@ -19624,7 +19732,8 @@ bool MapLongLongLongLongPubSubType::compute_key(
             MapLongLongLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongLongLong_max_key_cdr_typesize > 16)
     {
@@ -19804,7 +19913,8 @@ bool MapLongLongULongLongPubSubType::compute_key(
             MapLongLongULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongULongLong_max_key_cdr_typesize > 16)
     {
@@ -19984,7 +20094,8 @@ bool MapLongLongFloatPubSubType::compute_key(
             MapLongLongFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongFloat_max_key_cdr_typesize > 16)
     {
@@ -20164,7 +20275,8 @@ bool MapLongLongKeyDoubleValuePubSubType::compute_key(
             MapLongLongKeyDoubleValue_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongKeyDoubleValue_max_key_cdr_typesize > 16)
     {
@@ -20344,7 +20456,8 @@ bool MapLongLongLongDoublePubSubType::compute_key(
             MapLongLongLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongLongDouble_max_key_cdr_typesize > 16)
     {
@@ -20524,7 +20637,8 @@ bool MapLongLongBooleanPubSubType::compute_key(
             MapLongLongBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongBoolean_max_key_cdr_typesize > 16)
     {
@@ -20704,7 +20818,8 @@ bool MapLongLongOctetPubSubType::compute_key(
             MapLongLongOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongOctet_max_key_cdr_typesize > 16)
     {
@@ -20884,7 +20999,8 @@ bool MapLongLongCharPubSubType::compute_key(
             MapLongLongChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongChar_max_key_cdr_typesize > 16)
     {
@@ -21064,7 +21180,8 @@ bool MapLongLongWCharPubSubType::compute_key(
             MapLongLongWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongWChar_max_key_cdr_typesize > 16)
     {
@@ -21244,7 +21361,8 @@ bool MapLongLongStringPubSubType::compute_key(
             MapLongLongString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongString_max_key_cdr_typesize > 16)
     {
@@ -21424,7 +21542,8 @@ bool MapLongLongWStringPubSubType::compute_key(
             MapLongLongWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongWString_max_key_cdr_typesize > 16)
     {
@@ -21604,7 +21723,8 @@ bool MapLongLongInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapLongLongInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -21784,7 +21904,8 @@ bool MapLongLongInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapLongLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -21964,7 +22085,8 @@ bool MapLongLongInnerEnumHelperPubSubType::compute_key(
             MapLongLongInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -22144,7 +22266,8 @@ bool MapLongLongInnerBitMaskHelperPubSubType::compute_key(
             MapLongLongInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -22324,7 +22447,8 @@ bool MapLongLongInnerAliasHelperPubSubType::compute_key(
             MapLongLongInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -22504,7 +22628,8 @@ bool MapLongLongInnerAliasArrayHelperPubSubType::compute_key(
             MapLongLongInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -22684,7 +22809,8 @@ bool MapLongLongInnerAliasSequenceHelperPubSubType::compute_key(
             MapLongLongInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -22864,7 +22990,8 @@ bool MapLongLongInnerAliasMapHelperPubSubType::compute_key(
             MapLongLongInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -23044,7 +23171,8 @@ bool MapLongLongInnerUnionHelperPubSubType::compute_key(
             MapLongLongInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -23224,7 +23352,8 @@ bool MapLongLongInnerStructureHelperPubSubType::compute_key(
             MapLongLongInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -23404,7 +23533,8 @@ bool MapLongLongInnerBitsetHelperPubSubType::compute_key(
             MapLongLongInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapLongLongInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -23584,7 +23714,8 @@ bool MapULongLongShortPubSubType::compute_key(
             MapULongLongShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongShort_max_key_cdr_typesize > 16)
     {
@@ -23764,7 +23895,8 @@ bool MapULongLongUShortPubSubType::compute_key(
             MapULongLongUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongUShort_max_key_cdr_typesize > 16)
     {
@@ -23944,7 +24076,8 @@ bool MapULongLongLongPubSubType::compute_key(
             MapULongLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongLong_max_key_cdr_typesize > 16)
     {
@@ -24124,7 +24257,8 @@ bool MapULongLongULongPubSubType::compute_key(
             MapULongLongULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongULong_max_key_cdr_typesize > 16)
     {
@@ -24304,7 +24438,8 @@ bool MapULongLongLongLongPubSubType::compute_key(
             MapULongLongLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongLongLong_max_key_cdr_typesize > 16)
     {
@@ -24484,7 +24619,8 @@ bool MapULongLongULongLongPubSubType::compute_key(
             MapULongLongULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongULongLong_max_key_cdr_typesize > 16)
     {
@@ -24664,7 +24800,8 @@ bool MapULongLongFloatPubSubType::compute_key(
             MapULongLongFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongFloat_max_key_cdr_typesize > 16)
     {
@@ -24844,7 +24981,8 @@ bool MapKeyULongLongValueDoublePubSubType::compute_key(
             MapKeyULongLongValueDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapKeyULongLongValueDouble_max_key_cdr_typesize > 16)
     {
@@ -25024,7 +25162,8 @@ bool MapULongLongLongDoublePubSubType::compute_key(
             MapULongLongLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongLongDouble_max_key_cdr_typesize > 16)
     {
@@ -25204,7 +25343,8 @@ bool MapULongLongBooleanPubSubType::compute_key(
             MapULongLongBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongBoolean_max_key_cdr_typesize > 16)
     {
@@ -25384,7 +25524,8 @@ bool MapULongLongOctetPubSubType::compute_key(
             MapULongLongOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongOctet_max_key_cdr_typesize > 16)
     {
@@ -25564,7 +25705,8 @@ bool MapULongLongCharPubSubType::compute_key(
             MapULongLongChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongChar_max_key_cdr_typesize > 16)
     {
@@ -25744,7 +25886,8 @@ bool MapULongLongWCharPubSubType::compute_key(
             MapULongLongWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongWChar_max_key_cdr_typesize > 16)
     {
@@ -25924,7 +26067,8 @@ bool MapULongLongStringPubSubType::compute_key(
             MapULongLongString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongString_max_key_cdr_typesize > 16)
     {
@@ -26104,7 +26248,8 @@ bool MapULongLongWStringPubSubType::compute_key(
             MapULongLongWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongWString_max_key_cdr_typesize > 16)
     {
@@ -26284,7 +26429,8 @@ bool MapULongLongInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapULongLongInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -26464,7 +26610,8 @@ bool MapULongLongInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapULongLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -26644,7 +26791,8 @@ bool MapULongLongInnerEnumHelperPubSubType::compute_key(
             MapULongLongInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -26824,7 +26972,8 @@ bool MapULongLongInnerBitMaskHelperPubSubType::compute_key(
             MapULongLongInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -27004,7 +27153,8 @@ bool MapULongLongInnerAliasHelperPubSubType::compute_key(
             MapULongLongInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -27184,7 +27334,8 @@ bool MapULongLongInnerAliasArrayHelperPubSubType::compute_key(
             MapULongLongInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -27364,7 +27515,8 @@ bool MapULongLongInnerAliasSequenceHelperPubSubType::compute_key(
             MapULongLongInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -27544,7 +27696,8 @@ bool MapULongLongInnerAliasMapHelperPubSubType::compute_key(
             MapULongLongInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -27724,7 +27877,8 @@ bool MapULongLongInnerUnionHelperPubSubType::compute_key(
             MapULongLongInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -27904,7 +28058,8 @@ bool MapULongLongInnerStructureHelperPubSubType::compute_key(
             MapULongLongInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -28084,7 +28239,8 @@ bool MapULongLongInnerBitsetHelperPubSubType::compute_key(
             MapULongLongInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapULongLongInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -28264,7 +28420,8 @@ bool MapStringShortPubSubType::compute_key(
             MapStringShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringShort_max_key_cdr_typesize > 16)
     {
@@ -28444,7 +28601,8 @@ bool MapStringUShortPubSubType::compute_key(
             MapStringUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringUShort_max_key_cdr_typesize > 16)
     {
@@ -28624,7 +28782,8 @@ bool MapStringLongPubSubType::compute_key(
             MapStringLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringLong_max_key_cdr_typesize > 16)
     {
@@ -28804,7 +28963,8 @@ bool MapStringULongPubSubType::compute_key(
             MapStringULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringULong_max_key_cdr_typesize > 16)
     {
@@ -28984,7 +29144,8 @@ bool MapStringLongLongPubSubType::compute_key(
             MapStringLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringLongLong_max_key_cdr_typesize > 16)
     {
@@ -29164,7 +29325,8 @@ bool MapStringULongLongPubSubType::compute_key(
             MapStringULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringULongLong_max_key_cdr_typesize > 16)
     {
@@ -29344,7 +29506,8 @@ bool MapStringFloatPubSubType::compute_key(
             MapStringFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringFloat_max_key_cdr_typesize > 16)
     {
@@ -29524,7 +29687,8 @@ bool MapStringDoublePubSubType::compute_key(
             MapStringDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringDouble_max_key_cdr_typesize > 16)
     {
@@ -29704,7 +29868,8 @@ bool MapStringLongDoublePubSubType::compute_key(
             MapStringLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringLongDouble_max_key_cdr_typesize > 16)
     {
@@ -29884,7 +30049,8 @@ bool MapStringBooleanPubSubType::compute_key(
             MapStringBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringBoolean_max_key_cdr_typesize > 16)
     {
@@ -30064,7 +30230,8 @@ bool MapStringOctetPubSubType::compute_key(
             MapStringOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringOctet_max_key_cdr_typesize > 16)
     {
@@ -30244,7 +30411,8 @@ bool MapStringCharPubSubType::compute_key(
             MapStringChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringChar_max_key_cdr_typesize > 16)
     {
@@ -30424,7 +30592,8 @@ bool MapStringWCharPubSubType::compute_key(
             MapStringWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringWChar_max_key_cdr_typesize > 16)
     {
@@ -30604,7 +30773,8 @@ bool MapStringStringPubSubType::compute_key(
             MapStringString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringString_max_key_cdr_typesize > 16)
     {
@@ -30784,7 +30954,8 @@ bool MapStringWStringPubSubType::compute_key(
             MapStringWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringWString_max_key_cdr_typesize > 16)
     {
@@ -30964,7 +31135,8 @@ bool MapStringInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapStringInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -31144,7 +31316,8 @@ bool MapStringInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapStringInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -31324,7 +31497,8 @@ bool MapStringInnerEnumHelperPubSubType::compute_key(
             MapStringInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -31504,7 +31678,8 @@ bool MapStringInnerBitMaskHelperPubSubType::compute_key(
             MapStringInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -31684,7 +31859,8 @@ bool MapStringInnerAliasHelperPubSubType::compute_key(
             MapStringInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -31864,7 +32040,8 @@ bool MapStringInnerAliasArrayHelperPubSubType::compute_key(
             MapStringInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -32044,7 +32221,8 @@ bool MapStringInnerAliasSequenceHelperPubSubType::compute_key(
             MapStringInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -32224,7 +32402,8 @@ bool MapStringInnerAliasMapHelperPubSubType::compute_key(
             MapStringInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -32404,7 +32583,8 @@ bool MapStringInnerUnionHelperPubSubType::compute_key(
             MapStringInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -32584,7 +32764,8 @@ bool MapStringInnerStructureHelperPubSubType::compute_key(
             MapStringInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -32764,7 +32945,8 @@ bool MapStringInnerBitsetHelperPubSubType::compute_key(
             MapStringInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStringInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -32944,7 +33126,8 @@ bool MapWStringShortPubSubType::compute_key(
             MapWStringShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringShort_max_key_cdr_typesize > 16)
     {
@@ -33124,7 +33307,8 @@ bool MapWStringUShortPubSubType::compute_key(
             MapWStringUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringUShort_max_key_cdr_typesize > 16)
     {
@@ -33304,7 +33488,8 @@ bool MapWStringLongPubSubType::compute_key(
             MapWStringLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringLong_max_key_cdr_typesize > 16)
     {
@@ -33484,7 +33669,8 @@ bool MapWStringULongPubSubType::compute_key(
             MapWStringULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringULong_max_key_cdr_typesize > 16)
     {
@@ -33664,7 +33850,8 @@ bool MapWStringLongLongPubSubType::compute_key(
             MapWStringLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringLongLong_max_key_cdr_typesize > 16)
     {
@@ -33844,7 +34031,8 @@ bool MapWStringULongLongPubSubType::compute_key(
             MapWStringULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringULongLong_max_key_cdr_typesize > 16)
     {
@@ -34024,7 +34212,8 @@ bool MapWStringFloatPubSubType::compute_key(
             MapWStringFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringFloat_max_key_cdr_typesize > 16)
     {
@@ -34204,7 +34393,8 @@ bool MapWStringDoublePubSubType::compute_key(
             MapWStringDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringDouble_max_key_cdr_typesize > 16)
     {
@@ -34384,7 +34574,8 @@ bool MapWStringLongDoublePubSubType::compute_key(
             MapWStringLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringLongDouble_max_key_cdr_typesize > 16)
     {
@@ -34564,7 +34755,8 @@ bool MapWStringBooleanPubSubType::compute_key(
             MapWStringBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringBoolean_max_key_cdr_typesize > 16)
     {
@@ -34744,7 +34936,8 @@ bool MapWStringOctetPubSubType::compute_key(
             MapWStringOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringOctet_max_key_cdr_typesize > 16)
     {
@@ -34924,7 +35117,8 @@ bool MapWStringCharPubSubType::compute_key(
             MapWStringChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringChar_max_key_cdr_typesize > 16)
     {
@@ -35104,7 +35298,8 @@ bool MapWStringWCharPubSubType::compute_key(
             MapWStringWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringWChar_max_key_cdr_typesize > 16)
     {
@@ -35284,7 +35479,8 @@ bool MapWStringStringPubSubType::compute_key(
             MapWStringString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringString_max_key_cdr_typesize > 16)
     {
@@ -35464,7 +35660,8 @@ bool MapWStringWStringPubSubType::compute_key(
             MapWStringWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringWString_max_key_cdr_typesize > 16)
     {
@@ -35644,7 +35841,8 @@ bool MapWStringInnerAliasBoundedStringHelperPubSubType::compute_key(
             MapWStringInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -35824,7 +36022,8 @@ bool MapWStringInnerAliasBoundedWStringHelperPubSubType::compute_key(
             MapWStringInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -36004,7 +36203,8 @@ bool MapWStringInnerEnumHelperPubSubType::compute_key(
             MapWStringInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -36184,7 +36384,8 @@ bool MapWStringInnerBitMaskHelperPubSubType::compute_key(
             MapWStringInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -36364,7 +36565,8 @@ bool MapWStringInnerAliasHelperPubSubType::compute_key(
             MapWStringInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -36544,7 +36746,8 @@ bool MapWStringInnerAliasArrayHelperPubSubType::compute_key(
             MapWStringInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -36724,7 +36927,8 @@ bool MapWStringInnerAliasSequenceHelperPubSubType::compute_key(
             MapWStringInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -36904,7 +37108,8 @@ bool MapWStringInnerAliasMapHelperPubSubType::compute_key(
             MapWStringInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -37084,7 +37289,8 @@ bool MapWStringInnerUnionHelperPubSubType::compute_key(
             MapWStringInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -37264,7 +37470,8 @@ bool MapWStringInnerStructureHelperPubSubType::compute_key(
             MapWStringInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -37444,7 +37651,8 @@ bool MapWStringInnerBitsetHelperPubSubType::compute_key(
             MapWStringInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapWStringInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -37624,7 +37832,8 @@ bool MapInnerAliasBoundedStringHelperShortPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperShort_max_key_cdr_typesize > 16)
     {
@@ -37804,7 +38013,8 @@ bool MapInnerAliasBoundedStringHelperUShortPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperUShort_max_key_cdr_typesize > 16)
     {
@@ -37984,7 +38194,8 @@ bool MapInnerAliasBoundedStringHelperLongPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperLong_max_key_cdr_typesize > 16)
     {
@@ -38164,7 +38375,8 @@ bool MapInnerAliasBoundedStringHelperULongPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperULong_max_key_cdr_typesize > 16)
     {
@@ -38344,7 +38556,8 @@ bool MapInnerAliasBoundedStringHelperLongLongPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperLongLong_max_key_cdr_typesize > 16)
     {
@@ -38524,7 +38737,8 @@ bool MapInnerAliasBoundedStringHelperULongLongPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperULongLong_max_key_cdr_typesize > 16)
     {
@@ -38704,7 +38918,8 @@ bool MapInnerAliasBoundedStringHelperFloatPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperFloat_max_key_cdr_typesize > 16)
     {
@@ -38884,7 +39099,8 @@ bool MapInnerAliasBoundedStringHelperDoublePubSubType::compute_key(
             MapInnerAliasBoundedStringHelperDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperDouble_max_key_cdr_typesize > 16)
     {
@@ -39064,7 +39280,8 @@ bool MapInnerAliasBoundedStringHelperLongDoublePubSubType::compute_key(
             MapInnerAliasBoundedStringHelperLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperLongDouble_max_key_cdr_typesize > 16)
     {
@@ -39244,7 +39461,8 @@ bool MapInnerAliasBoundedStringHelperBooleanPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperBoolean_max_key_cdr_typesize > 16)
     {
@@ -39424,7 +39642,8 @@ bool MapInnerAliasBoundedStringHelperOctetPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperOctet_max_key_cdr_typesize > 16)
     {
@@ -39604,7 +39823,8 @@ bool MapInnerAliasBoundedStringHelperCharPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperChar_max_key_cdr_typesize > 16)
     {
@@ -39784,7 +40004,8 @@ bool MapInnerAliasBoundedStringHelperWCharPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperWChar_max_key_cdr_typesize > 16)
     {
@@ -39964,7 +40185,8 @@ bool MapInnerAliasBoundedStringHelperStringPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperString_max_key_cdr_typesize > 16)
     {
@@ -40144,7 +40366,8 @@ bool MapInnerAliasBoundedStringHelperWStringPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperWString_max_key_cdr_typesize > 16)
     {
@@ -40324,7 +40547,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelperPubSubType::co
             MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -40504,7 +40728,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelperPubSubType::c
             MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -40684,7 +40909,8 @@ bool MapInnerAliasBoundedStringHelperInnerEnumHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -40864,7 +41090,8 @@ bool MapInnerAliasBoundedStringHelperInnerBitMaskHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -41044,7 +41271,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -41224,7 +41452,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasArrayHelperPubSubType::compute_ke
             MapInnerAliasBoundedStringHelperInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -41404,7 +41633,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasSequenceHelperPubSubType::compute
             MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -41584,7 +41814,8 @@ bool MapInnerAliasBoundedStringHelperInnerAliasMapHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -41764,7 +41995,8 @@ bool MapInnerAliasBoundedStringHelperInnerUnionHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -41944,7 +42176,8 @@ bool MapInnerAliasBoundedStringHelperInnerStructureHelperPubSubType::compute_key
             MapInnerAliasBoundedStringHelperInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -42124,7 +42357,8 @@ bool MapInnerAliasBoundedStringHelperInnerBitsetHelperPubSubType::compute_key(
             MapInnerAliasBoundedStringHelperInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedStringHelperInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -42304,7 +42538,8 @@ bool MapInnerAliasBoundedWStringHelperShortPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperShort_max_key_cdr_typesize > 16)
     {
@@ -42484,7 +42719,8 @@ bool MapInnerAliasBoundedWStringHelperUShortPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperUShort_max_key_cdr_typesize > 16)
     {
@@ -42664,7 +42900,8 @@ bool MapInnerAliasBoundedWStringHelperLongPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperLong_max_key_cdr_typesize > 16)
     {
@@ -42844,7 +43081,8 @@ bool MapInnerAliasBoundedWStringHelperULongPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperULong_max_key_cdr_typesize > 16)
     {
@@ -43024,7 +43262,8 @@ bool MapInnerAliasBoundedWStringHelperLongLongPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperLongLong_max_key_cdr_typesize > 16)
     {
@@ -43204,7 +43443,8 @@ bool MapInnerAliasBoundedWStringHelperULongLongPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperULongLong_max_key_cdr_typesize > 16)
     {
@@ -43384,7 +43624,8 @@ bool MapInnerAliasBoundedWStringHelperFloatPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperFloat_max_key_cdr_typesize > 16)
     {
@@ -43564,7 +43805,8 @@ bool MapInnerAliasBoundedWStringHelperDoublePubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperDouble_max_key_cdr_typesize > 16)
     {
@@ -43744,7 +43986,8 @@ bool MapInnerAliasBoundedWStringHelperLongDoublePubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperLongDouble_max_key_cdr_typesize > 16)
     {
@@ -43924,7 +44167,8 @@ bool MapInnerAliasBoundedWStringHelperBooleanPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperBoolean_max_key_cdr_typesize > 16)
     {
@@ -44104,7 +44348,8 @@ bool MapInnerAliasBoundedWStringHelperOctetPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperOctet_max_key_cdr_typesize > 16)
     {
@@ -44284,7 +44529,8 @@ bool MapInnerAliasBoundedWStringHelperCharPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperChar_max_key_cdr_typesize > 16)
     {
@@ -44464,7 +44710,8 @@ bool MapInnerAliasBoundedWStringHelperWCharPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperWChar_max_key_cdr_typesize > 16)
     {
@@ -44644,7 +44891,8 @@ bool MapInnerAliasBoundedWStringHelperStringPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperString_max_key_cdr_typesize > 16)
     {
@@ -44824,7 +45072,8 @@ bool MapInnerAliasBoundedWStringHelperWStringPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperWString_max_key_cdr_typesize > 16)
     {
@@ -45004,7 +45253,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelperPubSubType::c
             MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasBoundedStringHelper_max_key_cdr_typesize > 16)
     {
@@ -45184,7 +45434,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelperPubSubType::
             MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasBoundedWStringHelper_max_key_cdr_typesize > 16)
     {
@@ -45364,7 +45615,8 @@ bool MapInnerAliasBoundedWStringHelperInnerEnumHelperPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -45544,7 +45796,8 @@ bool MapInnerAliasBoundedWStringHelperInnerBitMaskHelperPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -45724,7 +45977,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasHelperPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -45904,7 +46158,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasArrayHelperPubSubType::compute_k
             MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasArrayHelper_max_key_cdr_typesize > 16)
     {
@@ -46084,7 +46339,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelperPubSubType::comput
             MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasSequenceHelper_max_key_cdr_typesize > 16)
     {
@@ -46264,7 +46520,8 @@ bool MapInnerAliasBoundedWStringHelperInnerAliasMapHelperPubSubType::compute_key
             MapInnerAliasBoundedWStringHelperInnerAliasMapHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerAliasMapHelper_max_key_cdr_typesize > 16)
     {
@@ -46444,7 +46701,8 @@ bool MapInnerAliasBoundedWStringHelperInnerUnionHelperPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -46624,7 +46882,8 @@ bool MapInnerAliasBoundedWStringHelperInnerStructureHelperPubSubType::compute_ke
             MapInnerAliasBoundedWStringHelperInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -46804,7 +47063,8 @@ bool MapInnerAliasBoundedWStringHelperInnerBitsetHelperPubSubType::compute_key(
             MapInnerAliasBoundedWStringHelperInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapInnerAliasBoundedWStringHelperInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -46984,7 +47244,8 @@ bool BoundedSmallMapPubSubType::compute_key(
             BoundedSmallMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedSmallMap_max_key_cdr_typesize > 16)
     {
@@ -47164,7 +47425,8 @@ bool BoundedLargeMapPubSubType::compute_key(
             BoundedLargeMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedLargeMap_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/member_idCdrAux.ipp
+++ b/test/dds-types-test/member_idCdrAux.ipp
@@ -129,8 +129,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixId& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.s();
+
+                        scdr << data.l();
+
+                        scdr << data.ll();
+
 }
 
 
@@ -229,8 +238,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixHexId& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.ho();
+
+                        scdr << data.hs();
+
+                        scdr << data.hl();
+
+                        scdr << data.ll();
+
 }
 
 
@@ -329,8 +347,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixHashidDefault& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.s();
+
+                        scdr << data.l();
+
+                        scdr << data.ll();
+
 }
 
 
@@ -429,8 +456,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixHashid& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.l();
+
+                        scdr << data.ll();
+
+                        scdr << data.s();
+
 }
 
 
@@ -537,8 +573,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FixMix& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.ho();
+
+                        scdr << data.l();
+
+                        scdr << data.ll();
+
+                        scdr << data.s();
+
 }
 
 
@@ -645,8 +692,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AutoidDefault& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.c();
+
+                        scdr << data.ll();
+
+                        scdr << data.l();
+
+                        scdr << data.s();
+
 }
 
 
@@ -753,8 +811,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AutoidSequential& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.c();
+
+                        scdr << data.o();
+
+                        scdr << data.l();
+
+                        scdr << data.ll();
+
+                        scdr << data.s();
+
 }
 
 
@@ -861,8 +930,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AutoidHash& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.o();
+
+                        scdr << data.c();
+
+                        scdr << data.ll();
+
+                        scdr << data.l();
+
+                        scdr << data.s();
+
 }
 
 
@@ -1009,8 +1089,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidDefault& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.od();
+
+                        scdr << data.lld();
+
+                        scdr << data.cd();
+
+                        scdr << data.ld();
+
+                        scdr << data.sd();
+
 }
 
 
@@ -1117,6 +1208,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedEmptyAutoidSequential& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1265,8 +1357,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidSequential& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.od();
+
+                        scdr << data.cd();
+
+                        scdr << data.ld();
+
+                        scdr << data.lld();
+
+                        scdr << data.sd();
+
 }
 
 
@@ -1413,8 +1516,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidHash& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.od();
+
+                        scdr << data.lld();
+
+                        scdr << data.cd();
+
+                        scdr << data.ld();
+
+                        scdr << data.sd();
+
 }
 
 

--- a/test/dds-types-test/member_idCdrAux.ipp
+++ b/test/dds-types-test/member_idCdrAux.ipp
@@ -1089,19 +1089,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidDefault& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.od();
-
-                        scdr << data.lld();
-
-                        scdr << data.cd();
-
-                        scdr << data.ld();
-
-                        scdr << data.sd();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const AutoidDefault& data);
+    serialize_key(scdr, static_cast<const AutoidDefault&>(data));
 }
 
 
@@ -1208,9 +1199,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedEmptyAutoidSequential& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const AutoidSequential& data);
+    serialize_key(scdr, static_cast<const AutoidSequential&>(data));
 }
 
 
@@ -1357,19 +1349,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidSequential& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.od();
-
-                        scdr << data.cd();
-
-                        scdr << data.ld();
-
-                        scdr << data.lld();
-
-                        scdr << data.sd();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const DerivedEmptyAutoidSequential& data);
+    serialize_key(scdr, static_cast<const DerivedEmptyAutoidSequential&>(data));
 }
 
 
@@ -1516,19 +1499,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DerivedAutoidHash& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.od();
-
-                        scdr << data.lld();
-
-                        scdr << data.cd();
-
-                        scdr << data.ld();
-
-                        scdr << data.sd();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const AutoidHash& data);
+    serialize_key(scdr, static_cast<const AutoidHash&>(data));
 }
 
 

--- a/test/dds-types-test/member_idPubSubTypes.cxx
+++ b/test/dds-types-test/member_idPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool FixIdPubSubType::compute_key(
             FixId_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixId_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool FixHexIdPubSubType::compute_key(
             FixHexId_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixHexId_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool FixHashidDefaultPubSubType::compute_key(
             FixHashidDefault_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixHashidDefault_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool FixHashidPubSubType::compute_key(
             FixHashid_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixHashid_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool FixMixPubSubType::compute_key(
             FixMix_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FixMix_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool AutoidDefaultPubSubType::compute_key(
             AutoidDefault_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AutoidDefault_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool AutoidSequentialPubSubType::compute_key(
             AutoidSequential_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AutoidSequential_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool AutoidHashPubSubType::compute_key(
             AutoidHash_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AutoidHash_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool DerivedAutoidDefaultPubSubType::compute_key(
             DerivedAutoidDefault_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DerivedAutoidDefault_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool DerivedEmptyAutoidSequentialPubSubType::compute_key(
             DerivedEmptyAutoidSequential_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DerivedEmptyAutoidSequential_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool DerivedAutoidSequentialPubSubType::compute_key(
             DerivedAutoidSequential_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DerivedAutoidSequential_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool DerivedAutoidHashPubSubType::compute_key(
             DerivedAutoidHash_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DerivedAutoidHash_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/mutableCdrAux.ipp
+++ b/test/dds-types-test/mutableCdrAux.ipp
@@ -1276,11 +1276,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableEmptyInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const MutableEmptyStruct& data);
+    serialize_key(scdr, static_cast<const MutableEmptyStruct&>(data));
 }
 
 
@@ -1363,11 +1362,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableInheritanceStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_str();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const MutableShortStruct& data);
+    serialize_key(scdr, static_cast<const MutableShortStruct&>(data));
 }
 
 
@@ -1442,9 +1440,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableInheritanceEmptyStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
+    extern void serialize_key(
+            Cdr& scdr,
+            const MutableShortStruct& data);
+    serialize_key(scdr, static_cast<const MutableShortStruct&>(data));
 }
 
 
@@ -1527,11 +1526,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableExtensibilityInheritance& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.var_long();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const MutableShortStruct& data);
+    serialize_key(scdr, static_cast<const MutableShortStruct&>(data));
 }
 
 

--- a/test/dds-types-test/mutableCdrAux.ipp
+++ b/test/dds-types-test/mutableCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableUShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableULongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableLongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableULongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableFloatStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableLongDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableBooleanStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableOctetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char8();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableWCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char16();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableUnionStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union();
+
 }
 
 
@@ -1157,6 +1199,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1233,8 +1276,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableEmptyInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1317,8 +1363,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableInheritanceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_str();
+
 }
 
 
@@ -1393,6 +1442,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableInheritanceEmptyStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -1477,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableExtensibilityInheritance& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 

--- a/test/dds-types-test/mutablePubSubTypes.cxx
+++ b/test/dds-types-test/mutablePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool MutableShortStructPubSubType::compute_key(
             MutableShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableShortStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool MutableUShortStructPubSubType::compute_key(
             MutableUShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableUShortStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool MutableLongStructPubSubType::compute_key(
             MutableLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableLongStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool MutableULongStructPubSubType::compute_key(
             MutableULongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableULongStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool MutableLongLongStructPubSubType::compute_key(
             MutableLongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableLongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool MutableULongLongStructPubSubType::compute_key(
             MutableULongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableULongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool MutableFloatStructPubSubType::compute_key(
             MutableFloatStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableFloatStruct_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool MutableDoubleStructPubSubType::compute_key(
             MutableDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool MutableLongDoubleStructPubSubType::compute_key(
             MutableLongDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableLongDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool MutableBooleanStructPubSubType::compute_key(
             MutableBooleanStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableBooleanStruct_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool MutableOctetStructPubSubType::compute_key(
             MutableOctetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableOctetStruct_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool MutableCharStructPubSubType::compute_key(
             MutableCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool MutableWCharStructPubSubType::compute_key(
             MutableWCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableWCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool MutableUnionStructPubSubType::compute_key(
             MutableUnionStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableUnionStruct_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool MutableEmptyStructPubSubType::compute_key(
             MutableEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool MutableEmptyInheritanceStructPubSubType::compute_key(
             MutableEmptyInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableEmptyInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool MutableInheritanceStructPubSubType::compute_key(
             MutableInheritanceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableInheritanceStruct_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool MutableInheritanceEmptyStructPubSubType::compute_key(
             MutableInheritanceEmptyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableInheritanceEmptyStruct_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool MutableExtensibilityInheritancePubSubType::compute_key(
             MutableExtensibilityInheritance_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableExtensibilityInheritance_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/optionalCdrAux.ipp
+++ b/test/dds-types-test/optionalCdrAux.ipp
@@ -105,8 +105,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const short_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -181,8 +187,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ushort_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -257,8 +269,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const long_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -333,8 +351,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulong_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -409,8 +433,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longlong_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -485,8 +515,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulonglong_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -561,8 +597,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const float_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -637,8 +679,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const double_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -713,8 +761,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longdouble_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -789,8 +843,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const boolean_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -865,8 +925,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const octet_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -941,8 +1007,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const char_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1017,8 +1089,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const wchar_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1101,8 +1179,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const short_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1185,8 +1271,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const short_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1269,8 +1363,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const short_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1353,8 +1455,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ushort_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1437,8 +1547,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ushort_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1521,8 +1639,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ushort_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1605,8 +1731,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const long_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1689,8 +1823,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const long_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1773,8 +1915,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const long_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1857,8 +2007,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulong_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -1941,8 +2099,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulong_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2025,8 +2191,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulong_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2109,8 +2283,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longlong_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2193,8 +2375,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longlong_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2277,8 +2467,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longlong_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2361,8 +2559,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulonglong_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2445,8 +2651,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulonglong_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2529,8 +2743,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ulonglong_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2613,8 +2835,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const float_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2697,8 +2927,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const float_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2781,8 +3019,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const float_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2865,8 +3111,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const double_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -2949,8 +3203,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const double_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3033,8 +3295,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const double_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3117,8 +3387,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longdouble_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3201,8 +3479,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longdouble_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3285,8 +3571,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const longdouble_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3369,8 +3663,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const boolean_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3453,8 +3755,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const boolean_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3537,8 +3847,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const boolean_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3621,8 +3939,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const octet_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3705,8 +4031,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const octet_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3789,8 +4123,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const octet_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3873,8 +4215,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const char_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -3957,8 +4307,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const char_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4041,8 +4399,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const char_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4125,8 +4491,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const wchar_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4209,8 +4583,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const wchar_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4293,8 +4675,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const wchar_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4369,8 +4759,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const sequence_short_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4453,8 +4849,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const sequence_short_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4537,8 +4941,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const sequence_short_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4621,8 +5033,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const sequence_short_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4697,8 +5117,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_unbounded_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4781,8 +5207,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_unbounded_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4865,8 +5299,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_unbounded_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -4949,8 +5391,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_unbounded_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5025,8 +5475,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_bounded_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5109,8 +5565,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_bounded_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5193,8 +5657,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_bounded_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5277,8 +5749,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const string_bounded_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5353,8 +5833,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const map_short_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5437,8 +5923,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const map_short_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5521,8 +6015,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const map_short_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5605,8 +6107,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const map_short_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5681,8 +6191,14 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const array_short_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5765,8 +6281,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const array_short_align_1_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5849,8 +6373,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const array_short_align_2_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -5933,8 +6465,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const array_short_align_4_optional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            scdr << data.value().value();
+                        }
+
 }
 
 
@@ -6009,8 +6549,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6093,8 +6643,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_align_1_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6177,8 +6739,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_align_2_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6261,8 +6835,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const struct_align_4_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6345,8 +6931,16 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const InnerStructOptional& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.s();
+
+                        if (data.l().has_value())
+                        {
+                            scdr << data.l().value();
+                        }
+
 }
 
 
@@ -6421,8 +7015,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const opt_struct_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructOptional& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6505,8 +7109,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const opt_struct_align_1_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructOptional& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6589,8 +7205,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const opt_struct_align_2_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructOptional& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 
@@ -6673,8 +7301,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const opt_struct_align_4_optional& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructOptional& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.align();
+
+                        if (data.value().has_value())
+                        {
+                            serialize_key(scdr, data.value().value());
+                        }
+
 }
 
 

--- a/test/dds-types-test/optionalPubSubTypes.cxx
+++ b/test/dds-types-test/optionalPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool short_optionalPubSubType::compute_key(
             short_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || short_optional_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ushort_optionalPubSubType::compute_key(
             ushort_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ushort_optional_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool long_optionalPubSubType::compute_key(
             long_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || long_optional_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool ulong_optionalPubSubType::compute_key(
             ulong_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulong_optional_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool longlong_optionalPubSubType::compute_key(
             longlong_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longlong_optional_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool ulonglong_optionalPubSubType::compute_key(
             ulonglong_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulonglong_optional_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool float_optionalPubSubType::compute_key(
             float_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || float_optional_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool double_optionalPubSubType::compute_key(
             double_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || double_optional_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool longdouble_optionalPubSubType::compute_key(
             longdouble_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longdouble_optional_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool boolean_optionalPubSubType::compute_key(
             boolean_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || boolean_optional_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool octet_optionalPubSubType::compute_key(
             octet_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || octet_optional_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool char_optionalPubSubType::compute_key(
             char_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || char_optional_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool wchar_optionalPubSubType::compute_key(
             wchar_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || wchar_optional_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool short_align_1_optionalPubSubType::compute_key(
             short_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || short_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool short_align_2_optionalPubSubType::compute_key(
             short_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || short_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool short_align_4_optionalPubSubType::compute_key(
             short_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || short_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool ushort_align_1_optionalPubSubType::compute_key(
             ushort_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ushort_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool ushort_align_2_optionalPubSubType::compute_key(
             ushort_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ushort_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool ushort_align_4_optionalPubSubType::compute_key(
             ushort_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ushort_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool long_align_1_optionalPubSubType::compute_key(
             long_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || long_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool long_align_2_optionalPubSubType::compute_key(
             long_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || long_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool long_align_4_optionalPubSubType::compute_key(
             long_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || long_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool ulong_align_1_optionalPubSubType::compute_key(
             ulong_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulong_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool ulong_align_2_optionalPubSubType::compute_key(
             ulong_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulong_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool ulong_align_4_optionalPubSubType::compute_key(
             ulong_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulong_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool longlong_align_1_optionalPubSubType::compute_key(
             longlong_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longlong_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool longlong_align_2_optionalPubSubType::compute_key(
             longlong_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longlong_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool longlong_align_4_optionalPubSubType::compute_key(
             longlong_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longlong_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -5224,7 +5252,8 @@ bool ulonglong_align_1_optionalPubSubType::compute_key(
             ulonglong_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulonglong_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -5404,7 +5433,8 @@ bool ulonglong_align_2_optionalPubSubType::compute_key(
             ulonglong_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulonglong_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -5584,7 +5614,8 @@ bool ulonglong_align_4_optionalPubSubType::compute_key(
             ulonglong_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ulonglong_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -5764,7 +5795,8 @@ bool float_align_1_optionalPubSubType::compute_key(
             float_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || float_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -5944,7 +5976,8 @@ bool float_align_2_optionalPubSubType::compute_key(
             float_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || float_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -6124,7 +6157,8 @@ bool float_align_4_optionalPubSubType::compute_key(
             float_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || float_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -6304,7 +6338,8 @@ bool double_align_1_optionalPubSubType::compute_key(
             double_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || double_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -6484,7 +6519,8 @@ bool double_align_2_optionalPubSubType::compute_key(
             double_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || double_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -6664,7 +6700,8 @@ bool double_align_4_optionalPubSubType::compute_key(
             double_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || double_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -6844,7 +6881,8 @@ bool longdouble_align_1_optionalPubSubType::compute_key(
             longdouble_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longdouble_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -7024,7 +7062,8 @@ bool longdouble_align_2_optionalPubSubType::compute_key(
             longdouble_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longdouble_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -7204,7 +7243,8 @@ bool longdouble_align_4_optionalPubSubType::compute_key(
             longdouble_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || longdouble_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -7384,7 +7424,8 @@ bool boolean_align_1_optionalPubSubType::compute_key(
             boolean_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || boolean_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -7564,7 +7605,8 @@ bool boolean_align_2_optionalPubSubType::compute_key(
             boolean_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || boolean_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -7744,7 +7786,8 @@ bool boolean_align_4_optionalPubSubType::compute_key(
             boolean_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || boolean_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -7924,7 +7967,8 @@ bool octet_align_1_optionalPubSubType::compute_key(
             octet_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || octet_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -8104,7 +8148,8 @@ bool octet_align_2_optionalPubSubType::compute_key(
             octet_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || octet_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -8284,7 +8329,8 @@ bool octet_align_4_optionalPubSubType::compute_key(
             octet_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || octet_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -8464,7 +8510,8 @@ bool char_align_1_optionalPubSubType::compute_key(
             char_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || char_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -8644,7 +8691,8 @@ bool char_align_2_optionalPubSubType::compute_key(
             char_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || char_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -8824,7 +8872,8 @@ bool char_align_4_optionalPubSubType::compute_key(
             char_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || char_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -9004,7 +9053,8 @@ bool wchar_align_1_optionalPubSubType::compute_key(
             wchar_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || wchar_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -9184,7 +9234,8 @@ bool wchar_align_2_optionalPubSubType::compute_key(
             wchar_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || wchar_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -9364,7 +9415,8 @@ bool wchar_align_4_optionalPubSubType::compute_key(
             wchar_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || wchar_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -9544,7 +9596,8 @@ bool sequence_short_optionalPubSubType::compute_key(
             sequence_short_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || sequence_short_optional_max_key_cdr_typesize > 16)
     {
@@ -9724,7 +9777,8 @@ bool sequence_short_align_1_optionalPubSubType::compute_key(
             sequence_short_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || sequence_short_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -9904,7 +9958,8 @@ bool sequence_short_align_2_optionalPubSubType::compute_key(
             sequence_short_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || sequence_short_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -10084,7 +10139,8 @@ bool sequence_short_align_4_optionalPubSubType::compute_key(
             sequence_short_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || sequence_short_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -10264,7 +10320,8 @@ bool string_unbounded_optionalPubSubType::compute_key(
             string_unbounded_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_unbounded_optional_max_key_cdr_typesize > 16)
     {
@@ -10444,7 +10501,8 @@ bool string_unbounded_align_1_optionalPubSubType::compute_key(
             string_unbounded_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_unbounded_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -10624,7 +10682,8 @@ bool string_unbounded_align_2_optionalPubSubType::compute_key(
             string_unbounded_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_unbounded_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -10804,7 +10863,8 @@ bool string_unbounded_align_4_optionalPubSubType::compute_key(
             string_unbounded_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_unbounded_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -10984,7 +11044,8 @@ bool string_bounded_optionalPubSubType::compute_key(
             string_bounded_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_bounded_optional_max_key_cdr_typesize > 16)
     {
@@ -11164,7 +11225,8 @@ bool string_bounded_align_1_optionalPubSubType::compute_key(
             string_bounded_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_bounded_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -11344,7 +11406,8 @@ bool string_bounded_align_2_optionalPubSubType::compute_key(
             string_bounded_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_bounded_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -11524,7 +11587,8 @@ bool string_bounded_align_4_optionalPubSubType::compute_key(
             string_bounded_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || string_bounded_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -11704,7 +11768,8 @@ bool map_short_optionalPubSubType::compute_key(
             map_short_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || map_short_optional_max_key_cdr_typesize > 16)
     {
@@ -11884,7 +11949,8 @@ bool map_short_align_1_optionalPubSubType::compute_key(
             map_short_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || map_short_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -12064,7 +12130,8 @@ bool map_short_align_2_optionalPubSubType::compute_key(
             map_short_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || map_short_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -12244,7 +12311,8 @@ bool map_short_align_4_optionalPubSubType::compute_key(
             map_short_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || map_short_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -12424,7 +12492,8 @@ bool array_short_optionalPubSubType::compute_key(
             array_short_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || array_short_optional_max_key_cdr_typesize > 16)
     {
@@ -12604,7 +12673,8 @@ bool array_short_align_1_optionalPubSubType::compute_key(
             array_short_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || array_short_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -12784,7 +12854,8 @@ bool array_short_align_2_optionalPubSubType::compute_key(
             array_short_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || array_short_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -12964,7 +13035,8 @@ bool array_short_align_4_optionalPubSubType::compute_key(
             array_short_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || array_short_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -13144,7 +13216,8 @@ bool struct_optionalPubSubType::compute_key(
             struct_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_optional_max_key_cdr_typesize > 16)
     {
@@ -13324,7 +13397,8 @@ bool struct_align_1_optionalPubSubType::compute_key(
             struct_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -13504,7 +13578,8 @@ bool struct_align_2_optionalPubSubType::compute_key(
             struct_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -13684,7 +13759,8 @@ bool struct_align_4_optionalPubSubType::compute_key(
             struct_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || struct_align_4_optional_max_key_cdr_typesize > 16)
     {
@@ -13864,7 +13940,8 @@ bool InnerStructOptionalPubSubType::compute_key(
             InnerStructOptional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || InnerStructOptional_max_key_cdr_typesize > 16)
     {
@@ -14044,7 +14121,8 @@ bool opt_struct_optionalPubSubType::compute_key(
             opt_struct_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || opt_struct_optional_max_key_cdr_typesize > 16)
     {
@@ -14224,7 +14302,8 @@ bool opt_struct_align_1_optionalPubSubType::compute_key(
             opt_struct_align_1_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || opt_struct_align_1_optional_max_key_cdr_typesize > 16)
     {
@@ -14404,7 +14483,8 @@ bool opt_struct_align_2_optionalPubSubType::compute_key(
             opt_struct_align_2_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || opt_struct_align_2_optional_max_key_cdr_typesize > 16)
     {
@@ -14584,7 +14664,8 @@ bool opt_struct_align_4_optionalPubSubType::compute_key(
             opt_struct_align_4_optional_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || opt_struct_align_4_optional_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/primitivesCdrAux.ipp
+++ b/test/dds-types-test/primitivesCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UShortStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const LongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ULongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const LongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ULongLongStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FloatStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const DoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const LongDoubleStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BooleanStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const OctetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char8();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const WCharStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char16();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Int8Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_int8();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Uint8Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_uint8();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Int16Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_int16();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Uint16Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_uint16();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Int32Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_int32();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Uint32Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_uint32();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Int64Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_int64();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Uint64Struct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_uint64();
+
 }
 
 

--- a/test/dds-types-test/primitivesPubSubTypes.cxx
+++ b/test/dds-types-test/primitivesPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ShortStructPubSubType::compute_key(
             ShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ShortStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool UShortStructPubSubType::compute_key(
             UShortStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UShortStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool LongStructPubSubType::compute_key(
             LongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || LongStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool ULongStructPubSubType::compute_key(
             ULongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ULongStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool LongLongStructPubSubType::compute_key(
             LongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || LongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool ULongLongStructPubSubType::compute_key(
             ULongLongStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ULongLongStruct_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool FloatStructPubSubType::compute_key(
             FloatStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FloatStruct_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool DoubleStructPubSubType::compute_key(
             DoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || DoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool LongDoubleStructPubSubType::compute_key(
             LongDoubleStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || LongDoubleStruct_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool BooleanStructPubSubType::compute_key(
             BooleanStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BooleanStruct_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool OctetStructPubSubType::compute_key(
             OctetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || OctetStruct_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool CharStructPubSubType::compute_key(
             CharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CharStruct_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool WCharStructPubSubType::compute_key(
             WCharStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || WCharStruct_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool Int8StructPubSubType::compute_key(
             Int8Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Int8Struct_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool Uint8StructPubSubType::compute_key(
             Uint8Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Uint8Struct_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool Int16StructPubSubType::compute_key(
             Int16Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Int16Struct_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool Uint16StructPubSubType::compute_key(
             Uint16Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Uint16Struct_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool Int32StructPubSubType::compute_key(
             Int32Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Int32Struct_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool Uint32StructPubSubType::compute_key(
             Uint32Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Uint32Struct_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool Int64StructPubSubType::compute_key(
             Int64Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Int64Struct_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool Uint64StructPubSubType::compute_key(
             Uint64Struct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Uint64Struct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/relative_path_includeCdrAux.ipp
+++ b/test/dds-types-test/relative_path_includeCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const RelativePathIncludeStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 

--- a/test/dds-types-test/relative_path_includePubSubTypes.cxx
+++ b/test/dds-types-test/relative_path_includePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool RelativePathIncludeStructPubSubType::compute_key(
             RelativePathIncludeStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || RelativePathIncludeStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/sequencesCdrAux.ipp
+++ b/test/dds-types-test/sequencesCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_char();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_wchar();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_string();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_wstring();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceStringBounded& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_bounded_string();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceWStringBounded& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_bounded_wstring();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_enum();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_bitmask();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_alias();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceShortArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_short_array();
+
 }
 
 
@@ -1701,8 +1764,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_sequence();
+
 }
 
 
@@ -1777,8 +1843,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_map();
+
 }
 
 
@@ -1853,8 +1922,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_union();
+
 }
 
 
@@ -1929,8 +2001,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceStructure& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_structure();
+
 }
 
 
@@ -2005,8 +2080,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_bitset();
+
 }
 
 
@@ -2089,8 +2167,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedSmallSequences& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_small();
+
+                        scdr << data.var_unbounded_string_small_bounded_sequence();
+
 }
 
 
@@ -2173,8 +2256,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BoundedBigSequences& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence_big();
+
+                        scdr << data.var_unbounded_string_large_bounded_sequence();
+
 }
 
 

--- a/test/dds-types-test/sequencesPubSubTypes.cxx
+++ b/test/dds-types-test/sequencesPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool SequenceShortPubSubType::compute_key(
             SequenceShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceShort_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool SequenceUShortPubSubType::compute_key(
             SequenceUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceUShort_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool SequenceLongPubSubType::compute_key(
             SequenceLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceLong_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool SequenceULongPubSubType::compute_key(
             SequenceULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceULong_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool SequenceLongLongPubSubType::compute_key(
             SequenceLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceLongLong_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool SequenceULongLongPubSubType::compute_key(
             SequenceULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceULongLong_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool SequenceFloatPubSubType::compute_key(
             SequenceFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceFloat_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool SequenceDoublePubSubType::compute_key(
             SequenceDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceDouble_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool SequenceLongDoublePubSubType::compute_key(
             SequenceLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceLongDouble_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool SequenceBooleanPubSubType::compute_key(
             SequenceBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceBoolean_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool SequenceOctetPubSubType::compute_key(
             SequenceOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool SequenceCharPubSubType::compute_key(
             SequenceChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceChar_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool SequenceWCharPubSubType::compute_key(
             SequenceWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceWChar_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool SequenceStringPubSubType::compute_key(
             SequenceString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceString_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool SequenceWStringPubSubType::compute_key(
             SequenceWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceWString_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool SequenceStringBoundedPubSubType::compute_key(
             SequenceStringBounded_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceStringBounded_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool SequenceWStringBoundedPubSubType::compute_key(
             SequenceWStringBounded_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceWStringBounded_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool SequenceEnumPubSubType::compute_key(
             SequenceEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceEnum_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool SequenceBitMaskPubSubType::compute_key(
             SequenceBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceBitMask_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool SequenceAliasPubSubType::compute_key(
             SequenceAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceAlias_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool SequenceShortArrayPubSubType::compute_key(
             SequenceShortArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceShortArray_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool SequenceSequencePubSubType::compute_key(
             SequenceSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceSequence_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool SequenceMapPubSubType::compute_key(
             SequenceMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceMap_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool SequenceUnionPubSubType::compute_key(
             SequenceUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceUnion_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool SequenceStructurePubSubType::compute_key(
             SequenceStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceStructure_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool SequenceBitsetPubSubType::compute_key(
             SequenceBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceBitset_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool BoundedSmallSequencesPubSubType::compute_key(
             BoundedSmallSequences_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedSmallSequences_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool BoundedBigSequencesPubSubType::compute_key(
             BoundedBigSequences_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BoundedBigSequences_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/stringsCdrAux.ipp
+++ b/test/dds-types-test/stringsCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_string8();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const WStringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_string16();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SmallStringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_small_string();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SmallWStringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_small_wstring();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const LargeStringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_large_string();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const LargeWStringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_large_wstring();
+
 }
 
 

--- a/test/dds-types-test/stringsPubSubTypes.cxx
+++ b/test/dds-types-test/stringsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool StringStructPubSubType::compute_key(
             StringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StringStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool WStringStructPubSubType::compute_key(
             WStringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || WStringStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool SmallStringStructPubSubType::compute_key(
             SmallStringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SmallStringStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool SmallWStringStructPubSubType::compute_key(
             SmallWStringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SmallWStringStruct_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool LargeStringStructPubSubType::compute_key(
             LargeStringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || LargeStringStruct_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool LargeWStringStructPubSubType::compute_key(
             LargeWStringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || LargeWStringStruct_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/structuresCdrAux.ipp
+++ b/test/dds-types-test/structuresCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_short();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructUnsignedShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ushort();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_long();
+
 }
 
 
@@ -333,8 +342,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructUnsignedLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulong();
+
 }
 
 
@@ -409,8 +421,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longlong();
+
 }
 
 
@@ -485,8 +500,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructUnsignedLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_ulonglong();
+
 }
 
 
@@ -561,8 +579,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_float();
+
 }
 
 
@@ -637,8 +658,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_double();
+
 }
 
 
@@ -713,8 +737,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_longdouble();
+
 }
 
 
@@ -789,8 +816,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_boolean();
+
 }
 
 
@@ -865,8 +895,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_octet();
+
 }
 
 
@@ -941,8 +974,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructChar8& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char8();
+
 }
 
 
@@ -1017,8 +1053,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructChar16& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_char16();
+
 }
 
 
@@ -1093,8 +1132,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_string();
+
 }
 
 
@@ -1169,8 +1211,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_wstring();
+
 }
 
 
@@ -1245,8 +1290,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_bounded_string();
+
 }
 
 
@@ -1321,8 +1369,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_bounded_wstring();
+
 }
 
 
@@ -1397,8 +1448,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_enum();
+
 }
 
 
@@ -1473,8 +1527,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructBitMask& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_bitmask();
+
 }
 
 
@@ -1549,8 +1606,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_alias();
+
 }
 
 
@@ -1625,8 +1685,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructShortArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_array_short();
+
 }
 
 
@@ -1701,8 +1764,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_sequence();
+
 }
 
 
@@ -1777,8 +1843,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_map();
+
 }
 
 
@@ -1853,8 +1922,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructUnion& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union();
+
 }
 
 
@@ -1929,8 +2001,15 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructStructure& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const InnerStructureHelper& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.var_structure());
+
 }
 
 
@@ -2005,8 +2084,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructBitset& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_bitset();
+
 }
 
 
@@ -2069,6 +2151,7 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructEmpty& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
 }
@@ -2353,8 +2436,171 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const Structures& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructShort& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructUnsignedShort& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructLong& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructUnsignedLong& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructLongLong& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructUnsignedLongLong& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructFloat& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructDouble& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructLongDouble& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructBoolean& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructOctet& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructChar8& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructChar16& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructString& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructWString& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructBoundedString& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructBoundedWString& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructEnum& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructBitMask& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructAlias& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructShortArray& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructSequence& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructMap& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructUnion& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructStructure& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructBitset& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructEmpty& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.var_StructShort());
+
+                        serialize_key(scdr, data.var_StructUnsignedShort());
+
+                        serialize_key(scdr, data.var_StructLong());
+
+                        serialize_key(scdr, data.var_StructUnsignedLong());
+
+                        serialize_key(scdr, data.var_StructLongLong());
+
+                        serialize_key(scdr, data.var_StructUnsignedLongLong());
+
+                        serialize_key(scdr, data.var_StructFloat());
+
+                        serialize_key(scdr, data.var_StructDouble());
+
+                        serialize_key(scdr, data.var_StructLongDouble());
+
+                        serialize_key(scdr, data.var_StructBoolean());
+
+                        serialize_key(scdr, data.var_StructOctet());
+
+                        serialize_key(scdr, data.var_StructChar8());
+
+                        serialize_key(scdr, data.var_StructChar16());
+
+                        serialize_key(scdr, data.var_StructString());
+
+                        serialize_key(scdr, data.var_StructWString());
+
+                        serialize_key(scdr, data.var_StructBoundedString());
+
+                        serialize_key(scdr, data.var_StructBoundedWString());
+
+                        serialize_key(scdr, data.var_StructEnum());
+
+                        serialize_key(scdr, data.var_StructBitMask());
+
+                        serialize_key(scdr, data.var_StructAlias());
+
+                        serialize_key(scdr, data.var_StructShortArray());
+
+                        serialize_key(scdr, data.var_StructSequence());
+
+                        serialize_key(scdr, data.var_StructMap());
+
+                        serialize_key(scdr, data.var_StructUnion());
+
+                        serialize_key(scdr, data.var_StructStructure());
+
+                        serialize_key(scdr, data.var_StructBitset());
+
+                        serialize_key(scdr, data.var_StructEmpty());
+
 }
 
 
@@ -2447,6 +2693,10 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.a();
+
+                        scdr << data.b();
+
 }
 
 
@@ -2531,6 +2781,8 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.d();
+
 }
 
 
@@ -2605,8 +2857,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const bar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.e();
+
 }
 
 
@@ -2689,8 +2944,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const root1& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const testing_1::foo& data);
+
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.foo_struct());
+
+                        scdr << data.c();
+
 }
 
 
@@ -2773,8 +3038,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const root2& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const testing_2::foo& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const bar& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.foo_struct());
+
+                        serialize_key(scdr, data.bar_struct());
+
 }
 
 
@@ -2857,8 +3135,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const root& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const root1& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const root2& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.var_root1());
+
+                        serialize_key(scdr, data.var_root2());
+
 }
 
 

--- a/test/dds-types-test/structuresPubSubTypes.cxx
+++ b/test/dds-types-test/structuresPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool StructShortPubSubType::compute_key(
             StructShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructShort_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool StructUnsignedShortPubSubType::compute_key(
             StructUnsignedShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructUnsignedShort_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool StructLongPubSubType::compute_key(
             StructLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructLong_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool StructUnsignedLongPubSubType::compute_key(
             StructUnsignedLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructUnsignedLong_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool StructLongLongPubSubType::compute_key(
             StructLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructLongLong_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool StructUnsignedLongLongPubSubType::compute_key(
             StructUnsignedLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructUnsignedLongLong_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool StructFloatPubSubType::compute_key(
             StructFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructFloat_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool StructDoublePubSubType::compute_key(
             StructDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructDouble_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool StructLongDoublePubSubType::compute_key(
             StructLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructLongDouble_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool StructBooleanPubSubType::compute_key(
             StructBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructBoolean_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool StructOctetPubSubType::compute_key(
             StructOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool StructChar8PubSubType::compute_key(
             StructChar8_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructChar8_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool StructChar16PubSubType::compute_key(
             StructChar16_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructChar16_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool StructStringPubSubType::compute_key(
             StructString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructString_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool StructWStringPubSubType::compute_key(
             StructWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructWString_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool StructBoundedStringPubSubType::compute_key(
             StructBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructBoundedString_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool StructBoundedWStringPubSubType::compute_key(
             StructBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool StructEnumPubSubType::compute_key(
             StructEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructEnum_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool StructBitMaskPubSubType::compute_key(
             StructBitMask_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructBitMask_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool StructAliasPubSubType::compute_key(
             StructAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructAlias_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool StructShortArrayPubSubType::compute_key(
             StructShortArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructShortArray_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool StructSequencePubSubType::compute_key(
             StructSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructSequence_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool StructMapPubSubType::compute_key(
             StructMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructMap_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool StructUnionPubSubType::compute_key(
             StructUnion_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructUnion_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool StructStructurePubSubType::compute_key(
             StructStructure_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructStructure_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool StructBitsetPubSubType::compute_key(
             StructBitset_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructBitset_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool StructEmptyPubSubType::compute_key(
             StructEmpty_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructEmpty_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool StructuresPubSubType::compute_key(
             Structures_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || Structures_max_key_cdr_typesize > 16)
     {
@@ -5225,7 +5253,8 @@ namespace testing_1 {
                 testing_1_foo_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || testing_1_foo_max_key_cdr_typesize > 16)
         {
@@ -5408,7 +5437,8 @@ namespace testing_2 {
                 testing_2_foo_max_key_cdr_typesize);
 
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+        ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
         eprosima::fastcdr::serialize_key(ser, *p_type);
         if (force_md5 || testing_2_foo_max_key_cdr_typesize > 16)
         {
@@ -5590,7 +5620,8 @@ bool barPubSubType::compute_key(
             bar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || bar_max_key_cdr_typesize > 16)
     {
@@ -5770,7 +5801,8 @@ bool root1PubSubType::compute_key(
             root1_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || root1_max_key_cdr_typesize > 16)
     {
@@ -5950,7 +5982,8 @@ bool root2PubSubType::compute_key(
             root2_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || root2_max_key_cdr_typesize > 16)
     {
@@ -6130,7 +6163,8 @@ bool rootPubSubType::compute_key(
             root_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || root_max_key_cdr_typesize > 16)
     {

--- a/test/dds-types-test/unionsCdrAux.ipp
+++ b/test/dds-types-test/unionsCdrAux.ipp
@@ -5034,8 +5034,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_short();
+
 }
 
 
@@ -5110,8 +5113,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_ushort();
+
 }
 
 
@@ -5186,8 +5192,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_long();
+
 }
 
 
@@ -5262,8 +5271,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_ulong();
+
 }
 
 
@@ -5338,8 +5350,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_long_long();
+
 }
 
 
@@ -5414,8 +5429,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_ulong_long();
+
 }
 
 
@@ -5490,8 +5508,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionFloat& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_float();
+
 }
 
 
@@ -5566,8 +5587,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_double();
+
 }
 
 
@@ -5642,8 +5666,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionLongDouble& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_long_double();
+
 }
 
 
@@ -5718,8 +5745,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_boolean();
+
 }
 
 
@@ -5794,8 +5824,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_octet();
+
 }
 
 
@@ -5870,8 +5903,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_char();
+
 }
 
 
@@ -5946,8 +5982,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_wchar();
+
 }
 
 
@@ -6022,8 +6061,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_string();
+
 }
 
 
@@ -6098,8 +6140,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_wstring();
+
 }
 
 
@@ -6174,8 +6219,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionBoundedString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_bounded_string();
+
 }
 
 
@@ -6250,8 +6298,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionBoundedWString& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_bounded_wstring();
+
 }
 
 
@@ -6326,8 +6377,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerEnumHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_enum();
+
 }
 
 
@@ -6402,8 +6456,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerBitMaskHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_bit_mask();
+
 }
 
 
@@ -6478,8 +6535,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerAliasHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_alias();
+
 }
 
 
@@ -6554,8 +6614,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionArray& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_array();
+
 }
 
 
@@ -6630,8 +6693,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionSequence& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_sequence();
+
 }
 
 
@@ -6706,8 +6772,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionMap& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_map();
+
 }
 
 
@@ -6782,8 +6851,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerUnionHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_union();
+
 }
 
 
@@ -6858,8 +6930,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerStructureHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_structure();
+
 }
 
 
@@ -6934,8 +7009,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionInnerBitsetHelper& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_my_bitset();
+
 }
 
 
@@ -7010,8 +7088,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_short();
+
 }
 
 
@@ -7086,8 +7167,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorUShort& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_ushort();
+
 }
 
 
@@ -7162,8 +7246,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_long();
+
 }
 
 
@@ -7238,8 +7325,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorULong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_ulong();
+
 }
 
 
@@ -7314,8 +7404,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorLongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_long_long();
+
 }
 
 
@@ -7390,8 +7483,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorULongLong& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_ulong_long();
+
 }
 
 
@@ -7466,8 +7562,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorBoolean& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_boolean();
+
 }
 
 
@@ -7542,8 +7641,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorOctet& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_octet();
+
 }
 
 
@@ -7618,8 +7720,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_char();
+
 }
 
 
@@ -7694,8 +7799,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorWChar& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_wchar();
+
 }
 
 
@@ -7770,8 +7878,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorEnum& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_enum();
+
 }
 
 
@@ -7846,8 +7957,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorEnumLabel& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_enum();
+
 }
 
 
@@ -7922,8 +8036,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionDiscriminatorAlias& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_discriminator_alias();
+
 }
 
 
@@ -7998,8 +8115,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionSeveralFields& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_several_fields();
+
 }
 
 
@@ -8074,8 +8194,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionSeveralFieldsWithDefault& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.var_union_several_fields_with_default();
+
 }
 
 

--- a/test/dds-types-test/unionsPubSubTypes.cxx
+++ b/test/dds-types-test/unionsPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool UnionShortPubSubType::compute_key(
             UnionShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionShort_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool UnionUShortPubSubType::compute_key(
             UnionUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionUShort_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool UnionLongPubSubType::compute_key(
             UnionLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionLong_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool UnionULongPubSubType::compute_key(
             UnionULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionULong_max_key_cdr_typesize > 16)
     {
@@ -904,7 +908,8 @@ bool UnionLongLongPubSubType::compute_key(
             UnionLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionLongLong_max_key_cdr_typesize > 16)
     {
@@ -1084,7 +1089,8 @@ bool UnionULongLongPubSubType::compute_key(
             UnionULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionULongLong_max_key_cdr_typesize > 16)
     {
@@ -1264,7 +1270,8 @@ bool UnionFloatPubSubType::compute_key(
             UnionFloat_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionFloat_max_key_cdr_typesize > 16)
     {
@@ -1444,7 +1451,8 @@ bool UnionDoublePubSubType::compute_key(
             UnionDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDouble_max_key_cdr_typesize > 16)
     {
@@ -1624,7 +1632,8 @@ bool UnionLongDoublePubSubType::compute_key(
             UnionLongDouble_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionLongDouble_max_key_cdr_typesize > 16)
     {
@@ -1804,7 +1813,8 @@ bool UnionBooleanPubSubType::compute_key(
             UnionBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionBoolean_max_key_cdr_typesize > 16)
     {
@@ -1984,7 +1994,8 @@ bool UnionOctetPubSubType::compute_key(
             UnionOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionOctet_max_key_cdr_typesize > 16)
     {
@@ -2164,7 +2175,8 @@ bool UnionCharPubSubType::compute_key(
             UnionChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionChar_max_key_cdr_typesize > 16)
     {
@@ -2344,7 +2356,8 @@ bool UnionWCharPubSubType::compute_key(
             UnionWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionWChar_max_key_cdr_typesize > 16)
     {
@@ -2524,7 +2537,8 @@ bool UnionStringPubSubType::compute_key(
             UnionString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionString_max_key_cdr_typesize > 16)
     {
@@ -2704,7 +2718,8 @@ bool UnionWStringPubSubType::compute_key(
             UnionWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionWString_max_key_cdr_typesize > 16)
     {
@@ -2884,7 +2899,8 @@ bool UnionBoundedStringPubSubType::compute_key(
             UnionBoundedString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionBoundedString_max_key_cdr_typesize > 16)
     {
@@ -3064,7 +3080,8 @@ bool UnionBoundedWStringPubSubType::compute_key(
             UnionBoundedWString_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionBoundedWString_max_key_cdr_typesize > 16)
     {
@@ -3244,7 +3261,8 @@ bool UnionInnerEnumHelperPubSubType::compute_key(
             UnionInnerEnumHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerEnumHelper_max_key_cdr_typesize > 16)
     {
@@ -3424,7 +3442,8 @@ bool UnionInnerBitMaskHelperPubSubType::compute_key(
             UnionInnerBitMaskHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerBitMaskHelper_max_key_cdr_typesize > 16)
     {
@@ -3604,7 +3623,8 @@ bool UnionInnerAliasHelperPubSubType::compute_key(
             UnionInnerAliasHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerAliasHelper_max_key_cdr_typesize > 16)
     {
@@ -3784,7 +3804,8 @@ bool UnionArrayPubSubType::compute_key(
             UnionArray_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionArray_max_key_cdr_typesize > 16)
     {
@@ -3964,7 +3985,8 @@ bool UnionSequencePubSubType::compute_key(
             UnionSequence_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionSequence_max_key_cdr_typesize > 16)
     {
@@ -4144,7 +4166,8 @@ bool UnionMapPubSubType::compute_key(
             UnionMap_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionMap_max_key_cdr_typesize > 16)
     {
@@ -4324,7 +4347,8 @@ bool UnionInnerUnionHelperPubSubType::compute_key(
             UnionInnerUnionHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerUnionHelper_max_key_cdr_typesize > 16)
     {
@@ -4504,7 +4528,8 @@ bool UnionInnerStructureHelperPubSubType::compute_key(
             UnionInnerStructureHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerStructureHelper_max_key_cdr_typesize > 16)
     {
@@ -4684,7 +4709,8 @@ bool UnionInnerBitsetHelperPubSubType::compute_key(
             UnionInnerBitsetHelper_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionInnerBitsetHelper_max_key_cdr_typesize > 16)
     {
@@ -4864,7 +4890,8 @@ bool UnionDiscriminatorShortPubSubType::compute_key(
             UnionDiscriminatorShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorShort_max_key_cdr_typesize > 16)
     {
@@ -5044,7 +5071,8 @@ bool UnionDiscriminatorUShortPubSubType::compute_key(
             UnionDiscriminatorUShort_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorUShort_max_key_cdr_typesize > 16)
     {
@@ -5224,7 +5252,8 @@ bool UnionDiscriminatorLongPubSubType::compute_key(
             UnionDiscriminatorLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorLong_max_key_cdr_typesize > 16)
     {
@@ -5404,7 +5433,8 @@ bool UnionDiscriminatorULongPubSubType::compute_key(
             UnionDiscriminatorULong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorULong_max_key_cdr_typesize > 16)
     {
@@ -5584,7 +5614,8 @@ bool UnionDiscriminatorLongLongPubSubType::compute_key(
             UnionDiscriminatorLongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorLongLong_max_key_cdr_typesize > 16)
     {
@@ -5764,7 +5795,8 @@ bool UnionDiscriminatorULongLongPubSubType::compute_key(
             UnionDiscriminatorULongLong_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorULongLong_max_key_cdr_typesize > 16)
     {
@@ -5944,7 +5976,8 @@ bool UnionDiscriminatorBooleanPubSubType::compute_key(
             UnionDiscriminatorBoolean_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorBoolean_max_key_cdr_typesize > 16)
     {
@@ -6124,7 +6157,8 @@ bool UnionDiscriminatorOctetPubSubType::compute_key(
             UnionDiscriminatorOctet_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorOctet_max_key_cdr_typesize > 16)
     {
@@ -6304,7 +6338,8 @@ bool UnionDiscriminatorCharPubSubType::compute_key(
             UnionDiscriminatorChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorChar_max_key_cdr_typesize > 16)
     {
@@ -6484,7 +6519,8 @@ bool UnionDiscriminatorWCharPubSubType::compute_key(
             UnionDiscriminatorWChar_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorWChar_max_key_cdr_typesize > 16)
     {
@@ -6664,7 +6700,8 @@ bool UnionDiscriminatorEnumPubSubType::compute_key(
             UnionDiscriminatorEnum_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorEnum_max_key_cdr_typesize > 16)
     {
@@ -6844,7 +6881,8 @@ bool UnionDiscriminatorEnumLabelPubSubType::compute_key(
             UnionDiscriminatorEnumLabel_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorEnumLabel_max_key_cdr_typesize > 16)
     {
@@ -7024,7 +7062,8 @@ bool UnionDiscriminatorAliasPubSubType::compute_key(
             UnionDiscriminatorAlias_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionDiscriminatorAlias_max_key_cdr_typesize > 16)
     {
@@ -7204,7 +7243,8 @@ bool UnionSeveralFieldsPubSubType::compute_key(
             UnionSeveralFields_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionSeveralFields_max_key_cdr_typesize > 16)
     {
@@ -7384,7 +7424,8 @@ bool UnionSeveralFieldsWithDefaultPubSubType::compute_key(
             UnionSeveralFieldsWithDefault_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionSeveralFieldsWithDefault_max_key_cdr_typesize > 16)
     {

--- a/test/feature/dynamic_types/CMakeLists.txt
+++ b/test/feature/dynamic_types/CMakeLists.txt
@@ -29,6 +29,7 @@ set(DYNAMIC_TYPES_DDS_TYPES_TEST_SOURCE
     dds_types_tests/DynamicTypesEnumerationsDDSTypesTests.cpp
     dds_types_tests/DynamicTypesFinalDDSTypesTests.cpp
     dds_types_tests/DynamicTypesInheritanceDDSTypesTests.cpp
+    dds_types_tests/DynamicTypesKeyDDSTypesTests.cpp
     dds_types_tests/DynamicTypesMapsDDSTypesTests.cpp
     dds_types_tests/DynamicTypesMutableDDSTypesTests.cpp
     dds_types_tests/DynamicTypesPrimitivesDDSTypesTests.cpp
@@ -54,6 +55,8 @@ set(DYNAMIC_TYPES_DDS_TYPES_TEST_SOURCE
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/helpers/basic_inner_typesTypeObjectSupport.cxx
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/inheritancePubSubTypes.cxx
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/inheritanceTypeObjectSupport.cxx
+    ${PROJECT_SOURCE_DIR}/test/dds-types-test/keyPubSubTypes.cxx
+    ${PROJECT_SOURCE_DIR}/test/dds-types-test/keyTypeObjectSupport.cxx
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/mapsPubSubTypes.cxx
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/mapsTypeObjectSupport.cxx
     ${PROJECT_SOURCE_DIR}/test/dds-types-test/mutablePubSubTypes.cxx
@@ -72,8 +75,6 @@ set(DYNAMIC_TYPES_DDS_TYPES_TEST_SOURCE
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/constantsTypeObjectSupport.cxx
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/declarationsPubSubTypes.cxx
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/externalPubSubTypes.cxx
-    # ${PROJECT_SOURCE_DIR}/test/dds-types-test/keyPubSubTypes.cxx
-    # ${PROJECT_SOURCE_DIR}/test/dds-types-test/keyTypeObjectSupport.cxx
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/member_idPubSubTypes.cxx
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/member_idTypeObjectSupport.cxx
     # ${PROJECT_SOURCE_DIR}/test/dds-types-test/optionalPubSubTypes.cxx

--- a/test/feature/dynamic_types/DynamicTypesDDSTypesTest.hpp
+++ b/test/feature/dynamic_types/DynamicTypesDDSTypesTest.hpp
@@ -135,6 +135,17 @@ public:
         ASSERT_TRUE(dyn_pubsubType.deserialize(static_payload, &data2));
         EXPECT_TRUE(data2->equals(data));
 
+        // Check key hash calculation
+        if (static_pubsubType.get()->is_compute_key_provided)
+        {
+            eprosima::fastdds::rtps::InstanceHandle_t static_ih;
+            eprosima::fastdds::rtps::InstanceHandle_t dyn_ih;
+            ASSERT_TRUE(static_pubsubType.compute_key(&data_static, static_ih));
+            ASSERT_TRUE(dyn_pubsubType.compute_key(&data, dyn_ih));
+            EXPECT_NE(static_ih, eprosima::fastdds::dds::InstanceHandle_t());
+            EXPECT_EQ(static_ih, dyn_ih);
+        }
+
         EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data1), RETCODE_OK);
         EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data2), RETCODE_OK);
     }

--- a/test/feature/dynamic_types/DynamicTypesDDSTypesTest.hpp
+++ b/test/feature/dynamic_types/DynamicTypesDDSTypesTest.hpp
@@ -107,7 +107,8 @@ public:
             DynamicData::_ref_type& data,
             DataRepresentationId data_representation,
             static_data& data_static,
-            static_pubsub& static_pubsubType)
+            static_pubsub& static_pubsubType,
+            uint8_t ihandle_bytes_to_compare = rtps::RTPS_KEY_HASH_SIZE)
     {
         TypeSupport dyn_pubsubType {new DynamicPubSubType(type)};
 
@@ -143,7 +144,10 @@ public:
             ASSERT_TRUE(static_pubsubType.compute_key(&data_static, static_ih));
             ASSERT_TRUE(dyn_pubsubType.compute_key(&data, dyn_ih));
             EXPECT_NE(static_ih, eprosima::fastdds::dds::InstanceHandle_t());
-            EXPECT_EQ(static_ih, dyn_ih);
+            // Big endian target
+            const rtps::octet* static_ih_start = static_ih.value + rtps::RTPS_KEY_HASH_SIZE - ihandle_bytes_to_compare;
+            const rtps::octet* dyn_ih_start = dyn_ih.value + rtps::RTPS_KEY_HASH_SIZE - ihandle_bytes_to_compare;
+            ASSERT_EQ(memcmp(static_ih_start, dyn_ih_start, ihandle_bytes_to_compare), 0);
         }
 
         EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data1), RETCODE_OK);

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesKeyDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesKeyDDSTypesTests.cpp
@@ -1,0 +1,1201 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "../DynamicTypesDDSTypesTest.hpp"
+#include "../../../dds-types-test/keyPubSubTypes.hpp"
+#include "../../../dds-types-test/keyTypeObjectSupport.hpp"
+#include <fastdds/dds/xtypes/dynamic_types/DynamicData.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicDataFactory.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicType.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/MemberDescriptor.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/TypeDescriptor.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+constexpr const char* struct_short_name = "KeyedShortStruct";
+constexpr const char* struct_ushort_name = "KeyedUShortStruct";
+constexpr const char* struct_long_name = "KeyedLongStruct";
+constexpr const char* struct_ulong_name = "KeyedULongStruct";
+constexpr const char* struct_long_long_name = "KeyedLongLongStruct";
+constexpr const char* struct_ulong_long_name = "KeyedULongLongStruct";
+constexpr const char* struct_float_name = "KeyedFloatStruct";
+constexpr const char* struct_double_name = "KeyedDoubleStruct";
+constexpr const char* struct_long_double_name = "KeyedLongDoubleStruct";
+constexpr const char* struct_boolean_name = "KeyedBooleanStruct";
+constexpr const char* struct_byte_name = "KeyedOctetStruct";
+constexpr const char* struct_char_name = "KeyedCharStruct";
+constexpr const char* struct_wchar_name = "KeyedWCharStruct";
+constexpr const char* struct_empty_name = "KeyedEmptyStruct";
+constexpr const char* struct_empty_inheritance_name = "KeyedEmptyInheritanceStruct";
+constexpr const char* struct_inheritance_name = "KeyedInheritanceStruct";
+constexpr const char* struct_inheritance_empty_name = "InheritanceKeyedEmptyStruct";
+constexpr const char* struct_final_name = "KeyedFinal";
+constexpr const char* struct_appendable_name = "KeyedAppendable";
+constexpr const char* struct_mutable_name = "KeyedMutable";
+
+constexpr const char* var_key_short_name = "key_short";
+constexpr const char* var_key_ushort_name = "key_ushort";
+constexpr const char* var_key_long_name = "key_long";
+constexpr const char* var_key_ulong_name = "key_ulong";
+constexpr const char* var_key_long_long_name = "key_longlong";
+constexpr const char* var_key_ulong_long_name = "key_ulonglong";
+constexpr const char* var_key_float_name = "key_float";
+constexpr const char* var_key_double_name = "key_double";
+constexpr const char* var_key_long_double_name = "key_longdouble";
+constexpr const char* var_key_boolean_name = "key_boolean";
+constexpr const char* var_key_byte_name = "key_octet";
+constexpr const char* var_key_char_name = "key_char8";
+constexpr const char* var_key_wchar_name = "key_char16";
+constexpr const char* var_key_str_name = "key_str";
+constexpr const char* var_var_str_name = "var_str";
+constexpr const char* var_key_string_name = "key_string";
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedShortStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_short_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int16_t value {2};
+    int16_t test_value {0};
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedShortStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedShortStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_short(), test_value);
+        EXPECT_EQ(struct_data.var_short(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedShortStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedUShortStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_ushort_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_ushort_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_ushort_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT16));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    uint16_t value {2};
+    uint16_t test_value {0};
+    EXPECT_EQ(data->set_uint16_value(data->get_member_id_by_name(var_key_ushort_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint16_value(test_value, data->get_member_id_by_name(var_key_ushort_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_uint16_value(data->get_member_id_by_name(var_ushort_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint16_value(test_value, data->get_member_id_by_name(var_ushort_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedUShortStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedUShortStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_ushort(), test_value);
+        EXPECT_EQ(struct_data.var_ushort(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedUShortStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedLongStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_long_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int32_t value {2};
+    int32_t test_value {0};
+    EXPECT_EQ(data->set_int32_value(data->get_member_id_by_name(var_key_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test_value, data->get_member_id_by_name(var_key_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_int32_value(data->get_member_id_by_name(var_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test_value, data->get_member_id_by_name(var_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedLongStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedLongStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_long(), test_value);
+        EXPECT_EQ(struct_data.var_long(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedLongStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedULongStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_ulong_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_ulong_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_ulong_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT32));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    uint32_t value {2};
+    uint32_t test_value {0};
+    EXPECT_EQ(data->set_uint32_value(data->get_member_id_by_name(var_key_ulong_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint32_value(test_value, data->get_member_id_by_name(var_key_ulong_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_uint32_value(data->get_member_id_by_name(var_ulong_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint32_value(test_value, data->get_member_id_by_name(var_ulong_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedULongStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedULongStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_ulong(), test_value);
+        EXPECT_EQ(struct_data.var_ulong(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedULongStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedLongLongStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_long_long_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT64));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_long_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT64));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int64_t value {2};
+    int64_t test_value {0};
+
+    EXPECT_EQ(data->set_int64_value(data->get_member_id_by_name(var_key_long_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int64_value(test_value, data->get_member_id_by_name(var_key_long_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_int64_value(data->get_member_id_by_name(var_long_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int64_value(test_value, data->get_member_id_by_name(var_long_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedLongLongStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedLongLongStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_longlong(), test_value);
+        EXPECT_EQ(struct_data.var_longlong(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedLongLongStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedULongLongStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_ulong_long_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_ulong_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT64));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_ulong_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_UINT64));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    uint64_t value {2};
+    uint64_t test_value {0};
+    EXPECT_EQ(data->set_uint64_value(data->get_member_id_by_name(var_key_ulong_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint64_value(test_value, data->get_member_id_by_name(var_key_ulong_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_uint64_value(data->get_member_id_by_name(var_ulong_long_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint64_value(test_value, data->get_member_id_by_name(var_ulong_long_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedULongLongStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedULongLongStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_ulonglong(), test_value);
+        EXPECT_EQ(struct_data.var_ulonglong(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedULongLongStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedFloatStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_float_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_float_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT32));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_float_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT32));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    float value {2};
+    float test_value {0};
+    EXPECT_EQ(data->set_float32_value(data->get_member_id_by_name(var_key_float_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float32_value(test_value, data->get_member_id_by_name(var_key_float_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_float32_value(data->get_member_id_by_name(var_float_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float32_value(test_value, data->get_member_id_by_name(var_float_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedFloatStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedFloatStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_float(), test_value);
+        EXPECT_EQ(struct_data.var_float(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedFloatStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedDoubleStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_double_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_double_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT64));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_double_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT64));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    double value {2};
+    double test_value {0};
+    EXPECT_EQ(data->set_float64_value(data->get_member_id_by_name(var_key_double_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float64_value(test_value, data->get_member_id_by_name(var_key_double_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_float64_value(data->get_member_id_by_name(var_double_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float64_value(test_value, data->get_member_id_by_name(var_double_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedDoubleStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedDoubleStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_double(), test_value);
+        EXPECT_EQ(struct_data.var_double(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedDoubleStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedLongDoubleStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_long_double_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_double_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT128));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_long_double_name);
+    member_descriptor->type(factory->get_primitive_type(TK_FLOAT128));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    long double value {2};
+    long double test_value {0};
+    EXPECT_EQ(data->set_float128_value(data->get_member_id_by_name(var_key_long_double_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float128_value(test_value, data->get_member_id_by_name(var_key_long_double_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_float128_value(data->get_member_id_by_name(var_long_double_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_float128_value(test_value, data->get_member_id_by_name(var_long_double_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedLongDoubleStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedLongDoubleStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_longdouble(), test_value);
+        EXPECT_EQ(struct_data.var_longdouble(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedLongDoubleStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedBooleanStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_boolean_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_boolean_name);
+    member_descriptor->type(factory->get_primitive_type(TK_BOOLEAN));
+    member_descriptor->is_key(true);
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_bool_name);
+    member_descriptor->type(factory->get_primitive_type(TK_BOOLEAN));
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    bool value = true;
+    bool test_value = false;
+    EXPECT_EQ(data->set_boolean_value(data->get_member_id_by_name(var_key_boolean_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_boolean_value(test_value, data->get_member_id_by_name(var_key_boolean_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_boolean_value(data->get_member_id_by_name(var_bool_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_boolean_value(test_value, data->get_member_id_by_name(var_bool_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedBooleanStruct alias_data;
+        TypeSupport static_pubsubType {new KeyedBooleanStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, alias_data, static_pubsubType);
+        EXPECT_EQ(alias_data.key_boolean(), test_value);
+        EXPECT_EQ(alias_data.var_boolean(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedBooleanStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedOctetStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_byte_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_byte_name);
+    member_descriptor->type(factory->get_primitive_type(TK_BYTE));
+    member_descriptor->is_key(true);
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_byte_name);
+    member_descriptor->type(factory->get_primitive_type(TK_BYTE));
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    eprosima::fastdds::rtps::octet value {2};
+    eprosima::fastdds::rtps::octet test_value {0};
+    EXPECT_EQ(data->set_byte_value(data->get_member_id_by_name(var_key_byte_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_byte_value(test_value, data->get_member_id_by_name(var_key_byte_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_byte_value(data->get_member_id_by_name(var_byte_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_byte_value(test_value, data->get_member_id_by_name(var_byte_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedOctetStruct alias_data;
+        TypeSupport static_pubsubType {new KeyedOctetStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, alias_data, static_pubsubType);
+        EXPECT_EQ(alias_data.key_octet(), test_value);
+        EXPECT_EQ(alias_data.var_octet(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedOctetStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedCharStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_char_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_char_name);
+    member_descriptor->type(factory->get_primitive_type(TK_CHAR8));
+    member_descriptor->is_key(true);
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_char_name);
+    member_descriptor->type(factory->get_primitive_type(TK_CHAR8));
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    char value = 'a';
+    char test_value = 'b';
+    EXPECT_EQ(data->set_char8_value(data->get_member_id_by_name(var_key_char_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_char8_value(test_value, data->get_member_id_by_name(var_key_char_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_char8_value(data->get_member_id_by_name(var_char_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_char8_value(test_value, data->get_member_id_by_name(var_char_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedCharStruct alias_data;
+        TypeSupport static_pubsubType {new KeyedCharStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, alias_data, static_pubsubType);
+        EXPECT_EQ(alias_data.key_char8(), test_value);
+        EXPECT_EQ(alias_data.var_char8(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedCharStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedWCharStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_wchar_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_wchar_name);
+    member_descriptor->type(factory->get_primitive_type(TK_CHAR16));
+    member_descriptor->is_key(true);
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_wchar_name);
+    member_descriptor->type(factory->get_primitive_type(TK_CHAR16));
+    ASSERT_EQ(RETCODE_OK, type_builder->add_member(member_descriptor));
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    wchar_t value = L'a';
+    wchar_t test_value = L'b';
+    EXPECT_EQ(data->set_char16_value(data->get_member_id_by_name(var_key_wchar_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_char16_value(test_value, data->get_member_id_by_name(var_key_wchar_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_char16_value(data->get_member_id_by_name(var_wchar_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_char16_value(test_value, data->get_member_id_by_name(var_wchar_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedWCharStruct alias_data;
+        TypeSupport static_pubsubType {new KeyedWCharStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, alias_data, static_pubsubType);
+        EXPECT_EQ(alias_data.key_char16(), test_value);
+        EXPECT_EQ(alias_data.var_char16(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedWCharStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedEmptyStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_empty_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int16_t value {2};
+    int16_t test_value {0};
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedEmptyStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedEmptyStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_short(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedEmptyStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedEmptyInheritanceStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_empty_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type base_type {type_builder->build()};
+
+    type_descriptor = traits<TypeDescriptor>::make_shared();
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_empty_inheritance_name);
+    type_descriptor->base_type(base_type);
+    type_builder = factory->create_type(type_descriptor);
+    ASSERT_TRUE(type_builder);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_str_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_var_str_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int16_t value {2};
+    int16_t test_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_key_str_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_key_str_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_var_str_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_var_str_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedEmptyInheritanceStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedEmptyInheritanceStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_short(), test_value);
+        EXPECT_EQ(struct_data.key_str(), test_str_value);
+        EXPECT_EQ(struct_data.var_str(), test_str_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedEmptyInheritanceStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedInheritanceStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_short_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type base_type {type_builder->build()};
+
+    type_descriptor = traits<TypeDescriptor>::make_shared();
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_inheritance_name);
+    type_descriptor->base_type(base_type);
+    type_builder = factory->create_type(type_descriptor);
+    ASSERT_TRUE(type_builder);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_str_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_var_str_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int16_t value {2};
+    int16_t test_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_key_str_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_key_str_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_var_str_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_var_str_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedInheritanceStruct struct_data;
+        TypeSupport static_pubsubType {new KeyedInheritanceStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_short(), test_value);
+        EXPECT_EQ(struct_data.var_short(), test_value);
+        EXPECT_EQ(struct_data.key_str(), test_str_value);
+        EXPECT_EQ(struct_data.var_str(), test_str_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedInheritanceStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_InheritanceKeyedEmptyStruct)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_short_name);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type base_type {type_builder->build()};
+
+    type_descriptor = traits<TypeDescriptor>::make_shared();
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_inheritance_empty_name);
+    type_descriptor->base_type(base_type);
+    type_builder = factory->create_type(type_descriptor);
+    ASSERT_TRUE(type_builder);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int16_t value {2};
+    int16_t test_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_short_name), value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_value, data->get_member_id_by_name(var_short_name)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        InheritanceKeyedEmptyStruct struct_data;
+        TypeSupport static_pubsubType {new InheritanceKeyedEmptyStructPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_short(), test_value);
+        EXPECT_EQ(struct_data.var_short(), test_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_InheritanceKeyedEmptyStruct_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedFinal)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_final_name);
+    type_descriptor->extensibility_kind(ExtensibilityKind::FINAL);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
+    member_descriptor->is_key(true);
+    member_descriptor->id(2);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    member_descriptor->id(1);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_string_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    member_descriptor->is_key(true);
+    member_descriptor->id(0);
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int32_t l_value {3};
+    int32_t test_l_value {0};
+    int16_t s_value {2};
+    int16_t test_s_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int32_value(data->get_member_id_by_name(var_key_long_name), l_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test_l_value, data->get_member_id_by_name(var_key_long_name)), RETCODE_OK);
+    EXPECT_EQ(l_value, test_l_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), s_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_s_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(s_value, test_s_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_key_string_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_key_string_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedFinal struct_data;
+        TypeSupport static_pubsubType {new KeyedFinalPubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_long(), test_l_value);
+        EXPECT_EQ(struct_data.key_short(), test_s_value);
+        EXPECT_EQ(struct_data.key_string(), test_str_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedFinal_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedAppendable)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_appendable_name);
+    type_descriptor->extensibility_kind(ExtensibilityKind::APPENDABLE);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
+    member_descriptor->is_key(true);
+    member_descriptor->id(2);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    member_descriptor->id(1);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_string_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    member_descriptor->is_key(true);
+    member_descriptor->id(0);
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int32_t l_value {3};
+    int32_t test_l_value {0};
+    int16_t s_value {2};
+    int16_t test_s_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int32_value(data->get_member_id_by_name(var_key_long_name), l_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test_l_value, data->get_member_id_by_name(var_key_long_name)), RETCODE_OK);
+    EXPECT_EQ(l_value, test_l_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), s_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_s_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(s_value, test_s_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_key_string_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_key_string_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedAppendable struct_data;
+        TypeSupport static_pubsubType {new KeyedAppendablePubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_long(), test_l_value);
+        EXPECT_EQ(struct_data.key_short(), test_s_value);
+        EXPECT_EQ(struct_data.key_string(), test_str_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedAppendable_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedMutable)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(struct_mutable_name);
+    type_descriptor->extensibility_kind(ExtensibilityKind::MUTABLE);
+    DynamicTypeBuilder::_ref_type type_builder {factory->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_key_long_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT32));
+    member_descriptor->is_key(true);
+    member_descriptor->id(2);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_short_name);
+    member_descriptor->type(factory->get_primitive_type(TK_INT16));
+    member_descriptor->is_key(true);
+    member_descriptor->id(1);
+    type_builder->add_member(member_descriptor);
+
+    member_descriptor = traits<MemberDescriptor>::make_shared();
+    member_descriptor->name(var_key_string_name);
+    member_descriptor->type(factory->create_string_type(static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+    member_descriptor->is_key(true);
+    member_descriptor->id(0);
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    int32_t l_value {3};
+    int32_t test_l_value {0};
+    int16_t s_value {2};
+    int16_t test_s_value {0};
+    std::string str_value {"my_string"};
+    std::string test_str_value;
+    EXPECT_EQ(data->set_int32_value(data->get_member_id_by_name(var_key_long_name), l_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int32_value(test_l_value, data->get_member_id_by_name(var_key_long_name)), RETCODE_OK);
+    EXPECT_EQ(l_value, test_l_value);
+    EXPECT_EQ(data->set_int16_value(data->get_member_id_by_name(var_key_short_name), s_value), RETCODE_OK);
+    EXPECT_EQ(data->get_int16_value(test_s_value, data->get_member_id_by_name(var_key_short_name)), RETCODE_OK);
+    EXPECT_EQ(s_value, test_s_value);
+    EXPECT_EQ(data->set_string_value(data->get_member_id_by_name(var_key_string_name), str_value), RETCODE_OK);
+    EXPECT_EQ(data->get_string_value(test_str_value, data->get_member_id_by_name(var_key_string_name)), RETCODE_OK);
+    EXPECT_EQ(str_value, test_str_value);
+
+    for (auto encoding : encodings)
+    {
+        KeyedMutable struct_data;
+        TypeSupport static_pubsubType {new KeyedMutablePubSubType()};
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.key_long(), test_l_value);
+        EXPECT_EQ(struct_data.key_short(), test_s_value);
+        EXPECT_EQ(struct_data.key_string(), test_str_value);
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_KeyedMutable_type_identifier(static_type_ids);
+    check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+} // dds
+} // fastdds
+} // eprosima

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesKeyDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesKeyDDSTypesTests.cpp
@@ -515,7 +515,10 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_KeyedLongDoubleStruct)
     {
         KeyedLongDoubleStruct struct_data;
         TypeSupport static_pubsubType {new KeyedLongDoubleStructPubSubType()};
-        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        // Experimental analysis showed that long double is mostly accepted to truly
+        // use/have 10 bytes across implementations.
+        // Compare only those number of bytes of the instance handle.
+        check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType, 10);
         EXPECT_EQ(struct_data.key_longdouble(), test_value);
         EXPECT_EQ(struct_data.var_longdouble(), test_value);
     }

--- a/test/profiling/allocations/AllocTestTypeCdrAux.ipp
+++ b/test/profiling/allocations/AllocTestTypeCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AllocTestType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
 }
 
 

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool AllocTestTypePubSubType::compute_key(
             AllocTestType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AllocTestType_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.ipp
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.ipp
@@ -217,8 +217,39 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructType& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.char_field();
+
+                        scdr << data.uint8_field();
+
+                        scdr << data.int16_field();
+
+                        scdr << data.uint16_field();
+
+                        scdr << data.int32_field();
+
+                        scdr << data.uint32_field();
+
+                        scdr << data.int64_field();
+
+                        scdr << data.uint64_field();
+
+                        scdr << data.float_field();
+
+                        scdr << data.double_field();
+
+                        scdr << data.long_double_field();
+
+                        scdr << data.bool_field();
+
+                        scdr << data.string_field();
+
+                        scdr << data.enum_field();
+
+                        scdr << data.enum2_field();
+
 }
 
 
@@ -799,8 +830,189 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ContentFilterTestType& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const StructType& data);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.char_field();
+
+                        scdr << data.uint8_field();
+
+                        scdr << data.int16_field();
+
+                        scdr << data.uint16_field();
+
+                        scdr << data.int32_field();
+
+                        scdr << data.uint32_field();
+
+                        scdr << data.int64_field();
+
+                        scdr << data.uint64_field();
+
+                        scdr << data.float_field();
+
+                        scdr << data.double_field();
+
+                        scdr << data.long_double_field();
+
+                        scdr << data.bool_field();
+
+                        scdr << data.string_field();
+
+                        scdr << data.enum_field();
+
+                        scdr << data.enum2_field();
+
+                        serialize_key(scdr, data.struct_field());
+
+                        scdr << data.array_char_field();
+
+                        scdr << data.array_uint8_field();
+
+                        scdr << data.array_int16_field();
+
+                        scdr << data.array_uint16_field();
+
+                        scdr << data.array_int32_field();
+
+                        scdr << data.array_uint32_field();
+
+                        scdr << data.array_int64_field();
+
+                        scdr << data.array_uint64_field();
+
+                        scdr << data.array_float_field();
+
+                        scdr << data.array_double_field();
+
+                        scdr << data.array_long_double_field();
+
+                        scdr << data.array_bool_field();
+
+                        scdr << data.array_string_field();
+
+                        scdr << data.array_enum_field();
+
+                        scdr << data.array_enum2_field();
+
+                        scdr << data.array_struct_field();
+
+                        scdr << data.bounded_sequence_char_field();
+
+                        scdr << data.bounded_sequence_uint8_field();
+
+                        scdr << data.bounded_sequence_int16_field();
+
+                        scdr << data.bounded_sequence_uint16_field();
+
+                        scdr << data.bounded_sequence_int32_field();
+
+                        scdr << data.bounded_sequence_uint32_field();
+
+                        scdr << data.bounded_sequence_int64_field();
+
+                        scdr << data.bounded_sequence_uint64_field();
+
+                        scdr << data.bounded_sequence_float_field();
+
+                        scdr << data.bounded_sequence_double_field();
+
+                        scdr << data.bounded_sequence_long_double_field();
+
+                        scdr << data.bounded_sequence_bool_field();
+
+                        scdr << data.bounded_sequence_string_field();
+
+                        scdr << data.bounded_sequence_enum_field();
+
+                        scdr << data.bounded_sequence_enum2_field();
+
+                        scdr << data.bounded_sequence_struct_field();
+
+                        scdr << data.unbounded_sequence_char_field();
+
+                        scdr << data.unbounded_sequence_uint8_field();
+
+                        scdr << data.unbounded_sequence_int16_field();
+
+                        scdr << data.unbounded_sequence_uint16_field();
+
+                        scdr << data.unbounded_sequence_int32_field();
+
+                        scdr << data.unbounded_sequence_uint32_field();
+
+                        scdr << data.unbounded_sequence_int64_field();
+
+                        scdr << data.unbounded_sequence_uint64_field();
+
+                        scdr << data.unbounded_sequence_float_field();
+
+                        scdr << data.unbounded_sequence_double_field();
+
+                        scdr << data.unbounded_sequence_long_double_field();
+
+                        scdr << data.unbounded_sequence_bool_field();
+
+                        scdr << data.unbounded_sequence_string_field();
+
+                        scdr << data.unbounded_sequence_enum_field();
+
+                        scdr << data.unbounded_sequence_enum2_field();
+
+                        scdr << data.unbounded_sequence_struct_field();
+
 }
 
 

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool StructTypePubSubType::compute_key(
             StructType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructType_max_key_cdr_typesize > 16)
     {
@@ -366,7 +367,8 @@ bool ContentFilterTestTypePubSubType::compute_key(
             ContentFilterTestType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ContentFilterTestType_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structCdrAux.ipp
@@ -129,8 +129,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AliasStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_long();
+
+                        scdr << data.my_recursive_short();
+
+                        scdr << data.my_recursive_boolean();
+
+                        scdr << data.my_boolean();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool AliasStructPubSubType::compute_key(
             AliasStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AliasStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NestedArrayElement& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_string();
+
 }
 
 
@@ -197,8 +200,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ComplexArrayElement& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const NestedArrayElement& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_number();
+
+                        scdr << data.my_boolean();
+
+                        serialize_key(scdr, data.my_nested_element());
+
 }
 
 
@@ -297,8 +311,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_basic_array();
+
+                        scdr << data.my_multidimensional_array();
+
+                        scdr << data.my_complex_array();
+
+                        scdr << data.my_multidimensional_complex_array();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool NestedArrayElementPubSubType::compute_key(
             NestedArrayElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NestedArrayElement_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ComplexArrayElementPubSubType::compute_key(
             ComplexArrayElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ComplexArrayElement_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool ArrayStructPubSubType::compute_key(
             ArrayStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ArrayStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BitmaskStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_bitmask();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool BitmaskStructPubSubType::compute_key(
             BitmaskStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BitmaskStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structCdrAux.ipp
@@ -163,8 +163,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const BitsetStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_bitset();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool BitsetStructPubSubType::compute_key(
             BitsetStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || BitsetStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const EnumStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.enum_value();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool EnumStructPubSubType::compute_key(
             EnumStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || EnumStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const FinalStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_value();
+
 }
 
 
@@ -181,8 +184,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MutableStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_value();
+
 }
 
 
@@ -257,8 +263,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppendableStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_value();
+
 }
 
 
@@ -349,8 +358,27 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ExtensibilityStruct& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const FinalStruct& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const MutableStruct& data);
+
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const AppendableStruct& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.my_final_struct());
+
+                        serialize_key(scdr, data.my_mutable_struct());
+
+                        serialize_key(scdr, data.my_appendable_struct());
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool FinalStructPubSubType::compute_key(
             FinalStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || FinalStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool MutableStructPubSubType::compute_key(
             MutableStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MutableStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool AppendableStructPubSubType::compute_key(
             AppendableStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppendableStruct_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool ExtensibilityStructPubSubType::compute_key(
             ExtensibilityStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ExtensibilityStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structCdrAux.ipp
@@ -121,12 +121,13 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ImportantStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.my_first_value();
+                        scdr << data.my_first_value();
 
 
-                            scdr << data.my_third_value();
+                        scdr << data.my_third_value();
 
 }
 
@@ -226,13 +227,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const KeyStruct& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const ImportantStruct& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
-                            scdr << data.my_long();
+                        scdr << data.my_long();
 
-                            scdr << data.my_string();
+                        scdr << data.my_string();
 
-                                serialize_key(scdr, data.my_important_struct());
+                        serialize_key(scdr, data.my_important_struct());
 
 }
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ImportantStructPubSubType::compute_key(
             ImportantStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ImportantStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool KeyStructPubSubType::compute_key(
             KeyStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || KeyStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ValueStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.value();
+
 }
 
 
@@ -205,8 +208,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MapStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_basic_map();
+
+                        scdr << data.my_complex_map();
+
+                        scdr << data.my_basic_bounded_map();
+
+                        scdr << data.my_complex_bounded_map();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool ValueStructPubSubType::compute_key(
             ValueStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ValueStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool MapStructPubSubType::compute_key(
             MapStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MapStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structCdrAux.ipp
@@ -217,8 +217,39 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const PrimitivesStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_bool();
+
+                        scdr << data.my_octet();
+
+                        scdr << data.my_char();
+
+                        scdr << data.my_wchar();
+
+                        scdr << data.my_long();
+
+                        scdr << data.my_ulong();
+
+                        scdr << data.my_int8();
+
+                        scdr << data.my_uint8();
+
+                        scdr << data.my_short();
+
+                        scdr << data.my_ushort();
+
+                        scdr << data.my_longlong();
+
+                        scdr << data.my_ulonglong();
+
+                        scdr << data.my_float();
+
+                        scdr << data.my_double();
+
+                        scdr << data.my_longdouble();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool PrimitivesStructPubSubType::compute_key(
             PrimitivesStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || PrimitivesStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NestedSequenceElement& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_string();
+
 }
 
 
@@ -197,8 +200,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ComplexSequenceElement& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const NestedSequenceElement& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_short();
+
+                        scdr << data.my_long();
+
+                        serialize_key(scdr, data.my_complex_element());
+
 }
 
 
@@ -297,8 +311,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const SequenceStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_basic_sequence();
+
+                        scdr << data.my_bounded_sequence();
+
+                        scdr << data.my_complex_sequence();
+
+                        scdr << data.my_complex_bounded_sequence();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool NestedSequenceElementPubSubType::compute_key(
             NestedSequenceElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NestedSequenceElement_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ComplexSequenceElementPubSubType::compute_key(
             ComplexSequenceElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ComplexSequenceElement_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool SequenceStructPubSubType::compute_key(
             SequenceStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || SequenceStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structCdrAux.ipp
@@ -129,8 +129,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StringStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_string();
+
+                        scdr << data.my_wstring();
+
+                        scdr << data.my_bounded_string();
+
+                        scdr << data.my_bounded_wstring();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool StringStructPubSubType::compute_key(
             StringStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StringStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structCdrAux.ipp
@@ -208,19 +208,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ParentStruct& data)
 {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const GrandparentStruct& data);
-
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.my_short();
-
-                        scdr << data.my_string();
-
-                        serialize_key(scdr, data.my_grandparent());
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const GrandparentStruct& data);
+    serialize_key(scdr, static_cast<const GrandparentStruct&>(data));
 }
 
 
@@ -414,18 +405,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructStruct& data)
 {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const NestedStructElement& data);
-
-
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.my_nested_element());
-
-                        scdr << data.my_char();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const ParentStruct& data);
+    serialize_key(scdr, static_cast<const ParentStruct&>(data));
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structCdrAux.ipp
@@ -105,8 +105,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const GrandparentStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_long();
+
 }
 
 
@@ -205,8 +208,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ParentStruct& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const GrandparentStruct& data);
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_short();
+
+                        scdr << data.my_string();
+
+                        serialize_key(scdr, data.my_grandparent());
+
 }
 
 
@@ -281,8 +295,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NestedStructElement& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_boolean();
+
 }
 
 
@@ -397,8 +414,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructStruct& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const NestedStructElement& data);
+
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        serialize_key(scdr, data.my_nested_element());
+
+                        scdr << data.my_char();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool GrandparentStructPubSubType::compute_key(
             GrandparentStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || GrandparentStruct_max_key_cdr_typesize > 16)
     {
@@ -364,7 +365,8 @@ bool ParentStructPubSubType::compute_key(
             ParentStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ParentStruct_max_key_cdr_typesize > 16)
     {
@@ -544,7 +546,8 @@ bool NestedStructElementPubSubType::compute_key(
             NestedStructElement_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NestedStructElement_max_key_cdr_typesize > 16)
     {
@@ -724,7 +727,8 @@ bool StructStructPubSubType::compute_key(
             StructStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || StructStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structCdrAux.ipp
@@ -355,8 +355,11 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_complex_union();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
@@ -184,7 +184,8 @@ bool UnionStructPubSubType::compute_key(
             UnionStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UnionStruct_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
@@ -217,8 +217,39 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const PrimitivesStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_bool();
+
+                        scdr << data.my_octet();
+
+                        scdr << data.my_char();
+
+                        scdr << data.my_wchar();
+
+                        scdr << data.my_long();
+
+                        scdr << data.my_ulong();
+
+                        scdr << data.my_int8();
+
+                        scdr << data.my_uint8();
+
+                        scdr << data.my_short();
+
+                        scdr << data.my_ushort();
+
+                        scdr << data.my_longlong();
+
+                        scdr << data.my_ulonglong();
+
+                        scdr << data.my_float();
+
+                        scdr << data.my_double();
+
+                        scdr << data.my_longdouble();
+
 }
 
 
@@ -879,8 +910,49 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AllStruct& data)
 {
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.my_string();
+
+                        scdr << data.my_wstring();
+
+                        scdr << data.my_bounded_string();
+
+                        scdr << data.my_bounded_wstring();
+
+                        scdr << data.my_enum();
+
+                        scdr << data.my_bitmask();
+
+                        scdr << data.my_aliased_struct();
+
+                        scdr << data.my_aliased_enum();
+
+                        scdr << data.my_aliased_bounded_string();
+
+                        scdr << data.my_recursive_alias();
+
+                        scdr << data.bitmask_sequence();
+
+                        scdr << data.enum_sequence();
+
+                        scdr << data.short_sequence();
+
+                        scdr << data.long_array();
+
+                        scdr << data.string_unbounded_map();
+
+                        scdr << data.string_alias_unbounded_map();
+
+                        scdr << data.short_long_map();
+
+                        scdr << data.inner_union();
+
+                        scdr << data.complex_union();
+
+                        scdr << data.my_bitset();
+
 }
 
 
@@ -987,8 +1059,26 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ComprehensiveType& data)
 {
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const AllStruct& data);
+
+
+
+
+
     static_cast<void>(scdr);
     static_cast<void>(data);
+                        scdr << data.index();
+
+                        serialize_key(scdr, data.inner_struct());
+
+                        scdr << data.complex_sequence();
+
+                        scdr << data.complex_array();
+
+                        scdr << data.complex_map();
+
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
@@ -910,49 +910,10 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AllStruct& data)
 {
-
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.my_string();
-
-                        scdr << data.my_wstring();
-
-                        scdr << data.my_bounded_string();
-
-                        scdr << data.my_bounded_wstring();
-
-                        scdr << data.my_enum();
-
-                        scdr << data.my_bitmask();
-
-                        scdr << data.my_aliased_struct();
-
-                        scdr << data.my_aliased_enum();
-
-                        scdr << data.my_aliased_bounded_string();
-
-                        scdr << data.my_recursive_alias();
-
-                        scdr << data.bitmask_sequence();
-
-                        scdr << data.enum_sequence();
-
-                        scdr << data.short_sequence();
-
-                        scdr << data.long_array();
-
-                        scdr << data.string_unbounded_map();
-
-                        scdr << data.string_alias_unbounded_map();
-
-                        scdr << data.short_long_map();
-
-                        scdr << data.inner_union();
-
-                        scdr << data.complex_union();
-
-                        scdr << data.my_bitset();
-
+    extern void serialize_key(
+            Cdr& scdr,
+            const PrimitivesStruct& data);
+    serialize_key(scdr, static_cast<const PrimitivesStruct&>(data));
 }
 
 

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
@@ -184,7 +184,8 @@ bool PrimitivesStructPubSubType::compute_key(
             PrimitivesStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || PrimitivesStruct_max_key_cdr_typesize > 16)
     {
@@ -373,7 +374,8 @@ bool AllStructPubSubType::compute_key(
             AllStruct_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AllStruct_max_key_cdr_typesize > 16)
     {
@@ -553,7 +555,8 @@ bool ComprehensiveTypePubSubType::compute_key(
             ComprehensiveType_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv1);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || ComprehensiveType_max_key_cdr_typesize > 16)
     {

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
@@ -3250,9 +3250,9 @@ TEST(TypeObjectUtilsTests, add_to_complete_struct_member_seq)
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_struct_member(member_seq, second));
     EXPECT_THROW(TypeObjectUtils::add_complete_struct_member(member_seq, second), InvalidArgumentError);
     EXPECT_EQ(3, member_seq.size());
-    EXPECT_EQ(first, member_seq[0]);
-    EXPECT_EQ(second, member_seq[1]);
-    EXPECT_EQ(third, member_seq[2]);
+    EXPECT_EQ(third, member_seq[0]);
+    EXPECT_EQ(first, member_seq[1]);
+    EXPECT_EQ(second, member_seq[2]);
 }
 
 // Test add element to UnionCaseLabelSeq
@@ -3308,9 +3308,9 @@ TEST(TypeObjectUtilsTests, add_to_complete_union_member_seq)
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_union_member(member_seq, second_member));
     EXPECT_THROW(TypeObjectUtils::add_complete_union_member(member_seq, second_member), InvalidArgumentError);
     EXPECT_EQ(3, member_seq.size());
-    EXPECT_EQ(first_member, member_seq[0]);
-    EXPECT_EQ(second_member, member_seq[1]);
-    EXPECT_EQ(third_member, member_seq[2]);
+    EXPECT_EQ(third_member, member_seq[0]);
+    EXPECT_EQ(first_member, member_seq[1]);
+    EXPECT_EQ(second_member, member_seq[2]);
 }
 
 // Test add element to CompleteAnnotationParameterSeq


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR increases the number of tests of the DynamicTypes feature for testing the new key hash calculation according to DDS-XTypes 1.3
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Depends on:

- eprosima/fast-dds-gen#381
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

