### PR TITLE
[21435] Solve SecurityManager memory issue

### DIFF
--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -332,6 +332,8 @@ CacheChange_t* WriterHistory::remove_change_and_reuse(
         return nullptr;
     }
 
+    std::lock_guard<RecursiveTimedMutex> guard(*mp_mutex);
+
     // Create a temporary reference change associated to the sequence number
     CacheChange_t ch;
     ch.sequenceNumber = sequence_number;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

A memory issue is reported by ASAN when running tests using security such as BlackboxTests_DDS_PIM.Security.BuiltinAuthenticationPlugin_second_participant_creation_loop.
 
The issue is that the events thread might call `SecurityManager::resend_handshake_message_token`, which internally calls `WriterHistory::remove_change_and_reuse`, the latter not being (atomically) thread safe. If at the same time a handshake is processed (`SecurityManager::on_process_handshake`) from another thread, this may resolve in a change being added to the aforementioned writer history. As a result a change is added to `History::m_changes` vector, which would invalidate the iterator dealt with in `WriterHistory::remove_change_and_reuse` without protection.

Two potential solutions are proposed:

- Take the history/endpoint mutex before calling `WriterHistory::remove_change_and_reuse` from the security manager, as it's done when calling `PDPServer::remove_change_from_history_nts`
- Protect `WriterHistory::remove_change_and_reuse` fully, converting it in an atomic thread-safe method. Note that since the functions internally called from within this method already take the mutex, no (new) deadlocks should be introduced.


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
