### PR TITLE
[19036] Link SHM locator kind with Fast DDS major version

### DIFF
--- a/include/fastdds/rtps/common/Locator.hpp
+++ b/include/fastdds/rtps/common/Locator.hpp
@@ -19,19 +19,18 @@
 #ifndef FASTDDS_RTPS_COMMON__LOCATOR_HPP
 #define FASTDDS_RTPS_COMMON__LOCATOR_HPP
 
-#include <fastdds/fastdds_dll.hpp>
-
-#include <fastdds/rtps/common/Types.hpp>
-#include <fastdds/utils/IPLocator.hpp>
-
-#include <fastdds/dds/log/Log.hpp>
-
-#include <sstream>
-#include <vector>
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
-#include <algorithm>
+#include <sstream>
+#include <vector>
+
+#include <fastdds/config.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/rtps/common/Types.hpp>
+#include <fastdds/utils/IPLocator.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -61,7 +60,7 @@ namespace rtps {
 /// TCP over IPv6 locator kind
 #define LOCATOR_KIND_TCPv6 8
 /// Shared memory locator kind
-#define LOCATOR_KIND_SHM 16
+#define LOCATOR_KIND_SHM 16 + FASTDDS_VERSION_MAJOR
 
 /**
  * @brief Class Locator_t, uniquely identifies a communication channel for a particular transport.

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -16,17 +16,19 @@
 #define _FASTDDS_SHAREDMEM_GLOBAL_H_
 
 #include <algorithm>
-#include <vector>
-#include <mutex>
 #include <memory>
+#include <mutex>
 #include <thread>
+#include <vector>
 
-#include <utils/shared_memory/SharedMemSegment.hpp>
-#include <utils/shared_memory/RobustExclusiveLock.hpp>
-#include <utils/shared_memory/RobustSharedLock.hpp>
-#include <utils/shared_memory/SharedMemWatchdog.hpp>
+#include <fastdds/config.hpp>
+#include <fastdds/rtps/common/Locator.hpp>
 
 #include <rtps/transport/shared_mem/MultiProducerConsumerRingBuffer.hpp>
+#include <utils/shared_memory/RobustExclusiveLock.hpp>
+#include <utils/shared_memory/RobustSharedLock.hpp>
+#include <utils/shared_memory/SharedMemSegment.hpp>
+#include <utils/shared_memory/SharedMemWatchdog.hpp>
 
 #define THREADID "(ID:" << std::this_thread::get_id() << ") "
 
@@ -92,6 +94,8 @@ public:
     typedef MultiProducerConsumerRingBuffer<BufferDescriptor>::Cell PortCell;
 
     static const uint32_t CURRENT_ABI_VERSION = 5;
+    static_assert(CURRENT_ABI_VERSION == (2 + FASTDDS_VERSION_MAJOR), "ABI is not correct");
+    static_assert(LOCATOR_KIND_SHM == (16 + FASTDDS_VERSION_MAJOR), "LOCATOR_KIND_SHM is not correct");
 
     struct PortNode
     {

--- a/versions.md
+++ b/versions.md
@@ -113,6 +113,7 @@ Forthcoming
 * DDS implementation of `eprosima::fastdds::Time_t` moved to `eprosima::fastdds::dds::Time_t`.
 * `TopicDataType::auto_fill_type_information` has been removed in favor of `fastdds.type_propagation` participant property.
 * Add new custom pid PID_PRODUCT_VERSION.
+* SHM locator kind is now linked to Fast DDS' major version.
 
 Version 2.14.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR links the definition of the SHM locator kind to the Fast DDS major version. That way, we avoid keeping SHM locators from participants of different majors, as the port structure will be different (the SHM port ABI version will change from major to major).

This PR fixes compatibility issues with 2.x versions when all the participants have an SHM transport without requiring further modifications on any 2.x version.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
    - A static assert is added to ensure the value
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
