### PR TITLE
[21437] Builtin data related improvements

### DIFF
--- a/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
@@ -138,7 +138,7 @@ struct PublicationBuiltinTopicData
     uint32_t max_serialized_size = 0;
 
     /// Network configuration
-    NetworkConfigSet_t loopback_transformation;
+    NetworkConfigSet_t loopback_transformation{};
 
 };
 

--- a/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp
@@ -54,6 +54,9 @@ struct PublicationBuiltinTopicData
     /// Type name
     fastcdr::string_255 type_name;
 
+    /// Topic kind
+    TopicKind_t topic_kind = TopicKind_t::NO_KEY;
+
     // DataWriter Qos
 
     /// Durability Qos, implemented in the library.

--- a/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
@@ -128,7 +128,7 @@ struct SubscriptionBuiltinTopicData
     RemoteLocatorList remote_locators;
 
     /// Network configuration
-    NetworkConfigSet_t loopback_transformation;
+    NetworkConfigSet_t loopback_transformation{};
 
     /// Expects Inline Qos
     bool expects_inline_qos = false;

--- a/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
+++ b/include/fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp
@@ -47,6 +47,9 @@ struct SubscriptionBuiltinTopicData
     /// Type name
     fastcdr::string_255 type_name;
 
+    /// Topic kind
+    TopicKind_t topic_kind = TopicKind_t::NO_KEY;
+
     // DataReader Qos
 
     /// Durability Qos, implemented in the library.

--- a/include/fastdds/rtps/participant/ParticipantDiscoveryInfo.hpp
+++ b/include/fastdds/rtps/participant/ParticipantDiscoveryInfo.hpp
@@ -26,8 +26,7 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-//!Enum ParticipantDiscoveryStatus, four different status for discovered participants.
-//!@ingroup RTPS_MODULE
+//! Enum ParticipantDiscoveryStatus, four different status for discovered participants.
 // *INDENT-OFF* eduponz: Does not understand the #if correctly and ends up removing the ;
 //                       at the end of the enum, which does not build.
 #if defined(_WIN32)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1706,7 +1706,7 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
 
     publication_data.topic_name = topic_->get_name();
     publication_data.type_name = topic_->get_type_name();
-    publication_data.topic_data = topic_->get_qos().topic_data();
+    publication_data.topic_kind = type_->is_compute_key_provided ? TopicKind_t::WITH_KEY : TopicKind_t::NO_KEY;
 
     // DataWriter qos
     publication_data.durability = qos_.durability();
@@ -1724,6 +1724,7 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
     // Publisher qos
     publication_data.presentation = publisher_->qos_.presentation();
     publication_data.partition = publisher_->qos_.partition();
+    publication_data.topic_data = topic_->get_qos().topic_data();
     publication_data.group_data = publisher_->qos_.group_data();
 
     // XTypes 1.3

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -2212,6 +2212,7 @@ ReturnCode_t DataReaderImpl::get_subscription_builtin_topic_data(
 
     subscription_data.topic_name = topic_->get_impl()->get_rtps_topic_name();
     subscription_data.type_name = topic_->get_type_name();
+    subscription_data.topic_kind = type_->is_compute_key_provided ? WITH_KEY : NO_KEY;
 
     // DataReader qos
     subscription_data.durability = qos_.durability();

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -127,6 +127,7 @@ void from_proxy_to_builtin(
 
     builtin_data.topic_name = proxy_data.topicName();
     builtin_data.type_name = proxy_data.typeName();
+    builtin_data.topic_kind = proxy_data.topicKind();
     builtin_data.durability = proxy_data.m_qos.m_durability;
     builtin_data.deadline = proxy_data.m_qos.m_deadline;
     builtin_data.latency_budget = proxy_data.m_qos.m_latencyBudget;
@@ -169,6 +170,7 @@ void from_proxy_to_builtin(
 
     builtin_data.topic_name = proxy_data.topicName();
     builtin_data.type_name = proxy_data.typeName();
+    builtin_data.topic_kind = proxy_data.topicKind();
     builtin_data.durability = proxy_data.m_qos.m_durability;
     builtin_data.durability_service = proxy_data.m_qos.m_durabilityService;
     builtin_data.deadline = proxy_data.m_qos.m_deadline;
@@ -213,6 +215,7 @@ void from_builtin_to_proxy(
 
     proxy_data.topicName(builtin_data.topic_name);
     proxy_data.typeName(builtin_data.type_name);
+    proxy_data.topicKind(builtin_data.topic_kind);
 
     qos.m_durability = builtin_data.durability;
     qos.m_durabilityService = builtin_data.durability_service;
@@ -257,6 +260,8 @@ void from_builtin_to_proxy(
 
     proxy_data.topicName(builtin_data.topic_name);
     proxy_data.typeName(builtin_data.type_name);
+    proxy_data.topicKind(builtin_data.topic_kind);
+
     qos.m_durability = builtin_data.durability;
     qos.m_deadline = builtin_data.deadline;
     qos.m_latencyBudget = builtin_data.latency_budget;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2440,7 +2440,7 @@ bool RTPSParticipantImpl::get_new_entity_id(
     }
     else
     {
-        return !existsEntityId(entityId, READER) && !existsEntityId(entityId, WRITER);
+        return !entity_id_exists(entityId, READER) && !entity_id_exists(entityId, WRITER);
     }
 
     return true;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1693,7 +1693,7 @@ bool RTPSParticipantImpl::check_entity_id_conditions(
         if (!ret)
         {
             EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT,
-                "Endpoint's entityId is not consistent with the topic kind");
+                    "Endpoint's entityId is not consistent with the topic kind");
         }
     }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -643,7 +643,7 @@ private:
      * @param kind Endpoint Kind.
      * @return True if exists.
      */
-    bool existsEntityId(
+    bool entity_id_exists(
             const EntityId_t& ent,
             EndpointKind_t kind) const;
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -648,14 +648,14 @@ private:
             EndpointKind_t kind) const;
 
     /**
-     * Method to check if the EnityId conditions are coherent with the endpoint:
+     * Method to check if the EntityId conditions are coherent with the endpoint:
      * - Checks if it already exists in this RTPSParticipant.
      * - It is consistent with the topic kind of the endpoint.
      *
-     * @param entity_id EnityId to check
+     * @param entity_id EntityId to check
      * @param endpoint_kind Endpoint Kind.
      * @param topic_kind Topic kind.
-     * @return True if the EnityId conditions are correct.
+     * @return True if the EntityId conditions are correct.
      */
     bool check_entity_id_conditions(
             const EntityId_t& entity_id,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -648,6 +648,21 @@ private:
             EndpointKind_t kind) const;
 
     /**
+     * Method to check if the EnityId conditions are coherent with the endpoint:
+     * - Checks if it already exists in this RTPSParticipant.
+     * - It is consistent with the topic kind of the endpoint.
+     *
+     * @param entity_id EnityId to check
+     * @param endpoint_kind Endpoint Kind.
+     * @param topic_kind Topic kind.
+     * @return True if the EnityId conditions are correct.
+     */
+    bool check_entity_id_conditions(
+            const EntityId_t& entity_id,
+            EndpointKind_t endpoint_kind,
+            TopicKind_t topic_kind) const;
+
+    /**
      * Assign an endpoint to the ReceiverResources, based on its LocatorLists.
      * @param endp Pointer to the endpoint.
      * @return True if correct.

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -154,6 +154,15 @@ public:
         participant_attr_.builtin.discovery_config.discoveryProtocol =
                 eprosima::fastdds::rtps::DiscoveryProtocol::SIMPLE;
         participant_attr_.builtin.use_WriterLivelinessProtocol = true;
+
+        if (type_.is_compute_key_provided)
+        {
+            reader_attr_.endpoint.topicKind = eprosima::fastdds::rtps::WITH_KEY;
+        }
+        else
+        {
+            reader_attr_.endpoint.topicKind = eprosima::fastdds::rtps::NO_KEY;
+        }
     }
 
     virtual ~RTPSWithRegistrationReader()
@@ -180,8 +189,18 @@ public:
         // Create reader
         if (has_payload_pool_)
         {
-            reader_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSReader(participant_, reader_attr_, payload_pool_,
-                            history_, &listener_);
+            if (custom_entity_id_ != eprosima::fastdds::rtps::c_EntityId_Unknown)
+            {
+                reader_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSReader(participant_, custom_entity_id_,
+                                reader_attr_, payload_pool_,
+                                history_, &listener_);
+            }
+            else
+            {
+                reader_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSReader(participant_, reader_attr_,
+                                payload_pool_,
+                                history_, &listener_);
+            }
         }
         else
         {
@@ -432,6 +451,13 @@ public:
         return *this;
     }
 
+    RTPSWithRegistrationReader& set_entity_id(
+            const eprosima::fastdds::rtps::EntityId_t& entity_id)
+    {
+        custom_entity_id_ = entity_id;
+        return *this;
+    }
+
     RTPSWithRegistrationReader& history_depth(
             const int32_t depth)
     {
@@ -649,6 +675,7 @@ private:
     std::condition_variable cvDiscovery_;
     std::atomic<bool> receiving_;
     std::atomic<uint32_t> matched_;
+    eprosima::fastdds::rtps::EntityId_t custom_entity_id_ = eprosima::fastdds::rtps::c_EntityId_Unknown;
     eprosima::fastdds::rtps::SequenceNumber_t last_seq_;
     std::atomic<size_t> current_received_count_;
     std::atomic<size_t> number_samples_expected_;

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -143,6 +143,15 @@ public:
         participant_attr_.builtin.discovery_config.discoveryProtocol =
                 eprosima::fastdds::rtps::DiscoveryProtocol::SIMPLE;
         participant_attr_.builtin.use_WriterLivelinessProtocol = true;
+
+        if (type_.is_compute_key_provided)
+        {
+            writer_attr_.endpoint.topicKind = eprosima::fastdds::rtps::WITH_KEY;
+        }
+        else
+        {
+            writer_attr_.endpoint.topicKind = eprosima::fastdds::rtps::NO_KEY;
+        }
     }
 
     virtual ~RTPSWithRegistrationWriter()
@@ -174,8 +183,16 @@ public:
         }
 
         //Create writer
-        writer_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter(
-            participant_, writer_attr_, history_, &listener_);
+        if (custom_entity_id_ != eprosima::fastdds::rtps::c_EntityId_Unknown)
+        {
+            writer_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter(
+                participant_, custom_entity_id_, writer_attr_, history_, &listener_);
+        }
+        else
+        {
+            writer_ = eprosima::fastdds::rtps::RTPSDomain::createRTPSWriter(
+                participant_, writer_attr_, history_, &listener_);
+        }
 
         if (writer_ == nullptr)
         {
@@ -472,6 +489,13 @@ public:
 
 #endif // if HAVE_SQLITE3
 
+    RTPSWithRegistrationWriter& set_entity_id(
+            const eprosima::fastdds::rtps::EntityId_t& entity_id)
+    {
+        custom_entity_id_ = entity_id;
+        return *this;
+    }
+
     RTPSWithRegistrationWriter& history_depth(
             const int32_t depth)
     {
@@ -605,6 +629,7 @@ private:
     std::mutex mutex_;
     std::condition_variable cv_;
     uint32_t matched_;
+    eprosima::fastdds::rtps::EntityId_t custom_entity_id_ = eprosima::fastdds::rtps::c_EntityId_Unknown;
     type_support type_;
     std::shared_ptr<eprosima::fastdds::rtps::IPayloadPool> payload_pool_;
     bool has_payload_pool_ = false;

--- a/versions.md
+++ b/versions.md
@@ -20,6 +20,7 @@ Forthcoming
     * Some methods changed to `snake_case`: `register_reader`, `register_writer`, `update_reader`, `update_writer`.
 	* Register methods take a `TopicDescription` instead of `TopicAttributes`.
 	* Update methods no longer take `TopicAttributes`.
+  * Endpoint creation fails if the `EntityId` is inconsistent with the topic kind.
 * Discovery callbacks refactor:
   * on_participant_discovery now receives a `ParticipantDiscoveryStatus` and a `ParticipantBuiltinTopicData` instead of a `ParticipantDiscoveryInfo`
   * on_data_reader_discovery now receives a `ReaderDiscoveryStatus` and a `SubscriptionBuiltinTopicData` instead of a `ReaderDiscoveryInfo`


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR:
* Adds `topic_kind` to `PublicationBuiltinTopicData` and `SubscriptionBuiltinTopicData`.
* Removes `@ingroup` from the doxygen documentation of `ParticipantDiscoveryStatus`.
* Makes the creation of RTPS endpoints fail when the entity id is not consistent with the topic kind specified in the corresponding attributes.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- __NO__: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
