### PR TITLE
[19036] Discard local SHM locators that cannot be openned

### DIFF
--- a/include/fastdds/rtps/transport/ChainingTransport.hpp
+++ b/include/fastdds/rtps/transport/ChainingTransport.hpp
@@ -389,6 +389,16 @@ public:
         return low_level_transport_->is_locator_allowed(locator);
     }
 
+    /*!
+     * Call the low-level transport `is_locator_reachable()`.
+     * Must report whether the given locator is reachable by this transport.
+     */
+    FASTDDS_EXPORTED_API bool is_locator_reachable(
+            const fastdds::rtps::Locator_t& locator) override
+    {
+        return low_level_transport_->is_locator_reachable(locator);
+    }
+
 protected:
 
     std::unique_ptr<TransportInterface> low_level_transport_;

--- a/include/fastdds/rtps/transport/TransportInterface.hpp
+++ b/include/fastdds/rtps/transport/TransportInterface.hpp
@@ -117,6 +117,17 @@ public:
     virtual bool is_locator_allowed(
             const Locator&) const = 0;
 
+    /**
+     * Must report whether the given locator is reachable by this transport.
+     *
+     * @param [in] locator @ref Locator for which the reachability is checked.
+     *
+     * @return true if the input locator is reachable by this transport, false otherwise.
+     */
+    virtual bool is_locator_reachable(
+            const Locator_t& locator) = 0;
+
+
     //! Returns the locator describing the main (most general) channel that can write to the provided remote locator.
     virtual Locator RemoteToMainLocal(
             const Locator& remote) const = 0;

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -32,7 +32,7 @@
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
 #include <rtps/builtin/discovery/participant/PDPSimple.h>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/resources/TimedEvent.h>
 #include <rtps/transport/shared_mem/SHMLocator.hpp>
 #include <utils/TimeConversion.hpp>

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -446,13 +446,12 @@ bool ParticipantProxyData::writeToCDRMessage(
 bool ParticipantProxyData::readFromCDRMessage(
         CDRMessage_t* msg,
         bool use_encapsulation,
-        const NetworkFactory& network,
-        bool is_shm_transport_available,
+        NetworkFactory& network,
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
     auto param_process =
-            [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
+            [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
                 static_cast<void>(source_vendor_id);
@@ -503,7 +502,6 @@ bool ParticipantProxyData::readFromCDRMessage(
 
                         m_VendorId[0] = p.vendorId[0];
                         m_VendorId[1] = p.vendorId[1];
-                        is_shm_transport_available &= (m_VendorId == c_VendorId_eProsima);
                         break;
                     }
                     case fastdds::dds::PID_PRODUCT_VERSION:
@@ -613,7 +611,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                                         m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     metatraffic_locators,
                                     temp_locator,
                                     false);
@@ -643,7 +641,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                                         m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     metatraffic_locators,
                                     temp_locator,
                                     true);
@@ -673,7 +671,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                                         m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     default_locators,
                                     temp_locator,
                                     true);
@@ -703,7 +701,7 @@ bool ParticipantProxyData::readFromCDRMessage(
                                         m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     default_locators,
                                     temp_locator,
                                     false);

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -454,7 +454,7 @@ bool ParticipantProxyData::readFromCDRMessage(
             [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
-                static_cast<void>(source_vendor_id);
+                m_VendorId = source_vendor_id;
                 switch (pid){
                     case fastdds::dds::PID_KEY_HASH:
                     {

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -32,6 +32,7 @@
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/rtps/common/Token.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
+
 #include <rtps/network/NetworkFactory.hpp>
 
 namespace eprosima {

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -28,10 +28,11 @@
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
 #include <fastdds/rtps/attributes/WriterAttributes.hpp>
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
+#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/RemoteLocators.hpp>
 #include <fastdds/rtps/common/Token.hpp>
-#include <fastdds/rtps/common/ProductVersion_t.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
+#include <rtps/network/NetworkFactory.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -157,8 +158,7 @@ public:
     bool readFromCDRMessage(
             CDRMessage_t* msg,
             bool use_encapsulation,
-            const NetworkFactory& network,
-            bool is_shm_transport_available,
+            NetworkFactory& network,
             bool should_filter_locators,
             fastdds::rtps::VendorId_t source_vendor_id = c_VendorId_eProsima);
 

--- a/src/cpp/rtps/builtin/data/ProxyDataFilters.hpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataFilters.hpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _FASTDDS_RTPS_BUILTIN_DATA_PROXYDATAFILTERS_H_
-#define _FASTDDS_RTPS_BUILTIN_DATA_PROXYDATAFILTERS_H_
+#ifndef FASTDDS_RTPS_BUILTIN_DATA__PROXYDATAFILTERS_HPP
+#define FASTDDS_RTPS_BUILTIN_DATA__PROXYDATAFILTERS_HPP
 
 #include <fastdds/rtps/common/RemoteLocators.hpp>
+
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/transport/shared_mem/SHMLocator.hpp>
 
 namespace eprosima {
@@ -30,27 +32,20 @@ class ProxyDataFilters
 public:
 
     /**
-     * This function filters out SHM locators when they cannot be used for communication on the local host.
-     * @param [in] is_shm_transport_available Indicates whether the participant has SHM transport enabled.
+     * @brief This function filters out unreachable locators.
+     *
+     * @param [in] network_factory Reference to the @ref NetworkFactory
      * @param [in,out] target_locators_list List where parsed locators are stored
      * @param [in] temp_locator New locator to parse
      * @param [in] is_unicast true if temp_locator is unicast, false if it is multicast
      */
     static void filter_locators(
-            bool is_shm_transport_available,
+            NetworkFactory& network_factory,
             RemoteLocatorList& target_locators_list,
             const Locator_t& temp_locator,
             bool is_unicast)
     {
-        using SHMLocator = eprosima::fastdds::rtps::SHMLocator;
-
-        bool can_use_locator = LOCATOR_KIND_SHM != temp_locator.kind;
-        if (!can_use_locator)
-        {
-            can_use_locator = is_shm_transport_available && SHMLocator::is_shm_and_from_this_host(temp_locator);
-        }
-
-        if (can_use_locator)
+        if (network_factory.is_locator_reachable(temp_locator))
         {
             if (is_unicast)
             {
@@ -69,4 +64,4 @@ public:
 } /* namespace fastdds */
 } /* namespace eprosima */
 
-#endif // _FASTDDS_RTPS_BUILTIN_DATA_PROXYDATAFILTERS_H_
+#endif // FASTDDS_RTPS_BUILTIN_DATA__PROXYDATAFILTERS_HPP

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -24,7 +24,7 @@
 #include <fastdds/rtps/common/CDRMessage_t.hpp>
 #include <fastdds/rtps/common/VendorId_t.hpp>
 
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 
 #include "ProxyDataFilters.hpp"
 

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -647,12 +647,11 @@ bool ReaderProxyData::writeToCDRMessage(
 
 bool ReaderProxyData::readFromCDRMessage(
         CDRMessage_t* msg,
-        const NetworkFactory& network,
-        bool is_shm_transport_available,
+        NetworkFactory& network,
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
-    auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
+    auto param_process = [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
                 VendorId_t vendor_id = c_VendorId_Unknown;
@@ -668,7 +667,6 @@ bool ReaderProxyData::readFromCDRMessage(
                             return false;
                         }
 
-                        is_shm_transport_available &= (p.vendorId == c_VendorId_eProsima);
                         vendor_id = p.vendorId;
                         break;
                     }
@@ -902,7 +900,7 @@ bool ReaderProxyData::readFromCDRMessage(
                                     m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     remote_locators_,
                                     temp_locator,
                                     true);
@@ -930,7 +928,7 @@ bool ReaderProxyData::readFromCDRMessage(
                                     m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     remote_locators_,
                                     temp_locator,
                                     false);

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -654,7 +654,7 @@ bool ReaderProxyData::readFromCDRMessage(
     auto param_process = [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
-                VendorId_t vendor_id = c_VendorId_Unknown;
+                VendorId_t vendor_id = source_vendor_id;
 
                 switch (pid)
                 {

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
@@ -424,7 +424,6 @@ public:
      * parameter list.
      * @param msg Pointer to the message.
      * @param network Reference to network factory for locator validation and transformation
-     * @param is_shm_transport_available Indicates whether the Reader is reachable by SHM.
      * @param should_filter_locators Whether to retrieve the locators before the external locators filtering
      * @param source_vendor_id VendorId of the source participant from which the message was received
      * @return true on success

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
@@ -431,8 +431,7 @@ public:
      */
     bool readFromCDRMessage(
             CDRMessage_t* msg,
-            const NetworkFactory& network,
-            bool is_shm_transport_available,
+            NetworkFactory& network,
             bool should_filter_locators,
             fastdds::rtps::VendorId_t source_vendor_id = c_VendorId_eProsima);
 

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -23,7 +23,7 @@
 #include <fastdds/rtps/common/VendorId_t.hpp>
 
 #include <rtps/builtin/data/WriterProxyData.hpp>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 
 #include "ProxyDataFilters.hpp"
 

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -621,7 +621,7 @@ bool WriterProxyData::readFromCDRMessage(
     auto param_process = [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
-                VendorId_t vendor_id = c_VendorId_Unknown;
+                VendorId_t vendor_id = source_vendor_id;
 
                 switch (pid)
                 {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -614,12 +614,11 @@ bool WriterProxyData::writeToCDRMessage(
 
 bool WriterProxyData::readFromCDRMessage(
         CDRMessage_t* msg,
-        const NetworkFactory& network,
-        bool is_shm_transport_available,
+        NetworkFactory& network,
         bool should_filter_locators,
         fastdds::rtps::VendorId_t source_vendor_id)
 {
-    auto param_process = [this, &network, &is_shm_transport_available, &should_filter_locators, source_vendor_id](
+    auto param_process = [this, &network, &should_filter_locators, source_vendor_id](
         CDRMessage_t* msg, const ParameterId_t& pid, uint16_t plength)
             {
                 VendorId_t vendor_id = c_VendorId_Unknown;
@@ -635,7 +634,6 @@ bool WriterProxyData::readFromCDRMessage(
                             return false;
                         }
 
-                        is_shm_transport_available &= (p.vendorId == c_VendorId_eProsima);
                         vendor_id = p.vendorId;
                         break;
                     }
@@ -899,7 +897,7 @@ bool WriterProxyData::readFromCDRMessage(
                                     m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     remote_locators_,
                                     temp_locator,
                                     true);
@@ -926,7 +924,7 @@ bool WriterProxyData::readFromCDRMessage(
                                     m_guid.is_from_this_host()))
                             {
                                 ProxyDataFilters::filter_locators(
-                                    is_shm_transport_available,
+                                    network,
                                     remote_locators_,
                                     temp_locator,
                                     false);

--- a/src/cpp/rtps/builtin/data/WriterProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.hpp
@@ -451,8 +451,7 @@ public:
     //!Read a parameter list from a CDRMessage_t.
     bool readFromCDRMessage(
             CDRMessage_t* msg,
-            const NetworkFactory& network,
-            bool is_shm_transport_possible,
+            NetworkFactory& network,
             bool should_filter_locators,
             fastdds::rtps::VendorId_t source_vendor_id = c_VendorId_eProsima);
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -33,7 +33,7 @@
 #include <rtps/builtin/data/WriterProxyData.hpp>
 #include <rtps/builtin/discovery/endpoint/EDPSimple.h>
 #include <rtps/builtin/discovery/participant/PDPSimple.h>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/writer/StatefulWriter.hpp>
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimpleListeners.cpp
@@ -70,13 +70,12 @@ void EDPBasePUBListener::add_writer_from_change(
         const EndpointAddedCallback& writer_added_callback /* = nullptr*/)
 {
     //LOAD INFORMATION IN DESTINATION WRITER PROXY DATA
-    const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
+    NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
     auto temp_writer_data = edp->get_temporary_writer_proxies_pool().get();
     const auto type_server = change->writerGUID;
 
-    if (temp_writer_data->readFromCDRMessage(&tempMsg, network,
-            edp->mp_RTPSParticipant->has_shm_transport(), true, change->vendor_id))
+    if (temp_writer_data->readFromCDRMessage(&tempMsg, network, true, change->vendor_id))
     {
         if (temp_writer_data->guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
         {
@@ -215,13 +214,12 @@ void EDPBaseSUBListener::add_reader_from_change(
         const EndpointAddedCallback& reader_added_callback /* = nullptr*/)
 {
     //LOAD INFORMATION IN TEMPORAL READER PROXY DATA
-    const NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
+    NetworkFactory& network = edp->mp_RTPSParticipant->network_factory();
     CDRMessage_t tempMsg(change->serializedPayload);
     auto temp_reader_data = edp->get_temporary_reader_proxies_pool().get();
     const auto type_server = change->writerGUID;
 
-    if (temp_reader_data->readFromCDRMessage(&tempMsg, network,
-            edp->mp_RTPSParticipant->has_shm_transport(), true, change->vendor_id))
+    if (temp_reader_data->readFromCDRMessage(&tempMsg, network, true, change->vendor_id))
     {
         if (temp_reader_data->guid().guidPrefix == edp->mp_RTPSParticipant->getGuid().guidPrefix)
         {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -106,7 +106,7 @@ void PDPListener::on_new_cache_change_added(
         CDRMessage_t msg(change->serializedPayload);
         temp_participant_data_.clear();
         if (temp_participant_data_.readFromCDRMessage(&msg, true, parent_pdp_->getRTPSParticipant()->network_factory(),
-                parent_pdp_->getRTPSParticipant()->has_shm_transport(), true, change_in->vendor_id))
+                true, change_in->vendor_id))
         {
             // After correctly reading it
             change->instanceHandle = temp_participant_data_.m_key;

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -139,7 +139,6 @@ void PDPServerListener::on_new_cache_change_added(
                     &msg,
                     true,
                     pdp_server()->getRTPSParticipant()->network_factory(),
-                    pdp_server()->getRTPSParticipant()->has_shm_transport(),
                     true,
                     change_in->vendor_id))
         {

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 
 #include <limits>
 #include <utility>

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -284,6 +284,12 @@ bool NetworkFactory::is_locator_remote_or_allowed(
     return (is_locator_supported(locator) && !is_fastdds_local) || is_locator_allowed(locator);
 }
 
+bool NetworkFactory::is_locator_reachable(
+        const Locator_t& /*locator*/)
+{
+    return true;
+}
+
 void NetworkFactory::select_locators(
         LocatorSelector& selector) const
 {

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -285,9 +285,17 @@ bool NetworkFactory::is_locator_remote_or_allowed(
 }
 
 bool NetworkFactory::is_locator_reachable(
-        const Locator_t& /*locator*/)
+        const Locator_t& locator)
 {
-    return true;
+    for (auto& transport : mRegisteredTransports)
+    {
+        if (transport->is_locator_reachable(locator))
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void NetworkFactory::select_locators(

--- a/src/cpp/rtps/network/NetworkFactory.hpp
+++ b/src/cpp/rtps/network/NetworkFactory.hpp
@@ -196,6 +196,17 @@ public:
             bool is_fastdds_local) const;
 
     /**
+     * Must report whether the given locator is reachable by at least one of the registered transports.
+     *
+     * @param [in]  locator Locator to check if remote or allowed.
+     *
+     * @return true if the input locator is reachable by at least one of the registered transports,
+     *         false otherwise.
+     */
+    bool is_locator_reachable(
+            const Locator_t& locator);
+
+    /**
      * Perform the locator selection algorithm.
      *
      * It basically consists of the following steps

--- a/src/cpp/rtps/network/NetworkFactory.hpp
+++ b/src/cpp/rtps/network/NetworkFactory.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
-#define FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
+#ifndef FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP
+#define FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP
 
 #include <vector>
 #include <memory>
@@ -351,4 +351,4 @@ private:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
+#endif // FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP

--- a/src/cpp/rtps/network/NetworkFactory.hpp
+++ b/src/cpp/rtps/network/NetworkFactory.hpp
@@ -198,7 +198,7 @@ public:
     /**
      * Must report whether the given locator is reachable by at least one of the registered transports.
      *
-     * @param [in]  locator Locator to check if remote or allowed.
+     * @param [in] locator @ref Locator for which the reachability is checked.
      *
      * @return true if the input locator is reachable by at least one of the registered transports,
      *         false otherwise.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2958,7 +2958,6 @@ bool RTPSParticipantImpl::fill_discovery_data_from_cdr_message(
         &serialized_msg,
         true,
         network_factory(),
-        has_shm_transport(),
         false,
         c_VendorId_eProsima);
 
@@ -2990,7 +2989,6 @@ bool RTPSParticipantImpl::fill_discovery_data_from_cdr_message(
     ret = writer_data.readFromCDRMessage(
         &serialized_msg,
         network_factory(),
-        has_shm_transport(),
         false,
         c_VendorId_eProsima);
 
@@ -3026,7 +3024,6 @@ bool RTPSParticipantImpl::fill_discovery_data_from_cdr_message(
     ret = reader_data.readFromCDRMessage(
         &serialized_msg,
         network_factory(),
-        has_shm_transport(),
         false,
         c_VendorId_eProsima);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -54,7 +54,7 @@
 #include <rtps/messages/MessageReceiver.h>
 #include <rtps/messages/RTPSMessageGroup_t.hpp>
 #include <rtps/messages/SendBuffersManager.hpp>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/network/ReceiverResource.h>
 #include <rtps/resources/ResourceEvent.h>
 #include <statistics/rtps/monitor-service/interfaces/IConnectionsObserver.hpp>

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -37,7 +37,7 @@
 #include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/messages/CDRMessage.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/participant/RTPSParticipantImpl.h>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/reader/StatelessReader.hpp>

--- a/src/cpp/rtps/transport/TCPv4Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv4Transport.cpp
@@ -434,6 +434,12 @@ bool TCPv4Transport::is_locator_allowed(
     return is_interface_allowed(IPLocator::toIPv4string(locator));
 }
 
+bool TCPv4Transport::is_locator_reachable(
+        const Locator_t& locator)
+{
+    return IsLocatorSupported(locator);
+}
+
 bool TCPv4Transport::compare_locator_ip(
         const Locator& lh,
         const Locator& rh) const

--- a/src/cpp/rtps/transport/TCPv4Transport.h
+++ b/src/cpp/rtps/transport/TCPv4Transport.h
@@ -96,6 +96,10 @@ protected:
     bool is_locator_allowed(
             const Locator& locator) const override;
 
+    //! Checks for whether locator is reachable.
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
     //! Checks if the given ip has been included in the white list to use it.
     virtual bool is_interface_allowed(
             const std::string& iface) const override;

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -317,6 +317,12 @@ bool TCPv6Transport::is_locator_allowed(
     return is_interface_allowed(IPLocator::toIPv6string(locator));
 }
 
+bool TCPv6Transport::is_locator_reachable(
+        const Locator_t& locator)
+{
+    return IsLocatorSupported(locator);
+}
+
 bool TCPv6Transport::is_interface_whitelist_empty() const
 {
     return interface_whitelist_.empty();

--- a/src/cpp/rtps/transport/TCPv6Transport.h
+++ b/src/cpp/rtps/transport/TCPv6Transport.h
@@ -98,6 +98,10 @@ protected:
     bool is_locator_allowed(
             const Locator& locator) const override;
 
+    //! Checks for whether locator is reachable.
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
     //! Checks if the interfaces white list is empty.
     virtual bool is_interface_whitelist_empty() const override;
 

--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -603,6 +603,12 @@ bool UDPv4Transport::is_locator_allowed(
     return is_interface_allowed(IPLocator::toIPv4string(locator));
 }
 
+bool UDPv4Transport::is_locator_reachable(
+        const Locator_t& locator)
+{
+    return IsLocatorSupported(locator);
+}
+
 LocatorList UDPv4Transport::NormalizeLocator(
         const Locator& locator)
 {

--- a/src/cpp/rtps/transport/UDPv4Transport.h
+++ b/src/cpp/rtps/transport/UDPv4Transport.h
@@ -147,6 +147,10 @@ protected:
     bool is_locator_allowed(
             const Locator&) const override;
 
+    //! Checks for whether locator is reachable.
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
     //! Checks if the given interface is allowed by the white list.
     bool is_interface_allowed(
             const asio::ip::address_v4& ip) const;

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -608,6 +608,12 @@ bool UDPv6Transport::is_locator_allowed(
     return is_interface_allowed(IPLocator::toIPv6string(locator));
 }
 
+bool UDPv6Transport::is_locator_reachable(
+        const Locator_t& locator)
+{
+    return IsLocatorSupported(locator);
+}
+
 LocatorList UDPv6Transport::NormalizeLocator(
         const Locator& locator)
 {

--- a/src/cpp/rtps/transport/UDPv6Transport.h
+++ b/src/cpp/rtps/transport/UDPv6Transport.h
@@ -134,6 +134,10 @@ protected:
     bool is_locator_allowed(
             const Locator&) const override;
 
+    //! Checks for whether locator is reachable.
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
     /**
      * Method to get a list of interfaces to bind the socket associated to the given locator.
      * @return Vector of interfaces in string format.

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -155,7 +155,24 @@ bool SharedMemTransport::is_locator_allowed(
 bool SharedMemTransport::is_locator_reachable(
         const Locator_t& locator)
 {
-    return SHMLocator::is_shm_and_from_this_host(locator);
+    bool is_reachable = SHMLocator::is_shm_and_from_this_host(locator);
+
+    if (is_reachable)
+    {
+        try
+        {
+            is_reachable = (nullptr != find_port(locator.port));
+        }
+        catch (const std::exception& e)
+        {
+            EPROSIMA_LOG_INFO(RTPS_MSG_OUT,
+                    "Local SHM locator '" << locator <<
+                    "' is not reachable; discarding. Reason: " << e.what());
+            is_reachable = false;
+        }
+    }
+
+    return is_reachable;
 }
 
 LocatorList SharedMemTransport::NormalizeLocator(

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -152,6 +152,12 @@ bool SharedMemTransport::is_locator_allowed(
     return IsLocatorSupported(locator);
 }
 
+bool SharedMemTransport::is_locator_reachable(
+        const Locator_t& locator)
+{
+    return SHMLocator::is_shm_and_from_this_host(locator);
+}
+
 LocatorList SharedMemTransport::NormalizeLocator(
         const Locator& locator)
 {

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -604,6 +604,7 @@ bool SharedMemTransport::push_discard(
                 }
                 else
                 {
+                    std::lock_guard<std::mutex> lock(opened_ports_mutex_);
                     EPROSIMA_LOG_WARNING(RTPS_MSG_OUT, "Port " << remote_locator.port << " inconsistent. Port dropped");
                     opened_ports_.erase(remote_locator.port);
                 }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -237,6 +237,8 @@ private:
 
     void clean_up();
 
+    mutable std::mutex opened_ports_mutex_;
+
     std::map<uint32_t, std::shared_ptr<SharedMemManager::Port>> opened_ports_;
 
     mutable std::recursive_mutex input_channels_mutex_;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.h
@@ -225,6 +225,10 @@ private:
     bool is_locator_allowed(
             const Locator&) const override;
 
+    //! Checks for whether locator is reachable.
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
 protected:
 
     std::shared_ptr<SharedMemManager> shared_mem_manager_;

--- a/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
+++ b/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
@@ -90,6 +90,12 @@ public:
         return true;
     }
 
+    bool is_locator_reachable(
+            const Locator_t&)
+    {
+        return true;
+    }
+
     uint32_t get_min_send_buffer_size()
     {
         return 65536;

--- a/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
+++ b/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
-#define FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
+#ifndef FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP
+#define FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP
 
 #include <memory>
 #include <vector>
@@ -117,4 +117,4 @@ public:
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // FASTDDS_RTPS_NETWORK__NETWORKFACTORY_H
+#endif // FASTDDS_RTPS_NETWORK__NETWORKFACTORY_HPP

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -35,7 +35,7 @@
 #include <fastdds/rtps/writer/RTPSWriter.hpp>
 
 #include <fastdds/utils/TypePropagation.hpp>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/reader/BaseReader.hpp>
 #include <rtps/resources/ResourceEvent.h>
 #if HAVE_SECURITY

--- a/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
+++ b/test/mock/rtps/ReaderProxyData/rtps/builtin/data/ReaderProxyData.hpp
@@ -141,8 +141,7 @@ public:
 
     bool readFromCDRMessage(
             CDRMessage_t* /*msg*/,
-            const NetworkFactory& /*network*/,
-            bool /*is_shm_transport_possible*/,
+            NetworkFactory& /*network*/,
             fastdds::rtps::VendorId_t /*source_vendor_id*/)
     {
         return true;

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -32,7 +32,7 @@
 #include <rtps/builtin/data/WriterProxyData.hpp>
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
 #include <rtps/messages/CDRMessage.hpp>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 
 namespace eprosima {
 namespace fastdds {

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -118,7 +118,7 @@ TEST(BuiltinDataSerializationTests, ok_with_defaults)
 
         // Perform deserialization
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
         // EXPECT_EQ(in, out);
     }
 
@@ -137,7 +137,7 @@ TEST(BuiltinDataSerializationTests, ok_with_defaults)
 
         // Perform deserialization
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
     }
 }
 
@@ -150,7 +150,7 @@ TEST(BuiltinDataSerializationTests, msg_with_product_version)
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false,
                         c_VendorId_eProsima)));
             };
 
@@ -210,7 +210,7 @@ TEST(BuiltinDataSerializationTests, msg_without_datasharing)
         msg.length = msg.max_size;
 
         ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-        out.readFromCDRMessage(&msg, network, false, true);
+        out.readFromCDRMessage(&msg, network, true);
         ASSERT_EQ(out.m_qos.data_sharing.kind(), dds::OFF);
     }
 
@@ -227,7 +227,7 @@ TEST(BuiltinDataSerializationTests, msg_without_datasharing)
         msg.length = msg.max_size;
 
         ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-        out.readFromCDRMessage(&msg, network, false, true);
+        out.readFromCDRMessage(&msg, network, true);
         ASSERT_EQ(out.m_qos.data_sharing.kind(), dds::OFF);
     }
 }
@@ -250,7 +250,7 @@ TEST(BuiltinDataSerializationTests, msg_with_datasharing)
         msg.length = msg.max_size;
 
         ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-        out.readFromCDRMessage(&msg, network, false, true);
+        out.readFromCDRMessage(&msg, network, true);
         ASSERT_EQ(out.m_qos.data_sharing.kind(), dds::ON);
     }
 
@@ -270,7 +270,7 @@ TEST(BuiltinDataSerializationTests, msg_with_datasharing)
         msg.length = msg.max_size;
 
         ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-        out.readFromCDRMessage(&msg, network, false, true);
+        out.readFromCDRMessage(&msg, network, true);
         ASSERT_EQ(out.m_qos.data_sharing.kind(), dds::ON);
     }
 }
@@ -339,7 +339,7 @@ TEST(BuiltinDataSerializationTests, interoperability_with_opendds_3_27)
         msg.length = msg.max_size;
 
         WriterProxyData out(max_unicast_locators, max_multicast_locators);
-        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, true)));
+        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true)));
     }
 
     // DATA(r)
@@ -401,7 +401,7 @@ TEST(BuiltinDataSerializationTests, interoperability_with_opendds_3_27)
         msg.length = msg.max_size;
 
         ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, true)));
+        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true)));
     }
 }
 
@@ -516,7 +516,7 @@ TEST(BuiltinDataSerializationTests, ignore_unsupported_type_object)
         msg.length = msg.max_size;
 
         WriterProxyData out(max_unicast_locators, max_multicast_locators);
-        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, true)));
+        EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true)));
     }
 }
 
@@ -594,7 +594,7 @@ TEST(BuiltinDataSerializationTests, property_list_with_binary_properties)
     msg.length = msg.max_size;
 
     ParticipantProxyData out(RTPSParticipantAllocationAttributes{});
-    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, true)));
+    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, true)));
 }
 
 // Regression test for redmine tickets 20306 and 20307
@@ -607,7 +607,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false,
                         fastdds::rtps::VendorId_t({2, 0}))));
             };
 
@@ -617,7 +617,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false,
                         fastdds::rtps::VendorId_t({2, 0}))));
             };
 
@@ -627,7 +627,7 @@ TEST(BuiltinDataSerializationTests, other_vendor_parameter_list_with_custom_pids
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false,
                         fastdds::rtps::VendorId_t({2, 0}))));
             };
 
@@ -869,7 +869,7 @@ TEST(BuiltinDataSerializationTests, rti_parameter_list_with_custom_pids)
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, true, network, false,
                         fastdds::rtps::c_VendorId_rti_connext)));
             };
 
@@ -879,7 +879,7 @@ TEST(BuiltinDataSerializationTests, rti_parameter_list_with_custom_pids)
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false,
                         fastdds::rtps::c_VendorId_rti_connext)));
             };
 
@@ -889,7 +889,7 @@ TEST(BuiltinDataSerializationTests, rti_parameter_list_with_custom_pids)
                 msg.init(buffer, buffer_length);
                 msg.length = msg.max_size;
 
-                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, false,
+                EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false,
                         fastdds::rtps::c_VendorId_rti_connext)));
             };
 
@@ -1099,7 +1099,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_without_parameters)
 
     // Perform deserialization
     msg.pos = 0;
-    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
     ASSERT_EQ(in.content_filter().content_filtered_topic_name, out.content_filter().content_filtered_topic_name);
     ASSERT_EQ(in.content_filter().related_topic_name, out.content_filter().related_topic_name);
@@ -1140,7 +1140,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_with_parameters)
 
     // Perform deserialization
     msg.pos = 0;
-    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
     ASSERT_EQ(in.content_filter().content_filtered_topic_name, out.content_filter().content_filtered_topic_name);
     ASSERT_EQ(in.content_filter().related_topic_name, out.content_filter().related_topic_name);
@@ -1232,7 +1232,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_topic_name_deser
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1281,7 +1281,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_topic_name_deser
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1366,7 +1366,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_related_topic_na
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1415,7 +1415,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_related_topic_na
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1449,7 +1449,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_empty_filter_class)
 
     // Perform deserialization
     msg.pos = 0;
-    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
     assert_is_empty_content_filter(out.content_filter());
 }
@@ -1504,7 +1504,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_filter_class_des
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1553,7 +1553,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_filter_class_des
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1587,7 +1587,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_empty_filter_expressio
 
     // Perform deserialization
     msg.pos = 0;
-    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+    EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
     assert_is_empty_content_filter(out.content_filter());
 }
@@ -1642,7 +1642,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_wrong_filter_expressio
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         assert_is_empty_content_filter(out.content_filter());
     }
@@ -1829,7 +1829,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_interoperability)
     msg.length = msg.max_size;
 
     ReaderProxyData out(max_unicast_locators, max_multicast_locators);
-    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, false, true)));
+    EXPECT_NO_THROW(EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true)));
 
     ASSERT_EQ("ContentFilter_0", out.content_filter().content_filtered_topic_name.to_string());
     ASSERT_EQ("Square", out.content_filter().related_topic_name.to_string());
@@ -1898,7 +1898,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
         EXPECT_TRUE(fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(&msg));
 
         msg.pos = 0;
-        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true, true));
+        EXPECT_TRUE(out.readFromCDRMessage(&msg, network, true));
 
         ASSERT_EQ(100, out.content_filter().expression_parameters.size());
 
@@ -1942,7 +1942,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
 
         msg_fault.pos = 0;
         // Deserialization of messages with more than 100 parameters should fail
-        ASSERT_FALSE(out.readFromCDRMessage(&msg_fault, network, true, true));
+        ASSERT_FALSE(out.readFromCDRMessage(&msg_fault, network, true));
     }
 }
 

--- a/test/unittest/rtps/network/NetworkFactoryTests.cpp
+++ b/test/unittest/rtps/network/NetworkFactoryTests.cpp
@@ -25,7 +25,7 @@
 #include <fastdds/utils/IPLocator.hpp>
 
 #include <MockTransport.h>
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;

--- a/test/unittest/rtps/network/mock/MockTransport.cpp
+++ b/test/unittest/rtps/network/mock/MockTransport.cpp
@@ -73,6 +73,12 @@ bool MockTransport::is_locator_allowed(
     return true;
 }
 
+bool MockTransport::is_locator_reachable(
+        const Locator_t& /*locator*/)
+{
+    return true;
+}
+
 bool MockTransport::OpenOutputChannel(
         fastdds::rtps::SendResourceList& send_resource_list,
         const Locator_t& locator)

--- a/test/unittest/rtps/network/mock/MockTransport.h
+++ b/test/unittest/rtps/network/mock/MockTransport.h
@@ -86,8 +86,13 @@ public:
 
     bool IsLocatorSupported(
             const Locator_t&)  const override;
+
     bool is_locator_allowed(
             const Locator_t& locator) const override;
+
+    bool is_locator_reachable(
+            const Locator_t&) override;
+
     bool DoInputLocatorsMatch(
             const Locator_t&,
             const Locator_t&) const override;

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -26,7 +26,7 @@
 #include <fastdds/rtps/transport/NetworkBuffer.hpp>
 #include <fastdds/utils/IPLocator.hpp>
 
-#include <rtps/network/NetworkFactory.h>
+#include <rtps/network/NetworkFactory.hpp>
 #include <rtps/transport/TCPv6Transport.h>
 #include <utils/Semaphore.hpp>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds a `is_locator_reachable` API to `NetworkFactory` so that unreachable locators can be discarded while deserializing the `DATA(p)`, `DATA(r)`, or `DATA(w)` messages. To do so, the `NetworkFactory` iterates over the transports looking for one that can reach the given locator. It does so using a new `TransportInterface::is_locator_reachable` API.

This PR partially solves a long standing communication issue when the participants are run in the same host but under different  users. This used to cause the Fast DDS participants to keep SHM locators from the remote participant that could not be opened (due to permissions); and since Fast DDS limits the communication to SHM as soon as the remote participant has a reachable SHM locator, communication was not possible.

After this PR:
* ✅ Communication with between two different users with similar permissions works in both directions
* ✅ On a super-user user, subscribing to a topic from a normal user works.
* ❌ On a normal user, subscribing to a topic from a user with more permissions (such as a super-user) still does not work.

**Depends on:**

* #5116

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
