### PR TITLE
Add unsigned specification to literals

### DIFF
--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -299,7 +299,7 @@ inline std::ostream& operator <<(
     {
         ss << (int)iHandle.value[i] << ".";
     }
-    ss << (int)iHandle.value[15] << std::dec;
+    ss << (int)iHandle.value[15u] << std::dec;
     return output << ss.str();
 }
 
@@ -332,7 +332,7 @@ inline std::istream& operator >>(
                 input.setstate(std::ios_base::failbit);
             }
 
-            iHandle.value[0] = static_cast<octet>(hex);
+            iHandle.value[0u] = static_cast<octet>(hex);
 
             for (int i = 1; i < 16; ++i)
             {

--- a/include/fastdds/rtps/common/InstanceHandle.h
+++ b/include/fastdds/rtps/common/InstanceHandle.h
@@ -334,7 +334,7 @@ inline std::istream& operator >>(
 
             iHandle.value[0u] = static_cast<octet>(hex);
 
-            for (int i = 1; i < 16; ++i)
+            for (uint8_t i = 1; i < 16; ++i)
             {
                 input >> point >> hex;
                 if ( point != '.' || hex > 255 )


### PR DESCRIPTION
## Description

As the title says. The performance jobs in the OSRF buildfarm are getting a warning because the indexes used with the `iHandle InstanceHandle_t` are being forwarded to a template, and the compiler thinks that there may be lost data converting 0 and 15 from int to unsigned int.

Reference failing job: https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/68/gcc/ 

Silly error, I think this PR should fix it.

I will test this PR in the buildfarm before asking for the PR to be merged. 

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
