### PR TITLE
[21564] [21666] Change `xsd` files installation directory to `share/fastdds` and remove icons on windows uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,12 +579,12 @@ install(FILES ${PROJECT_SOURCE_DIR}/LICENSE
 
 # Install xml validators
 install(FILES ${PROJECT_SOURCE_DIR}/resources/xsd/fastdds_profiles.xsd
-    DESTINATION ${DATA_INSTALL_DIR}
+    DESTINATION ${DATA_INSTALL_DIR}/fastdds
     COMPONENT xsd
     )
 
 install(FILES ${PROJECT_SOURCE_DIR}/resources/xsd/fastdds_static_discovery.xsd
-    DESTINATION ${DATA_INSTALL_DIR}
+    DESTINATION ${DATA_INSTALL_DIR}/fastdds
     COMPONENT xsd
     )
 

--- a/fastdds.repos
+++ b/fastdds.repos
@@ -10,7 +10,7 @@ repositories:
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: bugfix/xsd-installdir
+        version: master
     fastddsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git

--- a/fastdds.repos
+++ b/fastdds.repos
@@ -10,7 +10,7 @@ repositories:
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git
-        version: master
+        version: bugfix/xsd-installdir
     fastddsgen:
         type: git
         url: https://github.com/eProsima/Fast-DDS-Gen.git

--- a/tools/fastdds/xml_ci/parser.py
+++ b/tools/fastdds/xml_ci/parser.py
@@ -108,4 +108,4 @@ class XMLParser:
         """
         tool_path = Path(os.path.dirname(os.path.realpath(__file__)))
         # We assume the schema path is relative to our installation path
-        return tool_path / '../../../share/fastdds_profiles.xsd'
+        return tool_path / '../../../share/fastdds/fastdds_profiles.xsd'

--- a/tools/fds/CMakeLists.txt
+++ b/tools/fds/CMakeLists.txt
@@ -101,12 +101,6 @@ install(EXPORT ${PROJECT_NAME}-targets
         COMPONENT cmake
         )
 
-# export xsd schema
-install(FILES ../../resources/xsd/fastdds_profiles.xsd
-        DESTINATION ${DATA_INSTALL_DIR}
-        COMPONENT cmake
-        )
-
 # symlink creation requires:
 #   - install( CODE using generator expressions (legacy code is provided for all cmake versions)
 #   - on windows privileges to create symlinks (a .bat file is provided on unprivileged installations)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This other PR:

* Moves `fastdds_profiles.xsd` and `fastdds_static_discovery.xsd` installation directory to `.../share/fastdds` (previously in `.../share`) .
* Removes redundant cmake installation of `fastdds_profiles.xsd` within the `/tools` `CMakeLists.txt`.

**IMPORTANT** this PR must be merged along with:

* https://gitlab.intranet.eprosima.com/eProsima/fastdds-installers/-/merge_requests/20. In turn, this MR has to be backported to `3.0.x` branch

  This MR:
  * Makes the windows uninstaller script to completely remove the `fastdds x.x.x`  installation directory.
  * Makes the windows installer to place the `*.xsd` files into `(install_prefix)\share\fastdds` 

* https://github.com/eProsima/Fast-DDS-docs/pull/925

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.0.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
