### PR TITLE
[21469] Fix windows issue with flow controller example

### DIFF
--- a/examples/cpp/flow_control/CMakeLists.txt
+++ b/examples/cpp/flow_control/CMakeLists.txt
@@ -47,6 +47,9 @@ target_compile_definitions(flow_control PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
     $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
     )
+if(WIN32)
+    set_target_properties(flow_control PROPERTIES LINK_FLAGS /STACK:4194304)
+endif()
 target_link_libraries(flow_control fastdds fastcdr foonathan_memory)
 install(TARGETS flow_control
     RUNTIME DESTINATION ${DATA_INSTALL_DIR}/fastdds/examples/cpp/flow_control/${BIN_INSTALL_DIR})

--- a/examples/cpp/flow_control/FlowControl.idl
+++ b/examples/cpp/flow_control/FlowControl.idl
@@ -1,3 +1,4 @@
+@extensibility(APPENDABLE)
 struct FlowControl
 {
    unsigned long index;

--- a/examples/cpp/flow_control/FlowControlTypeObjectSupport.cxx
+++ b/examples/cpp/flow_control/FlowControlTypeObjectSupport.cxx
@@ -54,6 +54,13 @@ void register_FlowControl_type_identifier(
         QualifiedTypeName type_name_FlowControl = "FlowControl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_FlowControl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_FlowControl;
+        AppliedAnnotationSeq tmp_ann_custom_FlowControl;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_FlowControl;
+        if (!tmp_ann_custom_FlowControl.empty())
+        {
+            ann_custom_FlowControl = tmp_ann_custom_FlowControl;
+        }
+
         CompleteTypeDetail detail_FlowControl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_FlowControl, ann_custom_FlowControl, type_name_FlowControl.to_string());
         CompleteStructHeader header_FlowControl;
         header_FlowControl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_FlowControl);

--- a/examples/cpp/flow_control/PublisherApp.cpp
+++ b/examples/cpp/flow_control/PublisherApp.cpp
@@ -191,7 +191,10 @@ void PublisherApp::run()
         }
         else
         {
-            throw std::runtime_error("Slow Publisher failed sending a message");
+            if (!is_stopped())
+            {
+                std::cout << "Slow Publisher failed sending a message" << std::endl;
+            }
         }
 
         if (publish(fast_writer_, msg))
@@ -200,7 +203,10 @@ void PublisherApp::run()
         }
         else
         {
-            throw std::runtime_error("Fast Publisher failed sending a message");
+            if (!is_stopped())
+            {
+                std::cout << "Fast Publisher failed sending a message" << std::endl;
+            }
         }
 
         // Wait for period or stop event
@@ -214,7 +220,7 @@ void PublisherApp::run()
 
 bool PublisherApp::publish(
         DataWriter* writer_,
-        FlowControl msg)
+        FlowControl& msg)
 {
     bool ret = false;
     // Wait for the data endpoints discovery

--- a/examples/cpp/flow_control/PublisherApp.hpp
+++ b/examples/cpp/flow_control/PublisherApp.hpp
@@ -72,7 +72,7 @@ private:
     //! Publish a sample
     bool publish(
             DataWriter* writer_,
-            FlowControl msg);
+            FlowControl& msg);
 
     DomainParticipant* participant_;
 

--- a/examples/cpp/rtps/CLIParser.hpp
+++ b/examples/cpp/rtps/CLIParser.hpp
@@ -131,7 +131,6 @@ public:
                         if (static_cast<uint16_t>(input) > std::numeric_limits<std::uint16_t>::max())
                         {
                             throw std::out_of_range("sample argument out of range");
-                            print_help(EXIT_FAILURE);
                         }
 
                         config.samples = static_cast<uint16_t>(input);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
During release testing, a crash in the flow controller example was caught. This PR fixes windows build in Debug mode, and fixes the crash in the flow controller example execution.

Edit: it has been added also a commit setting the extensibility explicitly, and regenerating the example types.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.

