### PR TITLE
[21366] Address some warnings when generating windows installer for v3.0.0

### DIFF
--- a/include/fastdds/config/doxygen_modules.hpp
+++ b/include/fastdds/config/doxygen_modules.hpp
@@ -143,7 +143,7 @@
 
 #ifdef FASTDDS_STATISTICS
 /** @defgroup STATISTICS_MODULE Statistics Module
- * @ingroup MANAGEMENT_MODULE
+ * @ingroup FASTDDS_GENERAL_API
  * This module contains the classes associated with the Statistics Protocols.
  */
 #endif // ifdef FASTDDS_STATISTICS

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -45,7 +45,6 @@ namespace rtps {
 
 /**
  * Struct to define participant types to set participant type parameter property
- * @ingroup DISCOVERY_MODULE
  */
 struct ParticipantType
 {

--- a/include/fastdds/rtps/builtin/data/ContentFilterProperty.hpp
+++ b/include/fastdds/rtps/builtin/data/ContentFilterProperty.hpp
@@ -31,7 +31,6 @@ namespace rtps {
 
 /**
  * Information about the content filter being applied by a reader.
- * @ingroup BUILTIN_MODULE
  */
 class ContentFilterProperty
 {
@@ -39,7 +38,6 @@ public:
 
     /**
      * Allocation configuration for a ContentFilterProperty.
-     * @ingroup BUILTIN_MODULE
      */
     struct AllocationConfiguration
     {

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -165,6 +165,8 @@ bool SharedMemTransport::is_locator_reachable(
         }
         catch (const std::exception& e)
         {
+            (void)e;
+
             EPROSIMA_LOG_INFO(RTPS_MSG_OUT,
                     "Local SHM locator '" << locator <<
                     "' is not reachable; discarding. Reason: " << e.what());

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -46,7 +46,6 @@ namespace rtps {
 
 /**
  * Struct to define participant types to set participant type parameter property
- * @ingroup DISCOVERY_MODULE
  */
 struct ParticipantType
 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR corrects some `@ingroup` doxygen calls mainly because some groups are defined under a `DOXYGEN_SHOULD_SKIP_THIS_PUBLIC` but then referenced in public headers. 
The `@defgroup statistics_module` should belong to a valid public group, because it is referenced in public headers.

In addition an `usued local variable` warning is addressed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **NA** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
