### PR TITLE
About DataSharingListener

### DIFF
--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -17,27 +17,34 @@
  */
 
 #include <rtps/DataSharing/DataSharingListener.hpp>
-#include <fastdds/rtps/reader/RTPSReader.h>
+
+#include <rtps/reader/BaseReader.hpp>
+#include <utils/thread.hpp>
+#include <utils/threading.hpp>
 
 #include <memory>
 #include <mutex>
 
 namespace eprosima {
-namespace fastrtps {
+namespace fastdds {
 namespace rtps {
 
+using BaseReader = fastdds::rtps::BaseReader;
+using ThreadSettings = fastdds::rtps::ThreadSettings;
 
 DataSharingListener::DataSharingListener(
         std::shared_ptr<DataSharingNotification> notification,
         const std::string& datasharing_pools_directory,
+        const ThreadSettings& thr_config,
         ResourceLimitedContainerConfig limits,
-        RTPSReader* reader)
+        BaseReader* reader)
     : notification_(notification)
     , is_running_(false)
     , reader_(reader)
     , writer_pools_(limits)
     , writer_pools_changed_(false)
     , datasharing_pools_directory_(datasharing_pools_directory)
+    , thread_config_(thr_config)
 {
 }
 
@@ -81,8 +88,7 @@ void DataSharingListener::run()
             // If some writer added new data, there may be something to read.
             // If there were matching/unmatching, we may not have finished our last loop
         } while (is_running_.load() &&
-                (notification_->notification_->new_data.load() ||
-                writer_pools_changed_.load(std::memory_order_relaxed)));
+        (notification_->notification_->new_data.load() || writer_pools_changed_.load(std::memory_order_relaxed)));
     }
 }
 
@@ -98,13 +104,15 @@ void DataSharingListener::start()
     }
 
     // Initialize the thread
-    listening_thread_ = new std::thread(&DataSharingListener::run, this);
+    uint32_t thread_id = reader_->getGuid().entityId.to_uint32() & 0x0000FFFF;
+    listening_thread_ = create_thread([this]()
+                    {
+                        run();
+                    }, thread_config_, "dds.dsha.%u", thread_id);
 }
 
 void DataSharingListener::stop()
 {
-    std::thread* thr = nullptr;
-
     {
         std::lock_guard<std::mutex> guard(mutex_);
 
@@ -114,15 +122,11 @@ void DataSharingListener::stop()
         {
             return;
         }
-
-        thr = listening_thread_;
-        listening_thread_ = nullptr;
     }
 
     // Notify the thread and wait for it to finish
     notification_->notify();
-    thr->join();
-    delete thr;
+    listening_thread_.join();
 }
 
 void DataSharingListener::process_new_data ()
@@ -150,13 +154,13 @@ void DataSharingListener::process_new_data ()
 
         // Take the pool to free the lock
         std::shared_ptr<ReaderPool> pool = it->pool;
-
+        lock.unlock();
 
         if (liveliness_assertion_needed)
         {
             reader_->assert_writer_liveliness(pool->writer());
         }
-        lock.unlock();
+
         uint64_t last_payload = pool->end();
         bool has_new_payload = true;
         while (has_new_payload)
@@ -172,7 +176,8 @@ void DataSharingListener::process_new_data ()
                 {
                     EPROSIMA_LOG_WARNING(RTPS_READER, "GAP (" << last_sequence + 1 << " - " << ch.sequenceNumber - 1 << ")"
                                                               << " detected on datasharing writer " << pool->writer());
-                    reader_->processGapMsg(pool->writer(), last_sequence + 1, SequenceNumberSet_t(ch.sequenceNumber));
+                    reader_->process_gap_msg(pool->writer(), last_sequence + 1,
+                            SequenceNumberSet_t(ch.sequenceNumber), c_VendorId_eProsima);
                 }
 
                 if (last_sequence == c_SequenceNumber_Unknown && ch.sequenceNumber > SequenceNumber_t(0, 1))
@@ -180,16 +185,16 @@ void DataSharingListener::process_new_data ()
                     EPROSIMA_LOG_INFO(RTPS_READER, "First change with SN " << ch.sequenceNumber
                                                                            << " detected on datasharing writer " <<
                             pool->writer());
-                    reader_->processGapMsg(pool->writer(), SequenceNumber_t(0, 1), SequenceNumberSet_t(
-                                ch.sequenceNumber));
+                    reader_->process_gap_msg(pool->writer(), SequenceNumber_t(0, 1),
+                            SequenceNumberSet_t(ch.sequenceNumber), c_VendorId_eProsima);
                 }
 
                 EPROSIMA_LOG_INFO(RTPS_READER, "New data found on writer " << pool->writer()
                                                                            << " with SN " << ch.sequenceNumber);
 
-                if (reader_->processDataMsg(&ch))
+                if (reader_->process_data_msg(&ch))
                 {
-                    pool->release_payload(ch);
+                    pool->release_payload(ch.serializedPayload);
                     pool->advance_to_next_payload();
                 }
             }
@@ -219,34 +224,30 @@ bool DataSharingListener::add_datasharing_writer(
 {
     std::lock_guard<std::mutex> lock(mutex_);
 
-    // Check if there is a match
     if (writer_is_matched(writer_guid))
     {
         EPROSIMA_LOG_INFO(RTPS_READER, "Attempting to add existing datasharing writer " << writer_guid);
         return false;
     }
 
-    // Get ReaderPool
-    auto pool = std::static_pointer_cast<ReaderPool>(DataSharingPayloadPool::get_reader_pool(is_volatile));
-    if (!pool->init_shared_memory(writer_guid, datasharing_pools_directory_))
+    std::shared_ptr<ReaderPool> pool =
+            std::static_pointer_cast<ReaderPool>(DataSharingPayloadPool::get_reader_pool(is_volatile));
+    if (pool->init_shared_memory(writer_guid, datasharing_pools_directory_))
     {
-        return false;  // Initialization fails and returns directly
+        if (0 >= reader_history_max_samples ||
+                reader_history_max_samples >= static_cast<int32_t>(pool->history_size()))
+        {
+            EPROSIMA_LOG_WARNING(RTPS_READER,
+                    "Reader " << reader_->getGuid() << " was configured to have a large history (" <<
+                    reader_history_max_samples << " max samples), but the history size used with writer " <<
+                    writer_guid << " will be " << pool->history_size() << " max samples.");
+        }
+        writer_pools_.emplace_back(pool, pool->last_liveliness_sequence());
+        writer_pools_changed_.store(true);
+        return true;
     }
 
-    // Check historical sample size
-    int32_t history_size = static_cast<int32_t>(pool->history_size());
-    if (reader_history_max_samples <= 0 || reader_history_max_samples >= history_size)
-    {
-        EPROSIMA_LOG_WARNING(RTPS_READER,
-                "Reader " << reader_->getGuid() << " was configured to have a large history (" <<
-                reader_history_max_samples << " max samples), but will use " << history_size << " max samples with writer " <<
-                writer_guid << ".");
-    }
-
-    // Add to writer pools and mark status changes
-    writer_pools_.emplace_back(pool, pool->last_liveliness_sequence());
-    writer_pools_changed_.store(true);
-    return true;
+    return false;
 }
 
 bool DataSharingListener::remove_datasharing_writer(
@@ -311,5 +312,5 @@ std::shared_ptr<ReaderPool> DataSharingListener::get_pool_for_writer(
 }
 
 }  // namespace rtps
-}  // namespace fastrtps
+}  // namespace fastdds
 }  // namespace eprosima


### PR DESCRIPTION
About DataSharingListener:
1.After checking and updating last_assertion_sequence, continue to hold the lock until all operations related to the shared data are completed. This ensures data consistency throughout the reading and processing process.
2.By handling all exit conditions at the beginning of the function, the nesting depth can be reduced and the logic clearer.