### PR TITLE
[21514] Make Fast DDS build compatible with gcc9

### DIFF
--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -32,7 +32,7 @@ traits<AnnotationDescriptor>::ref_type traits<AnnotationDescriptor>::make_shared
 
 ReturnCode_t AnnotationDescriptorImpl::get_value(
         ObjectName& value,
-        const ObjectName& key)
+        const ObjectName& key) noexcept
 {
     const AnnotationDescriptorImpl& myself = *this;
     return myself.get_value(value, key);

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -40,7 +40,7 @@ ReturnCode_t AnnotationDescriptorImpl::get_value(
 
 ReturnCode_t AnnotationDescriptorImpl::get_value(
         ObjectName& value,
-        const ObjectName& key) const
+        const ObjectName& key) const noexcept
 {
     auto it = value_.find(key);
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -102,13 +102,13 @@ bool AnnotationDescriptorImpl::equals(
 }
 
 bool AnnotationDescriptorImpl::equals(
-        AnnotationDescriptorImpl& descriptor)
+        AnnotationDescriptorImpl& descriptor) noexcept
 {
     return (type_ && type_->equals(descriptor.type_)) &&
            value_ == descriptor.value_;
 }
 
-bool AnnotationDescriptorImpl::is_consistent()
+bool AnnotationDescriptorImpl::is_consistent() noexcept
 {
     if (!type_ || type_->get_kind() != TK_ANNOTATION)
     {

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -87,7 +87,7 @@ ReturnCode_t AnnotationDescriptorImpl::copy_from(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::copy_from(
-        const AnnotationDescriptorImpl& descriptor)
+        const AnnotationDescriptorImpl& descriptor) noexcept
 {
     type_ = descriptor.type_;
     value_.clear();

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -32,7 +32,7 @@ traits<AnnotationDescriptor>::ref_type traits<AnnotationDescriptor>::make_shared
 
 ReturnCode_t AnnotationDescriptorImpl::get_value(
         ObjectName& value,
-        const ObjectName& key) noexcept
+        const ObjectName& key)
 {
     const AnnotationDescriptorImpl& myself = *this;
     return myself.get_value(value, key);
@@ -40,7 +40,7 @@ ReturnCode_t AnnotationDescriptorImpl::get_value(
 
 ReturnCode_t AnnotationDescriptorImpl::get_value(
         ObjectName& value,
-        const ObjectName& key) const noexcept
+        const ObjectName& key) const
 {
     auto it = value_.find(key);
 
@@ -54,14 +54,14 @@ ReturnCode_t AnnotationDescriptorImpl::get_value(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::get_all_value(
-        Parameters& value) noexcept
+        Parameters& value)
 {
     const AnnotationDescriptorImpl& myself = *this;
     return myself.get_all_value(value);
 }
 
 ReturnCode_t AnnotationDescriptorImpl::get_all_value(
-        Parameters& value) const noexcept
+        Parameters& value) const
 {
     value = value_;
     return RETCODE_OK;
@@ -69,14 +69,14 @@ ReturnCode_t AnnotationDescriptorImpl::get_all_value(
 
 ReturnCode_t AnnotationDescriptorImpl::set_value(
         const ObjectName& key,
-        const ObjectName& value) noexcept
+        const ObjectName& value)
 {
     value_[key] = value;
     return RETCODE_OK;
 }
 
 ReturnCode_t AnnotationDescriptorImpl::copy_from(
-        traits<AnnotationDescriptor>::ref_type descriptor) noexcept
+        traits<AnnotationDescriptor>::ref_type descriptor)
 {
     if (!descriptor)
     {
@@ -87,7 +87,7 @@ ReturnCode_t AnnotationDescriptorImpl::copy_from(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::copy_from(
-        const AnnotationDescriptorImpl& descriptor) noexcept
+        const AnnotationDescriptorImpl& descriptor)
 {
     type_ = descriptor.type_;
     value_.clear();
@@ -96,19 +96,19 @@ ReturnCode_t AnnotationDescriptorImpl::copy_from(
 }
 
 bool AnnotationDescriptorImpl::equals(
-        traits<AnnotationDescriptor>::ref_type descriptor) noexcept
+        traits<AnnotationDescriptor>::ref_type descriptor)
 {
     return equals(*traits<AnnotationDescriptor>::narrow<AnnotationDescriptorImpl>(descriptor));
 }
 
 bool AnnotationDescriptorImpl::equals(
-        AnnotationDescriptorImpl& descriptor) noexcept
+        AnnotationDescriptorImpl& descriptor)
 {
     return (type_ && type_->equals(descriptor.type_)) &&
            value_ == descriptor.value_;
 }
 
-bool AnnotationDescriptorImpl::is_consistent() noexcept
+bool AnnotationDescriptorImpl::is_consistent()
 {
     if (!type_ || type_->get_kind() != TK_ANNOTATION)
     {

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -96,7 +96,7 @@ ReturnCode_t AnnotationDescriptorImpl::copy_from(
 }
 
 bool AnnotationDescriptorImpl::equals(
-        traits<AnnotationDescriptor>::ref_type descriptor)
+        traits<AnnotationDescriptor>::ref_type descriptor) noexcept
 {
     return equals(*traits<AnnotationDescriptor>::narrow<AnnotationDescriptorImpl>(descriptor));
 }

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -76,7 +76,7 @@ ReturnCode_t AnnotationDescriptorImpl::set_value(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::copy_from(
-        traits<AnnotationDescriptor>::ref_type descriptor)
+        traits<AnnotationDescriptor>::ref_type descriptor) noexcept
 {
     if (!descriptor)
     {

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -54,7 +54,7 @@ ReturnCode_t AnnotationDescriptorImpl::get_value(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::get_all_value(
-        Parameters& value)
+        Parameters& value) noexcept
 {
     const AnnotationDescriptorImpl& myself = *this;
     return myself.get_all_value(value);

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -69,7 +69,7 @@ ReturnCode_t AnnotationDescriptorImpl::get_all_value(
 
 ReturnCode_t AnnotationDescriptorImpl::set_value(
         const ObjectName& key,
-        const ObjectName& value)
+        const ObjectName& value) noexcept
 {
     value_[key] = value;
     return RETCODE_OK;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.cpp
@@ -61,7 +61,7 @@ ReturnCode_t AnnotationDescriptorImpl::get_all_value(
 }
 
 ReturnCode_t AnnotationDescriptorImpl::get_all_value(
-        Parameters& value) const
+        Parameters& value) const noexcept
 {
     value = value_;
     return RETCODE_OK;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -73,7 +73,7 @@ public:
 
     ReturnCode_t set_value(
             const ObjectName& key,
-            const ObjectName& value)  override;
+            const ObjectName& value) noexcept override;
 
     ReturnCode_t copy_from(
             traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -82,7 +82,7 @@ public:
             const AnnotationDescriptorImpl& descriptor) noexcept;
 
     bool equals(
-            traits<AnnotationDescriptor>::ref_type descriptor)  override;
+            traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;
 
     bool equals(
             AnnotationDescriptorImpl& descriptor) noexcept;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -31,63 +31,63 @@ class AnnotationDescriptorImpl : public virtual AnnotationDescriptor
 
 public:
 
-    AnnotationDescriptorImpl() noexcept = default;
+    AnnotationDescriptorImpl()  = default;
 
     AnnotationDescriptorImpl(
-            const AnnotationDescriptorImpl&) noexcept = default;
+            const AnnotationDescriptorImpl&)  = default;
 
     AnnotationDescriptorImpl(
-            AnnotationDescriptorImpl&&) noexcept = default;
+            AnnotationDescriptorImpl&&)  = default;
 
-    virtual ~AnnotationDescriptorImpl() noexcept = default;
+    virtual ~AnnotationDescriptorImpl()  = default;
 
-    traits<DynamicType>::ref_type type() const noexcept override
+    traits<DynamicType>::ref_type type() const override
     {
         return type_;
     }
 
-    traits<DynamicType>::ref_type& type() noexcept override
+    traits<DynamicType>::ref_type& type()  override
     {
         return type_;
     }
 
     void type(
-            traits<DynamicType>::ref_type type) noexcept override
+            traits<DynamicType>::ref_type type)  override
     {
         type_ = type;
     }
 
     ReturnCode_t get_value(
             ObjectName& value,
-            const ObjectName& key) noexcept override;
+            const ObjectName& key)  override;
 
     ReturnCode_t get_value(
             ObjectName& value,
-            const ObjectName& key) const noexcept;
+            const ObjectName& key) const;
 
     ReturnCode_t get_all_value(
-            Parameters& value) noexcept override;
+            Parameters& value)  override;
 
     ReturnCode_t get_all_value(
-            Parameters& value) const noexcept;
+            Parameters& value) const;
 
     ReturnCode_t set_value(
             const ObjectName& key,
-            const ObjectName& value) noexcept override;
+            const ObjectName& value)  override;
 
     ReturnCode_t copy_from(
-            traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;
+            traits<AnnotationDescriptor>::ref_type descriptor)  override;
 
     ReturnCode_t copy_from(
-            const AnnotationDescriptorImpl& descriptor) noexcept;
+            const AnnotationDescriptorImpl& descriptor);
 
     bool equals(
-            traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;
+            traits<AnnotationDescriptor>::ref_type descriptor)  override;
 
     bool equals(
-            AnnotationDescriptorImpl& descriptor) noexcept;
+            AnnotationDescriptorImpl& descriptor);
 
-    bool is_consistent() noexcept override;
+    bool is_consistent()  override;
 };
 
 } // namespace dds

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -46,7 +46,7 @@ public:
         return type_;
     }
 
-    traits<DynamicType>::ref_type& type()  override
+    traits<DynamicType>::ref_type& type() noexcept override
     {
         return type_;
     }

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -41,7 +41,7 @@ public:
 
     virtual ~AnnotationDescriptorImpl()  = default;
 
-    traits<DynamicType>::ref_type type() const override
+    traits<DynamicType>::ref_type type() const noexcept override
     {
         return type_;
     }

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -52,7 +52,7 @@ public:
     }
 
     void type(
-            traits<DynamicType>::ref_type type)  override
+            traits<DynamicType>::ref_type type) noexcept override
     {
         type_ = type;
     }

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -87,7 +87,7 @@ public:
     bool equals(
             AnnotationDescriptorImpl& descriptor);
 
-    bool is_consistent()  override;
+    bool is_consistent() noexcept override;
 };
 
 } // namespace dds

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -66,10 +66,10 @@ public:
             const ObjectName& key) const noexcept;
 
     ReturnCode_t get_all_value(
-            Parameters& value)  override;
+            Parameters& value) noexcept override;
 
     ReturnCode_t get_all_value(
-            Parameters& value) const;
+            Parameters& value) const noexcept;
 
     ReturnCode_t set_value(
             const ObjectName& key,

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -63,7 +63,7 @@ public:
 
     ReturnCode_t get_value(
             ObjectName& value,
-            const ObjectName& key) const;
+            const ObjectName& key) const noexcept;
 
     ReturnCode_t get_all_value(
             Parameters& value)  override;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -79,7 +79,7 @@ public:
             traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;
 
     ReturnCode_t copy_from(
-            const AnnotationDescriptorImpl& descriptor);
+            const AnnotationDescriptorImpl& descriptor) noexcept;
 
     bool equals(
             traits<AnnotationDescriptor>::ref_type descriptor)  override;

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -76,7 +76,7 @@ public:
             const ObjectName& value)  override;
 
     ReturnCode_t copy_from(
-            traits<AnnotationDescriptor>::ref_type descriptor)  override;
+            traits<AnnotationDescriptor>::ref_type descriptor) noexcept override;
 
     ReturnCode_t copy_from(
             const AnnotationDescriptorImpl& descriptor);

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -59,7 +59,7 @@ public:
 
     ReturnCode_t get_value(
             ObjectName& value,
-            const ObjectName& key)  override;
+            const ObjectName& key) noexcept override;
 
     ReturnCode_t get_value(
             ObjectName& value,

--- a/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/AnnotationDescriptorImpl.hpp
@@ -85,7 +85,7 @@ public:
             traits<AnnotationDescriptor>::ref_type descriptor)  override;
 
     bool equals(
-            AnnotationDescriptorImpl& descriptor);
+            AnnotationDescriptorImpl& descriptor) noexcept;
 
     bool is_consistent() noexcept override;
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
*Edit: Fix the problem that gcc-9 cannot compile. The code should take into account version compatibility issues. Now our vehicle communication domain controllers all use gcc-9 and g++-9. You should take this into consideration*

Fixes: #5170
Fixes: #5150
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
