### PR TITLE
[21512] Set string arguments as const references

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -376,7 +376,7 @@ bool DiscoveryDataBase::update(
 
 bool DiscoveryDataBase::update(
         eprosima::fastdds::rtps::CacheChange_t* change,
-        std::string topic_name)
+        const std::string& topic_name)
 {
     // in case the ddb is persistent, we store every cache in queue in a file
     if (is_persistent_ && guid_from_change(change).guidPrefix != server_guid_prefix_)
@@ -1252,7 +1252,7 @@ void DiscoveryDataBase::match_writer_reader_(
 }
 
 bool DiscoveryDataBase::set_dirty_topic_(
-        std::string topic)
+        const std::string& topic)
 {
     EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Setting topic " << topic << " as dirty");
 
@@ -2647,7 +2647,7 @@ void DiscoveryDataBase::clean_backup()
 }
 
 void DiscoveryDataBase::persistence_enable(
-        std::string backup_file_name)
+        const std::string& backup_file_name)
 {
     is_persistent_ = true;
     backup_file_name_ = backup_file_name;

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -130,7 +130,7 @@ public:
      */
     bool update(
             eprosima::fastdds::rtps::CacheChange_t* change,
-            std::string topic_name);
+            const std::string& topic_name);
 
     bool update(
             eprosima::fastdds::rtps::CacheChange_t* change,
@@ -144,7 +144,7 @@ public:
 
     // enable ddb in persistence mode and open the file to backup up in append mode
     void persistence_enable(
-            std::string backup_file_name);
+            const std::string& backup_file_name);
 
     //! Disable the possibility to add new entries to the database
     void disable()
@@ -498,7 +498,7 @@ protected:
     //! Add a topic to the list of dirty topics, unless it's already present
     // Return true if added, false if already there
     bool set_dirty_topic_(
-            std::string topic);
+            const std::string& topic);
 
     // Add data in pdp_to_send if not already in it
     bool add_pdp_to_send_(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR updates the arguments of internal discovery database api to use constant references for string arguments.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #5175

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **NA** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

