### PR TITLE
[21563] TypeLookupService: also register the minimal created from the received complete TypeObject

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
@@ -175,6 +175,13 @@ void TypeLookupReplyListener::check_get_types_reply(
                     fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().get_type_object(
                         requests_it->second.type_id(), type_object);
                     xtypes::TypeObjectUtils::type_object_consistency(type_object);
+                    xtypes::TypeIdentifierPair type_ids;
+                    if (RETCODE_OK != fastdds::rtps::RTPSDomainImpl::get_instance()->type_object_registry_observer().
+                                    register_type_object(type_object, type_ids, true))
+                    {
+                        EPROSIMA_LOG_WARNING(TYPELOOKUP_SERVICE_REPLY_LISTENER,
+                                "Cannot register minimal of remote type");
+                    }
 
                     typelookup_manager_->notify_callbacks(requests_it->second);
                 }

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
@@ -71,7 +71,9 @@ ReturnCode_t TypeObjectRegistry::register_type_object(
     }
     catch (eprosima::fastdds::dds::xtypes::InvalidArgumentError& exception)
     {
-        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Inconsistent CompleteTypeObject: " << exception.what());
+        EPROSIMA_LOG_ERROR(
+            XTYPES_TYPE_REPRESENTATION,
+            "Inconsistent CompleteTypeObject: " << exception.what());
         return eprosima::fastdds::dds::RETCODE_PRECONDITION_NOT_MET;
     }
 #endif // !defined(NDEBUG)
@@ -79,37 +81,45 @@ ReturnCode_t TypeObjectRegistry::register_type_object(
     TypeRegistryEntry minimal_entry;
     complete_entry.type_object.complete(complete_type_object);
     minimal_entry.type_object = build_minimal_from_complete_type_object(complete_type_object);
-    type_ids.type_identifier1(calculate_type_identifier(minimal_entry.type_object,
+    type_ids.type_identifier1(
+        calculate_type_identifier(
+            minimal_entry.type_object,
             minimal_entry.type_object_serialized_size));
-    type_ids.type_identifier2(calculate_type_identifier(complete_entry.type_object,
+    type_ids.type_identifier2(
+        calculate_type_identifier(
+            complete_entry.type_object,
             complete_entry.type_object_serialized_size));
     complete_entry.complementary_type_id = type_ids.type_identifier1();
     minimal_entry.complementary_type_id = type_ids.type_identifier2();
 
     std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
     auto type_ids_result {local_type_identifiers_.insert({type_name, type_ids})};
-    auto min_entry_result {type_registry_entries_.insert({type_ids.type_identifier1(), minimal_entry})};
-    auto max_entry_result {type_registry_entries_.insert({type_ids.type_identifier2(), complete_entry})};
-    if (!type_ids_result.second || !max_entry_result.second)
+
+    if (type_ids_result.second)
     {
-        if (local_type_identifiers_[type_name] != type_ids ||
-                type_registry_entries_[type_ids.type_identifier1()] != minimal_entry ||
-                type_registry_entries_[type_ids.type_identifier2()] != complete_entry)
+        auto min_entry_result {type_registry_entries_.insert(
+                                   {type_ids.type_identifier1(), minimal_entry})};
+        if (!min_entry_result.second)
         {
-            if (type_ids_result.second)
-            {
-                local_type_identifiers_.erase(type_name);
-            }
-            if (min_entry_result.second)
-            {
-                type_registry_entries_.erase(type_ids.type_identifier1());
-            }
-            if (max_entry_result.second)
-            {
-                type_registry_entries_.erase(type_ids.type_identifier2());
-            }
-            return eprosima::fastdds::dds::RETCODE_BAD_PARAMETER;
+            EPROSIMA_LOG_INFO(
+                XTYPES_TYPE_REPRESENTATION,
+                "Type " << type_name << " already registered his EK_MINIMAL remotely.");
         }
+        auto max_entry_result {type_registry_entries_.insert(
+                                   {type_ids.type_identifier2(), complete_entry})};
+        if (!max_entry_result.second)
+        {
+            EPROSIMA_LOG_INFO(
+                XTYPES_TYPE_REPRESENTATION,
+                "Type " << type_name << " already registered his EK_COMPLETE remotely.");
+        }
+    }
+    else
+    {
+        EPROSIMA_LOG_ERROR(
+            XTYPES_TYPE_REPRESENTATION,
+            "Type " << type_name << " already registered locally.");
+        return eprosima::fastdds::dds::RETCODE_BAD_PARAMETER;
     }
     return eprosima::fastdds::dds::RETCODE_OK;
 }
@@ -119,7 +129,8 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
         TypeIdentifierPair& type_identifier)
 {
     // Preconditions
-    if (TypeObjectUtils::is_direct_hash_type_identifier(type_identifier.type_identifier1()) || type_name.empty())
+    if (TypeObjectUtils::is_direct_hash_type_identifier(type_identifier.type_identifier1()) ||
+            type_name.empty())
     {
         return eprosima::fastdds::dds::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -130,23 +141,25 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
     }
     catch (eprosima::fastdds::dds::xtypes::InvalidArgumentError& exception)
     {
-        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Inconsistent TypeIdentifier: " << exception.what());
+        EPROSIMA_LOG_ERROR(
+            XTYPES_TYPE_REPRESENTATION,
+            "Inconsistent TypeIdentifier: " << exception.what());
         return eprosima::fastdds::dds::RETCODE_PRECONDITION_NOT_MET;
     }
 #endif // !defined(NDEBUG)
 
     type_identifier.type_identifier2().no_value({});
 
-    switch (type_identifier.type_identifier1()._d())
-    {
+    switch (type_identifier.type_identifier1()._d()){
         case TI_PLAIN_SEQUENCE_SMALL:
             if (EK_BOTH != type_identifier.type_identifier1().seq_sdefn().header().equiv_kind())
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().seq_sdefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().seq_sdefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().seq_sdefn().element_identifier())));
+                type_identifier.type_identifier1().seq_sdefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().seq_sdefn().element_identifier())));
             }
             break;
         case TI_PLAIN_SEQUENCE_LARGE:
@@ -154,9 +167,10 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().seq_ldefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().seq_ldefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().seq_ldefn().element_identifier())));
+                type_identifier.type_identifier1().seq_ldefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().seq_ldefn().element_identifier())));
             }
             break;
         case TI_PLAIN_ARRAY_SMALL:
@@ -164,9 +178,10 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().array_sdefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().array_sdefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().array_sdefn().element_identifier())));
+                type_identifier.type_identifier1().array_sdefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().array_sdefn().element_identifier())));
             }
             break;
         case TI_PLAIN_ARRAY_LARGE:
@@ -174,9 +189,10 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().array_ldefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().array_ldefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().array_ldefn().element_identifier())));
+                type_identifier.type_identifier1().array_ldefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().array_ldefn().element_identifier())));
             }
             break;
         case TI_PLAIN_MAP_SMALL:
@@ -184,20 +200,23 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().map_sdefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().map_sdefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().map_sdefn().element_identifier())));
+                type_identifier.type_identifier1().map_sdefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().map_sdefn().element_identifier())));
             }
-            if (TypeObjectUtils::is_direct_hash_type_identifier(*type_identifier.type_identifier1().map_sdefn().
-                            key_identifier()))
+            if (TypeObjectUtils::is_direct_hash_type_identifier(
+                        *type_identifier.type_identifier1().map_sdefn().
+                                key_identifier()))
             {
                 if (TK_NONE == type_identifier.type_identifier2()._d())
                 {
                     type_identifier.type_identifier2(type_identifier.type_identifier1());
                 }
-                type_identifier.type_identifier1().map_sdefn().key_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().map_sdefn().key_identifier())));
+                type_identifier.type_identifier1().map_sdefn().key_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().map_sdefn().key_identifier())));
             }
             break;
         case TI_PLAIN_MAP_LARGE:
@@ -205,20 +224,23 @@ ReturnCode_t TypeObjectRegistry::register_type_identifier(
             {
                 type_identifier.type_identifier2(type_identifier.type_identifier1());
                 type_identifier.type_identifier1().map_ldefn().header().equiv_kind(EK_MINIMAL);
-                type_identifier.type_identifier1().map_ldefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().map_ldefn().element_identifier())));
+                type_identifier.type_identifier1().map_ldefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().map_ldefn().element_identifier())));
             }
-            if (TypeObjectUtils::is_direct_hash_type_identifier(*type_identifier.type_identifier1().map_ldefn().
-                            key_identifier()))
+            if (TypeObjectUtils::is_direct_hash_type_identifier(
+                        *type_identifier.type_identifier1().map_ldefn().
+                                key_identifier()))
             {
                 if (TK_NONE == type_identifier.type_identifier2()._d())
                 {
                     type_identifier.type_identifier2(type_identifier.type_identifier1());
                 }
-                type_identifier.type_identifier1().map_ldefn().key_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_identifier.type_identifier2().map_ldefn().key_identifier())));
+                type_identifier.type_identifier1().map_ldefn().key_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_identifier.type_identifier2().map_ldefn().key_identifier())));
             }
             break;
         default:
@@ -349,10 +371,13 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
         if (with_dependencies)
         {
             std::unordered_set<TypeIdentfierWithSize> type_dependencies;
-            if (RETCODE_OK == get_type_dependencies_impl({type_ids.type_identifier1()},
-                    type_dependencies))
+            if (RETCODE_OK == get_type_dependencies_impl(
+                        {type_ids.type_identifier1()},
+                        type_dependencies))
             {
-                type_information.complete().dependent_typeid_count(static_cast<int32_t>(type_dependencies.size()));
+                type_information.complete().dependent_typeid_count(
+                    static_cast<int32_t>(type_dependencies.
+                            size()));
                 for (auto& dependency : type_dependencies)
                 {
                     type_information.complete().dependent_typeids().emplace_back(std::move(dependency));
@@ -361,15 +386,20 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
             }
             else
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Error retrieving complete type dependenciest.");
+                EPROSIMA_LOG_ERROR(
+                    XTYPES_TYPE_REPRESENTATION,
+                    "Error retrieving complete type dependenciest.");
             }
 
             if (TK_NONE != type_ids.type_identifier2()._d())
             {
-                if (RETCODE_OK == get_type_dependencies_impl({type_ids.type_identifier2()},
-                        type_dependencies))
+                if (RETCODE_OK == get_type_dependencies_impl(
+                            {type_ids.type_identifier2()},
+                            type_dependencies))
                 {
-                    type_information.minimal().dependent_typeid_count(static_cast<int32_t>(type_dependencies.size()));
+                    type_information.minimal().dependent_typeid_count(
+                        static_cast<int32_t>(type_dependencies.
+                                size()));
                     for (auto& dependency : type_dependencies)
                     {
                         type_information.minimal().dependent_typeids().emplace_back(std::move(dependency));
@@ -378,7 +408,9 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
                 }
                 else
                 {
-                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Error retrieving minimal type dependenciest.");
+                    EPROSIMA_LOG_ERROR(
+                        XTYPES_TYPE_REPRESENTATION,
+                        "Error retrieving minimal type dependenciest.");
                 }
             }
             else
@@ -393,12 +425,14 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
         }
 
         std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
-        type_information.complete().typeid_with_size().typeobject_serialized_size(type_registry_entries_.at(
-                    type_ids.type_identifier1()).type_object_serialized_size);
+        type_information.complete().typeid_with_size().typeobject_serialized_size(
+            type_registry_entries_.at(
+                type_ids.type_identifier1()).type_object_serialized_size);
         if (TK_NONE != type_ids.type_identifier2()._d())
         {
-            type_information.minimal().typeid_with_size().typeobject_serialized_size(type_registry_entries_.at(
-                        type_ids.type_identifier2()).type_object_serialized_size);
+            type_information.minimal().typeid_with_size().typeobject_serialized_size(
+                type_registry_entries_.at(
+                    type_ids.type_identifier2()).type_object_serialized_size);
         }
     }
     else
@@ -409,10 +443,13 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
         if (with_dependencies)
         {
             std::unordered_set<TypeIdentfierWithSize> type_dependencies;
-            if (RETCODE_OK == get_type_dependencies_impl({type_ids.type_identifier1()},
-                    type_dependencies))
+            if (RETCODE_OK == get_type_dependencies_impl(
+                        {type_ids.type_identifier1()},
+                        type_dependencies))
             {
-                type_information.minimal().dependent_typeid_count(static_cast<int32_t>(type_dependencies.size()));
+                type_information.minimal().dependent_typeid_count(
+                    static_cast<int32_t>(type_dependencies.
+                            size()));
                 for (auto& dependency : type_dependencies)
                 {
                     type_information.minimal().dependent_typeids().emplace_back(std::move(dependency));
@@ -421,15 +458,20 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
             }
             else
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Error retrieving minimal type dependenciest.");
+                EPROSIMA_LOG_ERROR(
+                    XTYPES_TYPE_REPRESENTATION,
+                    "Error retrieving minimal type dependenciest.");
             }
 
             if (TK_NONE != type_ids.type_identifier2()._d())
             {
-                if (RETCODE_OK == get_type_dependencies_impl({type_ids.type_identifier2()},
-                        type_dependencies))
+                if (RETCODE_OK == get_type_dependencies_impl(
+                            {type_ids.type_identifier2()},
+                            type_dependencies))
                 {
-                    type_information.complete().dependent_typeid_count(static_cast<int32_t>(type_dependencies.size()));
+                    type_information.complete().dependent_typeid_count(
+                        static_cast<int32_t>(type_dependencies.
+                                size()));
                     for (auto& dependency : type_dependencies)
                     {
                         type_information.complete().dependent_typeids().emplace_back(std::move(dependency));
@@ -438,7 +480,9 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
                 }
                 else
                 {
-                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Error retrieving complete type dependenciest.");
+                    EPROSIMA_LOG_ERROR(
+                        XTYPES_TYPE_REPRESENTATION,
+                        "Error retrieving complete type dependenciest.");
                 }
             }
             else
@@ -453,12 +497,14 @@ ReturnCode_t TypeObjectRegistry::get_type_information(
         }
 
         std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
-        type_information.minimal().typeid_with_size().typeobject_serialized_size(type_registry_entries_.at(
-                    type_ids.type_identifier1()).type_object_serialized_size);
+        type_information.minimal().typeid_with_size().typeobject_serialized_size(
+            type_registry_entries_.at(
+                type_ids.type_identifier1()).type_object_serialized_size);
         if (TK_NONE != type_ids.type_identifier2()._d())
         {
-            type_information.complete().typeid_with_size().typeobject_serialized_size(type_registry_entries_.at(
-                        type_ids.type_identifier2()).type_object_serialized_size);
+            type_information.complete().typeid_with_size().typeobject_serialized_size(
+                type_registry_entries_.at(
+                    type_ids.type_identifier2()).type_object_serialized_size);
         }
     }
     return RETCODE_OK;
@@ -489,7 +535,8 @@ bool TypeObjectRegistry::is_type_identifier_known(
         if (it != type_registry_entries_.end())
         {
             // Check typeobject_serialized_size is the same
-            if (it->second.type_object_serialized_size == type_identifier_with_size.typeobject_serialized_size())
+            if (it->second.type_object_serialized_size ==
+                    type_identifier_with_size.typeobject_serialized_size())
             {
                 return true;
             }
@@ -519,7 +566,8 @@ bool TypeObjectRegistry::is_builtin_annotation(
     std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
     for (const auto& it : local_type_identifiers_)
     {
-        if (it.second.type_identifier1() == type_identifier || it.second.type_identifier2() == type_identifier)
+        if (it.second.type_identifier1() == type_identifier ||
+                it.second.type_identifier2() == type_identifier)
         {
             return is_builtin_annotation_name(it.first);
         }
@@ -536,7 +584,8 @@ const TypeIdentifier TypeObjectRegistry::calculate_type_identifier(
     size_t current_alignment {0};
     eprosima::fastdds::rtps::SerializedPayload_t payload(static_cast<uint32_t>(
                 calculator.calculate_serialized_size(type_object, current_alignment)));
-    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data),
+            payload.max_size);
     eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::LITTLE_ENDIANNESS,
             eprosima::fastcdr::CdrVersion::XCDRv2);
     ser << type_object;
@@ -565,7 +614,9 @@ ReturnCode_t TypeObjectRegistry::register_type_object(
         bool build_minimal)
 {
     uint32_t type_object_serialized_size {0};
-    TypeIdentifier type_identifier {calculate_type_identifier(type_object, type_object_serialized_size)};
+    TypeIdentifier type_identifier {calculate_type_identifier(
+                                        type_object,
+                                        type_object_serialized_size)};
 
     if (TK_NONE == type_ids.type_identifier1()._d())
     {
@@ -594,7 +645,9 @@ ReturnCode_t TypeObjectRegistry::register_type_object(
     {
         TypeRegistryEntry minimal_entry;
         minimal_entry.type_object = build_minimal_from_complete_type_object(type_object.complete());
-        type_ids.type_identifier1(calculate_type_identifier(minimal_entry.type_object,
+        type_ids.type_identifier1(
+            calculate_type_identifier(
+                minimal_entry.type_object,
                 minimal_entry.type_object_serialized_size));
         minimal_entry.complementary_type_id = type_ids.type_identifier2();
         complete_entry.complementary_type_id = type_ids.type_identifier1();
@@ -620,8 +673,9 @@ ReturnCode_t TypeObjectRegistry::register_type_object(
             }
             else if (type_ids.type_identifier1() != it->second.complementary_type_id)
             {
-                EPROSIMA_LOG_WARNING(XTYPES_TYPE_REPRESENTATION,
-                        "Registering an already registered complete type object but with different minimal type identifier");
+                EPROSIMA_LOG_WARNING(
+                    XTYPES_TYPE_REPRESENTATION,
+                    "Registering an already registered complete type object but with different minimal type identifier");
             }
         }
     }
@@ -644,29 +698,31 @@ ReturnCode_t TypeObjectRegistry::get_dependencies_from_type_object(
     ReturnCode_t ret_code {eprosima::fastdds::dds::RETCODE_OK};
     TypeIdentifierSeq dependent_type_ids;
     TypeIdentfierWithSize type_id_size;
-    switch (type_object._d())
-    {
+    switch (type_object._d()){
         case EK_MINIMAL:
-            switch (type_object.minimal()._d())
-            {
+            switch (type_object.minimal()._d()){
                 case TK_ALIAS:
                     ret_code = get_alias_dependencies(type_object.minimal().alias_type(), type_dependencies);
                     break;
                 case TK_ANNOTATION:
-                    ret_code = get_annotation_dependencies(type_object.minimal().annotation_type(), type_dependencies);
+                    ret_code = get_annotation_dependencies(
+                        type_object.minimal().annotation_type(), type_dependencies);
                     break;
                 case TK_STRUCTURE:
-                    ret_code = get_structure_dependencies(type_object.minimal().struct_type(), type_dependencies);
+                    ret_code = get_structure_dependencies(
+                        type_object.minimal().struct_type(), type_dependencies);
                     break;
                 case TK_UNION:
                     ret_code = get_union_dependencies(type_object.minimal().union_type(), type_dependencies);
                     break;
                 case TK_SEQUENCE:
-                    ret_code = get_sequence_array_dependencies(type_object.minimal().sequence_type(),
-                                    type_dependencies);
+                    ret_code = get_sequence_array_dependencies(
+                        type_object.minimal().sequence_type(),
+                        type_dependencies);
                     break;
                 case TK_ARRAY:
-                    ret_code = get_sequence_array_dependencies(type_object.minimal().array_type(), type_dependencies);
+                    ret_code = get_sequence_array_dependencies(
+                        type_object.minimal().array_type(), type_dependencies);
                     break;
                 case TK_MAP:
                     ret_code = get_map_dependencies(type_object.minimal().map_type(), type_dependencies);
@@ -679,8 +735,7 @@ ReturnCode_t TypeObjectRegistry::get_dependencies_from_type_object(
             }
             break;
         case EK_COMPLETE:
-            switch (type_object.complete()._d())
-            {
+            switch (type_object.complete()._d()){
                 case TK_ALIAS:
                     ret_code = get_alias_dependencies(type_object.complete().alias_type(), type_dependencies);
 
@@ -701,10 +756,12 @@ ReturnCode_t TypeObjectRegistry::get_dependencies_from_type_object(
                     }
                     break;
                 case TK_ANNOTATION:
-                    ret_code = get_annotation_dependencies(type_object.complete().annotation_type(), type_dependencies);
+                    ret_code = get_annotation_dependencies(
+                        type_object.complete().annotation_type(), type_dependencies);
                     break;
                 case TK_STRUCTURE:
-                    ret_code = get_structure_dependencies(type_object.complete().struct_type(), type_dependencies);
+                    ret_code = get_structure_dependencies(
+                        type_object.complete().struct_type(), type_dependencies);
                     if (ret_code == eprosima::fastdds::dds::RETCODE_OK &&
                             type_object.complete().struct_type().header().detail().ann_custom().has_value())
                     {
@@ -763,12 +820,14 @@ ReturnCode_t TypeObjectRegistry::get_dependencies_from_type_object(
                     }
                     break;
                 case TK_SEQUENCE:
-                    ret_code = get_sequence_array_dependencies(type_object.complete().sequence_type(),
-                                    type_dependencies);
+                    ret_code = get_sequence_array_dependencies(
+                        type_object.complete().sequence_type(),
+                        type_dependencies);
                     //TODO Collection annotations are not currently supported, so their dependencies are ignored.
                     break;
                 case TK_ARRAY:
-                    ret_code = get_sequence_array_dependencies(type_object.complete().array_type(), type_dependencies);
+                    ret_code = get_sequence_array_dependencies(
+                        type_object.complete().array_type(), type_dependencies);
                     //TODO Collection annotations are not currently supported, so their dependencies are ignored.
                     break;
                 case TK_MAP:
@@ -809,7 +868,8 @@ ReturnCode_t TypeObjectRegistry::get_dependencies_from_type_object(
                     }
                     if (ret_code == eprosima::fastdds::dds::RETCODE_OK)
                     {
-                        for (CompleteEnumeratedLiteral member : type_object.complete().enumerated_type().literal_seq())
+                        for (CompleteEnumeratedLiteral member :
+                                type_object.complete().enumerated_type().literal_seq())
                         {
                             if (member.detail().ann_custom().has_value())
                             {
@@ -894,8 +954,7 @@ ReturnCode_t TypeObjectRegistry::get_type_dependencies_impl(
         }
         else if (TypeObjectUtils::is_indirect_hash_type_identifier(type_id))
         {
-            switch (type_id._d())
-            {
+            switch (type_id._d()){
                 case TI_PLAIN_SEQUENCE_SMALL:
                     get_indirect_hash_collection_dependencies(type_id.seq_sdefn(), type_dependencies);
                     break;
@@ -930,7 +989,9 @@ void TypeObjectRegistry::add_dependency(
     type_id_size.type_id(type_id);
     {
         std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
-        type_id_size.typeobject_serialized_size(type_registry_entries_.at(type_id).type_object_serialized_size);
+        type_id_size.typeobject_serialized_size(
+            type_registry_entries_.at(
+                type_id).type_object_serialized_size);
     }
     type_dependencies.insert(type_id_size);
 }
@@ -963,17 +1024,22 @@ ReturnCode_t TypeObjectRegistry::get_custom_annotations_dependencies(
 bool TypeObjectRegistry::is_builtin_annotation_name(
         const std::string& name)
 {
-    if (name == id_annotation_name || name == autoid_annotation_name || name == optional_annotation_name ||
+    if (name == id_annotation_name || name == autoid_annotation_name ||
+            name == optional_annotation_name ||
             name == position_annotation_name || name == value_annotation_name ||
             name == extensibility_annotation_name ||
-            name == final_annotation_name || name == appendable_annotation_name || name == mutable_annotation_name ||
+            name == final_annotation_name || name == appendable_annotation_name ||
+            name == mutable_annotation_name ||
             name == key_annotation_name || name == must_understand_annotation_name ||
             name == default_literal_annotation_name || name == default_annotation_name ||
             name == range_annotation_name ||
             name == min_annotation_name || name == max_annotation_name || name == unit_annotation_name ||
-            name == bit_bound_annotation_name || name == external_annotation_name || name == nested_annotation_name ||
-            name == verbatim_annotation_name || name == service_annotation_name || name == oneway_annotation_name ||
-            name == ami_annotation_name || name == hashid_annotation_name || name == default_nested_annotation_name ||
+            name == bit_bound_annotation_name || name == external_annotation_name ||
+            name == nested_annotation_name ||
+            name == verbatim_annotation_name || name == service_annotation_name ||
+            name == oneway_annotation_name ||
+            name == ami_annotation_name || name == hashid_annotation_name ||
+            name == default_nested_annotation_name ||
             name == ignore_literal_names_annotation_name || name == try_construct_annotation_name ||
             name == non_serialized_annotation_name || name == data_representation_annotation_name ||
             name == topic_annotation_name)
@@ -987,8 +1053,7 @@ const TypeObject TypeObjectRegistry::build_minimal_from_complete_type_object(
         const CompleteTypeObject& complete_type_object)
 {
     MinimalTypeObject minimal_type_object;
-    switch (complete_type_object._d())
-    {
+    switch (complete_type_object._d()){
         case TK_ALIAS:
         {
             MinimalAliasType minimal_alias_type = build_minimal_from_complete_alias_type(
@@ -1072,8 +1137,9 @@ const MinimalAliasType TypeObjectRegistry::build_minimal_from_complete_alias_typ
     // alias_flags: unused. No flags apply.
     // header: empty. Available for future extension.
     minimal_alias_type.body().common(complete_alias_type.body().common());
-    minimal_alias_type.body().common().related_type(minimal_from_complete_type_identifier(
-                complete_alias_type.body().common().related_type()));
+    minimal_alias_type.body().common().related_type(
+        minimal_from_complete_type_identifier(
+            complete_alias_type.body().common().related_type()));
     return minimal_alias_type;
 }
 
@@ -1084,17 +1150,20 @@ const MinimalAnnotationType TypeObjectRegistry::build_minimal_from_complete_anno
     // annotation_flag: unused. No flags apply.
     // header: empty. Available for future extension.
     MinimalAnnotationParameterSeq minimal_annotation_parameter_sequence;
-    for (const CompleteAnnotationParameter& complete_annotation_parameter : complete_annotation_type.member_seq())
+    for (const CompleteAnnotationParameter& complete_annotation_parameter :
+            complete_annotation_type.member_seq())
     {
         MinimalAnnotationParameter minimal_annotation_parameter;
         minimal_annotation_parameter.common(complete_annotation_parameter.common());
-        minimal_annotation_parameter.common().member_type_id(minimal_from_complete_type_identifier(
-                    complete_annotation_parameter.common().member_type_id()));
-        minimal_annotation_parameter.name_hash(TypeObjectUtils::name_hash(
-                    complete_annotation_parameter.name().c_str()));
+        minimal_annotation_parameter.common().member_type_id(
+            minimal_from_complete_type_identifier(
+                complete_annotation_parameter.common().member_type_id()));
+        minimal_annotation_parameter.name_hash(
+            TypeObjectUtils::name_hash(
+                complete_annotation_parameter.name().c_str()));
         minimal_annotation_parameter.default_value(complete_annotation_parameter.default_value());
         auto it {minimal_annotation_parameter_sequence.begin()};
-        for (; it !=  minimal_annotation_parameter_sequence.end(); ++it)
+        for (; it != minimal_annotation_parameter_sequence.end(); ++it)
         {
             if (it->name_hash() > minimal_annotation_parameter.name_hash())
             {
@@ -1112,18 +1181,21 @@ const MinimalStructType TypeObjectRegistry::build_minimal_from_complete_struct_t
 {
     MinimalStructType minimal_struct_type;
     minimal_struct_type.struct_flags(complete_struct_type.struct_flags());
-    minimal_struct_type.header().base_type(minimal_from_complete_type_identifier(
-                complete_struct_type.header().base_type()));
+    minimal_struct_type.header().base_type(
+        minimal_from_complete_type_identifier(
+            complete_struct_type.header().base_type()));
     // header().detail: empty. Available for future extension.
     MinimalStructMemberSeq minimal_struct_member_sequence;
     for (const CompleteStructMember& complete_struct_member : complete_struct_type.member_seq())
     {
         MinimalStructMember minimal_struct_member;
         minimal_struct_member.common(complete_struct_member.common());
-        minimal_struct_member.common().member_type_id(minimal_from_complete_type_identifier(
-                    complete_struct_member.common().member_type_id()));
-        minimal_struct_member.detail().name_hash(TypeObjectUtils::name_hash(
-                    complete_struct_member.detail().name().c_str()));
+        minimal_struct_member.common().member_type_id(
+            minimal_from_complete_type_identifier(
+                complete_struct_member.common().member_type_id()));
+        minimal_struct_member.detail().name_hash(
+            TypeObjectUtils::name_hash(
+                complete_struct_member.detail().name().c_str()));
         minimal_struct_member_sequence.push_back(minimal_struct_member);
     }
     minimal_struct_type.member_seq(minimal_struct_member_sequence);
@@ -1137,17 +1209,20 @@ const MinimalUnionType TypeObjectRegistry::build_minimal_from_complete_union_typ
     minimal_union_type.union_flags(complete_union_type.union_flags());
     // header: empty. Available for future extension.
     minimal_union_type.discriminator().common(complete_union_type.discriminator().common());
-    minimal_union_type.discriminator().common().type_id(minimal_from_complete_type_identifier(
-                complete_union_type.discriminator().common().type_id()));
+    minimal_union_type.discriminator().common().type_id(
+        minimal_from_complete_type_identifier(
+            complete_union_type.discriminator().common().type_id()));
     MinimalUnionMemberSeq minimal_union_member_sequence;
     for (const CompleteUnionMember& complete_union_member : complete_union_type.member_seq())
     {
         MinimalUnionMember minimal_union_member;
         minimal_union_member.common(complete_union_member.common());
-        minimal_union_member.common().type_id(minimal_from_complete_type_identifier(
-                    minimal_union_member.common().type_id()));
-        minimal_union_member.detail().name_hash(TypeObjectUtils::name_hash(
-                    complete_union_member.detail().name().c_str()));
+        minimal_union_member.common().type_id(
+            minimal_from_complete_type_identifier(
+                minimal_union_member.common().type_id()));
+        minimal_union_member.detail().name_hash(
+            TypeObjectUtils::name_hash(
+                complete_union_member.detail().name().c_str()));
         minimal_union_member_sequence.push_back(minimal_union_member);
     }
     minimal_union_type.member_seq(minimal_union_member_sequence);
@@ -1165,8 +1240,9 @@ const MinimalBitsetType TypeObjectRegistry::build_minimal_from_complete_bitset_t
     {
         MinimalBitfield minimal_bitfield;
         minimal_bitfield.common(complete_bitfield.common());
-        minimal_bitfield.name_hash(TypeObjectUtils::name_hash(
-                    complete_bitfield.detail().name().c_str()));
+        minimal_bitfield.name_hash(
+            TypeObjectUtils::name_hash(
+                complete_bitfield.detail().name().c_str()));
         minimal_bitfield_sequence.push_back(minimal_bitfield);
     }
     minimal_bitset_type.field_seq(minimal_bitfield_sequence);
@@ -1180,8 +1256,9 @@ const MinimalSequenceType TypeObjectRegistry::build_minimal_from_complete_sequen
     // collection_flag: unused. No flags apply.
     minimal_sequence_type.header().common(complete_sequence_type.header().common());
     minimal_sequence_type.element().common(complete_sequence_type.element().common());
-    minimal_sequence_type.element().common().type(minimal_from_complete_type_identifier(
-                complete_sequence_type.element().common().type()));
+    minimal_sequence_type.element().common().type(
+        minimal_from_complete_type_identifier(
+            complete_sequence_type.element().common().type()));
     return minimal_sequence_type;
 }
 
@@ -1192,8 +1269,9 @@ const MinimalArrayType TypeObjectRegistry::build_minimal_from_complete_array_typ
     // collection_flag: unused. No flags apply.
     minimal_array_type.header().common(complete_array_type.header().common());
     minimal_array_type.element().common(complete_array_type.element().common());
-    minimal_array_type.element().common().type(minimal_from_complete_type_identifier(
-                complete_array_type.element().common().type()));
+    minimal_array_type.element().common().type(
+        minimal_from_complete_type_identifier(
+            complete_array_type.element().common().type()));
     return minimal_array_type;
 }
 
@@ -1204,11 +1282,13 @@ const MinimalMapType TypeObjectRegistry::build_minimal_from_complete_map_type(
     // collection_flag: unused. No flags apply.
     minimal_map_type.header().common(complete_map_type.header().common());
     minimal_map_type.key().common(complete_map_type.key().common());
-    minimal_map_type.key().common().type(minimal_from_complete_type_identifier(
-                complete_map_type.key().common().type()));
+    minimal_map_type.key().common().type(
+        minimal_from_complete_type_identifier(
+            complete_map_type.key().common().type()));
     minimal_map_type.element().common(complete_map_type.element().common());
-    minimal_map_type.element().common().type(minimal_from_complete_type_identifier(
-                complete_map_type.element().common().type()));
+    minimal_map_type.element().common().type(
+        minimal_from_complete_type_identifier(
+            complete_map_type.element().common().type()));
     return minimal_map_type;
 }
 
@@ -1219,12 +1299,14 @@ const MinimalEnumeratedType TypeObjectRegistry::build_minimal_from_complete_enum
     // enum_flags: unused. No flags apply.
     minimal_enumerated_type.header().common(complete_enumerated_type.header().common());
     MinimalEnumeratedLiteralSeq minimal_enumerated_literal_sequence;
-    for (const CompleteEnumeratedLiteral& complete_enumerated_literal : complete_enumerated_type.literal_seq())
+    for (const CompleteEnumeratedLiteral& complete_enumerated_literal :
+            complete_enumerated_type.literal_seq())
     {
         MinimalEnumeratedLiteral minimal_enumerated_literal;
         minimal_enumerated_literal.common(complete_enumerated_literal.common());
-        minimal_enumerated_literal.detail().name_hash(TypeObjectUtils::name_hash(
-                    complete_enumerated_literal.detail().name().c_str()));
+        minimal_enumerated_literal.detail().name_hash(
+            TypeObjectUtils::name_hash(
+                complete_enumerated_literal.detail().name().c_str()));
         minimal_enumerated_literal_sequence.push_back(minimal_enumerated_literal);
     }
     minimal_enumerated_type.literal_seq(minimal_enumerated_literal_sequence);
@@ -1242,8 +1324,9 @@ const MinimalBitmaskType TypeObjectRegistry::build_minimal_from_complete_bitmask
     {
         MinimalBitflag minimal_bitflag;
         minimal_bitflag.common(complete_bitflag.common());
-        minimal_bitflag.detail().name_hash(TypeObjectUtils::name_hash(
-                    complete_bitflag.detail().name().c_str()));
+        minimal_bitflag.detail().name_hash(
+            TypeObjectUtils::name_hash(
+                complete_bitflag.detail().name().c_str()));
         minimal_bitflag_sequence.push_back(minimal_bitflag);
     }
     minimal_bitmask_type.flag_seq(minimal_bitflag_sequence);
@@ -1289,8 +1372,7 @@ void TypeObjectRegistry::register_primitive_type_identifiers()
 const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
         const TypeIdentifier& type_id)
 {
-    switch (type_id._d())
-    {
+    switch (type_id._d()){
         case EK_COMPLETE:
         {
             std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
@@ -1307,9 +1389,10 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 TypeIdentifier ret_type_id;
                 ret_type_id = type_id;
                 ret_type_id.seq_sdefn().header().equiv_kind(EK_MINIMAL);
-                ret_type_id.seq_sdefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_id.seq_sdefn().element_identifier())));
+                ret_type_id.seq_sdefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_id.seq_sdefn().element_identifier())));
                 return ret_type_id;
             }
             break;
@@ -1319,9 +1402,10 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 TypeIdentifier ret_type_id;
                 ret_type_id = type_id;
                 ret_type_id.seq_ldefn().header().equiv_kind(EK_MINIMAL);
-                ret_type_id.seq_ldefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_id.seq_ldefn().element_identifier())));
+                ret_type_id.seq_ldefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_id.seq_ldefn().element_identifier())));
                 return ret_type_id;
             }
             break;
@@ -1331,9 +1415,10 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 TypeIdentifier ret_type_id;
                 ret_type_id = type_id;
                 ret_type_id.array_sdefn().header().equiv_kind(EK_MINIMAL);
-                ret_type_id.array_sdefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_id.array_sdefn().element_identifier())));
+                ret_type_id.array_sdefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_id.array_sdefn().element_identifier())));
                 return ret_type_id;
             }
             break;
@@ -1343,9 +1428,10 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 TypeIdentifier ret_type_id;
                 ret_type_id = type_id;
                 ret_type_id.array_ldefn().header().equiv_kind(EK_MINIMAL);
-                ret_type_id.array_ldefn().element_identifier(new TypeIdentifier(
-                            get_complementary_type_identifier(
-                                *type_id.array_ldefn().element_identifier())));
+                ret_type_id.array_ldefn().element_identifier(
+                    new TypeIdentifier(
+                        get_complementary_type_identifier(
+                            *type_id.array_ldefn().element_identifier())));
                 return ret_type_id;
             }
             break;
@@ -1359,15 +1445,17 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 if (type_id.map_sdefn().header().equiv_kind() == EK_COMPLETE)
                 {
                     ret_type_id.map_sdefn().header().equiv_kind(EK_MINIMAL);
-                    ret_type_id.map_sdefn().element_identifier(new TypeIdentifier(
-                                get_complementary_type_identifier(
-                                    *type_id.map_sdefn().element_identifier())));
+                    ret_type_id.map_sdefn().element_identifier(
+                        new TypeIdentifier(
+                            get_complementary_type_identifier(
+                                *type_id.map_sdefn().element_identifier())));
                 }
                 if (type_id.map_sdefn().key_identifier()->_d() == EK_COMPLETE)
                 {
-                    ret_type_id.map_sdefn().key_identifier(new TypeIdentifier(
-                                get_complementary_type_identifier(
-                                    *type_id.map_sdefn().key_identifier())));
+                    ret_type_id.map_sdefn().key_identifier(
+                        new TypeIdentifier(
+                            get_complementary_type_identifier(
+                                *type_id.map_sdefn().key_identifier())));
                 }
                 return ret_type_id;
             }
@@ -1382,15 +1470,17 @@ const TypeIdentifier TypeObjectRegistry::minimal_from_complete_type_identifier(
                 if (type_id.map_ldefn().header().equiv_kind() == EK_COMPLETE)
                 {
                     ret_type_id.map_ldefn().header().equiv_kind(EK_MINIMAL);
-                    ret_type_id.map_ldefn().element_identifier(new TypeIdentifier(
-                                get_complementary_type_identifier(
-                                    *type_id.map_ldefn().element_identifier())));
+                    ret_type_id.map_ldefn().element_identifier(
+                        new TypeIdentifier(
+                            get_complementary_type_identifier(
+                                *type_id.map_ldefn().element_identifier())));
                 }
                 if (type_id.map_ldefn().key_identifier()->_d() == EK_COMPLETE)
                 {
-                    ret_type_id.map_ldefn().key_identifier(new TypeIdentifier(
-                                get_complementary_type_identifier(
-                                    *type_id.map_ldefn().key_identifier())));
+                    ret_type_id.map_ldefn().key_identifier(
+                        new TypeIdentifier(
+                            get_complementary_type_identifier(
+                                *type_id.map_ldefn().key_identifier())));
                 }
                 return ret_type_id;
             }
@@ -1407,12 +1497,12 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
         TypeIdentifierPair& type_ids)
 {
     ReturnCode_t ret_code {eprosima::fastdds::dds::RETCODE_OK};
-    traits<DynamicTypeImpl>::ref_type dynamic_type_impl {traits<DynamicType>::narrow<DynamicTypeImpl>(dynamic_type)};
+    traits<DynamicTypeImpl>::ref_type dynamic_type_impl {traits<DynamicType>::narrow<DynamicTypeImpl>(
+                                                             dynamic_type)};
     type_ids.type_identifier1().no_value({});
     type_ids.type_identifier2().no_value({});
 
-    switch (dynamic_type_impl->get_kind())
-    {
+    switch (dynamic_type_impl->get_kind()){
         case eprosima::fastdds::dds::TK_ALIAS:
             ret_code = register_typeobject_w_alias_dynamic_type(dynamic_type_impl, type_ids);
             break;
@@ -1431,7 +1521,8 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
         case eprosima::fastdds::dds::TK_SEQUENCE:
         {
             const TypeDescriptorImpl& type_descriptor {dynamic_type_impl->get_descriptor()};
-            if (0 == dynamic_type_impl->get_annotation_count() && 0 == dynamic_type_impl->get_verbatim_text_count() &&
+            if (0 == dynamic_type_impl->get_annotation_count() &&
+                    0 == dynamic_type_impl->get_verbatim_text_count() &&
                     0 == type_descriptor.element_type()->get_annotation_count())
             {
                 ret_code = typeidentifier_w_sequence_dynamic_type(dynamic_type_impl, type_ids);
@@ -1445,10 +1536,13 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
         case eprosima::fastdds::dds::TK_ARRAY:
         {
             const TypeDescriptorImpl& type_descriptor {dynamic_type_impl->get_descriptor()};
-            if (0 == dynamic_type_impl->get_annotation_count() && 0 == dynamic_type_impl->get_verbatim_text_count() &&
+            if (0 == dynamic_type_impl->get_annotation_count() &&
+                    0 == dynamic_type_impl->get_verbatim_text_count() &&
                     0 == type_descriptor.element_type()->get_annotation_count())
             {
-                ret_code = typeidentifier_w_array_dynamic_type(dynamic_type_impl, type_ids.type_identifier1());
+                ret_code = typeidentifier_w_array_dynamic_type(
+                    dynamic_type_impl,
+                    type_ids.type_identifier1());
             }
             else
             {
@@ -1459,11 +1553,14 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
         case eprosima::fastdds::dds::TK_MAP:
         {
             const TypeDescriptorImpl& type_descriptor {dynamic_type_impl->get_descriptor()};
-            if (0 == dynamic_type_impl->get_annotation_count() && 0 == dynamic_type_impl->get_verbatim_text_count() &&
+            if (0 == dynamic_type_impl->get_annotation_count() &&
+                    0 == dynamic_type_impl->get_verbatim_text_count() &&
                     0 == type_descriptor.element_type()->get_annotation_count() &&
                     0 == type_descriptor.key_element_type()->get_annotation_count())
             {
-                ret_code = typeidentifier_w_map_dynamic_type(dynamic_type_impl, type_ids.type_identifier1());
+                ret_code = typeidentifier_w_map_dynamic_type(
+                    dynamic_type_impl,
+                    type_ids.type_identifier1());
             }
             else
             {
@@ -1534,7 +1631,6 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_dynamic_type(
     return ret_code;
 
 
-
 }
 
 ReturnCode_t TypeObjectRegistry::register_typeobject_w_alias_dynamic_type(
@@ -1553,12 +1649,14 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_alias_dynamic_type(
     register_typeobject_w_dynamic_type(type_descriptor.base_type(), alias_type_ids);
 
     bool ec {false};
-    CommonAliasBody common {TypeObjectUtils::build_common_alias_body(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                        alias_type_ids,
-                                        ec))};
-    CompleteAliasBody body {TypeObjectUtils::build_complete_alias_body(common,
-                                    eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
-                                    eprosima::fastcdr::optional<AppliedAnnotationSeq>())};
+    CommonAliasBody common {TypeObjectUtils::build_common_alias_body(
+                                0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                    alias_type_ids,
+                                    ec))};
+    CompleteAliasBody body {TypeObjectUtils::build_complete_alias_body(
+                                common,
+                                eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
+                                eprosima::fastcdr::optional<AppliedAnnotationSeq>())};
     CompleteAliasType alias_type = TypeObjectUtils::build_complete_alias_type(0, header, body);
     CompleteTypeObject complete_typeobject;
     complete_typeobject.alias_type(alias_type);
@@ -1576,7 +1674,8 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_annotation_dynamic_type(
 {
     ReturnCode_t ret_code {RETCODE_OK};
 
-    CompleteAnnotationHeader header {TypeObjectUtils::build_complete_annotation_header(dynamic_type->get_name())};
+    CompleteAnnotationHeader header {TypeObjectUtils::build_complete_annotation_header(
+                                         dynamic_type->get_name())};
 
     auto& parameters {dynamic_type->get_all_members_by_index()};
     CompleteAnnotationParameterSeq member_seq;
@@ -1586,20 +1685,25 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_annotation_dynamic_type(
         TypeIdentifierPair parameter_type_ids;
         register_typeobject_w_dynamic_type(member_descriptor.type(), parameter_type_ids);
         bool ec {false};
-        CommonAnnotationParameter common {TypeObjectUtils::build_common_annotation_parameter(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                      parameter_type_ids,
-                                                      ec))};
+        CommonAnnotationParameter common {TypeObjectUtils::build_common_annotation_parameter(
+                                              0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                  parameter_type_ids,
+                                                  ec))};
 
         AnnotationParameterValue default_value;
-        set_annotation_parameter_value(member_descriptor.type(), member_descriptor.default_value(),
-                default_value);
+        set_annotation_parameter_value(
+            member_descriptor.type(), member_descriptor.default_value(),
+            default_value);
 
-        CompleteAnnotationParameter param {TypeObjectUtils::build_complete_annotation_parameter(common,
-                                                   member_descriptor.name(), default_value)};
+        CompleteAnnotationParameter param {TypeObjectUtils::build_complete_annotation_parameter(
+                                               common,
+                                               member_descriptor.name(), default_value)};
         TypeObjectUtils::add_complete_annotation_parameter(member_seq, param);
     }
 
-    CompleteAnnotationType annotation_type {TypeObjectUtils::build_complete_annotation_type(0, header, member_seq)};
+    CompleteAnnotationType annotation_type {TypeObjectUtils::build_complete_annotation_type(
+                                                0, header,
+                                                member_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.annotation_type(annotation_type);
     TypeObject typeobject;
@@ -1632,34 +1736,42 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_struct_dynamic_type(
     }
 
     bool ec {false};
-    CompleteStructHeader header {TypeObjectUtils::build_complete_struct_header(TypeObjectUtils::retrieve_complete_type_identifier(
-                                             base_type_ids,
-                                             ec), detail)};
+    CompleteStructHeader header {TypeObjectUtils::build_complete_struct_header(
+                                     TypeObjectUtils::retrieve_complete_type_identifier(
+                                         base_type_ids,
+                                         ec), detail)};
 
     auto& struct_members {dynamic_type->get_all_members_by_index()};
     CompleteStructMemberSeq member_seq;
     uint32_t initial_index {dynamic_type->get_index_own_members()};
     assert(initial_index <= struct_members.size());
-    for (auto member {struct_members.begin() + initial_index}; member != struct_members.end(); ++member)
+    for (auto member {struct_members.begin() + initial_index}; member != struct_members.end();
+            ++member)
     {
         MemberDescriptorImpl& member_descriptor {(*member)->get_descriptor()};
         StructMemberFlag member_flags = TypeObjectUtils::build_struct_member_flag(
             try_construct_kind(member_descriptor.try_construct_kind()),
-            member_descriptor.is_optional(), member_descriptor.is_must_understand(), member_descriptor.is_key(),
+            member_descriptor.is_optional(),
+            member_descriptor.is_must_understand(), member_descriptor.is_key(),
             member_descriptor.is_shared());
         TypeIdentifierPair member_type_ids;
         register_typeobject_w_dynamic_type(member_descriptor.type(), member_type_ids);
-        CommonStructMember common {TypeObjectUtils::build_common_struct_member(member_descriptor.id(),
-                                           member_flags,
-                                           TypeObjectUtils::retrieve_complete_type_identifier(member_type_ids, ec))};
+        CommonStructMember common {TypeObjectUtils::build_common_struct_member(
+                                       member_descriptor.id(),
+                                       member_flags,
+                                       TypeObjectUtils::retrieve_complete_type_identifier(member_type_ids, ec))};
 
         CompleteMemberDetail member_detail;
         complete_member_detail(*member, member_detail);
-        CompleteStructMember struct_member {TypeObjectUtils::build_complete_struct_member(common, member_detail)};
+        CompleteStructMember struct_member {TypeObjectUtils::build_complete_struct_member(
+                                                common,
+                                                member_detail)};
         TypeObjectUtils::add_complete_struct_member(member_seq, struct_member);
     }
 
-    CompleteStructType struct_type {TypeObjectUtils::build_complete_struct_type(struct_flags, header, member_seq)};
+    CompleteStructType struct_type {TypeObjectUtils::build_complete_struct_type(
+                                        struct_flags, header,
+                                        member_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.struct_type(struct_type);
     TypeObject typeobject;
@@ -1700,8 +1812,9 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_union_dynamic_type(
     eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> ann_builtin;
     apply_verbatim_annotation(type_descriptor.discriminator_type(), ann_builtin);
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
-    apply_custom_annotations(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                type_descriptor.discriminator_type())->get_annotations(), ann_custom);
+    apply_custom_annotations(
+        traits<DynamicType>::narrow<DynamicTypeImpl>(
+            type_descriptor.discriminator_type())->get_annotations(), ann_custom);
     CompleteDiscriminatorMember discriminator {TypeObjectUtils::build_complete_discriminator_member(
                                                    common_discriminator, ann_builtin, ann_custom)};
 
@@ -1724,19 +1837,24 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_union_dynamic_type(
             {
                 TypeObjectUtils::add_union_case_label(labels, label);
             }
-            CommonUnionMember common {TypeObjectUtils::build_common_union_member(member_descriptor.id(), member_flags,
-                                              TypeObjectUtils::retrieve_complete_type_identifier(member_type_ids,
+            CommonUnionMember common {TypeObjectUtils::build_common_union_member(
+                                          member_descriptor.id(), member_flags,
+                                          TypeObjectUtils::retrieve_complete_type_identifier(
+                                              member_type_ids,
                                               ec), labels)};
 
             CompleteMemberDetail member_detail;
             complete_member_detail(member, member_detail);
-            CompleteUnionMember union_member {TypeObjectUtils::build_complete_union_member(common, member_detail)};
+            CompleteUnionMember union_member {TypeObjectUtils::build_complete_union_member(
+                                                  common,
+                                                  member_detail)};
             TypeObjectUtils::add_complete_union_member(member_seq, union_member);
         }
     }
 
-    CompleteUnionType union_type {TypeObjectUtils::build_complete_union_type(union_flags, header, discriminator,
-                                          member_seq)};
+    CompleteUnionType union_type {TypeObjectUtils::build_complete_union_type(
+                                      union_flags, header, discriminator,
+                                      member_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.union_type(union_type);
     TypeObject typeobject;
@@ -1764,16 +1882,21 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_bitset_dynamic_type(
     for (auto& bitfield : bitfields)
     {
         MemberDescriptorImpl& member_descriptor {bitfield->get_descriptor()};
-        CommonBitfield common {TypeObjectUtils::build_common_bitfield(static_cast<uint16_t>(member_descriptor.id()), 0,
-                                       static_cast<uint8_t>(type_descriptor.bound().at(member_descriptor.index())),
-                                       type_kind(member_descriptor.type()->get_kind()))};
+        CommonBitfield common {TypeObjectUtils::build_common_bitfield(
+                                   static_cast<uint16_t>(member_descriptor.id()), 0,
+                                   static_cast<uint8_t>(type_descriptor.bound().at(member_descriptor.index())),
+                                   type_kind(member_descriptor.type()->get_kind()))};
         CompleteMemberDetail member_detail;
         complete_member_detail(bitfield, member_detail);
-        CompleteBitfield bitfield_member {TypeObjectUtils::build_complete_bitfield(common, member_detail)};
+        CompleteBitfield bitfield_member {TypeObjectUtils::build_complete_bitfield(
+                                              common,
+                                              member_detail)};
         TypeObjectUtils::add_complete_bitfield(field_seq, bitfield_member);
     }
 
-    CompleteBitsetType bitset_type {TypeObjectUtils::build_complete_bitset_type(0, header, field_seq)};
+    CompleteBitsetType bitset_type {TypeObjectUtils::build_complete_bitset_type(
+                                        0, header,
+                                        field_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.bitset_type(bitset_type);
     TypeObject typeobject;
@@ -1799,26 +1922,33 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_sequence_dynamic_type(
     eprosima::fastcdr::optional<CompleteTypeDetail> detail;
     complete_type_detail(dynamic_type, detail.value());
 
-    CompleteCollectionHeader header {TypeObjectUtils::build_complete_collection_header(common, detail)};
+    CompleteCollectionHeader header {TypeObjectUtils::build_complete_collection_header(
+                                         common,
+                                         detail)};
 
     TypeIdentifierPair element_type_ids;
     register_typeobject_w_dynamic_type(type_descriptor.element_type(), element_type_ids);
     // CollectionElementFlags are not applicable (!)
     bool ec {false};
-    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                        element_type_ids,
-                                                        ec))};
+    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(
+                                                0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                    element_type_ids,
+                                                    ec))};
 
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
-    apply_custom_annotations(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                type_descriptor.element_type())->get_annotations(), ann_custom);
+    apply_custom_annotations(
+        traits<DynamicType>::narrow<DynamicTypeImpl>(
+            type_descriptor.element_type())->get_annotations(), ann_custom);
 
     CompleteElementDetail detail_element {TypeObjectUtils::build_complete_element_detail(
                                               eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
                                               ann_custom)};
-    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(common_element,
-                                               detail_element)};
-    CompleteSequenceType sequence_type {TypeObjectUtils::build_complete_sequence_type(0, header, element)};
+    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(
+                                           common_element,
+                                           detail_element)};
+    CompleteSequenceType sequence_type {TypeObjectUtils::build_complete_sequence_type(
+                                            0, header,
+                                            element)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.sequence_type(sequence_type);
     TypeObject typeobject;
@@ -1848,18 +1978,21 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_array_dynamic_type(
     register_typeobject_w_dynamic_type(type_descriptor.element_type(), element_type_ids);
     // CollectionElementFlags are not applicable (!)
     bool ec {false};
-    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                        element_type_ids,
-                                                        ec))};
+    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(
+                                                0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                    element_type_ids,
+                                                    ec))};
 
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
-    apply_custom_annotations(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                type_descriptor.element_type())->get_annotations(), ann_custom);
+    apply_custom_annotations(
+        traits<DynamicType>::narrow<DynamicTypeImpl>(
+            type_descriptor.element_type())->get_annotations(), ann_custom);
     CompleteElementDetail detail_element {TypeObjectUtils::build_complete_element_detail(
                                               eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
                                               ann_custom)};
-    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(common_element,
-                                               detail_element)};
+    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(
+                                           common_element,
+                                           detail_element)};
     CompleteArrayType array_type {TypeObjectUtils::build_complete_array_type(0, header, element)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.array_type(array_type);
@@ -1886,37 +2019,46 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_map_dynamic_type(
     eprosima::fastcdr::optional<CompleteTypeDetail> detail;
     complete_type_detail(dynamic_type, detail.value());
 
-    CompleteCollectionHeader header {TypeObjectUtils::build_complete_collection_header(common, detail)};
+    CompleteCollectionHeader header {TypeObjectUtils::build_complete_collection_header(
+                                         common,
+                                         detail)};
 
     TypeIdentifierPair element_type_ids;
     register_typeobject_w_dynamic_type(type_descriptor.element_type(), element_type_ids);
     // CollectionElementFlags are not applicable (!)
     bool ec {false};
-    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                        element_type_ids,
-                                                        ec))};
+    CommonCollectionElement common_element {TypeObjectUtils::build_common_collection_element(
+                                                0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                    element_type_ids,
+                                                    ec))};
 
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
-    apply_custom_annotations(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                type_descriptor.element_type())->get_annotations(), ann_custom);
+    apply_custom_annotations(
+        traits<DynamicType>::narrow<DynamicTypeImpl>(
+            type_descriptor.element_type())->get_annotations(), ann_custom);
     CompleteElementDetail detail_element {TypeObjectUtils::build_complete_element_detail(
                                               eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
                                               ann_custom)};
-    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(common_element,
-                                               detail_element)};
+    CompleteCollectionElement element {TypeObjectUtils::build_complete_collection_element(
+                                           common_element,
+                                           detail_element)};
 
     TypeIdentifierPair key_type_ids;
     register_typeobject_w_dynamic_type(type_descriptor.key_element_type(), key_type_ids);
-    CommonCollectionElement common_key {TypeObjectUtils::build_common_collection_element(0, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                    key_type_ids,
-                                                    ec))};
+    CommonCollectionElement common_key {TypeObjectUtils::build_common_collection_element(
+                                            0, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                key_type_ids,
+                                                ec))};
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_key;
-    apply_custom_annotations(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                type_descriptor.key_element_type())->get_annotations(), ann_custom_key);
+    apply_custom_annotations(
+        traits<DynamicType>::narrow<DynamicTypeImpl>(
+            type_descriptor.key_element_type())->get_annotations(), ann_custom_key);
     CompleteElementDetail detail_key {TypeObjectUtils::build_complete_element_detail(
                                           eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>(),
                                           ann_custom_key)};
-    CompleteCollectionElement key {TypeObjectUtils::build_complete_collection_element(common_key, detail_key)};
+    CompleteCollectionElement key {TypeObjectUtils::build_complete_collection_element(
+                                       common_key,
+                                       detail_key)};
 
     CompleteMapType map_type {TypeObjectUtils::build_complete_map_type(0, header, key, element)};
     CompleteTypeObject complete_typeobject;
@@ -1939,8 +2081,7 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_enum_dynamic_type(
     assert(0 < literals.size());
     MemberDescriptorImpl& first_member_descriptor {literals.at(0)->get_descriptor()};
     BitBound bound {32};
-    switch (first_member_descriptor.type()->get_kind())
-    {
+    switch (first_member_descriptor.type()->get_kind()){
         case TK_BOOLEAN:
             bound = 1;
             break;
@@ -1957,7 +2098,9 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_enum_dynamic_type(
     CommonEnumeratedHeader common {TypeObjectUtils::build_common_enumerated_header(bound)};
     CompleteTypeDetail detail;
     complete_type_detail(dynamic_type, detail);
-    CompleteEnumeratedHeader header {TypeObjectUtils::build_complete_enumerated_header(common, detail)};
+    CompleteEnumeratedHeader header {TypeObjectUtils::build_complete_enumerated_header(
+                                         common,
+                                         detail)};
 
     // Enum members cannot be accessed using get_all_members because the Member Id does not apply to enum literals.
     CompleteEnumeratedLiteralSeq literal_seq;
@@ -1971,12 +2114,15 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_enum_dynamic_type(
                                                     member_descriptor.index(), flags)};
         CompleteMemberDetail member_detail;
         complete_member_detail(literal, member_detail);
-        CompleteEnumeratedLiteral literal_member {TypeObjectUtils::build_complete_enumerated_literal(common_literal,
-                                                          member_detail)};
+        CompleteEnumeratedLiteral literal_member {TypeObjectUtils::build_complete_enumerated_literal(
+                                                      common_literal,
+                                                      member_detail)};
         TypeObjectUtils::add_complete_enumerated_literal(literal_seq, literal_member);
     }
 
-    CompleteEnumeratedType enumerated_type {TypeObjectUtils::build_complete_enumerated_type(0, header, literal_seq)};
+    CompleteEnumeratedType enumerated_type {TypeObjectUtils::build_complete_enumerated_type(
+                                                0, header,
+                                                literal_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.enumerated_type(enumerated_type);
     TypeObject typeobject;
@@ -1999,7 +2145,9 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_bitmask_dynamic_type(
                                        static_cast<BitBound>(type_descriptor.bound().front()), true)};
     CompleteTypeDetail detail;
     complete_type_detail(dynamic_type, detail);
-    CompleteEnumeratedHeader header {TypeObjectUtils::build_complete_enumerated_header(common, detail, true)};
+    CompleteEnumeratedHeader header {TypeObjectUtils::build_complete_enumerated_header(
+                                         common, detail,
+                                         true)};
 
     auto& bitflags {dynamic_type->get_all_members_by_index()};
     CompleteBitflagSeq flag_seq;
@@ -2010,10 +2158,14 @@ ReturnCode_t TypeObjectRegistry::register_typeobject_w_bitmask_dynamic_type(
                                           static_cast<uint16_t>(member_descriptor.id()), 0)};
         CompleteMemberDetail member_detail;
         complete_member_detail(bitflag, member_detail);
-        CompleteBitflag bitflag_member {TypeObjectUtils::build_complete_bitflag(common_bitflag, member_detail)};
+        CompleteBitflag bitflag_member {TypeObjectUtils::build_complete_bitflag(
+                                            common_bitflag,
+                                            member_detail)};
         TypeObjectUtils::add_complete_bitflag(flag_seq, bitflag_member);
     }
-    CompleteBitmaskType bitmask_type {TypeObjectUtils::build_complete_bitmask_type(0, header, flag_seq)};
+    CompleteBitmaskType bitmask_type {TypeObjectUtils::build_complete_bitmask_type(
+                                          0, header,
+                                          flag_seq)};
     CompleteTypeObject complete_typeobject;
     complete_typeobject.bitmask_type(bitmask_type);
     TypeObject typeobject;
@@ -2041,7 +2193,9 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_sequence_dynamic_type(
         element_type_ids.type_identifier1() :
         TypeObjectUtils::retrieve_complete_type_identifier(element_type_ids, ec)};
     EquivalenceKind equiv_kind {equivalence_kind(element_type_id)};
-    assert((TK_NONE == element_type_ids.type_identifier2()._d() && EK_BOTH == equiv_kind) || EK_COMPLETE == equiv_kind);
+    assert(
+        (TK_NONE == element_type_ids.type_identifier2()._d() && EK_BOTH == equiv_kind) ||
+        EK_COMPLETE == equiv_kind);
 
     // CollectionElementFlags cannot be applied because element_type is a DynamicType and the applicable annotations are
     // contained in MemberDescriptor (accessible through DynamicTypeMember). XTypes inconsistency (!)
@@ -2054,26 +2208,30 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_sequence_dynamic_type(
     {
         SBound bound = (static_cast<uint32_t>(LENGTH_UNLIMITED) == type_descriptor.bound().front()) ?
                 0 : static_cast<SBound>(type_descriptor.bound().front());
-        PlainSequenceSElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_s_elem_defn(header, bound,
-                                                 external_element_type_id)};
+        PlainSequenceSElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                                             header, bound,
+                                             external_element_type_id)};
         type_ids.type_identifier1().seq_sdefn(seq_defn);
     }
     else
     {
-        PlainSequenceLElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_l_elem_defn(header,
-                                                 type_descriptor.bound().front(), external_element_type_id)};
+        PlainSequenceLElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_l_elem_defn(
+                                             header,
+                                             type_descriptor.bound().front(), external_element_type_id)};
         type_ids.type_identifier1().seq_ldefn(seq_defn);
     }
 
     if (EK_BOTH != equiv_kind)
     {
-        const TypeIdentifier& element_type_id_minimal {TypeObjectUtils::retrieve_minimal_type_identifier(
+        const TypeIdentifier& element_type_id_minimal {TypeObjectUtils::
+                                                               retrieve_minimal_type_identifier(
                                                            element_type_ids, ec)};
         EquivalenceKind equiv_kind_minimal {equivalence_kind(element_type_id_minimal)};
 
         // CollectionElementFlags cannot be applied because element_type is a DynamicType and the applicable annotations are
         // contained in MemberDescriptor (accessible through DynamicTypeMember). XTypes inconsistency (!)
-        PlainCollectionHeader header_minimal {TypeObjectUtils::build_plain_collection_header(equiv_kind_minimal, 0)};
+        PlainCollectionHeader header_minimal {TypeObjectUtils::build_plain_collection_header(
+                                                  equiv_kind_minimal, 0)};
 
         eprosima::fastcdr::external<TypeIdentifier> external_element_type_id_minimal =
                 eprosima::fastcdr::external<TypeIdentifier>(new TypeIdentifier(element_type_id_minimal));
@@ -2082,15 +2240,17 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_sequence_dynamic_type(
         {
             SBound bound = (static_cast<uint32_t>(LENGTH_UNLIMITED) == type_descriptor.bound().front()) ?
                     0 : static_cast<SBound>(type_descriptor.bound().front());
-            PlainSequenceSElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_s_elem_defn(header_minimal, bound,
-                                                     external_element_type_id_minimal)};
+            PlainSequenceSElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                                                 header_minimal, bound,
+                                                 external_element_type_id_minimal)};
             type_ids.type_identifier2().seq_sdefn(seq_defn);
         }
         else
         {
-            PlainSequenceLElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_l_elem_defn(header_minimal,
-                                                     type_descriptor.bound().front(),
-                                                     external_element_type_id_minimal)};
+            PlainSequenceLElemDefn seq_defn {TypeObjectUtils::build_plain_sequence_l_elem_defn(
+                                                 header_minimal,
+                                                 type_descriptor.bound().front(),
+                                                 external_element_type_id_minimal)};
             type_ids.type_identifier2().seq_ldefn(seq_defn);
         }
     }
@@ -2115,7 +2275,8 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_array_dynamic_type(
     register_typeobject_w_dynamic_type(type_descriptor.element_type(), element_type_ids);
 
     bool ec {false};
-    const TypeIdentifier& element_type_id {TypeObjectUtils::retrieve_complete_type_identifier(element_type_ids, ec)};
+    const TypeIdentifier& element_type_id {TypeObjectUtils::retrieve_complete_type_identifier(
+                                               element_type_ids, ec)};
     EquivalenceKind equiv_kind {equivalence_kind(element_type_id)};
     PlainCollectionHeader header {TypeObjectUtils::build_plain_collection_header(equiv_kind, 0)};
 
@@ -2137,14 +2298,16 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_array_dynamic_type(
         {
             bounds.push_back(static_cast<SBound>(bound));
         }
-        PlainArraySElemDefn array_defn {TypeObjectUtils::build_plain_array_s_elem_defn(header,
-                                                bounds, external_element_type_id)};
+        PlainArraySElemDefn array_defn {TypeObjectUtils::build_plain_array_s_elem_defn(
+                                            header,
+                                            bounds, external_element_type_id)};
         type_id.array_sdefn(array_defn);
     }
     else
     {
-        PlainArrayLElemDefn array_defn {TypeObjectUtils::build_plain_array_l_elem_defn(header,
-                                                type_descriptor.bound(), external_element_type_id)};
+        PlainArrayLElemDefn array_defn {TypeObjectUtils::build_plain_array_l_elem_defn(
+                                            header,
+                                            type_descriptor.bound(), external_element_type_id)};
         type_id.array_ldefn(array_defn);
     }
 
@@ -2165,8 +2328,10 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_map_dynamic_type(
     register_typeobject_w_dynamic_type(type_descriptor.key_element_type(), key_type_ids);
 
     bool ec {false};
-    const TypeIdentifier& element_type_id {TypeObjectUtils::retrieve_complete_type_identifier(element_type_ids, ec)};
-    const TypeIdentifier& key_type_id {TypeObjectUtils::retrieve_complete_type_identifier(key_type_ids, ec)};
+    const TypeIdentifier& element_type_id {TypeObjectUtils::retrieve_complete_type_identifier(
+                                               element_type_ids, ec)};
+    const TypeIdentifier& key_type_id {TypeObjectUtils::retrieve_complete_type_identifier(
+                                           key_type_ids, ec)};
     EquivalenceKind equiv_kind {equivalence_kind(element_type_id, key_type_id)};
     PlainCollectionHeader header {TypeObjectUtils::build_plain_collection_header(equiv_kind, 0)};
     eprosima::fastcdr::external<TypeIdentifier> external_element_type_id =
@@ -2178,15 +2343,17 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_map_dynamic_type(
     {
         SBound bound = (static_cast<uint32_t>(LENGTH_UNLIMITED) == type_descriptor.bound().front()) ?
                 0 : static_cast<SBound>(type_descriptor.bound().front());
-        PlainMapSTypeDefn map_defn {TypeObjectUtils::build_plain_map_s_type_defn(header, bound,
-                                            external_element_type_id, 0, external_key_type_id)};
+        PlainMapSTypeDefn map_defn {TypeObjectUtils::build_plain_map_s_type_defn(
+                                        header, bound,
+                                        external_element_type_id, 0, external_key_type_id)};
         type_id.map_sdefn(map_defn);
     }
     else
     {
-        PlainMapLTypeDefn map_defn {TypeObjectUtils::build_plain_map_l_type_defn(header,
-                                            type_descriptor.bound().front(), external_element_type_id, 0,
-                                            external_key_type_id)};
+        PlainMapLTypeDefn map_defn {TypeObjectUtils::build_plain_map_l_type_defn(
+                                        header,
+                                        type_descriptor.bound().front(), external_element_type_id, 0,
+                                        external_key_type_id)};
         type_id.map_ldefn(map_defn);
     }
 
@@ -2211,7 +2378,8 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_string_dynamic_type(
     }
     else
     {
-        StringLTypeDefn string_defn {TypeObjectUtils::build_string_l_type_defn(type_descriptor.bound().front())};
+        StringLTypeDefn string_defn {TypeObjectUtils::build_string_l_type_defn(
+                                         type_descriptor.bound().front())};
         type_id.string_ldefn(string_defn);
     }
 
@@ -2223,8 +2391,7 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_wstring_dynamic_type(
         TypeIdentifier& type_id)
 {
     ReturnCode_t ret_code {typeidentifier_w_string_dynamic_type(dynamic_type, type_id)};
-    switch (type_id._d())
-    {
+    switch (type_id._d()){
         case TI_STRING8_SMALL:
             type_id._d(TI_STRING16_SMALL);
             break;
@@ -2232,7 +2399,7 @@ ReturnCode_t TypeObjectRegistry::typeidentifier_w_wstring_dynamic_type(
             type_id._d(TI_STRING16_LARGE);
             break;
     }
-    assert (RETCODE_OK == ret_code);
+    assert(RETCODE_OK == ret_code);
 
     return ret_code;
 }
@@ -2246,8 +2413,9 @@ ReturnCode_t TypeObjectRegistry::apply_custom_annotations(
     for (auto& annotation_descriptor : annotations)
     {
         TypeIdentifierPair annotation_typeids;
-        register_typeobject_w_annotation_dynamic_type(traits<DynamicType>::narrow<DynamicTypeImpl>(
-                    annotation_descriptor.type()), annotation_typeids);
+        register_typeobject_w_annotation_dynamic_type(
+            traits<DynamicType>::narrow<DynamicTypeImpl>(
+                annotation_descriptor.type()), annotation_typeids);
 
         Parameters parameter_seq;
         annotation_descriptor.get_all_value(parameter_seq); // Always returns RETCODE_OK
@@ -2265,8 +2433,9 @@ ReturnCode_t TypeObjectRegistry::apply_custom_annotations(
             assert(RETCODE_OK == ret_code);
             MemberDescriptor::_ref_type param_descriptor {traits<MemberDescriptor>::make_shared()};
             param_member->get_descriptor(param_descriptor);
-            set_annotation_parameter_value(param_descriptor->type(), param->second.to_string(),
-                    param_value);
+            set_annotation_parameter_value(
+                param_descriptor->type(), param->second.to_string(),
+                param_value);
             AppliedAnnotationParameter parameter {TypeObjectUtils::build_applied_annotation_parameter(
                                                       paramname_hash, param_value)};
             TypeObjectUtils::add_applied_annotation_parameter(tmp_param_seq, parameter);
@@ -2276,10 +2445,11 @@ ReturnCode_t TypeObjectRegistry::apply_custom_annotations(
             param_seq = tmp_param_seq;
         }
         bool ec {false};
-        AppliedAnnotation applied_annotation {TypeObjectUtils::build_applied_annotation(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          annotation_typeids,
-                                                          ec),
-                                                      param_seq)};
+        AppliedAnnotation applied_annotation {TypeObjectUtils::build_applied_annotation(
+                                                  TypeObjectUtils::retrieve_complete_type_identifier(
+                                                      annotation_typeids,
+                                                      ec),
+                                                  param_seq)};
         TypeObjectUtils::add_applied_annotation(tmp_ann_custom, applied_annotation);
     }
     if (!tmp_ann_custom.empty())
@@ -2295,7 +2465,8 @@ ReturnCode_t TypeObjectRegistry::apply_verbatim_annotation(
 {
     if (0 != dynamic_type->get_verbatim_text_count())
     {
-        VerbatimTextDescriptor::_ref_type verbatim_descriptor {traits<VerbatimTextDescriptor>::make_shared()};
+        VerbatimTextDescriptor::_ref_type verbatim_descriptor {traits<VerbatimTextDescriptor>::
+                                                               make_shared()};
         dynamic_type->get_verbatim_text(verbatim_descriptor, 0);
 
         // TypeObject only allows defining one @verbatim comment
@@ -2314,59 +2485,71 @@ ReturnCode_t TypeObjectRegistry::set_annotation_parameter_value(
         const std::string& value,
         AnnotationParameterValue& param_value)
 {
-    switch (dynamic_type->get_kind())
-    {
+    switch (dynamic_type->get_kind()){
         case TK_BOOLEAN:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<bool>(!value.empty() ?
-                            TypeValueConverter::sto(value) : false));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<bool>(!value.empty() ?
+                TypeValueConverter::sto(value) : false));
             break;
         case TK_BYTE:
-            param_value = TypeObjectUtils::build_annotation_parameter_value_byte(static_cast<uint8_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value_byte(
+                static_cast<uint8_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_INT8:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<int8_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<int8_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_UINT8:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<uint8_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<uint8_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_INT16:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<int16_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<int16_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_UINT16:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<uint16_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<uint16_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_INT32:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<int32_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<int32_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_UINT32:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<uint32_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<uint32_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_INT64:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<int64_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<int64_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_UINT64:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<uint64_t>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<uint64_t>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_FLOAT32:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<float>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<float>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_FLOAT64:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<double>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<double>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_FLOAT128:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(static_cast<long double>(!value.empty() ?
-                            TypeValueConverter::sto(value) : 0));
+            param_value = TypeObjectUtils::build_annotation_parameter_value(
+                static_cast<long double>(!value.empty() ?
+                TypeValueConverter::sto(value) : 0));
             break;
         case TK_CHAR8:
             param_value = TypeObjectUtils::build_annotation_parameter_value(!value.empty() ? value : 0);
@@ -2375,8 +2558,9 @@ ReturnCode_t TypeObjectRegistry::set_annotation_parameter_value(
         {
             DynamicTypeMember::_ref_type member;
             dynamic_type->get_member_by_index(member, 0);
-            param_value = TypeObjectUtils::build_annotation_parameter_value_enum(static_cast<int32_t>(!value.empty() ?
-                            std::stol(value) : member->get_id()));
+            param_value = TypeObjectUtils::build_annotation_parameter_value_enum(
+                static_cast<int32_t>(!value.empty() ?
+                std::stol(value) : member->get_id()));
             break;
         }
         case TK_STRING8:
@@ -2397,8 +2581,9 @@ ReturnCode_t TypeObjectRegistry::complete_type_detail(
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
     apply_custom_annotations(dynamic_type->get_annotations(), ann_custom);
 
-    detail = TypeObjectUtils::build_complete_type_detail(ann_builtin, ann_custom,
-                    dynamic_type->get_name());
+    detail = TypeObjectUtils::build_complete_type_detail(
+        ann_builtin, ann_custom,
+        dynamic_type->get_name());
 
     return RETCODE_OK;
 }
@@ -2413,8 +2598,9 @@ ReturnCode_t TypeObjectRegistry::complete_member_detail(
     eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom;
     apply_custom_annotations(member->get_annotations(), ann_custom);
 
-    member_detail = TypeObjectUtils::build_complete_member_detail(member->get_descriptor().name(),
-                    member_ann_builtin, ann_custom);
+    member_detail = TypeObjectUtils::build_complete_member_detail(
+        member->get_descriptor().name(),
+        member_ann_builtin, ann_custom);
     return RETCODE_OK;
 }
 
@@ -2422,8 +2608,7 @@ ExtensibilityKind TypeObjectRegistry::extensibility_kind(
         eprosima::fastdds::dds::ExtensibilityKind extensibility_kind) const
 {
     ExtensibilityKind ret_extensibility_kind {ExtensibilityKind::APPENDABLE};
-    switch (extensibility_kind)
-    {
+    switch (extensibility_kind){
         case eprosima::fastdds::dds::ExtensibilityKind::FINAL:
             ret_extensibility_kind = ExtensibilityKind::FINAL;
             break;
@@ -2441,8 +2626,7 @@ TryConstructFailAction TypeObjectRegistry::try_construct_kind(
         eprosima::fastdds::dds::TryConstructKind try_construct_kind) const
 {
     TryConstructFailAction ret_try_construct_kind {TryConstructFailAction::DISCARD};
-    switch (try_construct_kind)
-    {
+    switch (try_construct_kind){
         case eprosima::fastdds::dds::TryConstructKind::DISCARD:
             ret_try_construct_kind = TryConstructFailAction::DISCARD;
             break;
@@ -2460,8 +2644,7 @@ TypeKind TypeObjectRegistry::type_kind(
         eprosima::fastdds::dds::TypeKind type_kind) const
 {
     TypeKind ret_type_kind {TK_NONE};
-    switch (type_kind)
-    {
+    switch (type_kind){
         case eprosima::fastdds::dds::TK_NONE:
             ret_type_kind = TK_NONE;
             break;
@@ -2554,8 +2737,7 @@ EquivalenceKind TypeObjectRegistry::equivalence_kind(
         const TypeIdentifier& element_type_id)
 {
     EquivalenceKind equiv_kind {EK_BOTH};
-    switch (element_type_id._d())
-    {
+    switch (element_type_id._d()){
         case TI_PLAIN_SEQUENCE_SMALL:
             equiv_kind = element_type_id.seq_sdefn().header().equiv_kind();
             break;
@@ -2603,11 +2785,12 @@ PlacementKind TypeObjectRegistry::placement_kind(
 
     std::string lower_case_placement_kind;
     // XTypes v1.3 Section 7.2.2.4.8.2 [The placement] shall be interpreted in a case-insensitive manner.
-    std::transform(placement_kind.begin(), placement_kind.end(), lower_case_placement_kind.begin(),
-            [](char c)
-            {
-                return static_cast<char>(std::tolower(c));
-            });
+    std::transform(
+        placement_kind.begin(), placement_kind.end(), lower_case_placement_kind.begin(),
+        [](char c)
+        {
+            return static_cast<char>(std::tolower(c));
+        });
     if (lower_case_placement_kind == begin_declaration_file_str)
     {
         ret_placement_kind = PlacementKind::BEGIN_FILE;
@@ -2630,8 +2813,9 @@ PlacementKind TypeObjectRegistry::placement_kind(
     }
     else if (lower_case_placement_kind != before_declaration_str)
     {
-        EPROSIMA_LOG_WARNING(XTYPES_TYPE_REPRESENTATION,
-                "Verbatim placement kind not recognized: using BEFORE_DECLARATION (default value)");
+        EPROSIMA_LOG_WARNING(
+            XTYPES_TYPE_REPRESENTATION,
+            "Verbatim placement kind not recognized: using BEFORE_DECLARATION (default value)");
     }
     return ret_placement_kind;
 }

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
@@ -2768,7 +2768,7 @@ TEST(TypeObjectUtilsTests, register_alias_type_object)
     CompleteAliasType alias = TypeObjectUtils::build_complete_alias_type(0, empty_header, body);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_alias_type_object(alias, "alias", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_alias_type_object(alias, "alias", type_ids));
     CompleteTypeDetail detail = TypeObjectUtils::build_complete_type_detail(
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations>(),
@@ -2794,7 +2794,8 @@ TEST(TypeObjectUtilsTests, register_annotation_type_object)
     TypeIdentifierPair type_ids;
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_annotation_type_object(annotation,
             "annotation", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_annotation_type_object(annotation,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
+            TypeObjectUtils::build_and_register_annotation_type_object(annotation,
             "annotation", type_ids));
     CompleteAnnotationHeader other_header = TypeObjectUtils::build_complete_annotation_header("other_annotation_name");
     CompleteAnnotationType other_annotation = TypeObjectUtils::build_complete_annotation_type(0, other_header,
@@ -2821,7 +2822,8 @@ TEST(TypeObjectUtilsTests, register_structure_type_object)
     TypeIdentifierPair type_ids;
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_struct_type_object(structure,
             "structure", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_struct_type_object(structure,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
+            TypeObjectUtils::build_and_register_struct_type_object(structure,
             "structure", type_ids));
     StructTypeFlag other_flags = TypeObjectUtils::build_struct_type_flag(
         eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL, false, false);
@@ -2872,7 +2874,7 @@ TEST(TypeObjectUtilsTests, register_union_type_object)
                     discriminator, member_seq);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_union_type_object(union_type, "union", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_union_type_object(union_type, "union", type_ids));
     UnionTypeFlag other_flags = TypeObjectUtils::build_union_type_flag(
         eprosima::fastdds::dds::xtypes::ExtensibilityKind::MUTABLE, false, false);
@@ -2904,7 +2906,7 @@ TEST(TypeObjectUtilsTests, register_bitset_type_object)
     CompleteBitsetType bitset = TypeObjectUtils::build_complete_bitset_type(0, header, bitfield_seq);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_bitset_type_object(bitset, "bitset", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_bitset_type_object(bitset, "bitset", type_ids));
     CompleteTypeDetail detail = TypeObjectUtils::build_complete_type_detail(
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations>(),
@@ -2936,7 +2938,7 @@ TEST(TypeObjectUtilsTests, register_sequence_type_object)
     CompleteSequenceType sequence = TypeObjectUtils::build_complete_sequence_type(0, header, element);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_sequence_type_object(sequence, "sequence"));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_sequence_type_object(sequence, "sequence"));
     CompleteTypeDetail detail = TypeObjectUtils::build_complete_type_detail(
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations>(),
@@ -2973,7 +2975,7 @@ TEST(TypeObjectUtilsTests, register_array_type_object)
     CompleteArrayType array = TypeObjectUtils::build_complete_array_type(0, header, element);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_array_type_object(array, "array"));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_array_type_object(array, "array"));
     type_id._d(TK_INT16);
     CommonCollectionElement other_common_element = TypeObjectUtils::build_common_collection_element(flags, type_id);
@@ -3004,7 +3006,8 @@ TEST(TypeObjectUtilsTests, register_map_type_object)
                     CompleteElementDetail());
     CompleteMapType map = TypeObjectUtils::build_complete_map_type(0, header, element, element);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_map_type_object(map, "map"));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK, TypeObjectUtils::build_and_register_map_type_object(map, "map"));
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
+            TypeObjectUtils::build_and_register_map_type_object(map, "map"));
     type_id._d(TK_INT32);
     CommonCollectionElement key_element = TypeObjectUtils::build_common_collection_element(flags, type_id);
     CompleteCollectionElement key = TypeObjectUtils::build_complete_collection_element(key_element,
@@ -3040,7 +3043,7 @@ TEST(TypeObjectUtilsTests, register_enumerated_type_object)
     CompleteEnumeratedType enumeration = TypeObjectUtils::build_complete_enumerated_type(0, header, literal_seq);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_enumerated_type_object(enumeration, "enum", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_enumerated_type_object(enumeration, "enum", type_ids));
     CompleteTypeDetail detail = TypeObjectUtils::build_complete_type_detail(
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations>(),
@@ -3075,7 +3078,7 @@ TEST(TypeObjectUtilsTests, register_bitmask_type_object)
     CompleteBitmaskType bitmask = TypeObjectUtils::build_complete_bitmask_type(0, header, bitflag_seq);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
             TypeObjectUtils::build_and_register_bitmask_type_object(bitmask, "bitmask", type_ids));
-    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_BAD_PARAMETER,
             TypeObjectUtils::build_and_register_bitmask_type_object(bitmask, "bitmask", type_ids));
     CommonBitflag common = TypeObjectUtils::build_common_bitflag(1, 0);
     CompleteMemberDetail other_member_detail = TypeObjectUtils::build_complete_member_detail("other_member_name",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

DDS Router is having problems redirecting the TypeInformation from one side to another. This PR tries to solve this making the TypeLookupService registers the `EK_MINIMAL` TypeObject built from the received `EK_COMPLETE` TypeObject.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
