### PR TITLE
[21519] Fix issue with exclusive ownership and unordered samples

### DIFF
--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -853,12 +853,38 @@ bool DataReaderHistory::update_instance_nts(
 
     assert(vit != instances_.end());
     assert(false == change->isRead);
+    auto previous_owner = vit->second->current_owner.first;
     ++counters_.samples_unread;
     bool ret =
             vit->second->update_state(counters_, change->kind, change->writerGUID,
                     change->reader_info.writer_ownership_strength);
     change->reader_info.disposed_generation_count = vit->second->disposed_generation_count;
     change->reader_info.no_writers_generation_count = vit->second->no_writers_generation_count;
+
+    auto current_owner = vit->second->current_owner.first;
+    if (current_owner != previous_owner)
+    {
+        assert(current_owner == change->writerGUID);
+
+        // Remove all changes from different owners after the change.
+        DataReaderInstance::ChangeCollection& changes = vit->second->cache_changes;
+        auto it = std::lower_bound(changes.begin(), changes.end(), change, rtps::history_order_cmp);
+        assert(it != changes.end());
+        assert(*it == change);
+        ++it;
+        while (it != changes.end())
+        {
+            if ((*it)->writerGUID != current_owner)
+            {
+                // Remove from history
+                remove_change_sub(*it, it);
+
+                // Current iterator will point to change next to the one removed. Avoid incrementing.
+                continue;
+            }
+            ++it;
+        }
+    }
 
     return ret;
 }

--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -2165,6 +2165,83 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_besteffort_disposing_instance)
     exclusive_kind_keyed_disposing_instance(false);
 }
 
+/*!
+ * This is a regression test for redmine issue 20866.
+ *
+ * This test checks that a reader with a KEEP_ALL history and an exclusive ownership policy only returns the data
+ * from the writer with the highest strength.
+ */
+TEST(OwnershipQos, exclusive_kind_keep_all_reliable)
+{
+    PubSubReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<KeyedHelloWorldPubSubType> low_strength_writer(TEST_TOPIC_NAME);
+    PubSubWriter<KeyedHelloWorldPubSubType> high_strength_writer(TEST_TOPIC_NAME);
+
+    // Prepare data.
+    std::list<KeyedHelloWorld> generated_data = default_keyedhelloworld_data_generator(20);
+    auto middle = std::next(generated_data.begin(), 10);
+    std::list<KeyedHelloWorld> low_strength_data(generated_data.begin(), middle);
+    std::list<KeyedHelloWorld> high_strength_data(middle, generated_data.end());
+    auto expected_data = high_strength_data;
+
+    // Initialize writers.
+    low_strength_writer.ownership_strength(3)
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .init();
+    ASSERT_TRUE(low_strength_writer.isInitialized());
+
+    // High strength writer will use a custom transport to ensure its data is received after the low strength data.
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    std::atomic<bool> drop_messages(false);
+    test_transport->messages_filter_ = [&drop_messages](eprosima::fastdds::rtps::CDRMessage_t&)
+            {
+                return drop_messages.load();
+            };
+    high_strength_writer.ownership_strength(4)
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(high_strength_writer.isInitialized());
+
+    // Initialize reader.
+    reader.ownership_exclusive()
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    low_strength_writer.wait_discovery();
+    high_strength_writer.wait_discovery();
+    reader.wait_discovery(std::chrono::seconds::zero(), 2);
+
+    // Send high strength data first, so it has the lowest source timestamps, but drop the messages, so they arrive
+    // later to the reader.
+    drop_messages.store(true);
+    high_strength_writer.send(high_strength_data);
+    EXPECT_TRUE(high_strength_data.empty());
+
+    // Send low strength data, so it has the highest source timestamps.
+    low_strength_writer.send(low_strength_data);
+    EXPECT_TRUE(low_strength_data.empty());
+    // Wait for the reader to receive the data.
+    EXPECT_TRUE(low_strength_writer.waitForAllAcked(std::chrono::seconds(1)));
+
+    // Let high strength writer send the data.
+    drop_messages.store(false);
+
+    // Wait for the reader to receive the high strength data.
+    EXPECT_TRUE(high_strength_writer.waitForAllAcked(std::chrono::seconds(1)));
+
+    // Make the reader process the data, expecting only the high strength data.
+    // The issue was reproduced by the reader complaining about reception of unexpected data.
+    reader.startReception(expected_data);
+    reader.block_for_all();
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -2168,91 +2168,33 @@ TEST_P(OwnershipQos, exclusive_kind_keyed_besteffort_disposing_instance)
 /*!
  * This is a regression test for redmine issue 20866.
  *
- * This test checks that a reader with a KEEP_ALL history and an exclusive ownership policy only returns the data
- * from the writer with the highest strength.
- */
-TEST(OwnershipQos, exclusive_kind_keep_all_reliable)
-{
-    PubSubReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<KeyedHelloWorldPubSubType> low_strength_writer(TEST_TOPIC_NAME);
-    PubSubWriter<KeyedHelloWorldPubSubType> high_strength_writer(TEST_TOPIC_NAME);
-
-    // Prepare data.
-    std::list<KeyedHelloWorld> generated_data = default_keyedhelloworld_data_generator(20);
-    auto middle = std::next(generated_data.begin(), 10);
-    std::list<KeyedHelloWorld> low_strength_data(generated_data.begin(), middle);
-    std::list<KeyedHelloWorld> high_strength_data(middle, generated_data.end());
-    auto expected_data = high_strength_data;
-
-    // Initialize writers.
-    low_strength_writer.ownership_strength(3)
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .init();
-    ASSERT_TRUE(low_strength_writer.isInitialized());
-
-    // High strength writer will use a custom transport to ensure its data is received after the low strength data.
-    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
-    std::atomic<bool> drop_messages(false);
-    test_transport->messages_filter_ = [&drop_messages](eprosima::fastdds::rtps::CDRMessage_t&)
-            {
-                return drop_messages.load();
-            };
-    high_strength_writer.ownership_strength(4)
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .disable_builtin_transport()
-            .add_user_transport_to_pparams(test_transport)
-            .init();
-    ASSERT_TRUE(high_strength_writer.isInitialized());
-
-    // Initialize reader.
-    reader.ownership_exclusive()
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .init();
-    ASSERT_TRUE(reader.isInitialized());
-
-    // Wait for discovery.
-    low_strength_writer.wait_discovery();
-    high_strength_writer.wait_discovery();
-    reader.wait_discovery(std::chrono::seconds::zero(), 2);
-
-    // Send high strength data first, so it has the lowest source timestamps, but drop the messages, so they arrive
-    // later to the reader.
-    drop_messages.store(true);
-    high_strength_writer.send(high_strength_data);
-    EXPECT_TRUE(high_strength_data.empty());
-
-    // Send low strength data, so it has the highest source timestamps.
-    low_strength_writer.send(low_strength_data);
-    EXPECT_TRUE(low_strength_data.empty());
-    // Wait for the reader to receive the data.
-    EXPECT_TRUE(low_strength_writer.waitForAllAcked(std::chrono::seconds(1)));
-
-    // Let high strength writer send the data.
-    drop_messages.store(false);
-
-    // Wait for the reader to receive the high strength data.
-    EXPECT_TRUE(high_strength_writer.waitForAllAcked(std::chrono::seconds(1)));
-
-    // Make the reader process the data, expecting only the high strength data.
-    // The issue was reproduced by the reader complaining about reception of unexpected data.
-    reader.startReception(expected_data);
-    reader.block_for_all();
-}
-
-/*!
- * This is a regression test for redmine issue 20866.
+ * This test checks that a reader keeping a long number of samples and with an exclusive ownership policy only
+ * returns the data from the writer with the highest strength.
  *
- * This test checks that a reader with a KEEP_ALL history and an exclusive ownership policy only does not return
- * data from the writer with the lowest strength after returning data from the highest one.
+ * @param use_keep_all_history  Whether to use KEEP_ALL history or KEEP_LAST(20).
+ * @param mixed_data            Whether to send data from both writers in an interleaved way.
  */
-TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
+static void test_exclusive_kind_big_history(
+        bool use_keep_all_history,
+        bool mixed_data)
 {
     PubSubReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
     PubSubWriter<KeyedHelloWorldPubSubType> low_strength_writer(TEST_TOPIC_NAME);
     PubSubWriter<KeyedHelloWorldPubSubType> high_strength_writer(TEST_TOPIC_NAME);
+
+    // Configure history QoS.
+    if (use_keep_all_history)
+    {
+        reader.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
+        low_strength_writer.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
+        high_strength_writer.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS);
+    }
+    else
+    {
+        reader.history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS).history_depth(20);
+        low_strength_writer.history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS).history_depth(20);
+        high_strength_writer.history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS).history_depth(20);
+    }
 
     // Prepare data.
     std::list<KeyedHelloWorld> generated_data = default_keyedhelloworld_data_generator(20);
@@ -2260,14 +2202,17 @@ TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
     std::list<KeyedHelloWorld> low_strength_data(generated_data.begin(), middle);
     std::list<KeyedHelloWorld> high_strength_data(middle, generated_data.end());
     auto expected_data = high_strength_data;
-    auto it = low_strength_data.begin();
-    // Expect reception of the first two samples from the low strength writer (one per instance).
-    expected_data.push_front(*it++);
-    expected_data.push_front(*it);
+
+    if (mixed_data)
+    {
+        // Expect reception of the first two samples from the low strength writer (one per instance).
+        auto it = low_strength_data.begin();
+        expected_data.push_front(*it++);
+        expected_data.push_front(*it);
+    }
 
     // Initialize writers.
     low_strength_writer.ownership_strength(3)
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
             .init();
     ASSERT_TRUE(low_strength_writer.isInitialized());
@@ -2280,7 +2225,6 @@ TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
                 return drop_messages.load();
             };
     high_strength_writer.ownership_strength(4)
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
             .disable_builtin_transport()
             .add_user_transport_to_pparams(test_transport)
@@ -2289,7 +2233,6 @@ TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
 
     // Initialize reader.
     reader.ownership_exclusive()
-            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
             .init();
     ASSERT_TRUE(reader.isInitialized());
@@ -2302,13 +2245,27 @@ TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
     // Drop the messages from the high strength writer, so they arrive later to the reader.
     drop_messages.store(true);
 
-    // Send one sample from each writer, with low strength data first.
-    while (!low_strength_data.empty() && !high_strength_data.empty())
+    if (mixed_data)
     {
-        EXPECT_TRUE(low_strength_writer.send_sample(low_strength_data.front()));
-        EXPECT_TRUE(high_strength_writer.send_sample(high_strength_data.front()));
-        low_strength_data.pop_front();
-        high_strength_data.pop_front();
+        // Send one sample from each writer, with low strength data first.
+        while (!low_strength_data.empty() && !high_strength_data.empty())
+        {
+            EXPECT_TRUE(low_strength_writer.send_sample(low_strength_data.front()));
+            EXPECT_TRUE(high_strength_writer.send_sample(high_strength_data.front()));
+            low_strength_data.pop_front();
+            high_strength_data.pop_front();
+        }
+    }
+    else
+    {
+        // Send high strength data first, so it has the lowest source timestamps, but drop the messages, so they arrive
+        // later to the reader.
+        high_strength_writer.send(high_strength_data);
+        EXPECT_TRUE(high_strength_data.empty());
+
+        // Send low strength data, so it has the highest source timestamps.
+        low_strength_writer.send(low_strength_data);
+        EXPECT_TRUE(low_strength_data.empty());
     }
 
     // Wait for the reader to receive the low strength data.
@@ -2318,10 +2275,30 @@ TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
     drop_messages.store(false);
     EXPECT_TRUE(high_strength_writer.waitForAllAcked(std::chrono::seconds(1)));
 
-    // Make the reader process the data, expecting only the high strength data.
+    // Make the reader process the data, expecting only the required data.
     // The issue was reproduced by the reader complaining about reception of unexpected data.
     reader.startReception(expected_data);
     reader.block_for_all();
+}
+
+TEST(OwnershipQos, exclusive_kind_keep_all_reliable)
+{
+    test_exclusive_kind_big_history(true, false);
+}
+
+TEST(OwnershipQos, exclusive_kind_keep_all_reliable_mixed)
+{
+    test_exclusive_kind_big_history(true, true);
+}
+
+TEST(OwnershipQos, exclusive_kind_keep_last_reliable)
+{
+    test_exclusive_kind_big_history(false, false);
+}
+
+TEST(OwnershipQos, exclusive_kind_keep_last_reliable_mixed)
+{
+    test_exclusive_kind_big_history(false, true);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
@@ -51,6 +51,23 @@ public:
             (override));
 };
 
+bool add_test_change(
+        eprosima::fastdds::dds::detail::DataReaderHistory& history,
+        eprosima::fastdds::rtps::CacheChange_t& change,
+        std::vector<std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>>& test_changes)
+{
+    ++change.sequenceNumber;
+    eprosima::fastdds::rtps::Time_t::now(change.sourceTimestamp);
+    eprosima::fastdds::rtps::CacheChange_t* new_change = new eprosima::fastdds::rtps::CacheChange_t();
+    new_change->copy(&change);
+    new_change->reader_info.writer_ownership_strength = change.reader_info.writer_ownership_strength;
+
+    EXPECT_TRUE(history.received_change(new_change, 0));
+    bool ret = history.update_instance_nts(new_change);
+    test_changes.push_back(std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>(new_change));
+    return ret;
+}
+
 /*!
  * \test DDS-OWN-HIST-01 Tests `DataReaderInstance` handles successfully the reception of Non-Keyed samples with
  * different Ownership's strength.
@@ -65,6 +82,7 @@ TEST(DataReaderHistory, exclusive_ownership_non_keyed_sample_reception)
     DataReaderHistory history(type, topic, qos);
     eprosima::fastdds::RecursiveTimedMutex mutex;
     eprosima::fastdds::rtps::StatelessReader reader(&history, &mutex);
+    std::vector<std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>> changes;
 
     eprosima::fastdds::rtps::CacheChange_t dw1_change;
     dw1_change.writerGUID = {{}, 1};
@@ -77,50 +95,32 @@ TEST(DataReaderHistory, exclusive_ownership_non_keyed_sample_reception)
     dw3_change.reader_info.writer_ownership_strength = 3;
 
     // Receives a sample with seq 1 from DW1 and update instance with strength 1.
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw1_change));
+    ASSERT_TRUE(add_test_change(history, dw1_change, changes));
 
     // Receives a sample with seq 1 from DW2 and update instance with strength 2.
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     // Receives a sample with seq 2 from DW1 and update instance with strength 1.
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives a sample with seq 2 from DW2 and update instance with strength 2.
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     // Receives a sample with seq 1 from DW3 and update instance with strength 3.
-    ++dw3_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw3_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw3_change));
+    ASSERT_TRUE(add_test_change(history, dw3_change, changes));
 
     // Receives a sample with seq 3 from DW1 and update instance with strength 1.
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives a sample with seq 3 from DW2 and update instance with strength 2.
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw2_change));
+    ASSERT_FALSE(add_test_change(history, dw2_change, changes));
 
     // Receives a sample with seq 2 from DW3 and update instance with strength 1.
-    ++dw3_change.sequenceNumber;
     dw3_change.reader_info.writer_ownership_strength = 1;
-    ASSERT_TRUE(history.received_change(&dw3_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw3_change));
+    ASSERT_TRUE(add_test_change(history, dw3_change, changes));
 
     // Receives a sample with seq 4 from DW2 and update instance with strength 2.
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     ASSERT_EQ(9u, history.getHistorySize());
 }
@@ -142,6 +142,7 @@ TEST(DataReaderHistory, exclusive_ownership_keyed_sample_reception)
     DataReaderHistory history(type, topic, qos);
     eprosima::fastdds::RecursiveTimedMutex mutex;
     eprosima::fastdds::rtps::StatelessReader reader(&history, &mutex);
+    std::vector<std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>> changes;
 
     const InstanceHandle_t instance_1 = eprosima::fastdds::rtps::GUID_t{{}, 1};
     const InstanceHandle_t instance_2 = eprosima::fastdds::rtps::GUID_t{{}, 2};
@@ -158,112 +159,76 @@ TEST(DataReaderHistory, exclusive_ownership_keyed_sample_reception)
 
     // Receives instance 1 with seq 1 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_1;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw1_change));
+    ASSERT_TRUE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 2 with seq 2 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_2;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw1_change));
+    ASSERT_TRUE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 1 with seq 1 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_1;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     // Receives instance 1 with seq 3 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_1;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 2 with seq 4 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_2;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw1_change));
+    ASSERT_TRUE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 2 with seq 1 from DW3 and update instance with strength 3.
     dw3_change.instanceHandle = instance_2;
-    ++dw3_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw3_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw3_change));
+    ASSERT_TRUE(add_test_change(history, dw3_change, changes));
 
     // Receives instance 1 with seq 5 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_1;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 2 with seq 6 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_2;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 3 with seq 2 from DW3 and update instance with strength 3.
     dw3_change.instanceHandle = instance_3;
-    ++dw3_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw3_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw3_change));
+    ASSERT_TRUE(add_test_change(history, dw3_change, changes));
 
     // Receives instance 3 with seq 2 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_3;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw2_change));
+    ASSERT_FALSE(add_test_change(history, dw2_change, changes));
 
     // Receives instance 3 with seq 3 from DW3 and update instance with strength 1.
     dw3_change.instanceHandle = instance_3;
     dw3_change.reader_info.writer_ownership_strength = 1;
-    ++dw3_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw3_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw3_change));
+    ASSERT_TRUE(add_test_change(history, dw3_change, changes));
 
     // Receives instance 3 with seq 3 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_3;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     // Receives instance 1 with seq 7 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_1;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 2 with seq 8 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_2;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 3 with seq 9 from DW1 and update instance with strength 1.
     dw1_change.instanceHandle = instance_3;
-    ++dw1_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw1_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw1_change));
+    ASSERT_FALSE(add_test_change(history, dw1_change, changes));
 
     // Receives instance 1 with seq 4 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_1;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     // Receives instance 2 with seq 5 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_2;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_FALSE(history.update_instance_nts(&dw2_change));
+    ASSERT_FALSE(add_test_change(history, dw2_change, changes));
 
     // Receives instance 3 with seq 6 from DW2 and update instance with strength 2.
     dw2_change.instanceHandle = instance_3;
-    ++dw2_change.sequenceNumber;
-    ASSERT_TRUE(history.received_change(&dw2_change, 0));
-    ASSERT_TRUE(history.update_instance_nts(&dw2_change));
+    ASSERT_TRUE(add_test_change(history, dw2_change, changes));
 
     ASSERT_EQ(18u, history.getHistorySize());
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

During interoperability testing, some flakiness on [Test_Ownership_3](https://omg-dds.github.io/dds-rtps/test_description.html#test-ownership-3) unveiled that a reader with exclusive ownership and a `KEEP_ALL` history may return a mix of samples from writers with different strengths.

This PR adds a regression test and fixes the issue by removing inappropriate samples during the take operation.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
