### PR TITLE
[Backport]Fix datarace on WriterProxy stop while perform_initial_ack_nack (#3046)

### DIFF
--- a/include/fastdds/rtps/resources/TimedEvent.h
+++ b/include/fastdds/rtps/resources/TimedEvent.h
@@ -132,6 +132,12 @@ public:
     void restart_timer(
             const std::chrono::steady_clock::time_point& timeout);
 
+    /*!
+     * @brief Unregisters the event, sets its state to INACTIVE, and re-registers it.
+     * It may be seen as a blocking version of \c cancel_timer
+     */
+    void recreate_timer();
+
     /**
      * Update event interval.
      * When updating the interval, the timer is not restarted and the new interval will only be used the next time you call restart_timer().

--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -89,6 +89,7 @@ WriterProxy::WriterProxy(
     , locators_entry_(loc_alloc.max_unicast_locators, loc_alloc.max_multicast_locators)
     , is_datasharing_writer_(false)
     , received_at_least_one_heartbeat_(false)
+    , state_(StateCode::STOPPED)
 {
     //Create Events
     ResourceEvent& event_manager = reader_->getRTPSParticipant()->getEventResource();
@@ -139,6 +140,7 @@ void WriterProxy::start(
     locators_entry_.unicast = attributes.remote_locators().unicast;
     locators_entry_.multicast = attributes.remote_locators().multicast;
     is_datasharing_writer_ = is_datasharing;
+    state_.store(StateCode::IDLE);
     initial_acknack_->restart_timer();
     loaded_from_storage(initial_sequence);
     received_at_least_one_heartbeat_ = false;
@@ -159,7 +161,16 @@ void WriterProxy::update(
 
 void WriterProxy::stop()
 {
-    initial_acknack_->cancel_timer();
+    StateCode prev_code;
+    if ((prev_code = state_.exchange(StateCode::STOPPED)) == StateCode::BUSY)
+    {
+        // Initial ack_nack being performed, wait for it to finish
+        initial_acknack_->recreate_timer();
+    }
+    else
+    {
+        initial_acknack_->cancel_timer();
+    }
     heartbeat_response_->cancel_timer();
 
     clear();
@@ -509,6 +520,13 @@ bool WriterProxy::perform_initial_ack_nack()
 {
     bool ret_value = false;
 
+    StateCode expected = StateCode::IDLE;
+    if (!state_.compare_exchange_strong(expected, StateCode::BUSY))
+    {
+        // Stopped from another thread -> abort
+        return ret_value;
+    }
+
     if (!is_datasharing_writer_)
     {
         // Send initial NACK.
@@ -537,6 +555,9 @@ bool WriterProxy::perform_initial_ack_nack()
             }
         }
     }
+
+    expected = StateCode::BUSY;
+    state_.compare_exchange_strong(expected, StateCode::IDLE);
 
     return ret_value;
 }

--- a/src/cpp/rtps/reader/WriterProxy.h
+++ b/src/cpp/rtps/reader/WriterProxy.h
@@ -356,6 +356,13 @@ public:
 
 private:
 
+    enum StateCode
+    {
+        IDLE = 0, //! Writer Proxy is not performing any critical operations.
+        BUSY, //! Writer Proxy is performing a critical operation. Some actions (e.g. stop) should wait for its completion.
+        STOPPED, //! Writer Proxy has been requested to \c stop.
+    };
+
     /**
      * Set initial value for last acked sequence number.
      * @param[in] seq_num last acked sequence number.
@@ -415,6 +422,8 @@ private:
     bool is_datasharing_writer_;
     //! Wether at least one heartbeat was recevied.
     bool received_at_least_one_heartbeat_;
+    //! Current state of this Writer Proxy
+    std::atomic<StateCode> state_;
 
     using ChangeIterator = decltype(changes_received_)::iterator;
 

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -70,6 +70,13 @@ void TimedEvent::restart_timer(
     }
 }
 
+void TimedEvent::recreate_timer()
+{
+    service_.unregister_timer(impl_);
+    impl_->go_cancel();
+    service_.register_timer(impl_);
+}
+
 bool TimedEvent::update_interval(
         const Duration_t& inter)
 {

--- a/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
+++ b/test/mock/rtps/TimedEvent/fastdds/rtps/resources/TimedEvent.h
@@ -41,6 +41,7 @@ public:
     MOCK_METHOD0(restart_timer, void());
     MOCK_METHOD1(restart_timer, void(const std::chrono::steady_clock::time_point& timeout));
     MOCK_METHOD0(cancel_timer, void());
+    MOCK_METHOD0(recreate_timer, void());
     MOCK_METHOD1(update_interval, bool(const Duration_t&));
     MOCK_METHOD1(update_interval_millisec, bool(double));
     MOCK_METHOD0(getIntervalMilliSec, double());

--- a/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
+++ b/test/unittest/rtps/resources/timedevent/TimedEventTests.cpp
@@ -111,6 +111,43 @@ TEST(TimedEvent, Event_RestartEvents)
 }
 
 /*!
+ * @fn TEST(TimedEvent, Event_RecreateEvents)
+ * @brief This test checks the correct behavior of recreating events.
+ * First it is checked that recreating and restarting an event multiple times is possible.
+ * The event is then recreated (blocking cancel), and an object shared with the callback is modified in the main thread.
+ * A data race would be reported by thread sanitizer if cancelling (\c cancel_timer) the event instead.
+ */
+TEST(TimedEvent, Event_RecreateEvents)
+{
+    int num = 0;
+    auto callback = [&num]() -> void
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                num++;
+            };
+
+    MockEvent event(*env->service_, 100, false, callback);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        event.event().recreate_timer();
+        event.event().restart_timer();
+        event.wait();
+    }
+
+    // Recreate timer (blocking cancel) and modify object shared with callback
+    // A data race would be reported by thread sanitizer if using cancel_timer instead
+    event.event().recreate_timer();
+    num = 10;
+
+    ASSERT_FALSE(event.wait(120));
+
+    int successed = event.successed_.load(std::memory_order_relaxed);
+
+    ASSERT_EQ(successed, 10);
+}
+
+/*!
  * @fn TEST(TimedEvent, EventOnSuccessAutoDestruc_QuickCancelEvents)
  * @brief This test checks the event is not destroyed when it is canceled.
  * This test launches an event, configured to destroy itself when the event is executed successfully,

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.cpp
@@ -19,10 +19,12 @@ using namespace eprosima::fastrtps::rtps;
 MockEvent::MockEvent(
         eprosima::fastrtps::rtps::ResourceEvent& service,
         double milliseconds,
-        bool autorestart)
+        bool autorestart,
+        std::function<void()> inner_callback)
     : successed_(0)
     , sem_count_(0)
     , autorestart_(autorestart)
+    , inner_callback_(inner_callback)
     , event_(service, std::bind(&MockEvent::callback, this), milliseconds)
 {
 }
@@ -37,7 +39,7 @@ bool MockEvent::callback()
 
     successed_.fetch_add(1, std::memory_order_relaxed);
 
-    if(autorestart_)
+    if (autorestart_)
     {
         restart = true;
     }
@@ -47,6 +49,11 @@ bool MockEvent::callback()
     sem_mutex_.unlock();
     sem_cond_.notify_one();
 
+    if (inner_callback_)
+    {
+        inner_callback_();
+    }
+
     return restart;
 }
 
@@ -54,7 +61,10 @@ void MockEvent::wait()
 {
     std::unique_lock<std::mutex> lock(sem_mutex_);
 
-    sem_cond_.wait(lock, [&]() -> bool { return sem_count_ != 0; } );
+    sem_cond_.wait(lock, [&]() -> bool
+            {
+                return sem_count_ != 0;
+            } );
 
     --sem_count_;
 }
@@ -65,17 +75,24 @@ void MockEvent::wait_success()
 
     while (successed_.load(std::memory_order_relaxed) == 0)
     {
-        sem_cond_.wait(lock, [&]() -> bool { return sem_count_ != 0; } );
+        sem_cond_.wait(lock, [&]() -> bool
+                {
+                    return sem_count_ != 0;
+                } );
         --sem_count_;
     }
 }
 
-bool MockEvent::wait(unsigned int milliseconds)
+bool MockEvent::wait(
+        unsigned int milliseconds)
 {
     std::unique_lock<std::mutex> lock(sem_mutex_);
 
-    if(!sem_cond_.wait_for(lock, std::chrono::milliseconds(milliseconds),
-                [&]() -> bool { return sem_count_ != 0; } ))
+    if (!sem_cond_.wait_for(lock, std::chrono::milliseconds(milliseconds),
+            [&]() -> bool
+            {
+                return sem_count_ != 0;
+            } ))
     {
         return false;
     }

--- a/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
+++ b/test/unittest/rtps/resources/timedevent/mock/MockEvent.h
@@ -24,34 +24,40 @@
 
 class MockEvent
 {
-    public:
+public:
 
-        MockEvent(
-                eprosima::fastrtps::rtps::ResourceEvent& service,
-                double milliseconds,
-                bool autorestart);
+    MockEvent(
+            eprosima::fastrtps::rtps::ResourceEvent& service,
+            double milliseconds,
+            bool autorestart,
+            std::function<void()> inner_callback = {});
 
-        virtual ~MockEvent();
+    virtual ~MockEvent();
 
-        eprosima::fastrtps::rtps::TimedEvent& event() { return event_; }
+    eprosima::fastrtps::rtps::TimedEvent& event()
+    {
+        return event_;
+    }
 
-        bool callback();
+    bool callback();
 
-        void wait();
+    void wait();
 
-        void wait_success();
+    void wait_success();
 
-        bool wait(unsigned int milliseconds);
+    bool wait(
+            unsigned int milliseconds);
 
-        std::atomic<int> successed_;
+    std::atomic<int> successed_;
 
-    private:
+private:
 
-        int sem_count_;
-        std::mutex sem_mutex_;
-        std::condition_variable sem_cond_;
-        bool autorestart_;
-        eprosima::fastrtps::rtps::TimedEvent event_;
+    int sem_count_;
+    std::mutex sem_mutex_;
+    std::condition_variable sem_cond_;
+    bool autorestart_;
+    std::function<void()> inner_callback_;
+    eprosima::fastrtps::rtps::TimedEvent event_;
 };
 
 #endif // _TEST_RTPS_RESOURCES_TIMEDEVENT_MOCKEVENT_H_


### PR DESCRIPTION
* Fix datarace on WriterProxy stop while perform_initial_ack_nack



* Add test



* Uncrustify



* Recreate timer only if being triggered



* Apply suggestions

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
