### PR TITLE
[Backport]Fix performance tests - Overflow in received samples (#3309)

### DIFF
--- a/test/performance/throughput/ThroughputPublisher.cpp
+++ b/test/performance/throughput/ThroughputPublisher.cpp
@@ -825,8 +825,9 @@ bool ThroughputPublisher::test(
                 result.publisher.totaltime_us =
                         std::chrono::duration<double, std::micro>(t_end_ - t_start_) - clock_overhead;
 
-                result.subscriber.recv_samples = command_sample.m_lastrecsample - command_sample.m_lostsamples;
-                result.subscriber.lost_samples = command_sample.m_lostsamples;
+                result.subscriber.recv_samples = command_sample.m_receivedsamples;
+                assert(samples >= command_sample.m_receivedsamples);
+                result.subscriber.lost_samples = samples - (uint32_t)command_sample.m_receivedsamples;
                 result.subscriber.totaltime_us =
                         std::chrono::microseconds(command_sample.m_totaltime)
                         - test_start_ack_duration - clock_overhead;

--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -45,6 +45,7 @@ void ThroughputSubscriber::DataReaderListener::reset()
 {
     last_seq_num_ = 0;
     lost_samples_ = 0;
+    received_samples_ = 0;
     matched_ = 0;
     enable_ = true;
 }
@@ -119,6 +120,7 @@ void ThroughputSubscriber::DataReaderListener::on_data_available(
                 }
             }
             last_seq_num = seq_num;
+            received_samples_ += 1;
         }
 
         if ((last_seq_num_ + size) < last_seq_num)
@@ -152,6 +154,7 @@ void ThroughputSubscriber::DataReaderListener::on_data_available(
                     lost_samples_ += seq_num - last_seq_num_ - 1;
                 }
                 last_seq_num_ = seq_num;
+                received_samples_ += 1;
             }
             else
             {
@@ -165,6 +168,7 @@ void ThroughputSubscriber::DataReaderListener::save_numbers()
 {
     saved_last_seq_num_ = last_seq_num_;
     saved_lost_samples_ = lost_samples_;
+    saved_received_samples_ = received_samples_;
 }
 
 // *******************************************************************************************
@@ -753,6 +757,7 @@ void ThroughputSubscriber::run()
             command_sample.m_size = data_size_ + (uint32_t)ThroughputType::overhead;
             command_sample.m_lastrecsample = data_reader_listener_.saved_last_seq_num_;
             command_sample.m_lostsamples = data_reader_listener_.saved_lost_samples_;
+            command_sample.m_receivedsamples = data_reader_listener_.saved_received_samples_;
 
             double total_time_count =
                     (std::chrono::duration<double, std::micro>(t_end_ - t_start_) - t_overhead_).count();
@@ -772,8 +777,9 @@ void ThroughputSubscriber::run()
 
             std::cout << "Last Received Sample: " << command_sample.m_lastrecsample << std::endl;
             std::cout << "Lost Samples: " << command_sample.m_lostsamples << std::endl;
+            std::cout << "Received Samples: " << command_sample.m_receivedsamples << std::endl;
             std::cout << "Samples per second: "
-                      << (double)(command_sample.m_lastrecsample - command_sample.m_lostsamples) * 1000000 /
+                      << (double)(command_sample.m_receivedsamples) * 1000000 /
                 command_sample.m_totaltime
                       << std::endl;
             std::cout << "Test of size " << command_sample.m_size << " and demand " << command_sample.m_demand <<

--- a/test/performance/throughput/ThroughputSubscriber.hpp
+++ b/test/performance/throughput/ThroughputSubscriber.hpp
@@ -148,6 +148,7 @@ private:
         ThroughputSubscriber& throughput_subscriber_;
         uint32_t last_seq_num_ = 0;
         uint32_t lost_samples_ = 0;
+        uint64_t received_samples_ = 0;
         eprosima::fastdds::dds::SampleInfo info_;
         std::atomic_int matched_;
         std::atomic_bool enable_;
@@ -181,6 +182,7 @@ private:
 
         uint32_t saved_last_seq_num_;
         uint32_t saved_lost_samples_;
+        uint64_t saved_received_samples_;
     }
     data_reader_listener_;
 

--- a/test/performance/throughput/ThroughputTypes.cpp
+++ b/test/performance/throughput/ThroughputTypes.cpp
@@ -111,6 +111,8 @@ bool ThroughputCommandDataType::serialize(
     p->length += sizeof(t->m_demand);
     memcpy(&p->data[p->length], &t->m_lostsamples, sizeof(t->m_lostsamples));
     p->length += sizeof(t->m_lostsamples);
+    memcpy(&p->data[p->length], &t->m_receivedsamples, sizeof(t->m_receivedsamples));
+    p->length += sizeof(t->m_receivedsamples);
     memcpy(&p->data[p->length], &t->m_lastrecsample, sizeof(t->m_lastrecsample));
     p->length += sizeof(t->m_lastrecsample);
     memcpy(&p->data[p->length], &t->m_totaltime, sizeof(t->m_totaltime));
@@ -134,6 +136,8 @@ bool ThroughputCommandDataType::deserialize(
     p->pos += sizeof(t->m_demand);
     memcpy(&t->m_lostsamples, &p->data[p->pos], sizeof(t->m_lostsamples));
     p->pos += sizeof(t->m_lostsamples);
+    memcpy(&t->m_receivedsamples, &p->data[p->pos], sizeof(t->m_receivedsamples));
+    p->pos += sizeof(t->m_receivedsamples);
     memcpy(&t->m_lastrecsample, &p->data[p->pos], sizeof(t->m_lastrecsample));
     p->pos += sizeof(t->m_lastrecsample);
     memcpy(&t->m_totaltime, &p->data[p->pos], sizeof(t->m_totaltime));
@@ -149,7 +153,7 @@ std::function<uint32_t()> ThroughputCommandDataType::getSerializedSizeProvider(
                uint32_t size = 0;
 
                size = (uint32_t)(sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t)  + sizeof(uint32_t) +
-                       sizeof(uint64_t) + sizeof(uint64_t));
+                       sizeof(uint64_t) + sizeof(uint64_t) + sizeof(uint64_t));
 
                return size;
            };

--- a/test/performance/throughput/ThroughputTypes.hpp
+++ b/test/performance/throughput/ThroughputTypes.hpp
@@ -200,6 +200,7 @@ typedef struct ThroughputCommandType
     e_Command m_command;
     uint32_t m_size = 0;
     uint32_t m_demand = 0;
+    uint64_t m_receivedsamples = 0;
     uint32_t m_lostsamples = 0;
     uint64_t m_lastrecsample = 0;
     uint64_t m_totaltime = 0;
@@ -238,7 +239,7 @@ public:
     ThroughputCommandDataType()
     {
         setName("ThroughputCommand");
-        m_typeSize = 4 * sizeof(uint32_t) + 2 * sizeof(uint64_t) + sizeof(double);
+        m_typeSize = 4 * sizeof(uint32_t) + 3 * sizeof(uint64_t) + sizeof(double);
         m_isGetKeyDefined = false;
     }
 


### PR DESCRIPTION
* Refs #17004: Fix overflow by counting received samples directly and not from calculation



* Refs #17004: Cleaning



* Refs #17004: Extend change to data_loans case



* Refs #17004: Lost samples calculation is now done in Publisher instead of in Subscriber



* Refs #17004: Fix over samples count for data_loans reception



* Refs #17004: Fix data sizes



* Refs #17004: Fix assert comparison



* Refs #17004: Erase Windows warning



---------

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
