### PR TITLE
[Backport]Fix repeated matched event notification (#3396)

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1080,6 +1080,21 @@ void DataWriterImpl::InnerDataWriterListener::onWriterMatched(
         const PublicationMatchedStatus& info)
 {
     data_writer_->update_publication_matched_status(info);
+
+    StatusMask notify_status = StatusMask::publication_matched();
+    DataWriterListener* listener = data_writer_->get_listener_for(notify_status);
+    if (listener != nullptr)
+    {
+        PublicationMatchedStatus callback_status;
+        if (ReturnCode_t::RETCODE_OK == data_writer_->get_publication_matched_status(callback_status))
+        {
+            listener->on_publication_matched(data_writer_->user_datawriter_, callback_status);
+        }
+    }
+    else
+    {
+        data_writer_->user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
+    }
 }
 
 void DataWriterImpl::InnerDataWriterListener::on_offered_incompatible_qos(
@@ -1254,16 +1269,6 @@ void DataWriterImpl::update_publication_matched_status(
         publication_matched_status_.total_count_change += count_change;
     }
     publication_matched_status_.last_subscription_handle = status.last_subscription_handle;
-
-    StatusMask notify_status = StatusMask::publication_matched();
-    DataWriterListener* listener = get_listener_for(notify_status);
-    if (listener != nullptr)
-    {
-        listener->on_publication_matched(user_datawriter_, publication_matched_status_);
-        publication_matched_status_.current_count_change = 0;
-        publication_matched_status_.total_count_change = 0;
-    }
-    user_datawriter_->get_statuscondition().get_impl()->set_status(notify_status, true);
 }
 
 ReturnCode_t DataWriterImpl::get_publication_matched_status(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -854,6 +854,21 @@ void DataReaderImpl::InnerDataReaderListener::onReaderMatched(
         const SubscriptionMatchedStatus& info)
 {
     data_reader_->update_subscription_matched_status(info);
+
+    StatusMask notify_status = StatusMask::subscription_matched();
+    DataReaderListener* listener = data_reader_->get_listener_for(notify_status);
+    if (listener != nullptr)
+    {
+        SubscriptionMatchedStatus callback_status;
+        if (ReturnCode_t::RETCODE_OK == data_reader_->get_subscription_matched_status(callback_status))
+        {
+            listener->on_subscription_matched(data_reader_->user_datareader_, callback_status);
+        }
+    }
+    else
+    {
+        data_reader_->user_datareader_->get_statuscondition().get_impl()->set_status(notify_status, true);
+    }
 }
 
 void DataReaderImpl::InnerDataReaderListener::on_liveliness_changed(
@@ -994,16 +1009,6 @@ void DataReaderImpl::update_subscription_matched_status(
     {
         history_.writer_not_alive(iHandle2GUID(status.last_publication_handle));
     }
-
-    StatusMask notify_status = StatusMask::subscription_matched();
-    DataReaderListener* listener = get_listener_for(notify_status);
-    if (listener != nullptr)
-    {
-        listener->on_subscription_matched(user_datareader_, subscription_matched_status_);
-        subscription_matched_status_.current_count_change = 0;
-        subscription_matched_status_.total_count_change = 0;
-    }
-    user_datareader_->get_statuscondition().get_impl()->set_status(notify_status, true);
 }
 
 ReturnCode_t DataReaderImpl::get_subscription_matched_status(


### PR DESCRIPTION
* Fix repeated matched event notification



* Fix coding style



---------

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
