### PR TITLE
[Backport]Time t operators (#1781)

### DIFF
--- a/include/fastdds/rtps/common/Time_t.h
+++ b/include/fastdds/rtps/common/Time_t.h
@@ -18,7 +18,9 @@
 
 #ifndef _FASTDDS_RTPS_TIME_T_H_
 #define _FASTDDS_RTPS_TIME_T_H_
+
 #include <fastrtps/fastrtps_dll.h>
+
 #include <cmath>
 #include <cstdint>
 #include <iostream>
@@ -400,8 +402,8 @@ inline std::istream& operator >>(
 
             input >> sec;
             input >> point >> nano;
-            // nano could not be bigger than 1 sec
-            if ( point != '.' || nano > 1000000000 )
+            // nano could not be bigger or equal than 1 sec
+            if ( point != '.' || nano >= 1000000000 )
             {
                 input.setstate(std::ios_base::failbit);
                 nano = 0;

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -29,6 +29,9 @@ set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutConsumer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/log/StdoutErrConsumer.cpp)
 
+set(TIMETESTS_SOURCE TimeTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp)
+
 add_executable(CacheChangeTests ${CACHECHANGETESTS_SOURCE})
 target_compile_definitions(CacheChangeTests PRIVATE
     $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
@@ -126,3 +129,18 @@ target_include_directories(GuidTests PRIVATE
     ${PROJECT_SOURCE_DIR}/src/cpp)
 target_link_libraries(GuidTests GTest::gtest)
 add_gtest(GuidTests SOURCES ${GUIDTESTS_SOURCE} LABELS "NoMemoryCheck")
+
+
+#############
+# Time test #
+#############
+
+add_executable(TimeTests ${TIMETESTS_SOURCE})
+target_compile_definitions(TimeTests PRIVATE FASTRTPS_NO_LIB
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(TimeTests PRIVATE ${GTEST_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+target_link_libraries(TimeTests GTest::gtest)
+add_gtest(TimeTests SOURCES ${TIMETESTS_SOURCE} LABELS "NoMemoryCheck")

--- a/test/unittest/rtps/common/TimeTests.cpp
+++ b/test/unittest/rtps/common/TimeTests.cpp
@@ -1,0 +1,202 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastrtps/rtps/common/Time_t.h>
+
+#include <gtest/gtest.h>
+
+using namespace eprosima::fastrtps::rtps;
+
+/*
+ * Test << operator
+ * NOTE: The conversion from double to Time_t is not equitative, so the string conversion is not exact to double
+ *  i.e: Time_t(0.3) = 0.299999999
+ */
+TEST(TimeTest, serialize_operator)
+{
+    std::stringstream ss;
+
+    Time_t t1;
+    ss << t1;
+    ASSERT_EQ(ss.str(), "0.0");
+    ss.str("");
+    ss.clear();
+
+    // Set sec and nanosec
+    Time_t t2(1, 0);
+    t2.nanosec(1);
+    ss << t2;
+    ASSERT_EQ(ss.str(), "1.1");
+    ss.str("");
+    ss.clear();
+
+    Time_t t3(4346, 0);
+    t3.nanosec(415672901);
+    ss << t3;
+    ASSERT_EQ(ss.str(), "4346.415672901");
+    ss.str("");
+    ss.clear();
+
+    // double constructor
+    Time_t t4(2.0);
+    ss << t4;
+    ASSERT_EQ(ss.str(), "2.0");
+    ss.str("");
+    ss.clear();
+
+    //! numeric converison when fraction precision
+    Time_t t5(0.000002);
+    ss << t5;
+    ASSERT_EQ(ss.str(), "0.1999");
+    ss.str("");
+    ss.clear();
+
+    // sec & frac constructor
+    Time_t t6(4346, 5);
+    ss << t6;
+    ASSERT_EQ(ss.str(), "4346.1");
+    ss.str("");
+    ss.clear();
+}
+
+/*
+ * Test >> operator
+ */
+TEST(TimeTest, deserialize_operator)
+{
+    Time_t t;
+
+    // This does not work due to double precision
+    // std::stringstream st1("1.02");
+    // st1 >> t;
+    // ASSERT_EQ(t.seconds(), 1);
+    // ASSERT_EQ(t.nanosec(), 20000000u);
+
+    std::stringstream st1("1.002");
+    st1 >> t;
+    ASSERT_EQ(t.seconds(), 1);
+    ASSERT_EQ(t.nanosec(), 2u);
+
+    std::stringstream st2("0.000003");
+    st2 >> t;
+    ASSERT_EQ(t.seconds(), 0);
+    ASSERT_EQ(t.nanosec(), 3u);
+
+    // Non nanosecs
+    std::stringstream st3("12");
+    st3 >> t;
+    ASSERT_EQ(t.seconds(), 12);
+    ASSERT_EQ(t.nanosec(), 0u);
+
+    // Lowest time
+    std::stringstream st4("0.000000001");
+    st4 >> t;
+    ASSERT_EQ(t.seconds(), 0);
+    ASSERT_EQ(t.nanosec(), 1u);
+
+    // Check double precision
+    std::stringstream st5("4346.415672901");
+    st5 >> t;
+    ASSERT_EQ(t.seconds(), 4346);
+    ASSERT_EQ(t.nanosec(), 415672901u);
+
+    std::stringstream st6("123.456789");
+    st6 >> t;
+    ASSERT_EQ(t.seconds(), 123);
+    ASSERT_EQ(t.nanosec(), 456789u);
+}
+
+/*
+ * Test >> operator with bad format
+ */
+TEST(TimeTest, bad_format_deserialize_operator)
+{
+    Time_t t;
+
+    // Check more than 9 digits
+    {
+        std::stringstream st("1.1231231231");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 1);
+        ASSERT_EQ(t.nanosec(), 231231231u);
+    }
+
+    {
+        std::stringstream st("2.789789789789");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 2);
+        ASSERT_EQ(t.nanosec(), 294967295u);
+    }
+
+    {
+        std::stringstream st("1234.999999999999");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 1234);
+        ASSERT_EQ(t.nanosec(), 294967295u);
+    }
+
+    {
+        std::stringstream st("55.1000000001");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 55);
+        ASSERT_EQ(t.nanosec(), 1u);
+    }
+
+    // Check a negative case
+    {
+        std::stringstream st("-3");
+        st >> t;
+        ASSERT_EQ(t.seconds(), -3);
+        ASSERT_EQ(t.nanosec(), 0u);
+    }
+
+    // One second from nanosecond case, set to zero time
+    {
+        std::stringstream st("0.1000000000");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 0);
+        ASSERT_EQ(t.nanosec(), 0u);
+    }
+
+    // Non numeric case
+    {
+        std::stringstream st("non_number");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 0);
+        ASSERT_EQ(t.nanosec(), 0u);
+    }
+
+    // Non numeric case after number
+    {
+        std::stringstream st("2non_number");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 2);
+        ASSERT_EQ(t.nanosec(), 0u);
+    }
+
+    {
+        std::stringstream st("9.3non_number4");
+        st >> t;
+        ASSERT_EQ(t.seconds(), 9);
+        ASSERT_EQ(t.nanosec(), 3u);
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
* Refs #10652: fix operators and add test



* Refs #10652: uncrustify



* Refs #10652: minor fixes



* Refs #10652: apply suggestions



* Refs #10652: uncrustify



* Refs #10652: change deserialization to use double



* Refs #10652: Fix windows compilation



* Refs 10652: Revert changes, added >= in serialize operator, tests updated to expect output from former behavior



* Refs 10652: Suggested changes



* Refs 10652: Added u to unsigned asserts on nanoseconds

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
