### PR TITLE
[Backport]Change history remove change return statement (#3858)

### DIFF
--- a/include/fastdds/rtps/history/History.h
+++ b/include/fastdds/rtps/history/History.h
@@ -299,6 +299,18 @@ protected:
     RTPS_DllAPI virtual void do_release_cache(
             CacheChange_t* ch) = 0;
 
+    /**
+     * @brief Removes the constness of a const_iterator to obtain a regular iterator.
+     *
+     * This function takes a const_iterator as input and returns a regular iterator by removing the constness.
+     *
+     * @param c_it The const_iterator to remove constness from.
+     *
+     * @return An iterator with the same position as the input const_iterator.
+     */
+    History::iterator remove_iterator_constness(
+            const_iterator c_it);
+
 };
 
 } // namespace rtps

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -481,32 +481,13 @@ bool DataReaderHistory::remove_change_sub(
         return false;
     }
 
-    std::lock_guard<RecursiveTimedMutex> guard(*getMutex());
-    bool found = false;
-    InstanceCollection::iterator vit;
-    if (find_key(change->instanceHandle, vit))
-    {
-        for (auto chit = vit->second->cache_changes.begin(); chit != vit->second->cache_changes.end(); ++chit)
-        {
-            if ((*chit)->sequenceNumber == change->sequenceNumber &&
-                    (*chit)->writerGUID == change->writerGUID)
-            {
-                assert(it == chit);
-                it = vit->second->cache_changes.erase(chit);
-                found = true;
+    CacheChange_t dummy_change;
+    dummy_change.instanceHandle = change->instanceHandle;
+    dummy_change.isRead = change->isRead;
+    dummy_change.sequenceNumber = change->sequenceNumber;
+    dummy_change.writerGUID = change->writerGUID;
 
-                if (change->isRead)
-                {
-                    --counters_.samples_read;
-                }
-                break;
-            }
-        }
-    }
-    if (!found)
-    {
-        EPROSIMA_LOG_ERROR(SUBSCRIBER, "Change not found on this key, something is wrong");
-    }
+    std::lock_guard<RecursiveTimedMutex> guard(*getMutex());
 
     const_iterator chit = find_change_nts(change);
     if (chit == changesEnd())
@@ -515,11 +496,36 @@ bool DataReaderHistory::remove_change_sub(
         return false;
     }
 
-    m_isHistoryFull = false;
-    ReaderHistory::remove_change_nts(chit);
+    auto new_it = ReaderHistory::remove_change_nts(chit);
 
-    counters_.samples_unread = mp_reader->get_unread_count();
-    return true;
+    if (new_it == changesEnd() || !matches_change(&dummy_change, *new_it)) // Change was successfully removed.
+    {
+        InstanceCollection::iterator vit;
+        if (find_key(dummy_change.instanceHandle, vit))
+        {
+            auto in_it = std::find(vit->second->cache_changes.begin(), vit->second->cache_changes.end(), change);
+
+            if (vit->second->cache_changes.end() != in_it)
+            {
+                assert(it == in_it);
+                it = vit->second->cache_changes.erase(in_it);
+                if (dummy_change.isRead)
+                {
+                    --counters_.samples_read;
+                }
+            }
+            else
+            {
+                EPROSIMA_LOG_ERROR(SUBSCRIBER, "Change not found on this key, something is wrong");
+            }
+        }
+
+        m_isHistoryFull = false;
+        counters_.samples_unread = mp_reader->get_unread_count();
+        return true;
+    }
+
+    return false;
 }
 
 bool DataReaderHistory::set_next_deadline(
@@ -679,33 +685,47 @@ ReaderHistory::iterator DataReaderHistory::remove_change_nts(
 {
     if (removal != changesEnd())
     {
-        CacheChange_t* p_sample = *removal;
+        CacheChange_t* change_ptr = *removal;
+        CacheChange_t dummy_change;
+        bool is_fully_assembled = (*removal)->is_fully_assembled();
+        dummy_change.instanceHandle = (*removal)->instanceHandle;
+        dummy_change.isRead = (*removal)->isRead;
+        dummy_change.sequenceNumber = (*removal)->sequenceNumber;
+        dummy_change.writerGUID = (*removal)->writerGUID;
 
-        if (!has_keys_ || p_sample->is_fully_assembled())
+        // call the base class
+        auto ret_val = ReaderHistory::remove_change_nts(removal, release);
+
+        if (ret_val == changesEnd() || !matches_change(&dummy_change, *ret_val)) // Change was successfully removed.
         {
-            // clean any references to this CacheChange in the key state collection
-            auto it = instances_.find(p_sample->instanceHandle);
-
-            // if keyed and in history must be in the map
-            // There is a case when the sample could not be in the keyed map. The first received fragment of a
-            // fragmented sample is stored in the history, and when it is completed it is stored in the keyed map.
-            // But it can occur it is rejected when the sample is completed and removed without being stored in the
-            // keyed map.
-            if (it != instances_.end())
+            if (!has_keys_ || is_fully_assembled)
             {
-                it->second->cache_changes.remove(p_sample);
-                if (p_sample->isRead)
+                // clean any references to this CacheChange in the key state collection
+                auto it = instances_.find(dummy_change.instanceHandle);
+
+                // if keyed and in history must be in the map
+                // There is a case when the sample could not be in the keyed map. The first received fragment of a
+                // fragmented sample is stored in the history, and when it is completed it is stored in the keyed map.
+                // But it can occur it is rejected when the sample is completed and removed without being stored in the
+                // keyed map.
+                if (it != instances_.end())
                 {
-                    --counters_.samples_read;
+                    it->second->cache_changes.remove(change_ptr);
+                    if (dummy_change.isRead)
+                    {
+                        --counters_.samples_read;
+                    }
                 }
             }
+
+            counters_.samples_unread = mp_reader->get_unread_count();
+            return ret_val;
         }
+
+        return remove_iterator_constness(removal);
     }
 
-    // call the base class
-    auto ret_val = ReaderHistory::remove_change_nts(removal, release);
-    counters_.samples_unread = mp_reader->get_unread_count();
-    return ret_val;
+    return changesEnd();
 }
 
 bool DataReaderHistory::completed_change(

--- a/src/cpp/rtps/history/History.cpp
+++ b/src/cpp/rtps/history/History.cpp
@@ -74,7 +74,7 @@ History::iterator History::remove_change_nts(
 {
     if (nullptr == mp_mutex)
     {
-        return changesEnd();
+        return remove_iterator_constness(removal);
     }
 
     if (removal == changesEnd())
@@ -107,8 +107,21 @@ bool History::remove_change(
         return false;
     }
 
-    // remove using the virtual method
-    remove_change_nts(it);
+    // Dummy change just used to compare original change with change returned from remove_change_nts function
+    CacheChange_t dummy_change;
+    dummy_change.writerGUID = (*it)->writerGUID;
+    dummy_change.sequenceNumber = (*it)->sequenceNumber;
+
+    // Remove using the virtual method
+    History::iterator history_it = remove_change_nts(it);
+
+    // If remove_change_nts returns a valid iterator (not end()) and this is the same iterator means that it
+    // could not remove it so this function should fail
+    if (history_it != changesEnd() && matches_change(&dummy_change, *history_it))
+    {
+        EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Failed to remove a change from history");
+        return false;
+    }
 
     return true;
 }
@@ -221,6 +234,14 @@ bool History::get_earliest_change(
 
     *change = m_changes.front();
     return true;
+}
+
+History::iterator History::remove_iterator_constness(
+        const_iterator c_it)
+{
+    History::iterator it = changesBegin();
+    std::advance(it, std::distance<const_iterator>(m_changes.cbegin(), c_it));
+    return it;
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/history/ReaderHistory.cpp
+++ b/src/cpp/rtps/history/ReaderHistory.cpp
@@ -131,14 +131,14 @@ History::iterator ReaderHistory::remove_change_nts(
         const_iterator removal,
         bool release)
 {
-    if ( mp_reader == nullptr || mp_mutex == nullptr)
+    if (mp_reader == nullptr || mp_mutex == nullptr)
     {
         EPROSIMA_LOG_ERROR(RTPS_WRITER_HISTORY,
                 "You need to create a Writer with this History before removing any changes");
-        return changesEnd();
+        return remove_iterator_constness(removal);
     }
 
-    if ( removal == changesEnd())
+    if (removal == changesEnd())
     {
         EPROSIMA_LOG_INFO(RTPS_WRITER_HISTORY, "Trying to remove without a proper CacheChange_t referenced");
         return changesEnd();

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -1064,6 +1064,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
 {
     PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
     PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
+    auto transport = std::make_shared<UDPv4TransportDescriptor>();
 
     auto data = default_data300kb_data_generator();
     auto reader_data = data;
@@ -1072,6 +1073,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(static_cast<int32_t>(data.size()))
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .disable_builtin_transport().add_user_transport_to_pparams(transport)
             .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(writer.isInitialized());
@@ -1086,6 +1088,7 @@ TEST_P(PubSubHistory, ReliableTransientLocalKeepLast1Data300Kb)
             .history_depth(1)
             .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
             .durability_kind(eprosima::fastrtps::TRANSIENT_LOCAL_DURABILITY_QOS)
+            .disable_builtin_transport().add_user_transport_to_pparams(transport)
             .mem_policy(mem_policy_).init();
 
     ASSERT_TRUE(reader.isInitialized());

--- a/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
+++ b/test/mock/rtps/ReaderHistory/fastdds/rtps/history/ReaderHistory.h
@@ -147,6 +147,11 @@ public:
         return m_changes.cend();
     }
 
+    iterator changesEnd()
+    {
+        return m_changes.end();
+    }
+
     virtual iterator remove_change_nts(
             const_iterator removal,
             bool release = true)
@@ -167,6 +172,22 @@ public:
     {
         static_cast<void>(writer_guid);
         static_cast<void>(ownership_strength);
+    }
+
+    bool matches_change(
+            const CacheChange_t* inner_change,
+            CacheChange_t* outer_change)
+    {
+        return inner_change->sequenceNumber == outer_change->sequenceNumber &&
+               inner_change->writerGUID == outer_change->writerGUID;
+    }
+
+    iterator remove_iterator_constness(
+            const_iterator c_it)
+    {
+        iterator it = m_changes.begin();
+        std::advance(it, std::distance<const_iterator>(m_changes.cbegin(), c_it));
+        return it;
     }
 
     HistoryAttributes m_att;


### PR DESCRIPTION
* Change history remove change return statement



* Apply review changes



* Refs #19590. Update DataReaderHistory



* Refs #19590: Apply suggested changes



---------

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
