### PR TITLE
[Backport]Protect creation/destruction of boost's named_mutex (#3104)

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -479,7 +479,7 @@ public:
                     // recursive lock of port_mutex in create_port()
                     if (node_->is_port_ok)
                     {
-                        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex =
+                        deleted_unique_ptr<SharedMemSegment::named_mutex> port_mutex =
                                 SharedMemSegment::try_open_and_lock_named_mutex(segment_name + "_mutex");
 
                         std::unique_lock<SharedMemSegment::named_mutex> port_lock(*port_mutex, std::adopt_lock);
@@ -1043,7 +1043,7 @@ private:
         logInfo(RTPS_TRANSPORT_SHM, THREADID << "Opening "
                                              << port_segment_name);
 
-        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex =
+        deleted_unique_ptr<SharedMemSegment::named_mutex> port_mutex =
                 SharedMemSegment::open_or_create_and_lock_named_mutex(port_segment_name + "_mutex");
 
         std::unique_lock<SharedMemSegment::named_mutex> port_lock(*port_mutex, std::adopt_lock);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemLog.hpp
@@ -29,7 +29,7 @@ private:
 
     uint16_t dump_id_ = 0;
     FILE* f_;
-    std::unique_ptr<SharedMemSegment::named_mutex> f_mutex_;
+    deleted_unique_ptr<SharedMemSegment::named_mutex> f_mutex_;
 
 public:
 

--- a/src/cpp/utils/shared_memory/SharedMemSegment.hpp
+++ b/src/cpp/utils/shared_memory/SharedMemSegment.hpp
@@ -49,6 +49,9 @@ namespace rtps {
 
 using Log = fastdds::dds::Log;
 
+template<typename T>
+using deleted_unique_ptr = std::unique_ptr<T, std::function<void (T*)>>;
+
 /**
  * Provides shared memory functionallity abstrating from
  * lower level layers
@@ -101,13 +104,22 @@ public:
     virtual SharedSegmentBase::Offset get_offset_from_address(
             void* address) const = 0;
 
-    static std::unique_ptr<SharedSegmentBase::named_mutex> open_or_create_and_lock_named_mutex(
+    static deleted_unique_ptr<SharedSegmentBase::named_mutex> open_or_create_and_lock_named_mutex(
             const std::string& mutex_name)
     {
-        std::unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
+        deleted_unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
 
-        named_mutex = std::unique_ptr<SharedSegmentBase::named_mutex>(
-            new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()));
+        {
+            std::lock_guard<std::mutex> lock(mtx_());
+
+            named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
+                {
+                    std::lock_guard<std::mutex> lock(mtx_());
+                    delete p;
+                });
+        }
 
         boost::posix_time::ptime wait_time
             = boost::posix_time::microsec_clock::universal_time()
@@ -117,9 +129,18 @@ public:
             // Interprocess mutex timeout when locking. Possible deadlock: owner died without unlocking?
             // try to remove and create again
             SharedSegmentBase::named_mutex::remove(mutex_name.c_str());
+            named_mutex.reset();
+            {
+                std::lock_guard<std::mutex> lock(mtx_());
 
-            named_mutex = std::unique_ptr<SharedSegmentBase::named_mutex>(
-                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()));
+                named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
+                    new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                    [](SharedSegmentBase::named_mutex* p)
+                    {
+                        std::lock_guard<std::mutex> lock(mtx_());
+                        delete p;
+                    });
+            }
 
             if (!named_mutex->try_lock())
             {
@@ -130,13 +151,22 @@ public:
         return named_mutex;
     }
 
-    static std::unique_ptr<SharedSegmentBase::named_mutex> try_open_and_lock_named_mutex(
+    static deleted_unique_ptr<SharedSegmentBase::named_mutex> try_open_and_lock_named_mutex(
             const std::string& mutex_name)
     {
-        std::unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
+        deleted_unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
 
-        named_mutex = std::unique_ptr<SharedSegmentBase::named_mutex>(
-            new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()));
+        {
+            std::lock_guard<std::mutex> lock(mtx_());
+
+            named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
+                {
+                    std::lock_guard<std::mutex> lock(mtx_());
+                    delete p;
+                });
+        }
 
         boost::posix_time::ptime wait_time
             = boost::posix_time::microsec_clock::universal_time()
@@ -149,15 +179,46 @@ public:
         return named_mutex;
     }
 
-    static std::unique_ptr<SharedSegmentBase::named_mutex> open_named_mutex(
+    static deleted_unique_ptr<SharedSegmentBase::named_mutex> open_or_create_named_mutex(
             const std::string& mutex_name)
     {
-        std::unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
+        deleted_unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
 
         // Todo(Adolfo) : Dataraces could occur, this algorithm has to be improved
 
-        named_mutex = std::unique_ptr<SharedSegmentBase::named_mutex>(
-            new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()));
+        {
+            std::lock_guard<std::mutex> lock(mtx_());
+
+            named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_or_create, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
+                {
+                    std::lock_guard<std::mutex> lock(mtx_());
+                    delete p;
+                });
+        }
+
+        return named_mutex;
+    }
+
+    static deleted_unique_ptr<SharedSegmentBase::named_mutex> open_named_mutex(
+            const std::string& mutex_name)
+    {
+        deleted_unique_ptr<SharedSegmentBase::named_mutex> named_mutex;
+
+        // Todo(Adolfo) : Dataraces could occur, this algorithm has to be improved
+
+        {
+            std::lock_guard<std::mutex> lock(mtx_());
+
+            named_mutex = deleted_unique_ptr<SharedSegmentBase::named_mutex>(
+                new SharedSegmentBase::named_mutex(boost::interprocess::open_only, mutex_name.c_str()),
+                [](SharedSegmentBase::named_mutex* p)
+                {
+                    std::lock_guard<std::mutex> lock(mtx_());
+                    delete p;
+                });
+        }
 
         return named_mutex;
     }
@@ -242,6 +303,13 @@ private:
     shared_mem_environment_initializer_;
 
     std::string name_;
+
+    static std::mutex& mtx_()
+    {
+        static std::mutex mtx_;
+        return mtx_;
+    }
+
 };
 
 template<typename T, typename U>

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -2210,6 +2210,108 @@ TEST_F(SHMTransportTests, dump_file)
     std::remove(log_file.c_str());
 }
 
+TEST_F(SHMTransportTests, named_mutex_concurrent_open_create)
+{
+    const std::string domain_name("SHMTests");
+
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    MockPortSharedMemGlobal port_mocker;
+
+    port_mocker.remove_port_mutex(domain_name, 0);
+
+    Semaphore sem_get_port;
+    Semaphore sem_end_thread_get_port;
+    std::thread thread_get_port([&]
+            {
+                auto port_mutex = port_mocker.get_port_mutex(domain_name, 0, false);
+
+                sem_get_port.post();
+                sem_end_thread_get_port.wait();
+            }
+            );
+
+    auto global_port = shared_mem_global->open_port(0, 1, 1000);
+
+    sem_get_port.wait();
+    sem_end_thread_get_port.post();
+    thread_get_port.join();
+}
+
+TEST_F(SHMTransportTests, named_mutex_concurrent_open)
+{
+    const std::string domain_name("SHMTests");
+
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    MockPortSharedMemGlobal port_mocker;
+
+    port_mocker.remove_port_mutex(domain_name, 0);
+
+    auto global_port = shared_mem_global->open_port(0, 1, 1000);
+
+    Semaphore sem_lock_done;
+    Semaphore sem_second_lock;
+    Semaphore sem_second_lock_done;
+    Semaphore sem_end_thread_locker;
+    std::atomic<int> lock_count(0);
+    std::thread thread_locker([&]
+            {
+                // lock has to be done in another thread because
+                // boost::inteprocess_named_mutex and  interprocess_mutex are recursive in Win32
+                auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
+                bool locked = port_mutex->try_lock();
+                if (locked)
+                {
+                    ++lock_count;
+                }
+
+                sem_lock_done.post();
+                sem_second_lock.wait();
+
+                if (locked)
+                {
+                    port_mutex->unlock();
+                }
+                else
+                {
+                    port_mutex->lock();
+                    ++lock_count;
+                }
+
+                sem_second_lock_done.post();
+                sem_end_thread_locker.wait();
+            }
+            );
+
+    auto port_mutex = port_mocker.get_port_mutex(domain_name, 0);
+    bool locked = port_mutex->try_lock();
+    if (locked)
+    {
+        ++lock_count;
+    }
+
+    sem_lock_done.wait();
+    ASSERT_EQ(lock_count, 1);
+
+    sem_second_lock.post();
+    if (locked)
+    {
+        port_mutex->unlock();
+    }
+    else
+    {
+        port_mutex->lock();
+        ++lock_count;
+    }
+
+    sem_second_lock_done.wait();
+    ASSERT_EQ(lock_count, 2);
+
+    sem_end_thread_locker.post();
+    thread_locker.join();
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -17,33 +17,45 @@
 
 #include <rtps/transport/shared_mem/SharedMemGlobal.hpp>
 
-namespace eprosima{
-namespace fastdds{
-namespace rtps{
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
 
-class MockPortSharedMemGlobal 
+class MockPortSharedMemGlobal
 {
 public:
 
-    static void remove_port_mutex(const std::string& domain_name, uint32_t port_id)
+    static void remove_port_mutex(
+            const std::string& domain_name,
+            uint32_t port_id)
     {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
         SharedMemSegment::named_mutex::remove(port_segment_name.c_str());
     }
 
-    static std::unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(const std::string& domain_name, uint32_t port_id)
-    {        
+    static deleted_unique_ptr<SharedMemSegment::named_mutex> get_port_mutex(
+            const std::string& domain_name,
+            uint32_t port_id,
+            bool open_only = true)
+    {
         auto port_segment_name = domain_name + "_port" + std::to_string(port_id);
 
-        std::unique_ptr<SharedMemSegment::named_mutex> port_mutex = 
-                SharedMemSegment::open_named_mutex(port_segment_name + "_mutex");
-
-        return std::unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(port_segment_name + "_mutex"));
+        if (open_only)
+        {
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_named_mutex(
+                               port_segment_name + "_mutex"));
+        }
+        else
+        {
+            return deleted_unique_ptr<SharedMemSegment::named_mutex>(SharedMemSegment::open_or_create_named_mutex(
+                               port_segment_name + "_mutex"));
+        }
     }
 
-    static bool lock_empty_cv_mutex(SharedMemGlobal::Port& port)
-    {        
+    static bool lock_empty_cv_mutex(
+            SharedMemGlobal::Port& port)
+    {
         return port.node_->empty_cv_mutex.try_lock();
     }
 
@@ -60,39 +72,43 @@ public:
         (void)listener;
 
         std::unique_lock<SharedMemSegment::mutex> lock(port.node_->empty_cv_mutex);
-        
+
         port.node_->waiting_count++;
         auto& status = port.node_->listeners_status[listener_index];
         status.is_waiting = 1;
 
-        port.node_->empty_cv.wait(lock, [&] {
-                return is_listener_closed.load();
-            });
+        port.node_->empty_cv.wait(lock, [&]
+                {
+                    return is_listener_closed.load();
+                });
 
         status.is_waiting = 0;
         port.node_->waiting_count--;
     }
 
     static void unblock_wait_pop(
-        SharedMemGlobal::Port& port,
-        std::atomic<bool>& is_listener_closed)
+            SharedMemGlobal::Port& port,
+            std::atomic<bool>& is_listener_closed)
     {
         is_listener_closed.exchange(true);
         port.node_->empty_cv.notify_all();
     }
 
-    static void set_port_not_ok(SharedMemGlobal::Port& port)
+    static void set_port_not_ok(
+            SharedMemGlobal::Port& port)
     {
         port.node_->is_port_ok = false;
     }
 
-    static void forze_listener_leak(SharedMemGlobal::Port& port)
+    static void forze_listener_leak(
+            SharedMemGlobal::Port& port)
     {
         port.node_->ref_counter.fetch_add(1);
         auto listener = port.buffer_->register_listener();
         listener.release();
         port.node_->num_listeners++;
     }
+
 };
 
 } // namespace rtps


### PR DESCRIPTION
* Protect boost's named_mutex creation



* Add tests



* Refs #16273: Minor style changes. Linter pass



* Applied suggestions

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
