### PR TITLE
[21624] Fix compilation errors in Ubuntu 24.04 using `-Werror`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if(MSVC OR MSVC_IDE)
 else()
     # Add some generic warnings common to all compilers
     set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-switch-bool")
+        "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Wno-unknown-pragmas -Wno-error=deprecated-declarations -Wno-switch-bool")
     # Add compiler specific options
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
@@ -80,6 +80,10 @@ else()
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-builtins")
         endif()
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl")
+    endif()
+
+    if(EPROSIMA_EXTRA_CMAKE_CXX_FLAGS)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EPROSIMA_EXTRA_CMAKE_CXX_FLAGS}")
     endif()
 
     if(EPROSIMA_BUILD)

--- a/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
+++ b/test/mock/rtps/NetworkFactory/rtps/network/NetworkFactory.hpp
@@ -42,7 +42,8 @@ class NetworkFactory
 {
 public:
 
-    NetworkFactory()
+    NetworkFactory(
+            const RTPSParticipantAttributes&)
     {
     }
 

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h
@@ -131,7 +131,10 @@ public:
 
     MOCK_CONST_METHOD0(getGuid, const GUID_t& ());
 
-    MOCK_CONST_METHOD0(network_factory, const NetworkFactory& ());
+    const NetworkFactory& network_factory()
+    {
+        return network_factory_;
+    }
 
     MOCK_METHOD0(is_intraprocess_only, bool());
 
@@ -416,9 +419,11 @@ private:
 
     MockParticipantListener listener_;
 
-    ResourceEvent events_;
-
     RTPSParticipantAttributes attr_;
+
+    NetworkFactory network_factory_ {attr_};
+
+    ResourceEvent events_;
 
     std::map<GUID_t, Endpoint*> endpoints_;
 

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -41,7 +41,8 @@ namespace rtps {
 constexpr size_t max_unicast_locators = 4u;
 constexpr size_t max_multicast_locators = 1u;
 
-NetworkFactory network;
+RTPSParticipantAttributes participant_attributes;
+NetworkFactory network {participant_attributes};
 
 /*** Auxiliary functions ***/
 inline uint32_t string_cdr_serialized_size(

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -52,6 +52,7 @@ target_compile_definitions(EdpTests PRIVATE
 target_include_directories(EdpTests PRIVATE
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/PDP
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/external_locators
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/NetworkFactory
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/Endpoint
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderProxyData

--- a/test/unittest/rtps/discovery/EdpTests.cpp
+++ b/test/unittest/rtps/discovery/EdpTests.cpp
@@ -20,7 +20,6 @@
 #include <rtps/builtin/discovery/endpoint/EDP.h>
 #include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/participant/RTPSParticipantImpl.h>
-#include <rtps/participant/RTPSParticipantImpl.h>
 
 #if HAVE_SECURITY
 #include <rtps/security/accesscontrol/ParticipantSecurityAttributes.h>

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -69,6 +69,20 @@ public:
 
 typedef HandleImpl<MockParticipantCrypto, SecurityTest> MockParticipantCryptoHandle;
 
+struct SecurityTestsGlobalDefaultValues
+{
+    // Default Values
+    RTPSParticipantAttributes pattr;
+
+    SecurityTestsGlobalDefaultValues()
+    {
+        ::testing::DefaultValue<const RTPSParticipantAttributes&>::Set(pattr);
+    }
+
+};
+
+static SecurityTestsGlobalDefaultValues g_security_default_values_;
+
 class SecurityTest : public ::testing::Test
 {
 protected:
@@ -182,7 +196,7 @@ public:
     bool security_activated_;
 
     // Default Values
-    NetworkFactory network;
+    NetworkFactory network{g_security_default_values_.pattr};
     GUID_t guid;
     CDRMessage_t default_cdr_message;
 
@@ -217,19 +231,5 @@ public:
     }
 
 };
-
-struct SecurityTestsGlobalDefaultValues
-{
-    // Default Values
-    RTPSParticipantAttributes pattr;
-
-    SecurityTestsGlobalDefaultValues()
-    {
-        ::testing::DefaultValue<const RTPSParticipantAttributes&>::Set(pattr);
-    }
-
-};
-
-static SecurityTestsGlobalDefaultValues g_security_default_values_;
 
 #endif // __TEST_UNITTEST_RTPS_SECURITY_SECURITYTESTS_HPP__


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Fix compilation errors in Ubuntu 24.04 using `-Werror`.

Depends on:
- eprosima/fast-dds-gen#395

Fixes the related error in eprosima/fast-dds-gen#395 and also this error:

```
[ 66%] Building CXX object test/unittest/dds/status/CMakeFiles/ListenerTests.dir/__/__/__/__/src/cpp/fastdds/xtypes/type_representation/TypeObjectUtils.cpp.o
In file included from /usr/include/c++/13/vector:66,
                from /home/ricardo/workspace/eprosima/fastdds/include/fastdds/dds/core/policy/QosPolicies.hpp:24,
                from /home/ricardo/workspace/eprosima/fastdds/include/fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp:27,
                from /home/ricardo/workspace/eprosima/fastdds/include/fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp:22,
                from /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.hpp:24,
                from /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.cpp:19:
In member function ‘std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::size() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’,
   inlined from ‘R testing::internal::FunctionMocker<R(Args ...)>::InvokeWith(ArgumentTuple&&) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1755:33,
   inlined from ‘testing::internal::FunctionMocker<R(Args ...)>::Result testing::internal::FunctionMocker<R(Args ...)>::Invoke(Args ...) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1510:22,
   inlined from ‘const eprosima::fastdds::rtps::NetworkFactory& eprosima::fastdds::rtps::RTPSParticipantImpl::network_factory() const’ at /home/ricardo/workspace/eprosima/fastdds/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h:134:5,
   inlined from ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’ at /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.cpp:1745:61:
/usr/include/c++/13/bits/stl_vector.h:993:40: error: array subscript 2 is outside array bounds of ‘testing::internal::FunctionMocker<const eprosima::fastdds::rtps::NetworkFactory&()> [0]’ [-Werror=array-bounds=]
 993 |       { return size_type(this->_M_impl._M_finish - this->_M_impl._M_start); }
     |                          ~~~~~~~~~~~~~~^~~~~~~~~
In member function ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’:
cc1plus: note: source object is likely at address zero
In member function ‘std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::size() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’,
   inlined from ‘R testing::internal::FunctionMocker<R(Args ...)>::InvokeWith(ArgumentTuple&&) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1755:33,
   inlined from ‘testing::internal::FunctionMocker<R(Args ...)>::Result testing::internal::FunctionMocker<R(Args ...)>::Invoke(Args ...) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1510:22,
   inlined from ‘const eprosima::fastdds::rtps::NetworkFactory& eprosima::fastdds::rtps::RTPSParticipantImpl::network_factory() const’ at /home/ricardo/workspace/eprosima/fastdds/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h:134:5,
   inlined from ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’ at /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.cpp:1745:61:
/usr/include/c++/13/bits/stl_vector.h:993:66: error: array subscript 2 is outside array bounds of ‘testing::internal::FunctionMocker<const eprosima::fastdds::rtps::NetworkFactory&()> [0]’ [-Werror=array-bounds=]
 993 |       { return size_type(this->_M_impl._M_finish - this->_M_impl._M_start); }
     |                                                    ~~~~~~~~~~~~~~^~~~~~~~
In member function ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’:
cc1plus: note: source object is likely at address zero
In file included from /usr/include/c++/13/bits/stl_algobase.h:67,
                from /usr/include/c++/13/bits/stl_uninitialized.h:63,
                from /usr/include/c++/13/memory:69,
                from /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.hpp:22:
In constructor ‘__gnu_cxx::__normal_iterator<_Iterator, _Container>::__normal_iterator(const _Iterator&) [with _Iterator = const std::shared_ptr<testing::internal::ExpectationBase>*; _Container = std::vector<std::shared_ptr<testing::internal::ExpectationBase> >]’,
   inlined from ‘std::vector<_Tp, _Alloc>::const_iterator std::vector<_Tp, _Alloc>::end() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’ at /usr/include/c++/13/bits/stl_vector.h:904:16,
   inlined from ‘std::vector<_Tp, _Alloc>::const_reverse_iterator std::vector<_Tp, _Alloc>::rbegin() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’ at /usr/include/c++/13/bits/stl_vector.h:924:44,
   inlined from ‘testing::internal::TypedExpectation<R(Args ...)>* testing::internal::FunctionMocker<R(Args ...)>::FindMatchingExpectationLocked(const ArgumentTuple&) const [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1644:63,
   inlined from ‘const testing::internal::ExpectationBase* testing::internal::FunctionMocker<R(Args ...)>::UntypedFindMatchingExpectation(const void*, const void**, bool*, std::ostream*, std::ostream*) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1612:67,
   inlined from ‘R testing::internal::FunctionMocker<R(Args ...)>::InvokeWith(ArgumentTuple&&) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1813:43,
   inlined from ‘testing::internal::FunctionMocker<R(Args ...)>::Result testing::internal::FunctionMocker<R(Args ...)>::Invoke(Args ...) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1510:22,
   inlined from ‘const eprosima::fastdds::rtps::NetworkFactory& eprosima::fastdds::rtps::RTPSParticipantImpl::network_factory() const’ at /home/ricardo/workspace/eprosima/fastdds/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h:134:5,
   inlined from ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’ at /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.cpp:1745:61:
/usr/include/c++/13/bits/stl_iterator.h:1077:9: error: array subscript 7 is outside array bounds of ‘testing::internal::FunctionMocker<const eprosima::fastdds::rtps::NetworkFactory&()> [0]’ [-Werror=array-bounds=]
1077 |       : _M_current(__i) { }
     |         ^~~~~~~~~~~~~~~
In member function ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’:
cc1plus: note: source object is likely at address zero
In constructor ‘__gnu_cxx::__normal_iterator<_Iterator, _Container>::__normal_iterator(const _Iterator&) [with _Iterator = const std::shared_ptr<testing::internal::ExpectationBase>*; _Container = std::vector<std::shared_ptr<testing::internal::ExpectationBase> >]’,
   inlined from ‘std::vector<_Tp, _Alloc>::const_iterator std::vector<_Tp, _Alloc>::begin() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’ at /usr/include/c++/13/bits/stl_vector.h:884:16,
   inlined from ‘std::vector<_Tp, _Alloc>::const_reverse_iterator std::vector<_Tp, _Alloc>::rend() const [with _Tp = std::shared_ptr<testing::internal::ExpectationBase>; _Alloc = std::allocator<std::shared_ptr<testing::internal::ExpectationBase> >]’ at /usr/include/c++/13/bits/stl_vector.h:944:46,
   inlined from ‘testing::internal::TypedExpectation<R(Args ...)>* testing::internal::FunctionMocker<R(Args ...)>::FindMatchingExpectationLocked(const ArgumentTuple&) const [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1646:13,
   inlined from ‘const testing::internal::ExpectationBase* testing::internal::FunctionMocker<R(Args ...)>::UntypedFindMatchingExpectation(const void*, const void**, bool*, std::ostream*, std::ostream*) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1612:67,
   inlined from ‘R testing::internal::FunctionMocker<R(Args ...)>::InvokeWith(ArgumentTuple&&) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1813:43,
   inlined from ‘testing::internal::FunctionMocker<R(Args ...)>::Result testing::internal::FunctionMocker<R(Args ...)>::Invoke(Args ...) [with R = const eprosima::fastdds::rtps::NetworkFactory&; Args = {}]’ at /home/ricardo/workspace/install/googletest-distribution/include/gmock/gmock-spec-builders.h:1510:22,
   inlined from ‘const eprosima::fastdds::rtps::NetworkFactory& eprosima::fastdds::rtps::RTPSParticipantImpl::network_factory() const’ at /home/ricardo/workspace/eprosima/fastdds/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.h:134:5,
   inlined from ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’ at /home/ricardo/workspace/eprosima/fastdds/src/cpp/fastdds/publisher/DataWriterImpl.cpp:1745:61:
/usr/include/c++/13/bits/stl_iterator.h:1077:9: error: array subscript 6 is outside array bounds of ‘testing::internal::FunctionMocker<const eprosima::fastdds::rtps::NetworkFactory&()> [0]’ [-Werror=array-bounds=]
1077 |       : _M_current(__i) { }
     |         ^~~~~~~~~~~~~~~
In member function ‘eprosima::fastdds::dds::ReturnCode_t eprosima::fastdds::dds::DataWriterImpl::get_publication_builtin_topic_data(eprosima::fastdds::dds::PublicationBuiltinTopicData&) const’:
cc1plus: note: source object is likely at address zero
cc1plus: all warnings being treated as errors
make[2]: *** [test/unittest/dds/status/CMakeFiles/ListenerTests.dir/build.make:426: test/unittest/dds/status/CMakeFiles/ListenerTests.dir/__/__/__/__/src/cpp/fastdds/publisher/DataWriterImpl.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:2695: test/unittest/dds/status/CMakeFiles/ListenerTests.dir/all] Error 2
```

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

