### PR TITLE
[21538] Allow all `durability` configurations

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1942,8 +1942,7 @@ ReturnCode_t DataWriterImpl::check_qos(
 {
     if (qos.durability().kind == PERSISTENT_DURABILITY_QOS)
     {
-        EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "PERSISTENT Durability not supported");
-        return RETCODE_UNSUPPORTED;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
     }
     if (qos.destination_order().kind == BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS)
     {

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1940,10 +1940,6 @@ ReturnCode_t DataWriterImpl::check_qos_including_resource_limits(
 ReturnCode_t DataWriterImpl::check_qos(
         const DataWriterQos& qos)
 {
-    if (qos.durability().kind == PERSISTENT_DURABILITY_QOS)
-    {
-        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
-    }
     if (qos.destination_order().kind == BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS)
     {
         EPROSIMA_LOG_ERROR(RTPS_QOS_CHECK, "BY SOURCE TIMESTAMP DestinationOrder not supported");

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1497,10 +1497,6 @@ ReturnCode_t DataReaderImpl::check_qos_including_resource_limits(
 ReturnCode_t DataReaderImpl::check_qos(
         const DataReaderQos& qos)
 {
-    if (qos.durability().kind == PERSISTENT_DURABILITY_QOS)
-    {
-        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
-    }
     if (qos.destination_order().kind == BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS)
     {
         EPROSIMA_LOG_ERROR(DDS_QOS_CHECK, "BY SOURCE TIMESTAMP DestinationOrder not supported");

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1499,8 +1499,7 @@ ReturnCode_t DataReaderImpl::check_qos(
 {
     if (qos.durability().kind == PERSISTENT_DURABILITY_QOS)
     {
-        EPROSIMA_LOG_ERROR(DDS_QOS_CHECK, "PERSISTENT Durability not supported");
-        return RETCODE_UNSUPPORTED;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
     }
     if (qos.destination_order().kind == BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS)
     {

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -68,8 +68,7 @@ ReturnCode_t TopicImpl::check_qos(
 {
     if (PERSISTENT_DURABILITY_QOS == qos.durability().kind)
     {
-        EPROSIMA_LOG_ERROR(DDS_QOS_CHECK, "PERSISTENT Durability not supported");
-        return RETCODE_UNSUPPORTED;
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
     }
     if (BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS == qos.destination_order().kind)
     {

--- a/src/cpp/fastdds/topic/TopicImpl.cpp
+++ b/src/cpp/fastdds/topic/TopicImpl.cpp
@@ -66,10 +66,6 @@ ReturnCode_t TopicImpl::check_qos_including_resource_limits(
 ReturnCode_t TopicImpl::check_qos(
         const TopicQos& qos)
 {
-    if (PERSISTENT_DURABILITY_QOS == qos.durability().kind)
-    {
-        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "PERSISTENT Durability not supported, behaving as TRANSIENT instead");
-    }
     if (BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS == qos.destination_order().kind)
     {
         EPROSIMA_LOG_ERROR(DDS_QOS_CHECK, "BY SOURCE TIMESTAMP DestinationOrder not supported");

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2456,8 +2456,11 @@ bool RTPSParticipantImpl::get_persistence_service(
     {
         if (param.persistence_guid == c_Guid_Unknown)
         {
-            EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Cannot create persistence service. Persistence GUID not specified");
-            return false;
+            EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT,
+                    "Persistence GUID not specified. Behaving as TRANSIENT_LOCAL");
+            auto modified_durability_attrs = const_cast<EndpointAttributes&>(param);
+            modified_durability_attrs.durabilityKind = TRANSIENT_LOCAL;
+            return true;
         }
         service = get_persistence_service(param);
         if (service == nullptr)

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1631,16 +1631,31 @@ public:
     }
 
 #if HAVE_SQLITE3
+    PubSubReader& make_transient(
+            const std::string& filename,
+            const std::string& persistence_guid)
+    {
+        add_persitence_properties(filename, persistence_guid);
+        durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS);
+        return *this;
+    }
+
     PubSubReader& make_persistent(
+            const std::string& filename,
+            const std::string& persistence_guid)
+    {
+        add_persitence_properties(filename, persistence_guid);
+        durability_kind(eprosima::fastdds::dds::PERSISTENT_DURABILITY_QOS);
+        return *this;
+    }
+
+    void add_persitence_properties(
             const std::string& filename,
             const std::string& persistence_guid)
     {
         participant_qos_.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
         participant_qos_.properties().properties().emplace_back("dds.persistence.sqlite3.filename", filename);
-        datareader_qos_.durability().kind = eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
         datareader_qos_.properties().properties().emplace_back("dds.persistence.guid", persistence_guid);
-
-        return *this;
     }
 
 #endif // if HAVE_SQLITE3

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1708,16 +1708,31 @@ public:
     }
 
 #if HAVE_SQLITE3
+    PubSubWriter& make_transient(
+            const std::string& filename,
+            const std::string& persistence_guid)
+    {
+        add_persitence_properties(filename, persistence_guid);
+        durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS);
+        return *this;
+    }
+
     PubSubWriter& make_persistent(
+            const std::string& filename,
+            const std::string& persistence_guid)
+    {
+        add_persitence_properties(filename, persistence_guid);
+        durability_kind(eprosima::fastdds::dds::PERSISTENT_DURABILITY_QOS);
+        return *this;
+    }
+
+    void add_persitence_properties(
             const std::string& filename,
             const std::string& persistence_guid)
     {
         participant_qos_.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
         participant_qos_.properties().properties().emplace_back("dds.persistence.sqlite3.filename", filename);
-        datawriter_qos_.durability().kind = eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
         datawriter_qos_.properties().properties().emplace_back("dds.persistence.guid", persistence_guid);
-
-        return *this;
     }
 
 #endif // if HAVE_SQLITE3

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1246,9 +1246,9 @@ TEST(DDSStatus, sample_lost_re_dw_re_persistence_dr)
         PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
         writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-                .make_persistent(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.74");
+                .make_transient(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.74");
         reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-                .make_persistent(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.72");
+                .make_transient(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.72");
 
 
         std::mutex test_step_mtx;
@@ -1651,9 +1651,9 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_re_persistence_dr)
         PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
         writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-                .make_persistent(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.74");
+                .make_transient(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.74");
         reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-                .make_persistent(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.72");
+                .make_transient(db_file_name, "67.62.79.64.75.62.5f.60.75.72.73.5f|76.65.79.72");
 
         std::mutex test_step_mtx;
         std::condition_variable test_step_cv;

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -35,7 +35,7 @@ enum communication_type
     DATASHARING
 };
 
-class PersistenceLargeData : public testing::TestWithParam<communication_type>
+class DDSPersistenceTests : public testing::TestWithParam<communication_type>
 {
 public:
 
@@ -113,7 +113,7 @@ protected:
                 .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
                 .resource_limits_max_samples(100)
                 .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-                .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+                .make_transient(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
                 .disable_builtin_transport()
                 .add_user_transport_to_pparams(testTransport)
                 .init();
@@ -160,17 +160,17 @@ protected:
 
 };
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithFrag)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithFrag)
 {
     fragment_data(true);
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentNoFrag)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientNoFrag)
 {
     fragment_data(false);
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanBefore)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithLifespanBefore)
 {
     PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
@@ -179,7 +179,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanBefore)
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+            .make_transient(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
             .lifespan_period({1, 0})
             .init();
 
@@ -221,7 +221,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanBefore)
     ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBefore)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithLifespanSendingBefore)
 {
     PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
@@ -230,7 +230,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBef
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+            .make_transient(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
             .lifespan_period({0, 100})
             .init();
 
@@ -280,7 +280,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanSendingBef
     ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithLifespanAfter)
 {
     PubSubWriter<Data1mbPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<Data1mbPubSubType> reader(TEST_TOPIC_NAME);
@@ -289,7 +289,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+            .make_transient(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
             .lifespan_period({1, 0})
             .init();
 
@@ -332,7 +332,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithLifespanAfter)
     ASSERT_EQ(0u, reader.block_for_all(std::chrono::seconds(1)));
 }
 
-TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithStaticDiscovery)
 {
     char* value = nullptr;
     std::string TOPIC_RANDOM_NUMBER;
@@ -398,7 +398,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
     writer
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .make_persistent(db_file_name(), "78.73.69.74.65.72.5f.70.65.72.73.5f|67.75.69.1")
+            .make_transient(db_file_name(), "78.73.69.74.65.72.5f.70.65.72.73.5f|67.75.69.1")
             .static_discovery("file://PubSubWriterPersistence_static_disc.xml")
             .unicastLocatorList(WriterUnicastLocators)
             .multicastLocatorList(WriterMulticastLocators)
@@ -426,7 +426,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
             .history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
             .history_depth(10)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .make_persistent(db_file_name(), "78.73.69.74.65.72.5f.70.65.72.73.5f|67.75.69.3")
+            .make_transient(db_file_name(), "78.73.69.74.65.72.5f.70.65.72.73.5f|67.75.69.3")
             .static_discovery("file://PubSubReaderPersistence_static_disc.xml")
             .unicastLocatorList(ReaderUnicastLocators)
             .multicastLocatorList(ReaderMulticastLocators)
@@ -453,7 +453,6 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
     // Wait expecting not receiving data.
     ASSERT_EQ(10u, reader.block_for_all(std::chrono::seconds(1)));
 
-
     // Destroy the DataWriter
     writer.destroy();
     reader.stopReception();
@@ -473,16 +472,110 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
 }
 
 
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubPersistentBehavesAsTransient)
+{
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .resource_limits_max_samples(100)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            // A PERSISTENT writer with a persistence guid must behave as TRANSIENT
+            .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator();
+    auto received_data = data;
+
+    // Send data
+    writer.send(data);
+    // All data should be sent
+    ASSERT_TRUE(data.empty());
+    // Destroy the DataWriter
+    writer.destroy();
+
+    reader
+            .history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+            .history_depth(10)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
+            .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Load the transient DataWriter with the changes saved in the database
+    writer.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    reader.startReception(received_data);
+
+    // Wait expecting receiving all data.
+    reader.block_for_all();
+}
+
+TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithNoPersistenceGUIDBehavesAsTransientLocal)
+{
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .resource_limits_max_samples(100)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            // A TRANSIENT writer with a persistence guid must behave as TRANSIENT_LOCAL
+            .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    auto data = default_helloworld_data_generator();
+    auto received_data = data;
+
+    // Send data
+    writer.send(data);
+
+    // All data should be sent
+    ASSERT_TRUE(data.empty());
+
+    reader
+            .history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
+            .history_depth(10)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
+            .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    reader.startReception(received_data);
+
+    // Wait expecting receiving all data.
+    reader.block_for_all();
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
 #endif // ifdef INSTANTIATE_TEST_SUITE_P
 
-GTEST_INSTANTIATE_TEST_MACRO(PersistenceLargeData,
-        PersistenceLargeData,
+GTEST_INSTANTIATE_TEST_MACRO(DDSPersistenceTests,
+        DDSPersistenceTests,
         testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
-        [](const testing::TestParamInfo<PersistenceLargeData::ParamType>& info)
+        [](const testing::TestParamInfo<DDSPersistenceTests::ParamType>& info)
         {
             switch (info.param)
             {

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -564,6 +564,26 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithNoPersistenceGUIDBeh
 
     // Wait expecting receiving all data.
     reader.block_for_all();
+
+    // Recreate the DataWriter and DataReader
+    writer.destroy();
+    reader.destroy();
+
+    writer.init();
+    reader.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Reader should not receive any data
+    // as the writer is not transient
+    auto unreceived_data = default_helloworld_data_generator();
+
+    // Send data
+    reader.startReception(unreceived_data);
+
+    // Wait expecting not receiving data.
+    ASSERT_EQ(reader.block_for_all(std::chrono::seconds(2)), 0u);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -481,7 +481,7 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubPersistentBehavesAsTransient)
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            // A PERSISTENT writer with a persistence guid must behave as TRANSIENT
+    // A PERSISTENT writer with a persistence guid must behave as TRANSIENT
             .make_persistent(db_file_name(), "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64")
             .init();
 
@@ -501,7 +501,7 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubPersistentBehavesAsTransient)
             .history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
             .history_depth(10)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
+    // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
             .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
             .init();
 
@@ -531,7 +531,7 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithNoPersistenceGUIDBeh
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_samples(100)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            // A TRANSIENT writer with a persistence guid must behave as TRANSIENT_LOCAL
+    // A TRANSIENT writer with a persistence guid must behave as TRANSIENT_LOCAL
             .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
             .init();
 
@@ -550,7 +550,7 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithNoPersistenceGUIDBeh
             .history_kind(eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS)
             .history_depth(10)
             .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
+    // A TRANSIENT reader with no persistence guid should behave as TRANSIENT_LOCAL
             .durability_kind(eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS)
             .init();
 

--- a/test/blackbox/common/RTPSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistence.cpp
@@ -184,11 +184,11 @@ TEST_P(Persistence, RTPSAsNonReliableWithPersistence)
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     std::string ip("239.255.1.4");
 
-    reader.make_persistent(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).init();
+    reader.make_transient(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.make_persistent(db_file_name(), guid_prefix()).reliability(ReliabilityKind_t::BEST_EFFORT).init();
+    writer.make_transient(db_file_name(), guid_prefix()).reliability(ReliabilityKind_t::BEST_EFFORT).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -215,11 +215,11 @@ TEST_P(Persistence, AsyncRTPSAsNonReliableWithPersistence)
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     std::string ip("239.255.1.4");
 
-    reader.make_persistent(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).init();
+    reader.make_transient(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.make_persistent(db_file_name(), guid_prefix()).reliability(ReliabilityKind_t::BEST_EFFORT).
+    writer.make_transient(db_file_name(), guid_prefix()).reliability(ReliabilityKind_t::BEST_EFFORT).
             asynchronously(RTPSWriterPublishMode::ASYNCHRONOUS_WRITER).init();
 
     ASSERT_TRUE(writer.isInitialized());
@@ -247,12 +247,12 @@ TEST_P(Persistence, RTPSAsReliableWithPersistence)
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     std::string ip("239.255.1.4");
 
-    reader.make_persistent(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
+    reader.make_transient(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
             reliability(ReliabilityKind_t::RELIABLE).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.make_persistent(db_file_name(), guid_prefix()).init();
+    writer.make_transient(db_file_name(), guid_prefix()).init();
 
     ASSERT_TRUE(writer.isInitialized());
 
@@ -279,12 +279,12 @@ TEST_P(Persistence, AsyncRTPSAsReliableWithPersistence)
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     std::string ip("239.255.1.4");
 
-    reader.make_persistent(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
+    reader.make_transient(db_file_name(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
             reliability(ReliabilityKind_t::RELIABLE).init();
 
     ASSERT_TRUE(reader.isInitialized());
 
-    writer.make_persistent(db_file_name(), guid_prefix()).history_depth(10).
+    writer.make_transient(db_file_name(), guid_prefix()).history_depth(10).
             asynchronously(RTPSWriterPublishMode::ASYNCHRONOUS_WRITER).init();
 
     ASSERT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceNonIntraprocess.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceNonIntraprocess.cpp
@@ -78,7 +78,7 @@ public:
         // Wait for undiscovery
         reader.wait_undiscovery();
 
-        writer.make_persistent(db_file_name_writer(), guid_prefix())
+        writer.make_transient(db_file_name_writer(), guid_prefix())
                 .reliability(ReliabilityKind_t::RELIABLE).init();
 
         // Wait for discovery
@@ -196,11 +196,11 @@ TEST_F(PersistenceNonIntraprocess, InconsistentAcknackReceived)
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     std::string ip("239.255.1.4");
 
-    reader.make_persistent(db_file_name_reader(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
+    reader.make_transient(db_file_name_reader(), guid_prefix()).add_to_multicast_locator_list(ip, global_port).
             reliability(ReliabilityKind_t::RELIABLE).init();
     EXPECT_TRUE(reader.isInitialized());
 
-    writer.make_persistent(db_file_name_writer(), guid_prefix()).
+    writer.make_transient(db_file_name_writer(), guid_prefix()).
             reliability(ReliabilityKind_t::RELIABLE).init();
 
     EXPECT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -530,6 +530,21 @@ public:
     }
 
 #if HAVE_SQLITE3
+    RTPSWithRegistrationReader& make_transient(
+            const std::string& filename,
+            const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix)
+    {
+        reader_attr_.endpoint.persistence_guid.guidPrefix = guidPrefix;
+        reader_attr_.endpoint.persistence_guid.entityId = 0x55555555;
+
+        std::cout << "Initializing transient READER " << reader_attr_.endpoint.persistence_guid << " with file " <<
+            filename << std::endl;
+
+        return durability(eprosima::fastdds::rtps::DurabilityKind_t::TRANSIENT)
+                       .add_property("dds.persistence.plugin", "builtin.SQLITE3")
+                       .add_property("dds.persistence.sqlite3.filename", filename);
+    }
+
     RTPSWithRegistrationReader& make_persistent(
             const std::string& filename,
             const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix)
@@ -540,7 +555,7 @@ public:
         std::cout << "Initializing persistent READER " << reader_attr_.endpoint.persistence_guid << " with file " <<
             filename << std::endl;
 
-        return durability(eprosima::fastdds::rtps::DurabilityKind_t::TRANSIENT)
+        return durability(eprosima::fastdds::rtps::DurabilityKind_t::PERSISTENT)
                        .add_property("dds.persistence.plugin", "builtin.SQLITE3")
                        .add_property("dds.persistence.sqlite3.filename", filename);
     }

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -472,6 +472,21 @@ public:
     }
 
 #if HAVE_SQLITE3
+    RTPSWithRegistrationWriter& make_transient(
+            const std::string& filename,
+            const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix)
+    {
+        writer_attr_.endpoint.persistence_guid.guidPrefix = guidPrefix;
+        writer_attr_.endpoint.persistence_guid.entityId = 0xAAAAAAAA;
+
+        std::cout << "Initializing transient WRITER " << writer_attr_.endpoint.persistence_guid
+                  << " with file " << filename << std::endl;
+
+        return durability(eprosima::fastdds::rtps::DurabilityKind_t::TRANSIENT)
+                       .add_property("dds.persistence.plugin", "builtin.SQLITE3")
+                       .add_property("dds.persistence.sqlite3.filename", filename);
+    }
+
     RTPSWithRegistrationWriter& make_persistent(
             const std::string& filename,
             const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix)

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2157,7 +2157,7 @@ TEST(ParticipantTests, ChangeDefaultTopicQos)
     ASSERT_EQ(tqos.reliability().kind, BEST_EFFORT_RELIABILITY_QOS);
 
     qos.durability().kind = PERSISTENT_DURABILITY_QOS;
-    ASSERT_FALSE(participant->set_default_topic_qos(qos) == RETCODE_OK);
+    ASSERT_TRUE(participant->set_default_topic_qos(qos) == RETCODE_OK);
 
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == RETCODE_OK);
 }
@@ -2925,13 +2925,6 @@ TEST(ParticipantTests, CreateTopicNegativeClauses)
     // Check that the topic is not created if a wrong type name is provided
     Topic* topic;
     topic = participant->create_topic("footopic", "fake_type_name", TOPIC_QOS_DEFAULT);
-    ASSERT_EQ(topic, nullptr);
-
-    // Check that the topic is not created if a non supported durability QoS is provided
-    TopicQos tqos;
-    participant->get_default_topic_qos(tqos);
-    tqos.durability().kind = PERSISTENT_DURABILITY_QOS;
-    topic = participant->create_topic("footopic", type.get_type_name(), tqos);
     ASSERT_EQ(topic, nullptr);
 
     // Remove the participant

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -2909,7 +2909,6 @@ TEST(ParticipantTests, GetParticipantNames)
 /*
  * This test checks that a topic is not created with a wrong settings.
  * 1. Check that the topic is not created if a wrong type name is provided.
- * 2. Check that the topic is not created if a non supported durability QoS is provided.
  */
 TEST(ParticipantTests, CreateTopicNegativeClauses)
 {
@@ -2928,6 +2927,34 @@ TEST(ParticipantTests, CreateTopicNegativeClauses)
     ASSERT_EQ(topic, nullptr);
 
     // Remove the participant
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
+/*
+ * This test checks that a topic is created with a valid settings.
+ * 1. Check that the topic is created if a supported durability QoS is provided.
+ */
+TEST(ParticipantTests, CreateTopicPositiveClauses)
+{
+    // Create the participant
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+
+    // Register the type
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    // Check that the topic is created if a PERSITENT durability QoS is provided
+    TopicQos tqos;
+    Topic* topic;
+    participant->get_default_topic_qos(tqos);
+    tqos.durability().kind = PERSISTENT_DURABILITY_QOS;
+    topic = participant->create_topic("footopic", type.get_type_name(), tqos);
+    ASSERT_NE(topic, nullptr);
+
+    // Cleanup
+    ASSERT_EQ(participant->delete_topic(topic), RETCODE_OK);
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -650,9 +650,12 @@ TEST(DataWriterTests, InvalidQos)
     const ReturnCode_t unsupported_code = RETCODE_UNSUPPORTED;
 
     DataWriterQos qos;
-    qos = DATAWRITER_QOS_DEFAULT;
-    qos.durability().kind = PERSISTENT_DURABILITY_QOS;
-    EXPECT_EQ(unsupported_code, datawriter->set_qos(qos));
+
+    // qos = DATAWRITER_QOS_DEFAULT;
+    // qos.durability().kind = PERSISTENT_DURABILITY_QOS;
+    // Despite PERSISTENT_DURABILITY is not supported yet,
+    // DataWriter must behave as TRANSIENT
+    // EXPECT_EQ(unsupported_code, datawriter->set_qos(qos));
 
     qos = DATAWRITER_QOS_DEFAULT;
     qos.destination_order().kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -683,9 +683,11 @@ TEST_F(DataReaderTests, InvalidQos)
     /* Unsupported QoS */
     const ReturnCode_t unsupported_code = RETCODE_UNSUPPORTED;
 
-    qos = DATAREADER_QOS_DEFAULT;
-    qos.durability().kind = PERSISTENT_DURABILITY_QOS;
-    EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
+    // qos = DATAREADER_QOS_DEFAULT;
+    // qos.durability().kind = PERSISTENT_DURABILITY_QOS;
+    // Despite PERSISTENT_DURABILITY is not supported yet,
+    // DataReader must behave as TRANSIENT
+    // EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
 
     qos = DATAREADER_QOS_DEFAULT;
     qos.destination_order().kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -683,12 +683,6 @@ TEST_F(DataReaderTests, InvalidQos)
     /* Unsupported QoS */
     const ReturnCode_t unsupported_code = RETCODE_UNSUPPORTED;
 
-    // qos = DATAREADER_QOS_DEFAULT;
-    // qos.durability().kind = PERSISTENT_DURABILITY_QOS;
-    // Despite PERSISTENT_DURABILITY is not supported yet,
-    // DataReader must behave as TRANSIENT
-    // EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
-
     qos = DATAREADER_QOS_DEFAULT;
     qos.destination_order().kind = BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
     EXPECT_EQ(unsupported_code, data_reader_->set_qos(qos));
@@ -730,6 +724,10 @@ TEST_F(DataReaderTests, InvalidQos)
 
     /* Inmutable QoS */
     const ReturnCode_t inmutable_code = RETCODE_IMMUTABLE_POLICY;
+
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.durability().kind = PERSISTENT_DURABILITY_QOS;
+    EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
 
     qos = DATAREADER_QOS_DEFAULT;
     qos.resource_limits().max_samples = 5000;
@@ -781,6 +779,21 @@ TEST_F(DataReaderTests, InvalidQos)
     qos = DATAREADER_QOS_DEFAULT;
     qos.properties().properties().emplace_back("fastdds.unique_network_flows", "");
     EXPECT_EQ(inmutable_code, data_reader_->set_qos(qos));
+}
+
+TEST_F(DataReaderTests, PersistentDurabilityIsAValidQoS)
+{
+    DataReaderQos qos;
+    qos = DATAREADER_QOS_DEFAULT;
+    qos.durability().kind = PERSISTENT_DURABILITY_QOS;
+
+    create_entities(
+        nullptr,
+        qos
+        );
+
+    // PERSISTENT DataReader behaves as TRANSIENT
+    EXPECT_NE(nullptr, data_reader_);
 }
 
 /**

--- a/versions.md
+++ b/versions.md
@@ -1,7 +1,7 @@
 Forthcoming
 -----------
 
-
+* Allow `PERSISTENT_DURABILITY` behaving as `TRANSIENT_DURABILITY`. Fallback to `TRANSIENT_LOCAL_DURABILITY` if no persistence guid is set.
 
 Version v3.0.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR:

* Allows the creation of a  DataWriter/Reader with a `PERSISTENT` durability, but behaving as `TRANSIENT`.
* When in `TRANSIENT`, if no persistence guid is given, it fallbacks to `TRANSIENT_LOCAL`.
* Refactors BB `make_transient()` `make_persitent()` pubsub API to be clearer about the intention of making a transient or persistent endpoint. 
* Adds BB tests for the purpose.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#907
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
