### PR TITLE
[21706] Remove unused `validMatching` methods in `EDP`

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -564,15 +564,6 @@ bool EDP::unpairReaderProxy(
     return true;
 }
 
-bool EDP::validMatching(
-        const WriterProxyData* wdata,
-        const ReaderProxyData* rdata)
-{
-    MatchingFailureMask reason;
-    fastdds::dds::PolicyMask incompatible_qos;
-    return valid_matching(wdata, rdata, reason, incompatible_qos);
-}
-
 bool EDP::valid_matching(
         const WriterProxyData* wdata,
         const ReaderProxyData* rdata,
@@ -796,15 +787,6 @@ bool EDP::checkDataRepresentationQos(
     }
 
     return compatible;
-}
-
-bool EDP::validMatching(
-        const ReaderProxyData* rdata,
-        const WriterProxyData* wdata)
-{
-    MatchingFailureMask reason;
-    fastdds::dds::PolicyMask incompatible_qos;
-    return valid_matching(rdata, wdata, reason, incompatible_qos);
 }
 
 bool EDP::valid_matching(

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -216,26 +216,6 @@ public:
      * Check the validity of a matching between a local RTPSWriter and a ReaderProxyData object.
      * @param wdata Pointer to the WriterProxyData object of the local RTPSWriter.
      * @param rdata Pointer to the ReaderProxyData object.
-     * @return True if the two can be matched.
-     */
-    bool validMatching(
-            const WriterProxyData* wdata,
-            const ReaderProxyData* rdata);
-
-    /**
-     * Check the validity of a matching between a local RTPSReader and a WriterProxyData object.
-     * @param rdata Pointer to the ReaderProxyData object of the local RTPSReader.
-     * @param wdata Pointer to the WriterProxyData object.
-     * @return True if the two can be matched.
-     */
-    bool validMatching(
-            const ReaderProxyData* rdata,
-            const WriterProxyData* wdata);
-
-    /**
-     * Check the validity of a matching between a local RTPSWriter and a ReaderProxyData object.
-     * @param wdata Pointer to the WriterProxyData object of the local RTPSWriter.
-     * @param rdata Pointer to the ReaderProxyData object.
      * @param [out] reason On return will specify the reason of failed matching (if any).
      * @param [out] incompatible_qos On return will specify all the QoS values that were incompatible (if any).
      * @return True if the two can be matched.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR removes the `validMatching` deprecated methods in `EDP`

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A**Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
