### PR TITLE
[21726] Regression test for  Fast DDS-Gen Use different typename for collections of TK_UINT8 and TK_BYTE

### DIFF
--- a/examples/cpp/configuration/ConfigurationTypeObjectSupport.cxx
+++ b/examples/cpp/configuration/ConfigurationTypeObjectSupport.cxx
@@ -164,7 +164,7 @@ void register_Configuration_type_identifier(
             ReturnCode_t return_code_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_data =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_data);
+                "anonymous_sequence_byte_unbounded", type_ids_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_data)
             {
@@ -178,29 +178,29 @@ void register_Configuration_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
@@ -734,7 +734,7 @@ void register_LivelinessChangedStatus_s_type_identifier(
             ReturnCode_t return_code_last_publication_handle {eprosima::fastdds::dds::RETCODE_OK};
             return_code_last_publication_handle =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_last_publication_handle);
+                "anonymous_array_byte_16", type_ids_last_publication_handle);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_last_publication_handle)
             {
@@ -748,31 +748,31 @@ void register_LivelinessChangedStatus_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_publication_handle, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_publication_handle, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_last_publication_handle.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_last_publication_handle))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_last_publication_handle))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -857,7 +857,7 @@ void register_DeadlineMissedStatus_s_type_identifier(
             ReturnCode_t return_code_last_instance_handle {eprosima::fastdds::dds::RETCODE_OK};
             return_code_last_instance_handle =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_last_instance_handle);
+                "anonymous_array_byte_16", type_ids_last_instance_handle);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_last_instance_handle)
             {
@@ -871,31 +871,31 @@ void register_DeadlineMissedStatus_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_instance_handle, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_instance_handle, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_last_instance_handle.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_last_instance_handle))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_last_instance_handle))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1172,7 +1172,7 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_MonitorServiceData);
+                "anonymous_sequence_byte_unbounded", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
             {
@@ -1186,29 +1186,29 @@ void register_MonitorServiceData_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_MonitorServiceData.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_MonitorServiceData))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_MonitorServiceData))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/src/cpp/statistics/types/typesTypeObjectSupport.cxx
+++ b/src/cpp/statistics/types/typesTypeObjectSupport.cxx
@@ -67,7 +67,7 @@ void register_EntityId_s_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_4", type_ids_value);
+                "anonymous_array_byte_4", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -81,31 +81,31 @@ void register_EntityId_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_4_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_4_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_4_ec)
+                bool element_identifier_anonymous_array_byte_4_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_4_ec))};
+                if (!element_identifier_anonymous_array_byte_4_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_4 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_4 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_4 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_4 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_4 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_4, element_flags_anonymous_array_uint8_t_4);
+                CollectionElementFlag element_flags_anonymous_array_byte_4 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_4, element_flags_anonymous_array_byte_4);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(4));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_4, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_4));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_4, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_4));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_4", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_4", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_4 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_4 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -160,7 +160,7 @@ void register_GuidPrefix_s_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_12", type_ids_value);
+                "anonymous_array_byte_12", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -174,31 +174,31 @@ void register_GuidPrefix_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_12_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_12_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_12_ec)
+                bool element_identifier_anonymous_array_byte_12_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_12_ec))};
+                if (!element_identifier_anonymous_array_byte_12_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_12 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_12 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_12 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_12 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_12 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_12, element_flags_anonymous_array_uint8_t_12);
+                CollectionElementFlag element_flags_anonymous_array_byte_12 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_12, element_flags_anonymous_array_byte_12);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(12));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_12, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_12));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_12, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_12));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_12", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_12", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_12 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_12 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -572,7 +572,7 @@ void register_Locator_s_type_identifier(
             ReturnCode_t return_code_address {eprosima::fastdds::dds::RETCODE_OK};
             return_code_address =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_address);
+                "anonymous_array_byte_16", type_ids_address);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_address)
             {
@@ -586,31 +586,31 @@ void register_Locator_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_address.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_address))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_address))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/Data1mbTypeObjectSupport.cxx
+++ b/test/blackbox/types/Data1mbTypeObjectSupport.cxx
@@ -63,7 +63,7 @@ void register_Data1mb_type_identifier(
             ReturnCode_t return_code_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_data =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_1024000", type_ids_data);
+                "anonymous_sequence_byte_1024000", type_ids_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_data)
             {
@@ -77,29 +77,29 @@ void register_Data1mb_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_1024000_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_1024000 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_uint8_t_1024000_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_1024000_ec)
+                bool element_identifier_anonymous_sequence_byte_1024000_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_1024000 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_byte_1024000_ec))};
+                if (!element_identifier_anonymous_sequence_byte_1024000_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_1024000 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_1024000 = EK_COMPLETE;
                 if (TK_NONE == type_ids_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_1024000 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_1024000 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_1024000 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_1024000 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_1024000, element_flags_anonymous_sequence_uint8_t_1024000);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_1024000 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_1024000 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_1024000, element_flags_anonymous_sequence_byte_1024000);
                 {
                     LBound bound = 1024000;
-                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_uint8_t_1024000, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_1024000));
+                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_byte_1024000, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_1024000));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_uint8_t_1024000", type_ids_data))
+                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_byte_1024000", type_ids_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_1024000 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_1024000 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/Data64kbTypeObjectSupport.cxx
+++ b/test/blackbox/types/Data64kbTypeObjectSupport.cxx
@@ -63,7 +63,7 @@ void register_Data64kb_type_identifier(
             ReturnCode_t return_code_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_data =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_63996", type_ids_data);
+                "anonymous_sequence_byte_63996", type_ids_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_data)
             {
@@ -77,29 +77,29 @@ void register_Data64kb_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_63996_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_63996 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_uint8_t_63996_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_63996_ec)
+                bool element_identifier_anonymous_sequence_byte_63996_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_63996 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_byte_63996_ec))};
+                if (!element_identifier_anonymous_sequence_byte_63996_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_63996 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_63996 = EK_COMPLETE;
                 if (TK_NONE == type_ids_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_63996 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_63996 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_63996 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_63996 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_63996, element_flags_anonymous_sequence_uint8_t_63996);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_63996 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_63996 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_63996, element_flags_anonymous_sequence_byte_63996);
                 {
                     LBound bound = 63996;
-                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_uint8_t_63996, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_63996));
+                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_byte_63996, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_63996));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_uint8_t_63996", type_ids_data))
+                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_byte_63996", type_ids_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_63996 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_63996 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/KeyedData1mbTypeObjectSupport.cxx
+++ b/test/blackbox/types/KeyedData1mbTypeObjectSupport.cxx
@@ -106,7 +106,7 @@ void register_KeyedData1mb_type_identifier(
             ReturnCode_t return_code_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_data =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_1023996", type_ids_data);
+                "anonymous_sequence_byte_1023996", type_ids_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_data)
             {
@@ -120,29 +120,29 @@ void register_KeyedData1mb_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_1023996_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_1023996 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_uint8_t_1023996_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_1023996_ec)
+                bool element_identifier_anonymous_sequence_byte_1023996_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_1023996 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_data, element_identifier_anonymous_sequence_byte_1023996_ec))};
+                if (!element_identifier_anonymous_sequence_byte_1023996_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_1023996 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_1023996 = EK_COMPLETE;
                 if (TK_NONE == type_ids_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_1023996 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_1023996 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_1023996 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_1023996 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_1023996, element_flags_anonymous_sequence_uint8_t_1023996);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_1023996 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_1023996 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_1023996, element_flags_anonymous_sequence_byte_1023996);
                 {
                     LBound bound = 1023996;
-                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_uint8_t_1023996, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_1023996));
+                    PlainSequenceLElemDefn seq_ldefn = TypeObjectUtils::build_plain_sequence_l_elem_defn(header_anonymous_sequence_byte_1023996, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_1023996));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_uint8_t_1023996", type_ids_data))
+                            TypeObjectUtils::build_and_register_l_sequence_type_identifier(seq_ldefn, "anonymous_sequence_byte_1023996", type_ids_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_1023996 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_1023996 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/core/core_typesTypeObjectSupport.cxx
+++ b/test/blackbox/types/core/core_typesTypeObjectSupport.cxx
@@ -68,7 +68,7 @@ void register_EntityId_t_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_4", type_ids_value);
+                "anonymous_array_byte_4", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -82,31 +82,31 @@ void register_EntityId_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_4_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_4_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_4_ec)
+                bool element_identifier_anonymous_array_byte_4_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_4_ec))};
+                if (!element_identifier_anonymous_array_byte_4_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_4 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_4 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_4 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_4 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_4 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_4, element_flags_anonymous_array_uint8_t_4);
+                CollectionElementFlag element_flags_anonymous_array_byte_4 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_4, element_flags_anonymous_array_byte_4);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(4));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_4, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_4));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_4, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_4));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_4", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_4", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_4 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_4 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -250,7 +250,7 @@ void register_VendorId_t_type_identifier(
             ReturnCode_t return_code_vendorId {eprosima::fastdds::dds::RETCODE_OK};
             return_code_vendorId =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_2", type_ids_vendorId);
+                "anonymous_array_byte_2", type_ids_vendorId);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_vendorId)
             {
@@ -264,31 +264,31 @@ void register_VendorId_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_2_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_2 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_vendorId, element_identifier_anonymous_array_uint8_t_2_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_2_ec)
+                bool element_identifier_anonymous_array_byte_2_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_2 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_vendorId, element_identifier_anonymous_array_byte_2_ec))};
+                if (!element_identifier_anonymous_array_byte_2_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_2 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_2 = EK_COMPLETE;
                 if (TK_NONE == type_ids_vendorId.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_2 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_2 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_2 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_2 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_2, element_flags_anonymous_array_uint8_t_2);
+                CollectionElementFlag element_flags_anonymous_array_byte_2 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_2 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_2, element_flags_anonymous_array_byte_2);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(2));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_2, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_2));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_2, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_2));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_2", type_ids_vendorId))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_2", type_ids_vendorId))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_2 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_2 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -343,7 +343,7 @@ void register_GuidPrefix_t_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_12", type_ids_value);
+                "anonymous_array_byte_12", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -357,31 +357,31 @@ void register_GuidPrefix_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_12_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_12_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_12_ec)
+                bool element_identifier_anonymous_array_byte_12_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_12_ec))};
+                if (!element_identifier_anonymous_array_byte_12_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_12 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_12 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_12 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_12 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_12 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_12, element_flags_anonymous_array_uint8_t_12);
+                CollectionElementFlag element_flags_anonymous_array_byte_12 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_12, element_flags_anonymous_array_byte_12);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(12));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_12, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_12));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_12, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_12));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_12", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_12", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_12 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_12 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -864,7 +864,7 @@ void register_SequenceNumberSet_type_identifier(
             ReturnCode_t return_code_bitmap {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bitmap =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_8", type_ids_bitmap);
+                "anonymous_array_byte_8", type_ids_bitmap);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bitmap)
             {
@@ -878,31 +878,31 @@ void register_SequenceNumberSet_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_8_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_8 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bitmap, element_identifier_anonymous_array_uint8_t_8_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_8_ec)
+                bool element_identifier_anonymous_array_byte_8_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_8 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bitmap, element_identifier_anonymous_array_byte_8_ec))};
+                if (!element_identifier_anonymous_array_byte_8_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_8 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_8 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bitmap.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_8 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_8 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_8 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_8 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_8, element_flags_anonymous_array_uint8_t_8);
+                CollectionElementFlag element_flags_anonymous_array_byte_8 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_8 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_8, element_flags_anonymous_array_byte_8);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(8));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_8, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_8));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_8, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_8));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_8", type_ids_bitmap))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_8", type_ids_bitmap))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_8 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_8 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1017,7 +1017,7 @@ void register_Locator_t_type_identifier(
             ReturnCode_t return_code_address {eprosima::fastdds::dds::RETCODE_OK};
             return_code_address =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_address);
+                "anonymous_array_byte_16", type_ids_address);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_address)
             {
@@ -1031,31 +1031,31 @@ void register_Locator_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_address.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_address))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_address))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1299,7 +1299,7 @@ void register_StatusInfo_t_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_4", type_ids_value);
+                "anonymous_array_byte_4", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -1313,31 +1313,31 @@ void register_StatusInfo_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_4_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_4_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_4_ec)
+                bool element_identifier_anonymous_array_byte_4_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_4_ec))};
+                if (!element_identifier_anonymous_array_byte_4_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_4 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_4 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_4 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_4 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_4 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_4, element_flags_anonymous_array_uint8_t_4);
+                CollectionElementFlag element_flags_anonymous_array_byte_4 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_4, element_flags_anonymous_array_byte_4);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(4));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_4, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_4));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_4, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_4));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_4", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_4", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_4 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_4 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1392,7 +1392,7 @@ void register_KeyHash_t_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_value);
+                "anonymous_array_byte_16", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -1406,31 +1406,31 @@ void register_KeyHash_t_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1554,7 +1554,7 @@ void register_Header_type_identifier(
             ReturnCode_t return_code_prefix {eprosima::fastdds::dds::RETCODE_OK};
             return_code_prefix =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_4", type_ids_prefix);
+                "anonymous_array_byte_4", type_ids_prefix);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_prefix)
             {
@@ -1568,31 +1568,31 @@ void register_Header_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_4_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_prefix, element_identifier_anonymous_array_uint8_t_4_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_4_ec)
+                bool element_identifier_anonymous_array_byte_4_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_prefix, element_identifier_anonymous_array_byte_4_ec))};
+                if (!element_identifier_anonymous_array_byte_4_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_4 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_4 = EK_COMPLETE;
                 if (TK_NONE == type_ids_prefix.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_4 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_4 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_4 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_4, element_flags_anonymous_array_uint8_t_4);
+                CollectionElementFlag element_flags_anonymous_array_byte_4 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_4, element_flags_anonymous_array_byte_4);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(4));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_4, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_4));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_4, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_4));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_4", type_ids_prefix))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_4", type_ids_prefix))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_4 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_4 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
@@ -734,7 +734,7 @@ void register_LivelinessChangedStatus_s_type_identifier(
             ReturnCode_t return_code_last_publication_handle {eprosima::fastdds::dds::RETCODE_OK};
             return_code_last_publication_handle =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_last_publication_handle);
+                "anonymous_array_byte_16", type_ids_last_publication_handle);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_last_publication_handle)
             {
@@ -748,31 +748,31 @@ void register_LivelinessChangedStatus_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_publication_handle, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_publication_handle, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_last_publication_handle.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_last_publication_handle))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_last_publication_handle))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -857,7 +857,7 @@ void register_DeadlineMissedStatus_s_type_identifier(
             ReturnCode_t return_code_last_instance_handle {eprosima::fastdds::dds::RETCODE_OK};
             return_code_last_instance_handle =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_last_instance_handle);
+                "anonymous_array_byte_16", type_ids_last_instance_handle);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_last_instance_handle)
             {
@@ -871,31 +871,31 @@ void register_DeadlineMissedStatus_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_instance_handle, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_last_instance_handle, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_last_instance_handle.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_last_instance_handle))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_last_instance_handle))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -1172,7 +1172,7 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_MonitorServiceData);
+                "anonymous_sequence_byte_unbounded", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
             {
@@ -1186,29 +1186,29 @@ void register_MonitorServiceData_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_MonitorServiceData.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_MonitorServiceData))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_MonitorServiceData))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/blackbox/types/statistics/typesTypeObjectSupport.cxx
+++ b/test/blackbox/types/statistics/typesTypeObjectSupport.cxx
@@ -67,7 +67,7 @@ void register_EntityId_s_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_4", type_ids_value);
+                "anonymous_array_byte_4", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -81,31 +81,31 @@ void register_EntityId_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_4_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_4_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_4_ec)
+                bool element_identifier_anonymous_array_byte_4_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_4 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_4_ec))};
+                if (!element_identifier_anonymous_array_byte_4_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_4 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_4 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_4 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_4 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_4 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_4, element_flags_anonymous_array_uint8_t_4);
+                CollectionElementFlag element_flags_anonymous_array_byte_4 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_4 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_4, element_flags_anonymous_array_byte_4);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(4));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_4, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_4));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_4, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_4));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_4", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_4", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_4 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_4 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -160,7 +160,7 @@ void register_GuidPrefix_s_type_identifier(
             ReturnCode_t return_code_value {eprosima::fastdds::dds::RETCODE_OK};
             return_code_value =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_12", type_ids_value);
+                "anonymous_array_byte_12", type_ids_value);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_value)
             {
@@ -174,31 +174,31 @@ void register_GuidPrefix_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_12_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_uint8_t_12_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_12_ec)
+                bool element_identifier_anonymous_array_byte_12_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_12 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_value, element_identifier_anonymous_array_byte_12_ec))};
+                if (!element_identifier_anonymous_array_byte_12_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_12 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_12 = EK_COMPLETE;
                 if (TK_NONE == type_ids_value.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_12 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_12 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_12 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_12, element_flags_anonymous_array_uint8_t_12);
+                CollectionElementFlag element_flags_anonymous_array_byte_12 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_12 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_12, element_flags_anonymous_array_byte_12);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(12));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_12, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_12));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_12, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_12));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_12", type_ids_value))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_12", type_ids_value))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_12 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_12 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -572,7 +572,7 @@ void register_Locator_s_type_identifier(
             ReturnCode_t return_code_address {eprosima::fastdds::dds::RETCODE_OK};
             return_code_address =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_16", type_ids_address);
+                "anonymous_array_byte_16", type_ids_address);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_address)
             {
@@ -586,31 +586,31 @@ void register_Locator_s_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_16_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_uint8_t_16_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_16_ec)
+                bool element_identifier_anonymous_array_byte_16_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_16 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_address, element_identifier_anonymous_array_byte_16_ec))};
+                if (!element_identifier_anonymous_array_byte_16_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_16 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_16 = EK_COMPLETE;
                 if (TK_NONE == type_ids_address.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_16 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_16 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_16 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_16, element_flags_anonymous_array_uint8_t_16);
+                CollectionElementFlag element_flags_anonymous_array_byte_16 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_16 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_16, element_flags_anonymous_array_byte_16);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(16));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_16, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_16));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_16, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_16));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_16", type_ids_address))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_16", type_ids_address))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_16 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_16 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/dds-types-test/arrays.hpp
+++ b/test/dds-types-test/arrays.hpp
@@ -1520,6 +1520,139 @@ private:
 
 };
 /*!
+ * @brief This class represents the structure ArrayUInt8 defined by the user in the IDL file.
+ * @ingroup arrays
+ */
+class ArrayUInt8
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ArrayUInt8()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ArrayUInt8()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ArrayUInt8 that will be copied.
+     */
+    eProsima_user_DllExport ArrayUInt8(
+            const ArrayUInt8& x)
+    {
+                    m_var_array_uint8 = x.m_var_array_uint8;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ArrayUInt8 that will be copied.
+     */
+    eProsima_user_DllExport ArrayUInt8(
+            ArrayUInt8&& x) noexcept
+    {
+        m_var_array_uint8 = std::move(x.m_var_array_uint8);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ArrayUInt8 that will be copied.
+     */
+    eProsima_user_DllExport ArrayUInt8& operator =(
+            const ArrayUInt8& x)
+    {
+
+                    m_var_array_uint8 = x.m_var_array_uint8;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ArrayUInt8 that will be copied.
+     */
+    eProsima_user_DllExport ArrayUInt8& operator =(
+            ArrayUInt8&& x) noexcept
+    {
+
+        m_var_array_uint8 = std::move(x.m_var_array_uint8);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ArrayUInt8 object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ArrayUInt8& x) const
+    {
+        return (m_var_array_uint8 == x.m_var_array_uint8);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ArrayUInt8 object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ArrayUInt8& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function copies the value in member var_array_uint8
+     * @param _var_array_uint8 New value to be copied in member var_array_uint8
+     */
+    eProsima_user_DllExport void var_array_uint8(
+            const std::array<uint8_t, 10>& _var_array_uint8)
+    {
+        m_var_array_uint8 = _var_array_uint8;
+    }
+
+    /*!
+     * @brief This function moves the value in member var_array_uint8
+     * @param _var_array_uint8 New value to be moved in member var_array_uint8
+     */
+    eProsima_user_DllExport void var_array_uint8(
+            std::array<uint8_t, 10>&& _var_array_uint8)
+    {
+        m_var_array_uint8 = std::move(_var_array_uint8);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member var_array_uint8
+     * @return Constant reference to member var_array_uint8
+     */
+    eProsima_user_DllExport const std::array<uint8_t, 10>& var_array_uint8() const
+    {
+        return m_var_array_uint8;
+    }
+
+    /*!
+     * @brief This function returns a reference to member var_array_uint8
+     * @return Reference to member var_array_uint8
+     */
+    eProsima_user_DllExport std::array<uint8_t, 10>& var_array_uint8()
+    {
+        return m_var_array_uint8;
+    }
+
+
+
+private:
+
+    std::array<uint8_t, 10> m_var_array_uint8{0};
+
+};
+/*!
  * @brief This class represents the structure ArrayChar defined by the user in the IDL file.
  * @ingroup arrays
  */

--- a/test/dds-types-test/arraysCdrAux.hpp
+++ b/test/dds-types-test/arraysCdrAux.hpp
@@ -133,6 +133,9 @@ constexpr uint32_t ArraySingleDimensionLiteralsString_max_key_cdr_typesize {0UL}
 constexpr uint32_t ArraySingleDimensionLiteralsShortArray_max_cdr_typesize {204UL};
 constexpr uint32_t ArraySingleDimensionLiteralsShortArray_max_key_cdr_typesize {0UL};
 
+constexpr uint32_t ArrayUInt8_max_cdr_typesize {14UL};
+constexpr uint32_t ArrayUInt8_max_key_cdr_typesize {0UL};
+
 
 constexpr uint32_t ArrayMultiDimensionLiteralsUShort_max_cdr_typesize {504UL};
 constexpr uint32_t ArrayMultiDimensionLiteralsUShort_max_key_cdr_typesize {0UL};
@@ -400,6 +403,10 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ArrayOctet& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const ArrayUInt8& data);
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/test/dds-types-test/arraysCdrAux.ipp
+++ b/test/dds-types-test/arraysCdrAux.ipp
@@ -906,6 +906,85 @@ void serialize_key(
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const ArrayUInt8& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.var_array_uint8(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const ArrayUInt8& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.var_array_uint8()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        ArrayUInt8& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.var_array_uint8();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const ArrayUInt8& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.var_array_uint8();
+
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
         const ArrayChar& data,
         size_t& current_alignment)
 {

--- a/test/dds-types-test/arraysPubSubTypes.cxx
+++ b/test/dds-types-test/arraysPubSubTypes.cxx
@@ -2022,6 +2022,187 @@ void ArrayOctetPubSubType::register_type_object_representation()
     register_ArrayOctet_type_identifier(type_identifiers_);
 }
 
+ArrayUInt8PubSubType::ArrayUInt8PubSubType()
+{
+    set_name("ArrayUInt8");
+    uint32_t type_size = ArrayUInt8_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = false;
+    uint32_t key_length = ArrayUInt8_max_key_cdr_typesize > 16 ? ArrayUInt8_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+ArrayUInt8PubSubType::~ArrayUInt8PubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool ArrayUInt8PubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const ArrayUInt8* p_type = static_cast<const ArrayUInt8*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool ArrayUInt8PubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        ArrayUInt8* p_type = static_cast<ArrayUInt8*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t ArrayUInt8PubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const ArrayUInt8*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* ArrayUInt8PubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new ArrayUInt8());
+}
+
+void ArrayUInt8PubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<ArrayUInt8*>(data));
+}
+
+bool ArrayUInt8PubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    ArrayUInt8 data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool ArrayUInt8PubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const ArrayUInt8* p_type = static_cast<const ArrayUInt8*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            ArrayUInt8_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || ArrayUInt8_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void ArrayUInt8PubSubType::register_type_object_representation()
+{
+    register_ArrayUInt8_type_identifier(type_identifiers_);
+}
+
 ArrayCharPubSubType::ArrayCharPubSubType()
 {
     set_name("ArrayChar");

--- a/test/dds-types-test/arraysPubSubTypes.hpp
+++ b/test/dds-types-test/arraysPubSubTypes.hpp
@@ -931,6 +931,87 @@ private:
 };
 
 /*!
+ * @brief This class represents the TopicDataType of the type ArrayUInt8 defined by the user in the IDL file.
+ * @ingroup arrays
+ */
+class ArrayUInt8PubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef ArrayUInt8 type;
+
+    eProsima_user_DllExport ArrayUInt8PubSubType();
+
+    eProsima_user_DllExport ~ArrayUInt8PubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return true;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
+/*!
  * @brief This class represents the TopicDataType of the type ArrayChar defined by the user in the IDL file.
  * @ingroup arrays
  */

--- a/test/dds-types-test/arraysTypeObjectSupport.cxx
+++ b/test/dds-types-test/arraysTypeObjectSupport.cxx
@@ -994,7 +994,7 @@ void register_ArrayOctet_type_identifier(
             ReturnCode_t return_code_var_array_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_array_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_10", type_ids_var_array_octet);
+                "anonymous_array_byte_10", type_ids_var_array_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_octet)
             {
@@ -1008,31 +1008,31 @@ void register_ArrayOctet_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_10_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_uint8_t_10_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_10_ec)
+                bool element_identifier_anonymous_array_byte_10_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_byte_10_ec))};
+                if (!element_identifier_anonymous_array_byte_10_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_10 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_10 = EK_COMPLETE;
                 if (TK_NONE == type_ids_var_array_octet.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_10 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_10 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_10 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_10, element_flags_anonymous_array_uint8_t_10);
+                CollectionElementFlag element_flags_anonymous_array_byte_10 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_10, element_flags_anonymous_array_byte_10);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(10));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_10, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_10));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_10, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_10));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_10", type_ids_var_array_octet))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_10", type_ids_var_array_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_10 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_10 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -3638,7 +3638,7 @@ void register_ArrayMultiDimensionOctet_type_identifier(
             ReturnCode_t return_code_var_array_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_array_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_10_10_10", type_ids_var_array_octet);
+                "anonymous_array_byte_10_10_10", type_ids_var_array_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_octet)
             {
@@ -3652,20 +3652,20 @@ void register_ArrayMultiDimensionOctet_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_10_10_10_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_10_10_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_uint8_t_10_10_10_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_10_10_10_ec)
+                bool element_identifier_anonymous_array_byte_10_10_10_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_10_10_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_byte_10_10_10_ec))};
+                if (!element_identifier_anonymous_array_byte_10_10_10_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_10_10_10 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_10_10_10 = EK_COMPLETE;
                 if (TK_NONE == type_ids_var_array_octet.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_10_10_10 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_10_10_10 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_10_10_10 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_10_10_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_10_10_10, element_flags_anonymous_array_uint8_t_10_10_10);
+                CollectionElementFlag element_flags_anonymous_array_byte_10_10_10 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_10_10_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_10_10_10, element_flags_anonymous_array_byte_10_10_10);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(10));
@@ -3674,13 +3674,13 @@ void register_ArrayMultiDimensionOctet_type_identifier(
 
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(10));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_10_10_10, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_10_10_10));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_10_10_10, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_10_10_10));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_10_10_10", type_ids_var_array_octet))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_10_10_10", type_ids_var_array_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_10_10_10 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_10_10_10 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -6114,7 +6114,7 @@ void register_ArraySingleDimensionLiteralsOctet_type_identifier(
             ReturnCode_t return_code_var_array_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_array_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_10", type_ids_var_array_octet);
+                "anonymous_array_byte_10", type_ids_var_array_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_octet)
             {
@@ -6128,31 +6128,31 @@ void register_ArraySingleDimensionLiteralsOctet_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_10_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_uint8_t_10_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_10_ec)
+                bool element_identifier_anonymous_array_byte_10_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_byte_10_ec))};
+                if (!element_identifier_anonymous_array_byte_10_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_10 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_10 = EK_COMPLETE;
                 if (TK_NONE == type_ids_var_array_octet.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_10 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_10 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_10 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_10, element_flags_anonymous_array_uint8_t_10);
+                CollectionElementFlag element_flags_anonymous_array_byte_10 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_10, element_flags_anonymous_array_byte_10);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(10));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_10, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_10));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_10, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_10));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_10", type_ids_var_array_octet))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_10", type_ids_var_array_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_10 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_10 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -8665,7 +8665,7 @@ void register_ArrayMultiDimensionLiteralsOctet_type_identifier(
             ReturnCode_t return_code_var_array_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_array_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_5_10_5", type_ids_var_array_octet);
+                "anonymous_array_byte_5_10_5", type_ids_var_array_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_octet)
             {
@@ -8679,20 +8679,20 @@ void register_ArrayMultiDimensionLiteralsOctet_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_5_10_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_5_10_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_uint8_t_5_10_5_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_5_10_5_ec)
+                bool element_identifier_anonymous_array_byte_5_10_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_5_10_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_octet, element_identifier_anonymous_array_byte_5_10_5_ec))};
+                if (!element_identifier_anonymous_array_byte_5_10_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_5_10_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_5_10_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_var_array_octet.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_5_10_5 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_5_10_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_5_10_5 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_5_10_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_5_10_5, element_flags_anonymous_array_uint8_t_5_10_5);
+                CollectionElementFlag element_flags_anonymous_array_byte_5_10_5 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_5_10_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_5_10_5, element_flags_anonymous_array_byte_5_10_5);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(5));
@@ -8701,13 +8701,13 @@ void register_ArrayMultiDimensionLiteralsOctet_type_identifier(
 
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(5));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_5_10_5, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_5_10_5));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_5_10_5, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_5_10_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_5_10_5", type_ids_var_array_octet))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_5_10_5", type_ids_var_array_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_5_10_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_5_10_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/dds-types-test/arraysTypeObjectSupport.cxx
+++ b/test/dds-types-test/arraysTypeObjectSupport.cxx
@@ -1063,6 +1063,99 @@ void register_ArrayOctet_type_identifier(
     }
 }
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ArrayUInt8_type_identifier(
+        TypeIdentifierPair& type_ids_ArrayUInt8)
+{
+
+    ReturnCode_t return_code_ArrayUInt8 {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ArrayUInt8 =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "ArrayUInt8", type_ids_ArrayUInt8);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ArrayUInt8)
+    {
+        StructTypeFlag struct_flags_ArrayUInt8 = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ArrayUInt8 = "ArrayUInt8";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ArrayUInt8;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ArrayUInt8;
+        CompleteTypeDetail detail_ArrayUInt8 = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ArrayUInt8, ann_custom_ArrayUInt8, type_name_ArrayUInt8.to_string());
+        CompleteStructHeader header_ArrayUInt8;
+        header_ArrayUInt8 = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ArrayUInt8);
+        CompleteStructMemberSeq member_seq_ArrayUInt8;
+        {
+            TypeIdentifierPair type_ids_var_array_uint8;
+            ReturnCode_t return_code_var_array_uint8 {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_var_array_uint8 =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_array_uint8_t_10", type_ids_var_array_uint8);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_uint8)
+            {
+                return_code_var_array_uint8 =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_uint8_t", type_ids_var_array_uint8);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_array_uint8)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Array element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_array_uint8_t_10_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_uint8_t_10 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_uint8, element_identifier_anonymous_array_uint8_t_10_ec))};
+                if (!element_identifier_anonymous_array_uint8_t_10_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_array_uint8_t_10 = EK_COMPLETE;
+                if (TK_NONE == type_ids_var_array_uint8.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_array_uint8_t_10 = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_array_uint8_t_10 = 0;
+                PlainCollectionHeader header_anonymous_array_uint8_t_10 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_10, element_flags_anonymous_array_uint8_t_10);
+                {
+                    SBoundSeq array_bound_seq;
+                        TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(10));
+
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_10, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_10));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_10", type_ids_var_array_uint8))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_array_uint8_t_10 already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_var_array_uint8 = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_var_array_uint8 = 0x00000000;
+            bool common_var_array_uint8_ec {false};
+            CommonStructMember common_var_array_uint8 {TypeObjectUtils::build_common_struct_member(member_id_var_array_uint8, member_flags_var_array_uint8, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_array_uint8, common_var_array_uint8_ec))};
+            if (!common_var_array_uint8_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure var_array_uint8 member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_var_array_uint8 = "var_array_uint8";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_var_array_uint8;
+            ann_custom_ArrayUInt8.reset();
+            CompleteMemberDetail detail_var_array_uint8 = TypeObjectUtils::build_complete_member_detail(name_var_array_uint8, member_ann_builtin_var_array_uint8, ann_custom_ArrayUInt8);
+            CompleteStructMember member_var_array_uint8 = TypeObjectUtils::build_complete_struct_member(common_var_array_uint8, detail_var_array_uint8);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ArrayUInt8, member_var_array_uint8);
+        }
+        CompleteStructType struct_type_ArrayUInt8 = TypeObjectUtils::build_complete_struct_type(struct_flags_ArrayUInt8, header_ArrayUInt8, member_seq_ArrayUInt8);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ArrayUInt8, type_name_ArrayUInt8.to_string(), type_ids_ArrayUInt8))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "ArrayUInt8 already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_ArrayChar_type_identifier(
         TypeIdentifierPair& type_ids_ArrayChar)
 {

--- a/test/dds-types-test/arraysTypeObjectSupport.hpp
+++ b/test/dds-types-test/arraysTypeObjectSupport.hpp
@@ -171,6 +171,18 @@ eProsima_user_DllExport void register_ArrayBoolean_type_identifier(
 eProsima_user_DllExport void register_ArrayOctet_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 /**
+ * @brief Register ArrayUInt8 related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ArrayUInt8_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
  * @brief Register ArrayChar related TypeIdentifier.
  *        Fully-descriptive TypeIdentifiers are directly registered.
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is

--- a/test/dds-types-test/constants.hpp
+++ b/test/dds-types-test/constants.hpp
@@ -75,6 +75,7 @@ const uint64_t const_uint64 = 19;
 typedef int16_t alias_short;
 
 const alias_short alias_const = 55;
+const InnerEnumHelper const_enum = InnerEnumHelper::ENUM_VALUE_1;
 namespace const_module1 {
 
 const int16_t const_moduled = 11;
@@ -341,6 +342,7 @@ namespace const_module2 {
 
 const int16_t const_moduled = 22;
 const const_module1::alias_short_moduled alias_const_moduled = 2;
+const int16_t const_moduled_module1 = const_module1::const_moduled;
 /*!
  * @brief This class represents the structure Module2ConstsLiteralsStruct defined by the user in the IDL file.
  * @ingroup constants
@@ -378,6 +380,8 @@ public:
 
                     m_module2_array_literal_module1_const_moduled = x.m_module2_array_literal_module1_const_moduled;
 
+                    m_module2_array_literal_const_moduled_module1 = x.m_module2_array_literal_const_moduled_module1;
+
     }
 
     /*!
@@ -391,6 +395,7 @@ public:
         m_module2_array_literal_const_alias_const_moduled = std::move(x.m_module2_array_literal_const_alias_const_moduled);
         m_module2_array_literal_const_scoped_moduled = std::move(x.m_module2_array_literal_const_scoped_moduled);
         m_module2_array_literal_module1_const_moduled = std::move(x.m_module2_array_literal_module1_const_moduled);
+        m_module2_array_literal_const_moduled_module1 = std::move(x.m_module2_array_literal_const_moduled_module1);
     }
 
     /*!
@@ -409,6 +414,8 @@ public:
 
                     m_module2_array_literal_module1_const_moduled = x.m_module2_array_literal_module1_const_moduled;
 
+                    m_module2_array_literal_const_moduled_module1 = x.m_module2_array_literal_const_moduled_module1;
+
         return *this;
     }
 
@@ -424,6 +431,7 @@ public:
         m_module2_array_literal_const_alias_const_moduled = std::move(x.m_module2_array_literal_const_alias_const_moduled);
         m_module2_array_literal_const_scoped_moduled = std::move(x.m_module2_array_literal_const_scoped_moduled);
         m_module2_array_literal_module1_const_moduled = std::move(x.m_module2_array_literal_module1_const_moduled);
+        m_module2_array_literal_const_moduled_module1 = std::move(x.m_module2_array_literal_const_moduled_module1);
         return *this;
     }
 
@@ -437,7 +445,8 @@ public:
         return (m_module2_array_literal_const_moduled == x.m_module2_array_literal_const_moduled &&
            m_module2_array_literal_const_alias_const_moduled == x.m_module2_array_literal_const_alias_const_moduled &&
            m_module2_array_literal_const_scoped_moduled == x.m_module2_array_literal_const_scoped_moduled &&
-           m_module2_array_literal_module1_const_moduled == x.m_module2_array_literal_module1_const_moduled);
+           m_module2_array_literal_module1_const_moduled == x.m_module2_array_literal_module1_const_moduled &&
+           m_module2_array_literal_const_moduled_module1 == x.m_module2_array_literal_const_moduled_module1);
     }
 
     /*!
@@ -606,6 +615,45 @@ public:
     }
 
 
+    /*!
+     * @brief This function copies the value in member module2_array_literal_const_moduled_module1
+     * @param _module2_array_literal_const_moduled_module1 New value to be copied in member module2_array_literal_const_moduled_module1
+     */
+    eProsima_user_DllExport void module2_array_literal_const_moduled_module1(
+            const std::array<int16_t, const_moduled_module1>& _module2_array_literal_const_moduled_module1)
+    {
+        m_module2_array_literal_const_moduled_module1 = _module2_array_literal_const_moduled_module1;
+    }
+
+    /*!
+     * @brief This function moves the value in member module2_array_literal_const_moduled_module1
+     * @param _module2_array_literal_const_moduled_module1 New value to be moved in member module2_array_literal_const_moduled_module1
+     */
+    eProsima_user_DllExport void module2_array_literal_const_moduled_module1(
+            std::array<int16_t, const_moduled_module1>&& _module2_array_literal_const_moduled_module1)
+    {
+        m_module2_array_literal_const_moduled_module1 = std::move(_module2_array_literal_const_moduled_module1);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member module2_array_literal_const_moduled_module1
+     * @return Constant reference to member module2_array_literal_const_moduled_module1
+     */
+    eProsima_user_DllExport const std::array<int16_t, const_moduled_module1>& module2_array_literal_const_moduled_module1() const
+    {
+        return m_module2_array_literal_const_moduled_module1;
+    }
+
+    /*!
+     * @brief This function returns a reference to member module2_array_literal_const_moduled_module1
+     * @return Reference to member module2_array_literal_const_moduled_module1
+     */
+    eProsima_user_DllExport std::array<int16_t, const_moduled_module1>& module2_array_literal_const_moduled_module1()
+    {
+        return m_module2_array_literal_const_moduled_module1;
+    }
+
+
 
 private:
 
@@ -613,6 +661,7 @@ private:
     std::array<int16_t, alias_const_moduled> m_module2_array_literal_const_alias_const_moduled{0};
     std::array<int16_t, const_module2::const_moduled> m_module2_array_literal_const_scoped_moduled{0};
     std::array<int16_t, const_module1::const_moduled> m_module2_array_literal_module1_const_moduled{0};
+    std::array<int16_t, const_moduled_module1> m_module2_array_literal_const_moduled_module1{0};
 
 };
 

--- a/test/dds-types-test/constantsCdrAux.hpp
+++ b/test/dds-types-test/constantsCdrAux.hpp
@@ -31,7 +31,7 @@ constexpr uint32_t ConstsLiteralsStruct_max_key_cdr_typesize {0UL};
 
 
 
-constexpr uint32_t const_module2_Module2ConstsLiteralsStruct_max_cdr_typesize {118UL};
+constexpr uint32_t const_module2_Module2ConstsLiteralsStruct_max_cdr_typesize {140UL};
 constexpr uint32_t const_module2_Module2ConstsLiteralsStruct_max_key_cdr_typesize {0UL};
 
 constexpr uint32_t const_module1_ModuleConstsLiteralsStruct_max_cdr_typesize {50UL};

--- a/test/dds-types-test/constantsCdrAux.ipp
+++ b/test/dds-types-test/constantsCdrAux.ipp
@@ -180,6 +180,9 @@ eProsima_user_DllExport size_t calculate_serialized_size(
         calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
                 data.module2_array_literal_module1_const_moduled(), current_alignment);
 
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.module2_array_literal_const_moduled_module1(), current_alignment);
+
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
@@ -204,6 +207,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.module2_array_literal_const_alias_const_moduled()
         << eprosima::fastcdr::MemberId(2) << data.module2_array_literal_const_scoped_moduled()
         << eprosima::fastcdr::MemberId(3) << data.module2_array_literal_module1_const_moduled()
+        << eprosima::fastcdr::MemberId(4) << data.module2_array_literal_const_moduled_module1()
 ;
     scdr.end_serialize_type(current_state);
 }
@@ -239,6 +243,10 @@ eProsima_user_DllExport void deserialize(
                                                 dcdr >> data.module2_array_literal_module1_const_moduled();
                                             break;
 
+                                        case 4:
+                                                dcdr >> data.module2_array_literal_const_moduled_module1();
+                                            break;
+
                     default:
                         ret_value = false;
                         break;
@@ -262,6 +270,8 @@ void serialize_key(
                         scdr << data.module2_array_literal_const_scoped_moduled();
 
                         scdr << data.module2_array_literal_module1_const_moduled();
+
+                        scdr << data.module2_array_literal_const_moduled_module1();
 
 }
 

--- a/test/dds-types-test/constantsPubSubTypes.hpp
+++ b/test/dds-types-test/constantsPubSubTypes.hpp
@@ -40,6 +40,7 @@
 
 typedef int16_t alias_short;
 
+
 namespace const_module1
 {
     typedef int16_t alias_short_moduled;

--- a/test/dds-types-test/constantsTypeObjectSupport.cxx
+++ b/test/dds-types-test/constantsTypeObjectSupport.cxx
@@ -632,6 +632,70 @@ void register_Module2ConstsLiteralsStruct_type_identifier(
             CompleteStructMember member_module2_array_literal_module1_const_moduled = TypeObjectUtils::build_complete_struct_member(common_module2_array_literal_module1_const_moduled, detail_module2_array_literal_module1_const_moduled);
             TypeObjectUtils::add_complete_struct_member(member_seq_Module2ConstsLiteralsStruct, member_module2_array_literal_module1_const_moduled);
         }
+        {
+            TypeIdentifierPair type_ids_module2_array_literal_const_moduled_module1;
+            ReturnCode_t return_code_module2_array_literal_const_moduled_module1 {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_module2_array_literal_const_moduled_module1 =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_array_int16_t_11", type_ids_module2_array_literal_const_moduled_module1);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_module2_array_literal_const_moduled_module1)
+            {
+                return_code_module2_array_literal_const_moduled_module1 =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_int16_t", type_ids_module2_array_literal_const_moduled_module1);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_module2_array_literal_const_moduled_module1)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Array element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_array_int16_t_11_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_int16_t_11 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_module2_array_literal_const_moduled_module1, element_identifier_anonymous_array_int16_t_11_ec))};
+                if (!element_identifier_anonymous_array_int16_t_11_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_array_int16_t_11 = EK_COMPLETE;
+                if (TK_NONE == type_ids_module2_array_literal_const_moduled_module1.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_array_int16_t_11 = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_array_int16_t_11 = 0;
+                PlainCollectionHeader header_anonymous_array_int16_t_11 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_int16_t_11, element_flags_anonymous_array_int16_t_11);
+                {
+                    SBoundSeq array_bound_seq;
+                        TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(11));
+
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_int16_t_11, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_int16_t_11));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_int16_t_11", type_ids_module2_array_literal_const_moduled_module1))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_array_int16_t_11 already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_module2_array_literal_const_moduled_module1 = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_module2_array_literal_const_moduled_module1 = 0x00000004;
+            bool common_module2_array_literal_const_moduled_module1_ec {false};
+            CommonStructMember common_module2_array_literal_const_moduled_module1 {TypeObjectUtils::build_common_struct_member(member_id_module2_array_literal_const_moduled_module1, member_flags_module2_array_literal_const_moduled_module1, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_module2_array_literal_const_moduled_module1, common_module2_array_literal_const_moduled_module1_ec))};
+            if (!common_module2_array_literal_const_moduled_module1_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure module2_array_literal_const_moduled_module1 member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_module2_array_literal_const_moduled_module1 = "module2_array_literal_const_moduled_module1";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_module2_array_literal_const_moduled_module1;
+            ann_custom_Module2ConstsLiteralsStruct.reset();
+            CompleteMemberDetail detail_module2_array_literal_const_moduled_module1 = TypeObjectUtils::build_complete_member_detail(name_module2_array_literal_const_moduled_module1, member_ann_builtin_module2_array_literal_const_moduled_module1, ann_custom_Module2ConstsLiteralsStruct);
+            CompleteStructMember member_module2_array_literal_const_moduled_module1 = TypeObjectUtils::build_complete_struct_member(common_module2_array_literal_const_moduled_module1, detail_module2_array_literal_const_moduled_module1);
+            TypeObjectUtils::add_complete_struct_member(member_seq_Module2ConstsLiteralsStruct, member_module2_array_literal_const_moduled_module1);
+        }
         CompleteStructType struct_type_Module2ConstsLiteralsStruct = TypeObjectUtils::build_complete_struct_type(struct_flags_Module2ConstsLiteralsStruct, header_Module2ConstsLiteralsStruct, member_seq_Module2ConstsLiteralsStruct);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
                 TypeObjectUtils::build_and_register_struct_type_object(struct_type_Module2ConstsLiteralsStruct, type_name_Module2ConstsLiteralsStruct.to_string(), type_ids_Module2ConstsLiteralsStruct))

--- a/test/dds-types-test/mapsTypeObjectSupport.cxx
+++ b/test/dds-types-test/mapsTypeObjectSupport.cxx
@@ -1244,7 +1244,7 @@ void register_MapShortOctet_type_identifier(
             ReturnCode_t return_code_var_map_short_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_short_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_int16_t_uint8_t_unbounded", type_ids_var_map_short_octet);
+                "anonymous_map_int16_t_byte_unbounded", type_ids_var_map_short_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_short_octet)
             {
@@ -1258,12 +1258,12 @@ void register_MapShortOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_int16_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_short_octet, element_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_int16_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_int16_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_short_octet, element_identifier_anonymous_map_int16_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_int16_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int16_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_int16_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_short_octet =
@@ -1276,38 +1276,38 @@ void register_MapShortOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_int16_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_short_octet, key_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_int16_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_int16_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_int16_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_short_octet, key_identifier_anonymous_map_int16_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_int16_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int16_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_int16_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_int16_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_int16_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_int16_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int16_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int16_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_int16_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_int16_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_int16_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_int16_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_int16_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int16_t_uint8_t_unbounded, element_flags_anonymous_map_int16_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_int16_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_int16_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_int16_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int16_t_byte_unbounded, element_flags_anonymous_map_int16_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int16_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int16_t_uint8_t_unbounded), key_flags_anonymous_map_int16_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int16_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int16_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int16_t_byte_unbounded), key_flags_anonymous_map_int16_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int16_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int16_t_uint8_t_unbounded", type_ids_var_map_short_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int16_t_byte_unbounded", type_ids_var_map_short_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_int16_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_int16_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -4306,7 +4306,7 @@ void register_MapUShortOctet_type_identifier(
             ReturnCode_t return_code_var_map_ushort_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_ushort_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_uint16_t_uint8_t_unbounded", type_ids_var_map_ushort_octet);
+                "anonymous_map_uint16_t_byte_unbounded", type_ids_var_map_ushort_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_ushort_octet)
             {
@@ -4320,12 +4320,12 @@ void register_MapUShortOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_uint16_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ushort_octet, element_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_uint16_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_uint16_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ushort_octet, element_identifier_anonymous_map_uint16_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_uint16_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint16_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_uint16_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_ushort_octet =
@@ -4338,38 +4338,38 @@ void register_MapUShortOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_uint16_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ushort_octet, key_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_uint16_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_uint16_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_uint16_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ushort_octet, key_identifier_anonymous_map_uint16_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_uint16_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint16_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_uint16_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_uint16_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_uint16_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_uint16_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint16_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint16_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_uint16_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_uint16_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_uint16_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_uint16_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_uint16_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint16_t_uint8_t_unbounded, element_flags_anonymous_map_uint16_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_uint16_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_uint16_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_uint16_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint16_t_byte_unbounded, element_flags_anonymous_map_uint16_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint16_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint16_t_uint8_t_unbounded), key_flags_anonymous_map_uint16_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint16_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint16_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint16_t_byte_unbounded), key_flags_anonymous_map_uint16_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint16_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint16_t_uint8_t_unbounded", type_ids_var_map_ushort_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint16_t_byte_unbounded", type_ids_var_map_ushort_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_uint16_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_uint16_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -7368,7 +7368,7 @@ void register_MapLongOctet_type_identifier(
             ReturnCode_t return_code_var_map_long_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_long_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_int32_t_uint8_t_unbounded", type_ids_var_map_long_octet);
+                "anonymous_map_int32_t_byte_unbounded", type_ids_var_map_long_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_long_octet)
             {
@@ -7382,12 +7382,12 @@ void register_MapLongOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_int32_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_long_octet, element_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_int32_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_int32_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_long_octet, element_identifier_anonymous_map_int32_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_int32_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int32_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_int32_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_long_octet =
@@ -7400,38 +7400,38 @@ void register_MapLongOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_int32_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_long_octet, key_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_int32_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_int32_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_int32_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_long_octet, key_identifier_anonymous_map_int32_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_int32_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int32_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_int32_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_int32_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_int32_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_int32_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int32_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int32_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_int32_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_int32_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_int32_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_int32_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_int32_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int32_t_uint8_t_unbounded, element_flags_anonymous_map_int32_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_int32_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_int32_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_int32_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int32_t_byte_unbounded, element_flags_anonymous_map_int32_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int32_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int32_t_uint8_t_unbounded), key_flags_anonymous_map_int32_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int32_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int32_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int32_t_byte_unbounded), key_flags_anonymous_map_int32_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int32_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int32_t_uint8_t_unbounded", type_ids_var_map_long_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int32_t_byte_unbounded", type_ids_var_map_long_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_int32_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_int32_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -10430,7 +10430,7 @@ void register_MapULongOctet_type_identifier(
             ReturnCode_t return_code_var_map_ulong_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_ulong_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_uint32_t_uint8_t_unbounded", type_ids_var_map_ulong_octet);
+                "anonymous_map_uint32_t_byte_unbounded", type_ids_var_map_ulong_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_ulong_octet)
             {
@@ -10444,12 +10444,12 @@ void register_MapULongOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_uint32_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ulong_octet, element_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_uint32_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_uint32_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ulong_octet, element_identifier_anonymous_map_uint32_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_uint32_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint32_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_uint32_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_ulong_octet =
@@ -10462,38 +10462,38 @@ void register_MapULongOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_uint32_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ulong_octet, key_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_uint32_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_uint32_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_uint32_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_ulong_octet, key_identifier_anonymous_map_uint32_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_uint32_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint32_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_uint32_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_uint32_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_uint32_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_uint32_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint32_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint32_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_uint32_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_uint32_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_uint32_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_uint32_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_uint32_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint32_t_uint8_t_unbounded, element_flags_anonymous_map_uint32_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_uint32_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_uint32_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_uint32_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint32_t_byte_unbounded, element_flags_anonymous_map_uint32_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint32_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint32_t_uint8_t_unbounded), key_flags_anonymous_map_uint32_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint32_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint32_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint32_t_byte_unbounded), key_flags_anonymous_map_uint32_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint32_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint32_t_uint8_t_unbounded", type_ids_var_map_ulong_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint32_t_byte_unbounded", type_ids_var_map_ulong_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_uint32_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_uint32_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -13492,7 +13492,7 @@ void register_MapLongLongOctet_type_identifier(
             ReturnCode_t return_code_var_map_longlong_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_longlong_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_int64_t_uint8_t_unbounded", type_ids_var_map_longlong_octet);
+                "anonymous_map_int64_t_byte_unbounded", type_ids_var_map_longlong_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_longlong_octet)
             {
@@ -13506,12 +13506,12 @@ void register_MapLongLongOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_int64_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_longlong_octet, element_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_int64_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_int64_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_longlong_octet, element_identifier_anonymous_map_int64_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_int64_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int64_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_int64_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_longlong_octet =
@@ -13524,38 +13524,38 @@ void register_MapLongLongOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_int64_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_longlong_octet, key_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_int64_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_int64_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_int64_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_longlong_octet, key_identifier_anonymous_map_int64_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_int64_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_int64_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_int64_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_int64_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_int64_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_int64_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_int64_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_int64_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_int64_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_int64_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_int64_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_int64_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_int64_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int64_t_uint8_t_unbounded, element_flags_anonymous_map_int64_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_int64_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_int64_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_int64_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_int64_t_byte_unbounded, element_flags_anonymous_map_int64_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int64_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int64_t_uint8_t_unbounded), key_flags_anonymous_map_int64_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int64_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_int64_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_int64_t_byte_unbounded), key_flags_anonymous_map_int64_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_int64_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int64_t_uint8_t_unbounded", type_ids_var_map_longlong_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_int64_t_byte_unbounded", type_ids_var_map_longlong_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_int64_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_int64_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -16554,7 +16554,7 @@ void register_MapULongLongOctet_type_identifier(
             ReturnCode_t return_code_var_map_u_long_long_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_u_long_long_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_uint64_t_uint8_t_unbounded", type_ids_var_map_u_long_long_octet);
+                "anonymous_map_uint64_t_byte_unbounded", type_ids_var_map_u_long_long_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_u_long_long_octet)
             {
@@ -16568,12 +16568,12 @@ void register_MapULongLongOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_uint64_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_u_long_long_octet, element_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_uint64_t_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_uint64_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_u_long_long_octet, element_identifier_anonymous_map_uint64_t_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_uint64_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint64_t_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_uint64_t_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_u_long_long_octet =
@@ -16586,38 +16586,38 @@ void register_MapULongLongOctet_type_identifier(
                             "Map key TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool key_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_uint64_t_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_u_long_long_octet, key_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_uint64_t_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_uint64_t_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_uint64_t_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_u_long_long_octet, key_identifier_anonymous_map_uint64_t_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_uint64_t_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_uint64_t_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_uint64_t_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_uint64_t_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_uint64_t_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_uint64_t_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_uint64_t_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_uint64_t_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_uint64_t_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_uint64_t_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_uint64_t_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_uint64_t_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_uint64_t_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint64_t_uint8_t_unbounded, element_flags_anonymous_map_uint64_t_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_uint64_t_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_uint64_t_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_uint64_t_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_uint64_t_byte_unbounded, element_flags_anonymous_map_uint64_t_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint64_t_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint64_t_uint8_t_unbounded), key_flags_anonymous_map_uint64_t_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint64_t_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_uint64_t_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_uint64_t_byte_unbounded), key_flags_anonymous_map_uint64_t_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_uint64_t_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint64_t_uint8_t_unbounded", type_ids_var_map_u_long_long_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_uint64_t_byte_unbounded", type_ids_var_map_u_long_long_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_uint64_t_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_uint64_t_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -19696,7 +19696,7 @@ void register_MapStringOctet_type_identifier(
             ReturnCode_t return_code_var_map_string_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_string_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_anonymous_string_unbounded_uint8_t_unbounded", type_ids_var_map_string_octet);
+                "anonymous_map_anonymous_string_unbounded_byte_unbounded", type_ids_var_map_string_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_string_octet)
             {
@@ -19710,12 +19710,12 @@ void register_MapStringOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_string_octet, element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_string_octet, element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_string_unbounded_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_anonymous_string_unbounded_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_string_octet =
@@ -19736,38 +19736,38 @@ void register_MapStringOctet_type_identifier(
                         }
                     }
                 }
-                bool key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_string_octet, key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_string_octet, key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_string_unbounded_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_anonymous_string_unbounded_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_anonymous_string_unbounded_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_anonymous_string_unbounded_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded, element_flags_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_anonymous_string_unbounded_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_anonymous_string_unbounded_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_anonymous_string_unbounded_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_string_unbounded_byte_unbounded, element_flags_anonymous_map_anonymous_string_unbounded_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded), key_flags_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_string_unbounded_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_string_unbounded_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded), key_flags_anonymous_map_anonymous_string_unbounded_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_string_unbounded_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_string_unbounded_uint8_t_unbounded", type_ids_var_map_string_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_string_unbounded_byte_unbounded", type_ids_var_map_string_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_anonymous_string_unbounded_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_anonymous_string_unbounded_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -22966,7 +22966,7 @@ void register_MapWStringOctet_type_identifier(
             ReturnCode_t return_code_var_map_wstring_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_wstring_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded", type_ids_var_map_wstring_octet);
+                "anonymous_map_anonymous_wstring_unbounded_byte_unbounded", type_ids_var_map_wstring_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_wstring_octet)
             {
@@ -22980,12 +22980,12 @@ void register_MapWStringOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_wstring_octet, element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_wstring_octet, element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_anonymous_wstring_unbounded_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_wstring_octet =
@@ -23006,38 +23006,38 @@ void register_MapWStringOctet_type_identifier(
                         }
                     }
                 }
-                bool key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_wstring_octet, key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_wstring_octet, key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_anonymous_wstring_unbounded_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_anonymous_wstring_unbounded_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_anonymous_wstring_unbounded_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded, element_flags_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_anonymous_wstring_unbounded_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_anonymous_wstring_unbounded_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_anonymous_wstring_unbounded_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_wstring_unbounded_byte_unbounded, element_flags_anonymous_map_anonymous_wstring_unbounded_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded), key_flags_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_wstring_unbounded_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded), key_flags_anonymous_map_anonymous_wstring_unbounded_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_wstring_unbounded_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded", type_ids_var_map_wstring_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_wstring_unbounded_byte_unbounded", type_ids_var_map_wstring_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_anonymous_wstring_unbounded_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_anonymous_wstring_unbounded_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -26136,7 +26136,7 @@ void register_MapInnerAliasBoundedStringHelperOctet_type_identifier(
             ReturnCode_t return_code_var_map_inneraliasboundedstringhelper_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_inneraliasboundedstringhelper_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_anonymous_string_10_uint8_t_unbounded", type_ids_var_map_inneraliasboundedstringhelper_octet);
+                "anonymous_map_anonymous_string_10_byte_unbounded", type_ids_var_map_inneraliasboundedstringhelper_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_inneraliasboundedstringhelper_octet)
             {
@@ -26150,12 +26150,12 @@ void register_MapInnerAliasBoundedStringHelperOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedstringhelper_octet, element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_anonymous_string_10_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedstringhelper_octet, element_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_string_10_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_anonymous_string_10_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_inneraliasboundedstringhelper_octet =
@@ -26166,38 +26166,38 @@ void register_MapInnerAliasBoundedStringHelperOctet_type_identifier(
                 {
                 ::register_Inner_alias_bounded_string_helper_type_identifier(type_ids_var_map_inneraliasboundedstringhelper_octet);
                 }
-                bool key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedstringhelper_octet, key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_anonymous_string_10_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedstringhelper_octet, key_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_anonymous_string_10_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_string_10_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_anonymous_string_10_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_anonymous_string_10_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_anonymous_string_10_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_string_10_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_anonymous_string_10_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_anonymous_string_10_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_anonymous_string_10_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_anonymous_string_10_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_anonymous_string_10_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_string_10_uint8_t_unbounded, element_flags_anonymous_map_anonymous_string_10_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_anonymous_string_10_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_anonymous_string_10_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_anonymous_string_10_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_string_10_byte_unbounded, element_flags_anonymous_map_anonymous_string_10_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_string_10_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded), key_flags_anonymous_map_anonymous_string_10_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_string_10_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_string_10_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_string_10_byte_unbounded), key_flags_anonymous_map_anonymous_string_10_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_string_10_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_string_10_uint8_t_unbounded", type_ids_var_map_inneraliasboundedstringhelper_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_string_10_byte_unbounded", type_ids_var_map_inneraliasboundedstringhelper_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_anonymous_string_10_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_anonymous_string_10_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -29146,7 +29146,7 @@ void register_MapInnerAliasBoundedWStringHelperOctet_type_identifier(
             ReturnCode_t return_code_var_map_inneraliasboundedwstringhelper_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_map_inneraliasboundedwstringhelper_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_map_anonymous_wstring_10_uint8_t_unbounded", type_ids_var_map_inneraliasboundedwstringhelper_octet);
+                "anonymous_map_anonymous_wstring_10_byte_unbounded", type_ids_var_map_inneraliasboundedwstringhelper_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_map_inneraliasboundedwstringhelper_octet)
             {
@@ -29160,12 +29160,12 @@ void register_MapInnerAliasBoundedWStringHelperOctet_type_identifier(
                             "Map element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedwstringhelper_octet, element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedwstringhelper_octet, element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_wstring_10_uint8_t_unbounded inconsistent element TypeIdentifier.");
+                        "anonymous_map_anonymous_wstring_10_byte_unbounded inconsistent element TypeIdentifier.");
                     return;
                 }
                 return_code_var_map_inneraliasboundedwstringhelper_octet =
@@ -29176,38 +29176,38 @@ void register_MapInnerAliasBoundedWStringHelperOctet_type_identifier(
                 {
                 ::register_Inner_alias_bounded_wstring_helper_type_identifier(type_ids_var_map_inneraliasboundedwstringhelper_octet);
                 }
-                bool key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec {false};
-                TypeIdentifier* key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedwstringhelper_octet, key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec))};
-                if (!key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded_ec)
+                bool key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec {false};
+                TypeIdentifier* key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_map_inneraliasboundedwstringhelper_octet, key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec))};
+                if (!key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "anonymous_map_anonymous_wstring_10_uint8_t_unbounded inconsistent key TypeIdentifier.");
+                        "anonymous_map_anonymous_wstring_10_byte_unbounded inconsistent key TypeIdentifier.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_map_anonymous_wstring_10_uint8_t_unbounded = EK_BOTH;
-                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d()) ||
-                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->seq_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->seq_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->array_sdefn().header().equiv_kind()) ||
-                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->array_ldefn().header().equiv_kind()) ||
-                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->map_sdefn().header().equiv_kind())) ||
-                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded->map_ldefn().header().equiv_kind())))
+                EquivalenceKind equiv_kind_anonymous_map_anonymous_wstring_10_byte_unbounded = EK_BOTH;
+                if ((EK_COMPLETE == key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d()) ||
+                        (TI_PLAIN_SEQUENCE_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->seq_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_SEQUENCE_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->seq_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->array_sdefn().header().equiv_kind()) ||
+                        (TI_PLAIN_ARRAY_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->array_ldefn().header().equiv_kind()) ||
+                        (TI_PLAIN_MAP_SMALL == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->map_sdefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->map_sdefn().header().equiv_kind())) ||
+                        (TI_PLAIN_MAP_LARGE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->_d() && (EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->map_ldefn().key_identifier()->_d() || EK_COMPLETE == element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded->map_ldefn().header().equiv_kind())))
                 {
-                    equiv_kind_anonymous_map_anonymous_wstring_10_uint8_t_unbounded = EK_COMPLETE;
+                    equiv_kind_anonymous_map_anonymous_wstring_10_byte_unbounded = EK_COMPLETE;
                 }
-                CollectionElementFlag element_flags_anonymous_map_anonymous_wstring_10_uint8_t_unbounded = 0;
-                CollectionElementFlag key_flags_anonymous_map_anonymous_wstring_10_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_map_anonymous_wstring_10_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_wstring_10_uint8_t_unbounded, element_flags_anonymous_map_anonymous_wstring_10_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_map_anonymous_wstring_10_byte_unbounded = 0;
+                CollectionElementFlag key_flags_anonymous_map_anonymous_wstring_10_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_map_anonymous_wstring_10_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_map_anonymous_wstring_10_byte_unbounded, element_flags_anonymous_map_anonymous_wstring_10_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_wstring_10_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded), key_flags_anonymous_map_anonymous_wstring_10_uint8_t_unbounded,
-                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_wstring_10_uint8_t_unbounded));
+                    PlainMapSTypeDefn map_sdefn = TypeObjectUtils::build_plain_map_s_type_defn(header_anonymous_map_anonymous_wstring_10_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded), key_flags_anonymous_map_anonymous_wstring_10_byte_unbounded,
+                                eprosima::fastcdr::external<TypeIdentifier>(key_identifier_anonymous_map_anonymous_wstring_10_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_wstring_10_uint8_t_unbounded", type_ids_var_map_inneraliasboundedwstringhelper_octet))
+                            TypeObjectUtils::build_and_register_s_map_type_identifier(map_sdefn, "anonymous_map_anonymous_wstring_10_byte_unbounded", type_ids_var_map_inneraliasboundedwstringhelper_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_map_anonymous_wstring_10_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_map_anonymous_wstring_10_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/dds-types-test/sequencesTypeObjectSupport.cxx
+++ b/test/dds-types-test/sequencesTypeObjectSupport.cxx
@@ -974,7 +974,7 @@ void register_SequenceOctet_type_identifier(
             ReturnCode_t return_code_var_sequence_octet {eprosima::fastdds::dds::RETCODE_OK};
             return_code_var_sequence_octet =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_var_sequence_octet);
+                "anonymous_sequence_byte_unbounded", type_ids_var_sequence_octet);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_var_sequence_octet)
             {
@@ -988,29 +988,29 @@ void register_SequenceOctet_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_sequence_octet, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_var_sequence_octet, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_var_sequence_octet.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_var_sequence_octet))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_var_sequence_octet))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }

--- a/test/dds-types-test/unions.hpp
+++ b/test/dds-types-test/unions.hpp
@@ -18812,6 +18812,353 @@ private:
 
     std::function<void()> member_destructor_;
 };
+/*!
+ * @brief This class represents the union DefaultAnnotationExternalValue defined by the user in the IDL file.
+ * @ingroup unions
+ */
+class DefaultAnnotationExternalValue
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport DefaultAnnotationExternalValue()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~DefaultAnnotationExternalValue()
+    {
+        if (member_destructor_)
+        {
+            member_destructor_();
+        }
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object DefaultAnnotationExternalValue that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotationExternalValue(
+            const DefaultAnnotationExternalValue& x)
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = x.m_a;
+                            break;
+
+                        case 0x00000002:
+                            b_() = x.m_b;
+                            break;
+
+        }
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object DefaultAnnotationExternalValue that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotationExternalValue(
+            DefaultAnnotationExternalValue&& x) noexcept
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = std::move(x.m_a);
+                            break;
+
+                        case 0x00000002:
+                            b_() = std::move(x.m_b);
+                            break;
+
+        }
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object DefaultAnnotationExternalValue that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotationExternalValue& operator =(
+            const DefaultAnnotationExternalValue& x)
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = x.m_a;
+                            break;
+
+                        case 0x00000002:
+                            b_() = x.m_b;
+                            break;
+
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object DefaultAnnotationExternalValue that will be copied.
+     */
+    eProsima_user_DllExport DefaultAnnotationExternalValue& operator =(
+            DefaultAnnotationExternalValue&& x) noexcept
+    {
+        m__d = x.m__d;
+
+        switch (x.selected_member_)
+        {
+                        case 0x00000001:
+                            a_() = std::move(x.m_a);
+                            break;
+
+                        case 0x00000002:
+                            b_() = std::move(x.m_b);
+                            break;
+
+        }
+
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x DefaultAnnotationExternalValue object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const DefaultAnnotationExternalValue& x) const
+    {
+        bool ret_value {false};
+
+        if (m__d == x.m__d &&
+                selected_member_ == x.selected_member_)
+        {
+            switch (selected_member_)
+            {
+                                case 0x00000001:
+                                    ret_value = (m_a == x.m_a);
+                                    break;
+
+                                case 0x00000002:
+                                    ret_value = (m_b == x.m_b);
+                                    break;
+
+            }
+        }
+
+        return ret_value;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x DefaultAnnotationExternalValue object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const DefaultAnnotationExternalValue& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets the discriminator value.
+     * @param __d New value for the discriminator.
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the new value doesn't correspond to the selected union member.
+     */
+    eProsima_user_DllExport void _d(
+            int32_t __d)
+    {
+        bool valid_discriminator = false;
+
+        switch (__d)
+        {
+                        case 0:
+                            if (0x00000001 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case 1:
+                            if (0x00000002 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+        }
+
+        if (!valid_discriminator)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("Discriminator doesn't correspond with the selected union member");
+        }
+
+        m__d = __d;
+    }
+
+    /*!
+     * @brief This function returns the value of the discriminator.
+     * @return Value of the discriminator
+     */
+    eProsima_user_DllExport int32_t _d() const
+    {
+        return m__d;
+    }
+
+    /*!
+     * @brief This function sets a value in member a
+     * @param _a New value for member a
+     */
+    eProsima_user_DllExport void a(
+            uint8_t _a)
+    {
+        a_() = _a;
+        m__d = 0;
+    }
+
+    /*!
+     * @brief This function returns the value of member a
+     * @return Value of member a
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport uint8_t a() const
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_a;
+    }
+
+    /*!
+     * @brief This function returns a reference to member a
+     * @return Reference to member a
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport uint8_t& a()
+    {
+        if (0x00000001 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_a;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member b
+     * @param _b New value for member b
+     */
+    eProsima_user_DllExport void b(
+            int16_t _b)
+    {
+        b_() = _b;
+        m__d = 1;
+    }
+
+    /*!
+     * @brief This function returns the value of member b
+     * @return Value of member b
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int16_t b() const
+    {
+        if (0x00000002 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_b;
+    }
+
+    /*!
+     * @brief This function returns a reference to member b
+     * @return Reference to member b
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport int16_t& b()
+    {
+        if (0x00000002 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_b;
+    }
+
+
+    void _default()
+    {
+        if (member_destructor_)
+        {
+            member_destructor_();
+        }
+
+        selected_member_ = 0x0FFFFFFFu;
+    }
+
+
+private:
+
+            uint8_t& a_()
+            {
+                if (0x00000001 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000001;
+                    member_destructor_ = nullptr;
+                    m_a = {0};
+
+                }
+
+                return m_a;
+            }
+
+            int16_t& b_()
+            {
+                if (0x00000002 != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x00000002;
+                    member_destructor_ = nullptr;
+                    m_b = {0};
+
+                }
+
+                return m_b;
+            }
+
+
+    int32_t m__d {2};
+
+    union
+    {
+        uint8_t m_a;
+        int16_t m_b;
+    };
+
+    uint32_t selected_member_ {0x0FFFFFFFu};
+
+    std::function<void()> member_destructor_;
+};
 
 #endif // _FAST_DDS_GENERATED_UNIONS_HPP_
 

--- a/test/dds-types-test/unionsCdrAux.hpp
+++ b/test/dds-types-test/unionsCdrAux.hpp
@@ -78,6 +78,7 @@ constexpr uint32_t UnionDiscriminatorUShort_max_key_cdr_typesize {0UL};
 
 
 
+
 constexpr uint32_t UnionLong_max_cdr_typesize {16UL};
 constexpr uint32_t UnionLong_max_key_cdr_typesize {0UL};
 
@@ -374,6 +375,7 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UnionSeveralFieldsWithDefault& data);
+
 
 
 

--- a/test/dds-types-test/unionsCdrAux.ipp
+++ b/test/dds-types-test/unionsCdrAux.ipp
@@ -8344,6 +8344,136 @@ eProsima_user_DllExport void deserialize(
             });
 }
 
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const DefaultAnnotationExternalValue& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0), data._d(),
+                    current_alignment);
+
+    switch (data._d())
+    {
+                case 0:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                                data.a(), current_alignment);
+                    break;
+
+                case 1:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                                data.b(), current_alignment);
+                    break;
+
+        default:
+            break;
+    }
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const DefaultAnnotationExternalValue& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr << eprosima::fastcdr::MemberId(0) << data._d();
+
+    switch (data._d())
+    {
+                case 0:
+                    scdr << eprosima::fastcdr::MemberId(1) << data.a();
+                    break;
+
+                case 1:
+                    scdr << eprosima::fastcdr::MemberId(2) << data.b();
+                    break;
+
+        default:
+            break;
+    }
+
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        DefaultAnnotationExternalValue& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                if (0 == mid.id)
+                {
+                    int32_t discriminator;
+                    dcdr >> discriminator;
+
+                    switch (discriminator)
+                    {
+                                                case 0:
+                                                    {
+                                                        uint8_t a_value{0};
+                                                        data.a(std::move(a_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
+                                                case 1:
+                                                    {
+                                                        int16_t b_value{0};
+                                                        data.b(std::move(b_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
+                        default:
+                            data._default();
+                            break;
+                    }
+                }
+                else
+                {
+                    switch (data._d())
+                    {
+                                                case 0:
+                                                    dcdr >> data.a();
+                                                    break;
+
+                                                case 1:
+                                                    dcdr >> data.b();
+                                                    break;
+
+                        default:
+                            break;
+                    }
+                    ret_value = false;
+                }
+                return ret_value;
+            });
+}
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/test/dds-types-test/unionsPubSubTypes.cxx
+++ b/test/dds-types-test/unionsPubSubTypes.cxx
@@ -7454,5 +7454,6 @@ void UnionSeveralFieldsWithDefaultPubSubType::register_type_object_representatio
 
 
 
+
 // Include auxiliary functions like for serializing/deserializing.
 #include "unionsCdrAux.ipp"

--- a/test/dds-types-test/unionsPubSubTypes.hpp
+++ b/test/dds-types-test/unionsPubSubTypes.hpp
@@ -3361,5 +3361,6 @@ private:
 };
 
 
+
 #endif // FAST_DDS_GENERATED__UNIONS_PUBSUBTYPES_HPP
 

--- a/test/dds-types-test/unionsTypeObjectSupport.cxx
+++ b/test/dds-types-test/unionsTypeObjectSupport.cxx
@@ -7098,4 +7098,134 @@ void register_DefaultAnnotation_type_identifier(
         }
     }
 }
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_DefaultAnnotationExternalValue_type_identifier(
+        TypeIdentifierPair& type_ids_DefaultAnnotationExternalValue)
+{
+    ReturnCode_t return_code_DefaultAnnotationExternalValue {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_DefaultAnnotationExternalValue =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "DefaultAnnotationExternalValue", type_ids_DefaultAnnotationExternalValue);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotationExternalValue)
+    {
+        UnionTypeFlag union_flags_DefaultAnnotationExternalValue = TypeObjectUtils::build_union_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_DefaultAnnotationExternalValue = "DefaultAnnotationExternalValue";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_DefaultAnnotationExternalValue;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_DefaultAnnotationExternalValue;
+        CompleteTypeDetail detail_DefaultAnnotationExternalValue = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_DefaultAnnotationExternalValue, ann_custom_DefaultAnnotationExternalValue, type_name_DefaultAnnotationExternalValue.to_string());
+        CompleteUnionHeader header_DefaultAnnotationExternalValue = TypeObjectUtils::build_complete_union_header(detail_DefaultAnnotationExternalValue);
+        UnionDiscriminatorFlag member_flags_DefaultAnnotationExternalValue = TypeObjectUtils::build_union_discriminator_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false);
+        return_code_DefaultAnnotationExternalValue =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "_int32_t", type_ids_DefaultAnnotationExternalValue);
+
+        if (return_code_DefaultAnnotationExternalValue != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "Union discriminator TypeIdentifier unknown to TypeObjectRegistry.");
+            return;
+        }
+        CommonDiscriminatorMember common_DefaultAnnotationExternalValue;
+        if (EK_COMPLETE == type_ids_DefaultAnnotationExternalValue.type_identifier1()._d() || TK_NONE == type_ids_DefaultAnnotationExternalValue.type_identifier2()._d())
+        {
+            common_DefaultAnnotationExternalValue = TypeObjectUtils::build_common_discriminator_member(member_flags_DefaultAnnotationExternalValue, type_ids_DefaultAnnotationExternalValue.type_identifier1());
+        }
+        else if (EK_COMPLETE == type_ids_DefaultAnnotationExternalValue.type_identifier2()._d())
+        {
+            common_DefaultAnnotationExternalValue = TypeObjectUtils::build_common_discriminator_member(member_flags_DefaultAnnotationExternalValue, type_ids_DefaultAnnotationExternalValue.type_identifier2());
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "DefaultAnnotationExternalValue discriminator TypeIdentifier inconsistent.");
+            return;
+        }
+        type_ann_builtin_DefaultAnnotationExternalValue.reset();
+        ann_custom_DefaultAnnotationExternalValue.reset();
+        AppliedAnnotationSeq tmp_ann_custom_discriminator;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_discriminator;
+        if (!tmp_ann_custom_discriminator.empty())
+        {
+            ann_custom_DefaultAnnotationExternalValue = tmp_ann_custom_discriminator;
+        }
+
+        CompleteDiscriminatorMember discriminator_DefaultAnnotationExternalValue = TypeObjectUtils::build_complete_discriminator_member(common_DefaultAnnotationExternalValue,
+                type_ann_builtin_DefaultAnnotationExternalValue, ann_custom_DefaultAnnotationExternalValue);
+        CompleteUnionMemberSeq member_seq_DefaultAnnotationExternalValue;
+        {
+            return_code_DefaultAnnotationExternalValue =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_byte", type_ids_DefaultAnnotationExternalValue);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotationExternalValue)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "a Union member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            UnionMemberFlag member_flags_a = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_a;
+            TypeObjectUtils::add_union_case_label(label_seq_a, static_cast<int32_t>(0));
+            MemberId member_id_a = 0x00000001;
+            bool common_a_ec {false};
+            CommonUnionMember common_a {TypeObjectUtils::build_common_union_member(member_id_a,
+                    member_flags_a, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_DefaultAnnotationExternalValue,
+                        common_a_ec), label_seq_a)};
+            if (!common_a_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union a member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_a = "a";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_a;
+            ann_custom_DefaultAnnotationExternalValue.reset();
+            CompleteMemberDetail detail_a = TypeObjectUtils::build_complete_member_detail(name_a, member_ann_builtin_a, ann_custom_DefaultAnnotationExternalValue);
+            CompleteUnionMember member_a = TypeObjectUtils::build_complete_union_member(common_a, detail_a);
+            TypeObjectUtils::add_complete_union_member(member_seq_DefaultAnnotationExternalValue, member_a);
+        }
+        {
+            return_code_DefaultAnnotationExternalValue =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int16_t", type_ids_DefaultAnnotationExternalValue);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_DefaultAnnotationExternalValue)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "b Union member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            UnionMemberFlag member_flags_b = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_b;
+            TypeObjectUtils::add_union_case_label(label_seq_b, static_cast<int32_t>(1));
+            MemberId member_id_b = 0x00000002;
+            bool common_b_ec {false};
+            CommonUnionMember common_b {TypeObjectUtils::build_common_union_member(member_id_b,
+                    member_flags_b, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_DefaultAnnotationExternalValue,
+                        common_b_ec), label_seq_b)};
+            if (!common_b_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union b member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_b = "b";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_b;
+            ann_custom_DefaultAnnotationExternalValue.reset();
+            CompleteMemberDetail detail_b = TypeObjectUtils::build_complete_member_detail(name_b, member_ann_builtin_b, ann_custom_DefaultAnnotationExternalValue);
+            CompleteUnionMember member_b = TypeObjectUtils::build_complete_union_member(common_b, detail_b);
+            TypeObjectUtils::add_complete_union_member(member_seq_DefaultAnnotationExternalValue, member_b);
+        }
+        CompleteUnionType union_type_DefaultAnnotationExternalValue = TypeObjectUtils::build_complete_union_type(union_flags_DefaultAnnotationExternalValue, header_DefaultAnnotationExternalValue, discriminator_DefaultAnnotationExternalValue,
+                member_seq_DefaultAnnotationExternalValue);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_union_type_object(union_type_DefaultAnnotationExternalValue, type_name_DefaultAnnotationExternalValue.to_string(), type_ids_DefaultAnnotationExternalValue))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "DefaultAnnotationExternalValue already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
 

--- a/test/dds-types-test/unionsTypeObjectSupport.hpp
+++ b/test/dds-types-test/unionsTypeObjectSupport.hpp
@@ -1034,6 +1034,18 @@ eProsima_user_DllExport void register_UnionSeveralFieldsWithDefault_type_identif
  */
 eProsima_user_DllExport void register_DefaultAnnotation_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register DefaultAnnotationExternalValue related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_DefaultAnnotationExternalValue_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesArraysDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesArraysDDSTypesTests.cpp
@@ -45,6 +45,7 @@ constexpr const char* double_array_struct_name = "ArrayDouble";
 constexpr const char* longdouble_array_struct_name = "ArrayLongDouble";
 constexpr const char* bool_array_struct_name = "ArrayBoolean";
 constexpr const char* byte_array_struct_name = "ArrayOctet";
+constexpr const char* uint8_array_struct_name = "ArrayUInt8";
 constexpr const char* char_array_struct_name = "ArrayChar";
 constexpr const char* wchar_array_struct_name = "ArrayWChar";
 constexpr const char* string_array_struct_name = "ArrayString";
@@ -98,6 +99,7 @@ constexpr const char* var_double_array = "var_array_double";
 constexpr const char* var_longdouble_array = "var_array_longdouble";
 constexpr const char* var_bool_array = "var_array_boolean";
 constexpr const char* var_byte_array = "var_array_octet";
+constexpr const char* var_uint8_array = "var_array_uint8";
 constexpr const char* var_char_array = "var_array_char";
 constexpr const char* var_wchar_array = "var_array_wchar";
 constexpr const char* var_string_array = "var_array_string";
@@ -586,6 +588,65 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayOctet)
     check_typeobject_registry(struct_type, static_type_ids);
 
     EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+void DDSTypesTest_ArrayUInt8_common()
+{
+    eprosima::fastdds::dds::DynamicTypesDDSTypesTest_DDSTypesTest_ArrayOctet_Test support;
+
+    TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
+    type_descriptor->kind(TK_STRUCTURE);
+    type_descriptor->name(uint8_array_struct_name);
+    DynamicTypeBuilder::_ref_type type_builder {DynamicTypeBuilderFactory::get_instance()->create_type(type_descriptor)};
+    ASSERT_TRUE(type_builder);
+
+    MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
+    member_descriptor->name(var_uint8_array);
+    member_descriptor->type(DynamicTypeBuilderFactory::get_instance()->create_array_type(DynamicTypeBuilderFactory::
+                    get_instance()->get_primitive_type(TK_UINT8), {10})->build());
+    type_builder->add_member(member_descriptor);
+
+    DynamicType::_ref_type struct_type {type_builder->build()};
+    DynamicData::_ref_type data {DynamicDataFactory::get_instance()->create_data(struct_type)};
+    ASSERT_TRUE(data);
+
+    UInt8Seq value = {0, 1, 2, 4, 8, 16, 32, 64, 128, 255};
+    UInt8Seq test_value;
+    EXPECT_EQ(data->set_uint8_values(data->get_member_id_by_name(var_uint8_array), value), RETCODE_OK);
+    EXPECT_EQ(data->get_uint8_values(test_value, data->get_member_id_by_name(var_uint8_array)), RETCODE_OK);
+    EXPECT_EQ(value, test_value);
+
+    for (auto encoding : encodings)
+    {
+        ArrayUInt8 struct_data;
+        TypeSupport static_pubsubType {new ArrayUInt8PubSubType()};
+        support.check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
+        EXPECT_EQ(struct_data.var_array_uint8().size(), test_value.size());
+        for (size_t i = 0; i < test_value.size(); ++i)
+        {
+            EXPECT_EQ(struct_data.var_array_uint8()[i], test_value[i]);
+        }
+    }
+
+    xtypes::TypeIdentifierPair static_type_ids;
+    register_ArrayUInt8_type_identifier(static_type_ids);
+    support.check_typeobject_registry(struct_type, static_type_ids);
+
+    EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
+}
+
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayUInt8)
+{
+    DDSTypesTest_ArrayUInt8_common();
+}
+
+// Regression test for redmine ticket #20878.
+TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayUInt8_Regression20878)
+{
+    xtypes::TypeIdentifierPair regression_type_ids;
+    register_ArrayOctet_type_identifier(regression_type_ids);
+
+    DDSTypesTest_ArrayUInt8_common();
 }
 
 TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayChar)

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesArraysDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesArraysDDSTypesTests.cpp
@@ -590,10 +590,9 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayOctet)
     EXPECT_EQ(DynamicDataFactory::get_instance()->delete_data(data), RETCODE_OK);
 }
 
-void DDSTypesTest_ArrayUInt8_common()
+void DDSTypesTest_ArrayUInt8_common(
+        DynamicTypesDDSTypesTest& support)
 {
-    eprosima::fastdds::dds::DynamicTypesDDSTypesTest_DDSTypesTest_ArrayOctet_Test support;
-
     TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
     type_descriptor->kind(TK_STRUCTURE);
     type_descriptor->name(uint8_array_struct_name);
@@ -637,7 +636,7 @@ void DDSTypesTest_ArrayUInt8_common()
 
 TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayUInt8)
 {
-    DDSTypesTest_ArrayUInt8_common();
+    DDSTypesTest_ArrayUInt8_common(*this);
 }
 
 // Regression test for redmine ticket #20878.
@@ -646,7 +645,7 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayUInt8_Regression20878)
     xtypes::TypeIdentifierPair regression_type_ids;
     register_ArrayOctet_type_identifier(regression_type_ids);
 
-    DDSTypesTest_ArrayUInt8_common();
+    DDSTypesTest_ArrayUInt8_common(*this);
 }
 
 TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_ArrayChar)

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeTypeObjectSupport.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeTypeObjectSupport.cxx
@@ -1253,7 +1253,7 @@ void register_ContentFilterTestType_type_identifier(
             ReturnCode_t return_code_array_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_array_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_array_uint8_t_3", type_ids_array_uint8_field);
+                "anonymous_array_byte_3", type_ids_array_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_array_uint8_field)
             {
@@ -1267,31 +1267,31 @@ void register_ContentFilterTestType_type_identifier(
                             "Array element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_array_uint8_t_3_ec {false};
-                TypeIdentifier* element_identifier_anonymous_array_uint8_t_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_uint8_t_3_ec))};
-                if (!element_identifier_anonymous_array_uint8_t_3_ec)
+                bool element_identifier_anonymous_array_byte_3_ec {false};
+                TypeIdentifier* element_identifier_anonymous_array_byte_3 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_array_uint8_field, element_identifier_anonymous_array_byte_3_ec))};
+                if (!element_identifier_anonymous_array_byte_3_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Array element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_array_uint8_t_3 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_array_byte_3 = EK_COMPLETE;
                 if (TK_NONE == type_ids_array_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_array_uint8_t_3 = EK_BOTH;
+                    equiv_kind_anonymous_array_byte_3 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_array_uint8_t_3 = 0;
-                PlainCollectionHeader header_anonymous_array_uint8_t_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_uint8_t_3, element_flags_anonymous_array_uint8_t_3);
+                CollectionElementFlag element_flags_anonymous_array_byte_3 = 0;
+                PlainCollectionHeader header_anonymous_array_byte_3 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_array_byte_3, element_flags_anonymous_array_byte_3);
                 {
                     SBoundSeq array_bound_seq;
                         TypeObjectUtils::add_array_dimension(array_bound_seq, static_cast<SBound>(3));
 
-                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_uint8_t_3, array_bound_seq,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_uint8_t_3));
+                    PlainArraySElemDefn array_sdefn = TypeObjectUtils::build_plain_array_s_elem_defn(header_anonymous_array_byte_3, array_bound_seq,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_array_byte_3));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_uint8_t_3", type_ids_array_uint8_field))
+                            TypeObjectUtils::build_and_register_s_array_type_identifier(array_sdefn, "anonymous_array_byte_3", type_ids_array_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_array_uint8_t_3 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_array_byte_3 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -2277,7 +2277,7 @@ void register_ContentFilterTestType_type_identifier(
             ReturnCode_t return_code_bounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_bounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field);
+                "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_bounded_sequence_uint8_field)
             {
@@ -2291,29 +2291,29 @@ void register_ContentFilterTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_5_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_5_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_5_ec)
+                bool element_identifier_anonymous_sequence_byte_5_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_5 {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_bounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_5_ec))};
+                if (!element_identifier_anonymous_sequence_byte_5_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_5 = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_5 = EK_COMPLETE;
                 if (TK_NONE == type_ids_bounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_5 = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_5 = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_5 = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_5, element_flags_anonymous_sequence_uint8_t_5);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_5 = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_5 = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_5, element_flags_anonymous_sequence_byte_5);
                 {
                     SBound bound = static_cast<SBound>(5);
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_5, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_5));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_5, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_5));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_5", type_ids_bounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_5", type_ids_bounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_5 already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_5 already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
@@ -3271,7 +3271,7 @@ void register_ContentFilterTestType_type_identifier(
             ReturnCode_t return_code_unbounded_sequence_uint8_field {eprosima::fastdds::dds::RETCODE_OK};
             return_code_unbounded_sequence_uint8_field =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field);
+                "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_unbounded_sequence_uint8_field)
             {
@@ -3285,29 +3285,29 @@ void register_ContentFilterTestType_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_unbounded_sequence_uint8_field, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_unbounded_sequence_uint8_field.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded, element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint8_t_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint8_t_unbounded", type_ids_unbounded_sequence_uint8_field))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_unbounded_sequence_uint8_field))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds a regression test for changes in generated coded coming from eprosima/fast-dds-gen#400 

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

