### PR TITLE
[21745] Add QoS getters from raw XML

### DIFF
--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -936,7 +936,7 @@ public:
      *
      * @return true if any, false otherwise.
      */
-    bool has_active_entities();
+    FASTDDS_EXPORTED_API bool has_active_entities();
 
 protected:
 

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -665,9 +665,17 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_profile(
+            const std::string& profile_name,
+            TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type) const;
+
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type,
             const std::string& profile_name = "") const;
 
     /**

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -547,6 +547,11 @@ public:
             const std::string& profile_name,
             PublisherQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& xml,
+            PublisherQos& qos,
+            const std::string& profile_name = "") const;
+
     /**
      * This operation sets a default value of the Subscriber QoS policies that will be used for newly created
      * Subscriber entities in the case where the QoS policies are defaulted in the create_subscriber operation.
@@ -600,6 +605,11 @@ public:
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_profile(
             const std::string& profile_name,
             SubscriberQos& qos) const;
+
+    FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& xml,
+            SubscriberQos& qos,
+            const std::string& profile_name = "") const;
 
     /**
      * This operation sets a default value of the Topic QoS policies which will be used for newly created
@@ -655,6 +665,11 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            const std::string& profile_name = "") const;
+
     /**
      * Fills the ReplierQos with the values of the XML profile.
      *
@@ -666,6 +681,11 @@ public:
             const std::string& profile_name,
             ReplierQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
+            const std::string& xml,
+            ReplierQos& qos,
+            const std::string& profile_name = "") const;
+
     /**
      * Fills the RequesterQos with the values of the XML profile.
      *
@@ -676,6 +696,11 @@ public:
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_profile(
             const std::string& profile_name,
             RequesterQos& qos) const;
+
+    FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
+            const std::string& xml,
+            RequesterQos& qos,
+            const std::string& profile_name = "") const;
 
     /**
      * Retrieves the list of DomainParticipants that have been discovered in the domain and are not "ignored".

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -697,6 +697,19 @@ public:
             std::string& topic_data_type) const;
 
     /**
+     * Fills the TopicQos with the first topic profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @param profile_name Topic profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            const std::string& profile_name = "") const;
+
+    /**
      * Fills the TopicQos with the first topic profile found in the given XML (or the one specified), and also its corresponding topic and data type names (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -547,6 +547,14 @@ public:
             const std::string& profile_name,
             PublisherQos& qos) const;
 
+    /**
+     * Fills the PublisherQos with the first publisher profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos PublisherQos object where the qos is returned.
+     * @param profile_name Publisher profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
             const std::string& xml,
             PublisherQos& qos,
@@ -606,6 +614,14 @@ public:
             const std::string& profile_name,
             SubscriberQos& qos) const;
 
+    /**
+     * Fills the SubscriberQos with the first subscriber profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos SubscriberQos object where the qos is returned.
+     * @param profile_name Subscriber profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& xml,
             SubscriberQos& qos,
@@ -665,12 +681,31 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
+    /**
+     * Fills the TopicQos with the values of the XML profile, and also its corresponding topic and data type names (if specified).
+     *
+     * @param profile_name Topic profile name.
+     * @param qos TopicQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
+     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_profile(
             const std::string& profile_name,
             TopicQos& qos,
             std::string& topic_name,
             std::string& topic_data_type) const;
 
+    /**
+     * Fills the TopicQos with the first topic profile found in the given XML (or the one specified), and also its corresponding topic and data type names (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
+     * @param profile_name Topic profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos,
@@ -689,6 +724,14 @@ public:
             const std::string& profile_name,
             ReplierQos& qos) const;
 
+    /**
+     * Fills the ReplierQos with the first replier profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos ReplierQos object where the qos is returned.
+     * @param profile_name Replier profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
             const std::string& xml,
             ReplierQos& qos,
@@ -705,6 +748,14 @@ public:
             const std::string& profile_name,
             RequesterQos& qos) const;
 
+    /**
+     * Fills the RequesterQos with the first requester profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos RequesterQos object where the qos is returned.
+     * @param profile_name Requester profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
             const std::string& xml,
             RequesterQos& qos,

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -548,17 +548,39 @@ public:
             PublisherQos& qos) const;
 
     /**
-     * Fills the PublisherQos with the first publisher profile found in the given XML (or the one specified).
+     * Fills the PublisherQos with the first publisher profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos PublisherQos object where the qos is returned.
-     * @param profile_name Publisher profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& xml,
+            PublisherQos& qos) const;
+
+    /**
+     * Fills the PublisherQos with the publisher profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos PublisherQos object where the qos is returned.
+     * @param profile_name Publisher profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
             const std::string& xml,
             PublisherQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the PublisherQos with the default publisher profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos PublisherQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_publisher_qos_from_xml(
+            const std::string& xml,
+            PublisherQos& qos) const;
 
     /**
      * This operation sets a default value of the Subscriber QoS policies that will be used for newly created
@@ -615,17 +637,39 @@ public:
             SubscriberQos& qos) const;
 
     /**
-     * Fills the SubscriberQos with the first subscriber profile found in the given XML (or the one specified).
+     * Fills the SubscriberQos with the first subscriber profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos SubscriberQos object where the qos is returned.
-     * @param profile_name Subscriber profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& xml,
+            SubscriberQos& qos) const;
+
+    /**
+     * Fills the SubscriberQos with the subscriber profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos SubscriberQos object where the qos is returned.
+     * @param profile_name Subscriber profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& xml,
             SubscriberQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the SubscriberQos with the default subscriber profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos SubscriberQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_subscriber_qos_from_xml(
+            const std::string& xml,
+            SubscriberQos& qos) const;
 
     /**
      * This operation sets a default value of the Topic QoS policies which will be used for newly created
@@ -697,26 +741,52 @@ public:
             std::string& topic_data_type) const;
 
     /**
-     * Fills the TopicQos with the first topic profile found in the given XML (or the one specified).
+     * Fills the TopicQos with the first topic profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos TopicQos object where the qos is returned.
-     * @param profile_name Topic profile name. Empty by default (first one found).
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
-            TopicQos& qos,
-            const std::string& profile_name = "") const;
+            TopicQos& qos) const;
 
     /**
-     * Fills the TopicQos with the first topic profile found in the given XML (or the one specified), and also its corresponding topic and data type names (if specified).
+     * Fills the TopicQos with the first topic profile found in the provided XML, and also its corresponding topic and data type names (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
-     * @param profile_name Topic profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type) const;
+
+    /**
+     * Fills the TopicQos with the topic profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @param profile_name Topic profile name.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the TopicQos with the topic profile with \c profile_name to be found in the provided XML, and also its corresponding topic and data type names (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
+     * @param profile_name Topic profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
@@ -724,7 +794,33 @@ public:
             TopicQos& qos,
             std::string& topic_name,
             std::string& topic_data_type,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the TopicQos with the default topic profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos) const;
+
+    /**
+     * Fills the TopicQos with the default topic profile found in the provided XML (if there is), and also its corresponding topic and data type names (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos TopicQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type) const;
 
     /**
      * Fills the ReplierQos with the values of the XML profile.
@@ -738,17 +834,39 @@ public:
             ReplierQos& qos) const;
 
     /**
-     * Fills the ReplierQos with the first replier profile found in the given XML (or the one specified).
+     * Fills the ReplierQos with the first replier profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos ReplierQos object where the qos is returned.
-     * @param profile_name Replier profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
+            const std::string& xml,
+            ReplierQos& qos) const;
+
+    /**
+     * Fills the ReplierQos with the replier profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos ReplierQos object where the qos is returned.
+     * @param profile_name Replier profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
             const std::string& xml,
             ReplierQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the ReplierQos with the default replier profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos ReplierQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_replier_qos_from_xml(
+            const std::string& xml,
+            ReplierQos& qos) const;
 
     /**
      * Fills the RequesterQos with the values of the XML profile.
@@ -762,17 +880,39 @@ public:
             RequesterQos& qos) const;
 
     /**
-     * Fills the RequesterQos with the first requester profile found in the given XML (or the one specified).
+     * Fills the RequesterQos with the first requester profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos RequesterQos object where the qos is returned.
-     * @param profile_name Requester profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
+            const std::string& xml,
+            RequesterQos& qos) const;
+
+    /**
+     * Fills the RequesterQos with the requester profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos RequesterQos object where the qos is returned.
+     * @param profile_name Requester profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
             const std::string& xml,
             RequesterQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the RequesterQos with the default requester profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos RequesterQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_requester_qos_from_xml(
+            const std::string& xml,
+            RequesterQos& qos) const;
 
     /**
      * Retrieves the list of DomainParticipants that have been discovered in the domain and are not "ignored".

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -574,6 +574,8 @@ public:
     /**
      * Fills the PublisherQos with the default publisher profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default publisher qos (returned by \c get_default_publisher_qos).
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos PublisherQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -662,6 +664,8 @@ public:
 
     /**
      * Fills the SubscriberQos with the default subscriber profile found in the provided XML (if there is).
+     *
+     * @note This method does not update the default subscriber qos (returned by \c get_default_subscriber_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos SubscriberQos object where the qos is returned.
@@ -799,6 +803,8 @@ public:
     /**
      * Fills the TopicQos with the default topic profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default topic qos (returned by \c get_default_topic_qos).
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos TopicQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -809,6 +815,8 @@ public:
 
     /**
      * Fills the TopicQos with the default topic profile found in the provided XML (if there is), and also its corresponding topic and data type names (if specified).
+     *
+     * @note This method does not update the default topic qos (returned by \c get_default_topic_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos TopicQos object where the qos is returned.
@@ -860,6 +868,8 @@ public:
     /**
      * Fills the ReplierQos with the default replier profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default replier qos.
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos ReplierQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -905,6 +915,8 @@ public:
 
     /**
      * Fills the RequesterQos with the default requester profile found in the provided XML (if there is).
+     *
+     * @note This method does not update the default requester qos.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos RequesterQos object where the qos is returned.

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -541,7 +541,7 @@ public:
      *
      * @param profile_name Publisher profile name.
      * @param qos @ref PublisherQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_profile(
             const std::string& profile_name,
@@ -632,7 +632,7 @@ public:
      *
      * @param profile_name Subscriber profile name.
      * @param qos @ref SubscriberQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_profile(
             const std::string& profile_name,
@@ -723,7 +723,7 @@ public:
      *
      * @param profile_name Topic profile name.
      * @param qos @ref TopicQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_profile(
             const std::string& profile_name,
@@ -736,7 +736,7 @@ public:
      * @param qos @ref TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_profile(
             const std::string& profile_name,
@@ -835,7 +835,7 @@ public:
      *
      * @param profile_name Replier profile name.
      * @param qos @ref ReplierQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_profile(
             const std::string& profile_name,
@@ -883,7 +883,7 @@ public:
      *
      * @param profile_name Requester profile name.
      * @param qos @ref RequesterQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_profile(
             const std::string& profile_name,

--- a/include/fastdds/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/dds/domain/DomainParticipant.hpp
@@ -537,10 +537,10 @@ public:
             PublisherQos& qos) const;
 
     /**
-     * Fills the PublisherQos with the values of the XML profile.
+     * Fills the @ref PublisherQos with the values of the XML profile.
      *
      * @param profile_name Publisher profile name.
-     * @param qos PublisherQos object where the qos is returned.
+     * @param qos @ref PublisherQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_profile(
@@ -548,23 +548,23 @@ public:
             PublisherQos& qos) const;
 
     /**
-     * Fills the PublisherQos with the first publisher profile found in the provided XML.
+     * Fills the @ref PublisherQos with the first publisher profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos PublisherQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref PublisherQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
             const std::string& xml,
             PublisherQos& qos) const;
 
     /**
-     * Fills the PublisherQos with the publisher profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref PublisherQos with the publisher profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos PublisherQos object where the qos is returned.
+     * @param qos @ref PublisherQos object where the qos is returned.
      * @param profile_name Publisher profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_publisher_qos_from_xml(
             const std::string& xml,
@@ -572,13 +572,13 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the PublisherQos with the default publisher profile found in the provided XML (if there is).
+     * Fills the @ref PublisherQos with the default publisher profile found in the provided XML (if there is).
      *
      * @note This method does not update the default publisher qos (returned by \c get_default_publisher_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos PublisherQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref PublisherQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_publisher_qos_from_xml(
             const std::string& xml,
@@ -628,10 +628,10 @@ public:
             SubscriberQos& qos) const;
 
     /**
-     * Fills the SubscriberQos with the values of the XML profile.
+     * Fills the @ref SubscriberQos with the values of the XML profile.
      *
      * @param profile_name Subscriber profile name.
-     * @param qos SubscriberQos object where the qos is returned.
+     * @param qos @ref SubscriberQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_profile(
@@ -639,23 +639,23 @@ public:
             SubscriberQos& qos) const;
 
     /**
-     * Fills the SubscriberQos with the first subscriber profile found in the provided XML.
+     * Fills the @ref SubscriberQos with the first subscriber profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos SubscriberQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref SubscriberQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& xml,
             SubscriberQos& qos) const;
 
     /**
-     * Fills the SubscriberQos with the subscriber profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref SubscriberQos with the subscriber profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos SubscriberQos object where the qos is returned.
+     * @param qos @ref SubscriberQos object where the qos is returned.
      * @param profile_name Subscriber profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& xml,
@@ -663,13 +663,13 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the SubscriberQos with the default subscriber profile found in the provided XML (if there is).
+     * Fills the @ref SubscriberQos with the default subscriber profile found in the provided XML (if there is).
      *
      * @note This method does not update the default subscriber qos (returned by \c get_default_subscriber_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos SubscriberQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref SubscriberQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_subscriber_qos_from_xml(
             const std::string& xml,
@@ -719,10 +719,10 @@ public:
             TopicQos& qos) const;
 
     /**
-     * Fills the TopicQos with the values of the XML profile.
+     * Fills the @ref TopicQos with the values of the XML profile.
      *
      * @param profile_name Topic profile name.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_profile(
@@ -730,10 +730,10 @@ public:
             TopicQos& qos) const;
 
     /**
-     * Fills the TopicQos with the values of the XML profile, and also its corresponding topic and data type names (if specified).
+     * Fills the @ref TopicQos with the values of the XML profile, and also its corresponding topic and data type names (if specified).
      *
      * @param profile_name Topic profile name.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
@@ -745,24 +745,24 @@ public:
             std::string& topic_data_type) const;
 
     /**
-     * Fills the TopicQos with the first topic profile found in the provided XML.
+     * Fills the @ref TopicQos with the first topic profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref TopicQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos) const;
 
     /**
-     * Fills the TopicQos with the first topic profile found in the provided XML, and also its corresponding topic and data type names (if specified).
+     * Fills the @ref TopicQos with the first topic profile found in the provided XML, and also its corresponding topic and data type names (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
@@ -771,12 +771,12 @@ public:
             std::string& topic_data_type) const;
 
     /**
-     * Fills the TopicQos with the topic profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref TopicQos with the topic profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @param profile_name Topic profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
@@ -784,14 +784,14 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the TopicQos with the topic profile with \c profile_name to be found in the provided XML, and also its corresponding topic and data type names (if specified).
+     * Fills the @ref TopicQos with the topic profile with \c profile_name to be found in the provided XML, and also its corresponding topic and data type names (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
      * @param profile_name Topic profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
@@ -801,28 +801,28 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the TopicQos with the default topic profile found in the provided XML (if there is).
+     * Fills the @ref TopicQos with the default topic profile found in the provided XML (if there is).
      *
      * @note This method does not update the default topic qos (returned by \c get_default_topic_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref TopicQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos) const;
 
     /**
-     * Fills the TopicQos with the default topic profile found in the provided XML (if there is), and also its corresponding topic and data type names (if specified).
+     * Fills the @ref TopicQos with the default topic profile found in the provided XML (if there is), and also its corresponding topic and data type names (if specified).
      *
      * @note This method does not update the default topic qos (returned by \c get_default_topic_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos TopicQos object where the qos is returned.
+     * @param qos @ref TopicQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param topic_data_type String where the name of the topic data type associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_topic_qos_from_xml(
             const std::string& xml,
@@ -831,10 +831,10 @@ public:
             std::string& topic_data_type) const;
 
     /**
-     * Fills the ReplierQos with the values of the XML profile.
+     * Fills the @ref ReplierQos with the values of the XML profile.
      *
      * @param profile_name Replier profile name.
-     * @param qos ReplierQos object where the qos is returned.
+     * @param qos @ref ReplierQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_profile(
@@ -842,23 +842,23 @@ public:
             ReplierQos& qos) const;
 
     /**
-     * Fills the ReplierQos with the first replier profile found in the provided XML.
+     * Fills the @ref ReplierQos with the first replier profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos ReplierQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref ReplierQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
             const std::string& xml,
             ReplierQos& qos) const;
 
     /**
-     * Fills the ReplierQos with the replier profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref ReplierQos with the replier profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos ReplierQos object where the qos is returned.
+     * @param qos @ref ReplierQos object where the qos is returned.
      * @param profile_name Replier profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_replier_qos_from_xml(
             const std::string& xml,
@@ -866,23 +866,23 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the ReplierQos with the default replier profile found in the provided XML (if there is).
+     * Fills the @ref ReplierQos with the default replier profile found in the provided XML (if there is).
      *
      * @note This method does not update the default replier qos.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos ReplierQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref ReplierQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_replier_qos_from_xml(
             const std::string& xml,
             ReplierQos& qos) const;
 
     /**
-     * Fills the RequesterQos with the values of the XML profile.
+     * Fills the @ref RequesterQos with the values of the XML profile.
      *
      * @param profile_name Requester profile name.
-     * @param qos RequesterQos object where the qos is returned.
+     * @param qos @ref RequesterQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_profile(
@@ -890,23 +890,23 @@ public:
             RequesterQos& qos) const;
 
     /**
-     * Fills the RequesterQos with the first requester profile found in the provided XML.
+     * Fills the @ref RequesterQos with the first requester profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos RequesterQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref RequesterQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
             const std::string& xml,
             RequesterQos& qos) const;
 
     /**
-     * Fills the RequesterQos with the requester profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref RequesterQos with the requester profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos RequesterQos object where the qos is returned.
+     * @param qos @ref RequesterQos object where the qos is returned.
      * @param profile_name Requester profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_requester_qos_from_xml(
             const std::string& xml,
@@ -914,13 +914,13 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the RequesterQos with the default requester profile found in the provided XML (if there is).
+     * Fills the @ref RequesterQos with the default requester profile found in the provided XML (if there is).
      *
      * @note This method does not update the default requester qos.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos RequesterQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref RequesterQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_requester_qos_from_xml(
             const std::string& xml,

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -256,6 +256,8 @@ public:
     /**
      * Fills the DomainParticipantQos with the default DomainParticipant profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default participant qos (returned by \c get_default_participant_qos).
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DomainParticipantQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -301,6 +303,8 @@ public:
 
     /**
      * Fills the DomainParticipantExtendedQos with the default DomainParticipant profile found in the provided XML (if there is).
+     *
+     * @note This method does not update the default participant extended qos.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
      * @param qos DomainParticipantExtendedQos object where the qos is returned.

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -219,10 +219,10 @@ public:
             const DomainParticipantQos& qos);
 
     /**
-     * Fills the DomainParticipantQos with the values of the XML profile.
+     * Fills the @ref DomainParticipantQos with the values of the XML profile.
      *
      * @param profile_name DomainParticipant profile name.
-     * @param qos DomainParticipantQos object where the qos is returned.
+     * @param qos @ref DomainParticipantQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_profile(
@@ -230,23 +230,23 @@ public:
             DomainParticipantQos& qos) const;
 
     /**
-     * Fills the DomainParticipantQos with the first DomainParticipant profile found in the provided XML.
+     * Fills the @ref DomainParticipantQos with the first DomainParticipant profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DomainParticipantQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DomainParticipantQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
             const std::string& xml,
             DomainParticipantQos& qos) const;
 
     /**
-     * Fills the DomainParticipantQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref DomainParticipantQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DomainParticipantQos object where the qos is returned.
+     * @param qos @ref DomainParticipantQos object where the qos is returned.
      * @param profile_name DomainParticipant profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
             const std::string& xml,
@@ -254,20 +254,20 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DomainParticipantQos with the default DomainParticipant profile found in the provided XML (if there is).
+     * Fills the @ref DomainParticipantQos with the default DomainParticipant profile found in the provided XML (if there is).
      *
      * @note This method does not update the default participant qos (returned by \c get_default_participant_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DomainParticipantQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DomainParticipantQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_participant_qos_from_xml(
             const std::string& xml,
             DomainParticipantQos& qos) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the values of the XML profile.
+     * Fills the @ref DomainParticipantExtendedQos with the values of the XML profile.
      *
      * @param profile_name DomainParticipant profile name.
      * @param extended_qos DomainParticipantExtendedQos object where the domain and qos are returned.
@@ -278,23 +278,23 @@ public:
             DomainParticipantExtendedQos& extended_qos) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the first DomainParticipant profile found in the provided XML.
+     * Fills the @ref DomainParticipantExtendedQos with the first DomainParticipant profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
-     * @param extended_qos DomainParticipantExtendedQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param extended_qos @ref DomainParticipantExtendedQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
             const std::string& xml,
             DomainParticipantExtendedQos& extended_qos) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref DomainParticipantExtendedQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
-     * @param extended_qos DomainParticipantExtendedQos object where the qos is returned.
+     * @param extended_qos @ref DomainParticipantExtendedQos object where the qos is returned.
      * @param profile_name DomainParticipant profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
             const std::string& xml,
@@ -302,22 +302,22 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the default DomainParticipant profile found in the provided XML (if there is).
+     * Fills the @ref DomainParticipantExtendedQos with the default DomainParticipant profile found in the provided XML (if there is).
      *
      * @note This method does not update the default participant extended qos.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
-     * @param qos DomainParticipantExtendedQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param extended_qos @ref DomainParticipantExtendedQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_participant_extended_qos_from_xml(
             const std::string& xml,
             DomainParticipantExtendedQos& extended_qos) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the values of the default XML profile.
+     * Fills the @ref DomainParticipantExtendedQos with the values of the default XML profile.
      *
-     * @param extended_qos DomainParticipantExtendedQos object where the domain and qos are returned.
+     * @param extended_qos @ref DomainParticipantExtendedQos object where the domain and qos are returned.
      * @return RETCODE_OK
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_default_profile(

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -257,7 +257,7 @@ public:
      * Fills the DomainParticipantExtendedQos with the first DomainParticipant profile found in the given XML (or the one specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DomainParticipantExtendedQos object where the qos is returned.
+     * @param extended_qos DomainParticipantExtendedQos object where the qos is returned.
      * @param profile_name DomainParticipant profile name. Empty by default (first one found).
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -229,6 +229,11 @@ public:
             const std::string& profile_name,
             DomainParticipantQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantQos& qos,
+            const std::string& profile_name = "") const;
+
     /**
      * Fills the DomainParticipantExtendedQos with the values of the XML profile.
      *

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -245,6 +245,11 @@ public:
             const std::string& profile_name,
             DomainParticipantExtendedQos& extended_qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantExtendedQos& extended_qos,
+            const std::string& profile_name = "") const;
+
     /**
      * Fills the DomainParticipantExtendedQos with the values of the default XML profile.
      *

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -229,6 +229,14 @@ public:
             const std::string& profile_name,
             DomainParticipantQos& qos) const;
 
+    /**
+     * Fills the DomainParticipantQos with the first DomainParticipant profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DomainParticipantQos object where the qos is returned.
+     * @param profile_name DomainParticipant profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
             const std::string& xml,
             DomainParticipantQos& qos,
@@ -245,6 +253,14 @@ public:
             const std::string& profile_name,
             DomainParticipantExtendedQos& extended_qos) const;
 
+    /**
+     * Fills the DomainParticipantExtendedQos with the first DomainParticipant profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DomainParticipantExtendedQos object where the qos is returned.
+     * @param profile_name DomainParticipant profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
             const std::string& xml,
             DomainParticipantExtendedQos& extended_qos,

--- a/include/fastdds/dds/domain/DomainParticipantFactory.hpp
+++ b/include/fastdds/dds/domain/DomainParticipantFactory.hpp
@@ -230,17 +230,39 @@ public:
             DomainParticipantQos& qos) const;
 
     /**
-     * Fills the DomainParticipantQos with the first DomainParticipant profile found in the given XML (or the one specified).
+     * Fills the DomainParticipantQos with the first DomainParticipant profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DomainParticipantQos object where the qos is returned.
-     * @param profile_name DomainParticipant profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantQos& qos) const;
+
+    /**
+     * Fills the DomainParticipantQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DomainParticipantQos object where the qos is returned.
+     * @param profile_name DomainParticipant profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_qos_from_xml(
             const std::string& xml,
             DomainParticipantQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DomainParticipantQos with the default DomainParticipant profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DomainParticipantQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_participant_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantQos& qos) const;
 
     /**
      * Fills the DomainParticipantExtendedQos with the values of the XML profile.
@@ -254,17 +276,39 @@ public:
             DomainParticipantExtendedQos& extended_qos) const;
 
     /**
-     * Fills the DomainParticipantExtendedQos with the first DomainParticipant profile found in the given XML (or the one specified).
+     * Fills the DomainParticipantExtendedQos with the first DomainParticipant profile found in the provided XML.
      *
-     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
      * @param extended_qos DomainParticipantExtendedQos object where the qos is returned.
-     * @param profile_name DomainParticipant profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantExtendedQos& extended_qos) const;
+
+    /**
+     * Fills the DomainParticipantExtendedQos with the DomainParticipant profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
+     * @param extended_qos DomainParticipantExtendedQos object where the qos is returned.
+     * @param profile_name DomainParticipant profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_participant_extended_qos_from_xml(
             const std::string& xml,
             DomainParticipantExtendedQos& extended_qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DomainParticipantExtendedQos with the default DomainParticipant profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c extended_qos structure.
+     * @param qos DomainParticipantExtendedQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_participant_extended_qos_from_xml(
+            const std::string& xml,
+            DomainParticipantExtendedQos& extended_qos) const;
 
     /**
      * Fills the DomainParticipantExtendedQos with the values of the default XML profile.

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -356,32 +356,80 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataWriterQos with the first DataWriter profile found in the given XML (or the one specified).
+     * Fills the DataWriterQos with the first DataWriter profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataWriterQos object where the qos is returned.
-     * @param profile_name DataWriter profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos) const;
+
+    /**
+     * Fills the DataWriterQos with the first DataWriter profile found in the provided XML, and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,
-            const std::string& profile_name = "") const;
+            std::string& topic_name) const;
 
     /**
-     * Fills the DataWriterQos with the first DataWriter profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
+     * Fills the DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param profile_name DataWriter profile name.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @param profile_name DataWriter profile name. Empty by default (first one found).
+     * @param profile_name DataWriter profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,
             std::string& topic_name,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos) const;
+
+    /**
+     * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            std::string& topic_name) const;
 
     /**
      * Returns the Publisher's handle.

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -342,6 +342,11 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_profile(
+            const std::string& profile_name,
+            DataWriterQos& qos,
+            std::string& topic_name) const;
+
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -356,6 +356,19 @@ public:
             std::string& topic_name) const;
 
     /**
+     * Fills the DataWriterQos with the first DataWriter profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param profile_name DataWriter profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            const std::string& profile_name = "") const;
+
+    /**
      * Fills the DataWriterQos with the first DataWriter profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -342,11 +342,28 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
+    /**
+     * Fills the DataWriterQos with the values of the XML profile, and also its corresponding topic name (if specified).
+     *
+     * @param profile_name DataWriter profile name.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_profile(
             const std::string& profile_name,
             DataWriterQos& qos,
             std::string& topic_name) const;
 
+    /**
+     * Fills the DataWriterQos with the first DataWriter profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataWriterQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param profile_name DataWriter profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -342,6 +342,12 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            std::string& topic_name,
+            const std::string& profile_name = "") const;
+
     /**
      * Returns the Publisher's handle.
      *

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -332,10 +332,10 @@ public:
             const fastdds::dds::TopicQos& topic_qos);
 
     /**
-     * Fills the DataWriterQos with the values of the XML profile.
+     * Fills the @ref DataWriterQos with the values of the XML profile.
      *
      * @param profile_name DataWriter profile name.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_profile(
@@ -343,10 +343,10 @@ public:
             DataWriterQos& qos) const;
 
     /**
-     * Fills the DataWriterQos with the values of the XML profile, and also its corresponding topic name (if specified).
+     * Fills the @ref DataWriterQos with the values of the XML profile, and also its corresponding topic name (if specified).
      *
      * @param profile_name DataWriter profile name.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
@@ -356,23 +356,23 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataWriterQos with the first DataWriter profile found in the provided XML.
+     * Fills the @ref DataWriterQos with the first DataWriter profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DataWriterQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos) const;
 
     /**
-     * Fills the DataWriterQos with the first DataWriter profile found in the provided XML, and also its corresponding topic name (if specified).
+     * Fills the @ref DataWriterQos with the first DataWriter profile found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
@@ -380,12 +380,12 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @param profile_name DataWriter profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
@@ -393,13 +393,13 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
+     * Fills the @ref DataWriterQos with the DataWriter profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param profile_name DataWriter profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
@@ -408,27 +408,27 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is).
+     * Fills the @ref DataWriterQos with the default DataWriter profile found in the provided XML (if there is).
      *
      * @note This method does not update the default datawriter qos (returned by \c get_default_datawriter_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DataWriterQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos) const;
 
     /**
-     * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     * Fills the @ref DataWriterQos with the default DataWriter profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
      *
      * @note This method does not update the default datawriter qos (returned by \c get_default_datawriter_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataWriterQos object where the qos is returned.
+     * @param qos @ref DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_datawriter_qos_from_xml(
             const std::string& xml,

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -336,7 +336,7 @@ public:
      *
      * @param profile_name DataWriter profile name.
      * @param qos @ref DataWriterQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_profile(
             const std::string& profile_name,
@@ -348,7 +348,7 @@ public:
      * @param profile_name DataWriter profile name.
      * @param qos @ref DataWriterQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datawriter_qos_from_profile(
             const std::string& profile_name,

--- a/include/fastdds/dds/publisher/Publisher.hpp
+++ b/include/fastdds/dds/publisher/Publisher.hpp
@@ -410,6 +410,8 @@ public:
     /**
      * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default datawriter qos (returned by \c get_default_datawriter_qos).
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataWriterQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -420,6 +422,8 @@ public:
 
     /**
      * Fills the DataWriterQos with the default DataWriter profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     *
+     * @note This method does not update the default datawriter qos (returned by \c get_default_datawriter_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataWriterQos object where the qos is returned.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -369,32 +369,80 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataReaderQos with the first DataReader profile found in the given XML (or the one specified).
+     * Fills the DataReaderQos with the first DataReader profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataReaderQos object where the qos is returned.
-     * @param profile_name DataReader profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos) const;
+
+    /**
+     * Fills the DataReaderQos with the first DataReader profile found in the provided XML, and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,
-            const std::string& profile_name = "") const;
+            std::string& topic_name) const;
 
     /**
-     * Fills the DataReaderQos with the first DataReader profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
+     * Fills the DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML.
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param profile_name DataReader profile name.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @param profile_name DataReader profile name. Empty by default (first one found).
+     * @param profile_name DataReader profile name.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,
             std::string& topic_name,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    /**
+     * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos) const;
+
+    /**
+     * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_default_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            std::string& topic_name) const;
 
     /**
      * @brief Copies TopicQos into the corresponding DataReaderQos

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -355,6 +355,11 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_profile(
+            const std::string& profile_name,
+            DataReaderQos& qos,
+            std::string& topic_name) const;
+
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -355,6 +355,12 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
+    FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            std::string& topic_name,
+            const std::string& profile_name = "") const;
+
     /**
      * @brief Copies TopicQos into the corresponding DataReaderQos
      *

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -423,6 +423,8 @@ public:
     /**
      * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is).
      *
+     * @note This method does not update the default datareader qos (returned by \c get_default_datareader_qos).
+     *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataReaderQos object where the qos is returned.
      * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
@@ -433,6 +435,8 @@ public:
 
     /**
      * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     *
+     * @note This method does not update the default datareader qos (returned by \c get_default_datareader_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
      * @param qos DataReaderQos object where the qos is returned.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -349,7 +349,7 @@ public:
      *
      * @param profile_name DataReader profile name.
      * @param qos @ref DataReaderQos object where the qos is returned.
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_profile(
             const std::string& profile_name,
@@ -361,7 +361,7 @@ public:
      * @param profile_name DataReader profile name.
      * @param qos @ref DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK if the profile exists. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_profile(
             const std::string& profile_name,

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -369,6 +369,19 @@ public:
             std::string& topic_name) const;
 
     /**
+     * Fills the DataReaderQos with the first DataReader profile found in the given XML (or the one specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param profile_name DataReader profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            const std::string& profile_name = "") const;
+
+    /**
      * Fills the DataReaderQos with the first DataReader profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -345,10 +345,10 @@ public:
             DataReaderQos& qos) const;
 
     /**
-     * Fills the DataReaderQos with the values of the XML profile.
+     * Fills the @ref DataReaderQos with the values of the XML profile.
      *
      * @param profile_name DataReader profile name.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_profile(
@@ -356,10 +356,10 @@ public:
             DataReaderQos& qos) const;
 
     /**
-     * Fills the DataReaderQos with the values of the XML profile, and also its corresponding topic name (if specified).
+     * Fills the @ref DataReaderQos with the values of the XML profile, and also its corresponding topic name (if specified).
      *
      * @param profile_name DataReader profile name.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
      */
@@ -369,23 +369,23 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataReaderQos with the first DataReader profile found in the provided XML.
+     * Fills the @ref DataReaderQos with the first DataReader profile found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DataReaderQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos) const;
 
     /**
-     * Fills the DataReaderQos with the first DataReader profile found in the provided XML, and also its corresponding topic name (if specified).
+     * Fills the @ref DataReaderQos with the first DataReader profile found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
@@ -393,12 +393,12 @@ public:
             std::string& topic_name) const;
 
     /**
-     * Fills the DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML.
+     * Fills the @ref DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML.
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @param profile_name DataReader profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
@@ -406,13 +406,13 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
+     * Fills the @ref DataReaderQos with the DataReader profile with \c profile_name to be found in the provided XML, and also its corresponding topic name (if specified).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
      * @param profile_name DataReader profile name.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
@@ -421,27 +421,27 @@ public:
             const std::string& profile_name) const;
 
     /**
-     * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is).
+     * Fills the @ref DataReaderQos with the default DataReader profile found in the provided XML (if there is).
      *
      * @note This method does not update the default datareader qos (returned by \c get_default_datareader_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @param qos @ref DataReaderQos object where the qos is returned.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos) const;
 
     /**
-     * Fills the DataReaderQos with the default DataReader profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
+     * Fills the @ref DataReaderQos with the default DataReader profile found in the provided XML (if there is), and also its corresponding topic name (if specified).
      *
      * @note This method does not update the default datareader qos (returned by \c get_default_datareader_qos).
      *
      * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
-     * @param qos DataReaderQos object where the qos is returned.
+     * @param qos @ref DataReaderQos object where the qos is returned.
      * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
-     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     * @return @ref RETCODE_OK on success. @ref RETCODE_BAD_PARAMETER otherwise.
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_default_datareader_qos_from_xml(
             const std::string& xml,

--- a/include/fastdds/dds/subscriber/Subscriber.hpp
+++ b/include/fastdds/dds/subscriber/Subscriber.hpp
@@ -355,11 +355,28 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
+    /**
+     * Fills the DataReaderQos with the values of the XML profile, and also its corresponding topic name (if specified).
+     *
+     * @param profile_name DataReader profile name.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @return RETCODE_OK if the profile exists. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_profile(
             const std::string& profile_name,
             DataReaderQos& qos,
             std::string& topic_name) const;
 
+    /**
+     * Fills the DataReaderQos with the first DataReader profile found in the given XML (or the one specified), and also its corresponding topic name (if specified).
+     *
+     * @param xml Raw XML string containing the profile to be used to fill the \c qos structure.
+     * @param qos DataReaderQos object where the qos is returned.
+     * @param topic_name String where the name of the topic associated to this profile is returned (if specified).
+     * @param profile_name DataReader profile name. Empty by default (first one found).
+     * @return RETCODE_OK on success. RETCODE_BAD_PARAMETER otherwise.
+     */
     FASTDDS_EXPORTED_API ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -338,10 +338,24 @@ ReturnCode_t DomainParticipant::get_publisher_qos_from_profile(
 
 ReturnCode_t DomainParticipant::get_publisher_qos_from_xml(
         const std::string& xml,
+        PublisherQos& qos) const
+{
+    return impl_->get_publisher_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_publisher_qos_from_xml(
+        const std::string& xml,
         PublisherQos& qos,
         const std::string& profile_name) const
 {
     return impl_->get_publisher_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_default_publisher_qos_from_xml(
+        const std::string& xml,
+        PublisherQos& qos) const
+{
+    return impl_->get_default_publisher_qos_from_xml(xml, qos);
 }
 
 ReturnCode_t DomainParticipant::set_default_subscriber_qos(
@@ -371,10 +385,24 @@ ReturnCode_t DomainParticipant::get_subscriber_qos_from_profile(
 
 ReturnCode_t DomainParticipant::get_subscriber_qos_from_xml(
         const std::string& xml,
+        SubscriberQos& qos) const
+{
+    return impl_->get_subscriber_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_subscriber_qos_from_xml(
+        const std::string& xml,
         SubscriberQos& qos,
         const std::string& profile_name) const
 {
     return impl_->get_subscriber_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_default_subscriber_qos_from_xml(
+        const std::string& xml,
+        SubscriberQos& qos) const
+{
+    return impl_->get_default_subscriber_qos_from_xml(xml, qos);
 }
 
 ReturnCode_t DomainParticipant::set_default_topic_qos(
@@ -413,6 +441,22 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 
 ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
         const std::string& xml,
+        TopicQos& qos) const
+{
+    return impl_->get_topic_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    return impl_->get_topic_qos_from_xml(xml, qos, topic_name, topic_data_type);
+}
+
+ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
+        const std::string& xml,
         TopicQos& qos,
         const std::string& profile_name) const
 {
@@ -429,6 +473,22 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
     return impl_->get_topic_qos_from_xml(xml, qos, topic_name, topic_data_type, profile_name);
 }
 
+ReturnCode_t DomainParticipant::get_default_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos) const
+{
+    return impl_->get_default_topic_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_default_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    return impl_->get_default_topic_qos_from_xml(xml, qos, topic_name, topic_data_type);
+}
+
 ReturnCode_t DomainParticipant::get_requester_qos_from_profile(
         const std::string& profile_name,
         RequesterQos& qos) const
@@ -438,10 +498,24 @@ ReturnCode_t DomainParticipant::get_requester_qos_from_profile(
 
 ReturnCode_t DomainParticipant::get_requester_qos_from_xml(
         const std::string& xml,
+        RequesterQos& qos) const
+{
+    return impl_->get_requester_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_requester_qos_from_xml(
+        const std::string& xml,
         RequesterQos& qos,
         const std::string& profile_name) const
 {
     return impl_->get_requester_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_default_requester_qos_from_xml(
+        const std::string& xml,
+        RequesterQos& qos) const
+{
+    return impl_->get_default_requester_qos_from_xml(xml, qos);
 }
 
 ReturnCode_t DomainParticipant::get_replier_qos_from_profile(
@@ -453,10 +527,24 @@ ReturnCode_t DomainParticipant::get_replier_qos_from_profile(
 
 ReturnCode_t DomainParticipant::get_replier_qos_from_xml(
         const std::string& xml,
+        ReplierQos& qos) const
+{
+    return impl_->get_replier_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t DomainParticipant::get_replier_qos_from_xml(
+        const std::string& xml,
         ReplierQos& qos,
         const std::string& profile_name) const
 {
     return impl_->get_replier_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_default_replier_qos_from_xml(
+        const std::string& xml,
+        ReplierQos& qos) const
+{
+    return impl_->get_default_replier_qos_from_xml(xml, qos);
 }
 
 ReturnCode_t DomainParticipant::get_discovered_participants(

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -402,12 +402,23 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
     return impl_->get_topic_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
+        const std::string& profile_name,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    return impl_->get_topic_qos_from_profile(profile_name, qos, topic_name, topic_data_type);
+}
+
 ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
         const std::string& xml,
         TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type,
         const std::string& profile_name) const
 {
-    return impl_->get_topic_qos_from_xml(xml, qos, profile_name);
+    return impl_->get_topic_qos_from_xml(xml, qos, topic_name, topic_data_type, profile_name);
 }
 
 ReturnCode_t DomainParticipant::get_requester_qos_from_profile(

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -336,6 +336,14 @@ ReturnCode_t DomainParticipant::get_publisher_qos_from_profile(
     return impl_->get_publisher_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t DomainParticipant::get_publisher_qos_from_xml(
+        const std::string& xml,
+        PublisherQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_publisher_qos_from_xml(xml, qos, profile_name);
+}
+
 ReturnCode_t DomainParticipant::set_default_subscriber_qos(
         const SubscriberQos& qos)
 {
@@ -359,6 +367,14 @@ ReturnCode_t DomainParticipant::get_subscriber_qos_from_profile(
         SubscriberQos& qos) const
 {
     return impl_->get_subscriber_qos_from_profile(profile_name, qos);
+}
+
+ReturnCode_t DomainParticipant::get_subscriber_qos_from_xml(
+        const std::string& xml,
+        SubscriberQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_subscriber_qos_from_xml(xml, qos, profile_name);
 }
 
 ReturnCode_t DomainParticipant::set_default_topic_qos(
@@ -386,11 +402,12 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
     return impl_->get_topic_qos_from_profile(profile_name, qos);
 }
 
-ReturnCode_t DomainParticipant::get_replier_qos_from_profile(
-        const std::string& profile_name,
-        ReplierQos& qos) const
+ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        const std::string& profile_name) const
 {
-    return impl_->get_replier_qos_from_profile(profile_name, qos);
+    return impl_->get_topic_qos_from_xml(xml, qos, profile_name);
 }
 
 ReturnCode_t DomainParticipant::get_requester_qos_from_profile(
@@ -398,6 +415,29 @@ ReturnCode_t DomainParticipant::get_requester_qos_from_profile(
         RequesterQos& qos) const
 {
     return impl_->get_requester_qos_from_profile(profile_name, qos);
+}
+
+ReturnCode_t DomainParticipant::get_requester_qos_from_xml(
+        const std::string& xml,
+        RequesterQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_requester_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_replier_qos_from_profile(
+        const std::string& profile_name,
+        ReplierQos& qos) const
+{
+    return impl_->get_replier_qos_from_profile(profile_name, qos);
+}
+
+ReturnCode_t DomainParticipant::get_replier_qos_from_xml(
+        const std::string& xml,
+        ReplierQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_replier_qos_from_xml(xml, qos, profile_name);
 }
 
 ReturnCode_t DomainParticipant::get_discovered_participants(

--- a/src/cpp/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipant.cpp
@@ -414,6 +414,14 @@ ReturnCode_t DomainParticipant::get_topic_qos_from_profile(
 ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
         const std::string& xml,
         TopicQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_topic_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t DomainParticipant::get_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
         std::string& topic_name,
         std::string& topic_data_type,
         const std::string& profile_name) const

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -372,6 +372,22 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_profile
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
+        const std::string& xml,
+        DomainParticipantExtendedQos& extended_qos,
+        const std::string& profile_name) const
+{
+    extended_qos = default_participant_qos_;
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, profile_name))
+    {
+        utils::set_extended_qos_from_attributes(extended_qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_default_profile(
         DomainParticipantExtendedQos& extended_qos) const
 {

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -397,10 +397,10 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_profile
         const std::string& profile_name,
         DomainParticipantExtendedQos& extended_qos) const
 {
-    extended_qos = default_participant_qos_;
     ParticipantAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillParticipantAttributes(profile_name, attr, false))
     {
+        extended_qos = default_participant_qos_;
         utils::set_extended_qos_from_attributes(extended_qos, attr);
         return RETCODE_OK;
     }
@@ -412,10 +412,10 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
         const std::string& xml,
         DomainParticipantExtendedQos& extended_qos) const
 {
-    extended_qos = default_participant_qos_;
     ParticipantAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, false))
     {
+        extended_qos = default_participant_qos_;
         utils::set_extended_qos_from_attributes(extended_qos, attr);
         return RETCODE_OK;
     }
@@ -434,10 +434,10 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
         return RETCODE_BAD_PARAMETER;
     }
 
-    extended_qos = default_participant_qos_;
     ParticipantAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, true, profile_name))
     {
+        extended_qos = default_participant_qos_;
         utils::set_extended_qos_from_attributes(extended_qos, attr);
         return RETCODE_OK;
     }
@@ -449,10 +449,10 @@ ReturnCode_t DomainParticipantFactory::get_default_participant_extended_qos_from
         const std::string& xml,
         DomainParticipantExtendedQos& extended_qos) const
 {
-    extended_qos = default_participant_qos_;
     ParticipantAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_participant_attributes_from_xml(xml, attr, true))
     {
+        extended_qos = default_participant_qos_;
         utils::set_extended_qos_from_attributes(extended_qos, attr);
         return RETCODE_OK;
     }

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -343,11 +343,47 @@ ReturnCode_t DomainParticipantFactory::get_participant_qos_from_profile(
 
 ReturnCode_t DomainParticipantFactory::get_participant_qos_from_xml(
         const std::string& xml,
+        DomainParticipantQos& qos) const
+{
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_participant_qos_;
+        utils::set_qos_from_attributes(qos, attr.rtps);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantFactory::get_participant_qos_from_xml(
+        const std::string& xml,
         DomainParticipantQos& qos,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     ParticipantAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_participant_qos_;
+        utils::set_qos_from_attributes(qos, attr.rtps);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantFactory::get_default_participant_qos_from_xml(
+        const std::string& xml,
+        DomainParticipantQos& qos) const
+{
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_participant_attributes_from_xml(xml, attr, true))
     {
         qos = default_participant_qos_;
         utils::set_qos_from_attributes(qos, attr.rtps);
@@ -374,12 +410,48 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_profile
 
 ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
         const std::string& xml,
-        DomainParticipantExtendedQos& extended_qos,
-        const std::string& profile_name) const
+        DomainParticipantExtendedQos& extended_qos) const
 {
     extended_qos = default_participant_qos_;
     ParticipantAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, false))
+    {
+        utils::set_extended_qos_from_attributes(extended_qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
+        const std::string& xml,
+        DomainParticipantExtendedQos& extended_qos,
+        const std::string& profile_name) const
+{
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
+    extended_qos = default_participant_qos_;
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        utils::set_extended_qos_from_attributes(extended_qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantFactory::get_default_participant_extended_qos_from_xml(
+        const std::string& xml,
+        DomainParticipantExtendedQos& extended_qos) const
+{
+    extended_qos = default_participant_qos_;
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_participant_attributes_from_xml(xml, attr, true))
     {
         utils::set_extended_qos_from_attributes(extended_qos, attr);
         return RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -341,6 +341,22 @@ ReturnCode_t DomainParticipantFactory::get_participant_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantFactory::get_participant_qos_from_xml(
+        const std::string& xml,
+        DomainParticipantQos& qos,
+        const std::string& profile_name) const
+{
+    ParticipantAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_participant_attributes_from_xml(xml, attr, profile_name))
+    {
+        qos = default_participant_qos_;
+        utils::set_qos_from_attributes(qos, attr.rtps);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_profile(
         const std::string& profile_name,
         DomainParticipantExtendedQos& extended_qos) const

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1192,11 +1192,11 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 }
 
 ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
-        const std::string& profile_name,
+        const std::string& xml,
         TopicQos& qos,
         std::string& topic_name,
         std::string& topic_data_type,
-        const std::string& xml) const
+        const std::string& profile_name) const
 {
     xmlparser::TopicAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fill_topic_attributes_from_xml(xml, attr, profile_name))

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1044,6 +1044,22 @@ ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_xml(
+        const std::string& xml,
+        PublisherQos& qos,
+        const std::string& profile_name) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, profile_name))
+    {
+        qos = default_pub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantImpl::set_default_subscriber_qos(
         const SubscriberQos& qos)
 {
@@ -1083,6 +1099,22 @@ ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_profile(
 {
     xmlparser::SubscriberAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr))
+    {
+        qos = default_sub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_xml(
+        const std::string& xml,
+        SubscriberQos& qos,
+        const std::string& profile_name) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, profile_name))
     {
         qos = default_sub_qos_;
         utils::set_qos_from_attributes(qos, attr);
@@ -1140,6 +1172,22 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
+        const std::string& profile_name,
+        TopicQos& qos,
+        const std::string& xml) const
+{
+    xmlparser::TopicAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_topic_attributes_from_xml(xml, attr, profile_name))
+    {
+        qos = default_topic_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantImpl::get_replier_qos_from_profile(
         const std::string& profile_name,
         ReplierQos& qos) const
@@ -1154,12 +1202,42 @@ ReturnCode_t DomainParticipantImpl::get_replier_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantImpl::get_replier_qos_from_xml(
+        const std::string& xml,
+        ReplierQos& qos,
+        const std::string& profile_name) const
+{
+    xmlparser::ReplierAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_replier_attributes_from_xml(xml, attr, profile_name))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantImpl::get_requester_qos_from_profile(
         const std::string& profile_name,
         RequesterQos& qos) const
 {
     xmlparser::RequesterAttributes attr;
     if (XMLP_ret::XML_OK == XMLProfileManager::fillRequesterAttributes(profile_name, attr))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_requester_qos_from_xml(
+        const std::string& xml,
+        RequesterQos& qos,
+        const std::string& profile_name) const
+{
+    xmlparser::RequesterAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_requester_attributes_from_xml(xml, attr, profile_name))
     {
         utils::set_qos_from_attributes(qos, attr);
         return RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1172,9 +1172,30 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
+        const std::string& profile_name,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    xmlparser::TopicAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
+    {
+        qos = default_topic_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.getTopicName();
+        topic_data_type = attr.getTopicDataType();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
         const std::string& profile_name,
         TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type,
         const std::string& xml) const
 {
     xmlparser::TopicAttributes attr;
@@ -1182,6 +1203,8 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
     {
         qos = default_topic_qos_;
         utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.getTopicName();
+        topic_data_type = attr.getTopicDataType();
         return RETCODE_OK;
     }
 

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1161,15 +1161,9 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
         const std::string& profile_name,
         TopicQos& qos) const
 {
-    xmlparser::TopicAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fillTopicAttributes(profile_name, attr))
-    {
-        qos = default_topic_qos_;
-        utils::set_qos_from_attributes(qos, attr);
-        return RETCODE_OK;
-    }
-
-    return RETCODE_BAD_PARAMETER;
+    std::string _topic_name;
+    std::string _topic_data_type;
+    return get_topic_qos_from_profile(profile_name, qos, _topic_name, _topic_data_type);
 }
 
 ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
@@ -1189,6 +1183,16 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
     }
 
     return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        const std::string& profile_name) const
+{
+    std::string _topic_name;
+    std::string _topic_data_type;
+    return get_topic_qos_from_xml(xml, qos, _topic_name, _topic_data_type, profile_name);
 }
 
 ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -1046,11 +1046,47 @@ ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_profile(
 
 ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_xml(
         const std::string& xml,
+        PublisherQos& qos) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_pub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_publisher_qos_from_xml(
+        const std::string& xml,
         PublisherQos& qos,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::PublisherAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_pub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_publisher_qos_from_xml(
+        const std::string& xml,
+        PublisherQos& qos) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_publisher_attributes_from_xml(xml, attr, true))
     {
         qos = default_pub_qos_;
         utils::set_qos_from_attributes(qos, attr);
@@ -1110,11 +1146,47 @@ ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_profile(
 
 ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_xml(
         const std::string& xml,
+        SubscriberQos& qos) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_sub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_subscriber_qos_from_xml(
+        const std::string& xml,
         SubscriberQos& qos,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::SubscriberAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_sub_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_subscriber_qos_from_xml(
+        const std::string& xml,
+        SubscriberQos& qos) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_subscriber_attributes_from_xml(xml, attr, true))
     {
         qos = default_sub_qos_;
         utils::set_qos_from_attributes(qos, attr);
@@ -1161,8 +1233,7 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
         const std::string& profile_name,
         TopicQos& qos) const
 {
-    std::string _topic_name;
-    std::string _topic_data_type;
+    std::string _topic_name, _topic_data_type;
     return get_topic_qos_from_profile(profile_name, qos, _topic_name, _topic_data_type);
 }
 
@@ -1187,11 +1258,37 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_profile(
 
 ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
         const std::string& xml,
+        TopicQos& qos) const
+{
+    std::string _topic_name, _topic_data_type;
+    return get_topic_qos_from_xml(xml, qos, _topic_name, _topic_data_type);
+}
+
+ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    xmlparser::TopicAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_topic_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_topic_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.getTopicName();
+        topic_data_type = attr.getTopicDataType();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
+        const std::string& xml,
         TopicQos& qos,
         const std::string& profile_name) const
 {
-    std::string _topic_name;
-    std::string _topic_data_type;
+    std::string _topic_name, _topic_data_type;
     return get_topic_qos_from_xml(xml, qos, _topic_name, _topic_data_type, profile_name);
 }
 
@@ -1202,8 +1299,41 @@ ReturnCode_t DomainParticipantImpl::get_topic_qos_from_xml(
         std::string& topic_data_type,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::TopicAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_topic_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_topic_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_topic_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.getTopicName();
+        topic_data_type = attr.getTopicDataType();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos) const
+{
+    std::string _topic_name, _topic_data_type;
+    return get_default_topic_qos_from_xml(xml, qos, _topic_name, _topic_data_type);
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_topic_qos_from_xml(
+        const std::string& xml,
+        TopicQos& qos,
+        std::string& topic_name,
+        std::string& topic_data_type) const
+{
+    xmlparser::TopicAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_topic_attributes_from_xml(xml, attr, true))
     {
         qos = default_topic_qos_;
         utils::set_qos_from_attributes(qos, attr);
@@ -1231,11 +1361,45 @@ ReturnCode_t DomainParticipantImpl::get_replier_qos_from_profile(
 
 ReturnCode_t DomainParticipantImpl::get_replier_qos_from_xml(
         const std::string& xml,
+        ReplierQos& qos) const
+{
+    xmlparser::ReplierAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_replier_attributes_from_xml(xml, attr, false))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_replier_qos_from_xml(
+        const std::string& xml,
         ReplierQos& qos,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::ReplierAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_replier_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_replier_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_replier_qos_from_xml(
+        const std::string& xml,
+        ReplierQos& qos) const
+{
+    xmlparser::ReplierAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_replier_attributes_from_xml(xml, attr, true))
     {
         utils::set_qos_from_attributes(qos, attr);
         return RETCODE_OK;
@@ -1260,11 +1424,45 @@ ReturnCode_t DomainParticipantImpl::get_requester_qos_from_profile(
 
 ReturnCode_t DomainParticipantImpl::get_requester_qos_from_xml(
         const std::string& xml,
+        RequesterQos& qos) const
+{
+    xmlparser::RequesterAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_requester_attributes_from_xml(xml, attr, false))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_requester_qos_from_xml(
+        const std::string& xml,
         RequesterQos& qos,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::RequesterAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_requester_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_requester_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        utils::set_qos_from_attributes(qos, attr);
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t DomainParticipantImpl::get_default_requester_qos_from_xml(
+        const std::string& xml,
+        RequesterQos& qos) const
+{
+    xmlparser::RequesterAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_requester_attributes_from_xml(xml, attr, true))
     {
         utils::set_qos_from_attributes(qos, attr);
         return RETCODE_OK;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -416,6 +416,11 @@ public:
     ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos,
+            const std::string& profile_name = "") const;
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
             std::string& topic_name,
             std::string& topic_data_type,
             const std::string& profile_name = "") const;

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -377,8 +377,16 @@ public:
 
     ReturnCode_t get_publisher_qos_from_xml(
             const std::string& xml,
+            PublisherQos& qos) const;
+
+    ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& xml,
             PublisherQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name ) const;
+
+    ReturnCode_t get_default_publisher_qos_from_xml(
+            const std::string& xml,
+            PublisherQos& qos) const;
 
     ReturnCode_t set_default_subscriber_qos(
             const SubscriberQos& qos);
@@ -393,8 +401,16 @@ public:
 
     ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& xml,
+            SubscriberQos& qos) const;
+
+    ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& xml,
             SubscriberQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_subscriber_qos_from_xml(
+            const std::string& xml,
+            SubscriberQos& qos) const;
 
     ReturnCode_t set_default_topic_qos(
             const TopicQos& qos);
@@ -415,15 +431,35 @@ public:
 
     ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
+            TopicQos& qos) const;
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
             TopicQos& qos,
-            const std::string& profile_name = "") const;
+            std::string& topic_name,
+            std::string& topic_data_type) const;
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            const std::string& profile_name) const;
 
     ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos,
             std::string& topic_name,
             std::string& topic_data_type,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos) const;
+
+    ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type) const;
 
     ReturnCode_t get_replier_qos_from_profile(
             const std::string& profile_name,
@@ -431,8 +467,16 @@ public:
 
     ReturnCode_t get_replier_qos_from_xml(
             const std::string& xml,
+            ReplierQos& qos) const;
+
+    ReturnCode_t get_replier_qos_from_xml(
+            const std::string& xml,
             ReplierQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_replier_qos_from_xml(
+            const std::string& xml,
+            ReplierQos& qos) const;
 
     ReturnCode_t get_requester_qos_from_profile(
             const std::string& profile_name,
@@ -440,8 +484,16 @@ public:
 
     ReturnCode_t get_requester_qos_from_xml(
             const std::string& xml,
+            RequesterQos& qos) const;
+
+    ReturnCode_t get_requester_qos_from_xml(
+            const std::string& xml,
             RequesterQos& qos,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_requester_qos_from_xml(
+            const std::string& xml,
+            RequesterQos& qos) const;
 
     /* TODO
        bool get_discovered_participants(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -375,6 +375,11 @@ public:
             const std::string& profile_name,
             PublisherQos& qos) const;
 
+    ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& xml,
+            PublisherQos& qos,
+            const std::string& profile_name = "") const;
+
     ReturnCode_t set_default_subscriber_qos(
             const SubscriberQos& qos);
 
@@ -385,6 +390,11 @@ public:
     ReturnCode_t get_subscriber_qos_from_profile(
             const std::string& profile_name,
             SubscriberQos& qos) const;
+
+    ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& xml,
+            SubscriberQos& qos,
+            const std::string& profile_name = "") const;
 
     ReturnCode_t set_default_topic_qos(
             const TopicQos& qos);
@@ -397,13 +407,28 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& xml,
+            TopicQos& qos,
+            const std::string& profile_name = "") const;
+
     ReturnCode_t get_replier_qos_from_profile(
             const std::string& profile_name,
             ReplierQos& qos) const;
 
+    ReturnCode_t get_replier_qos_from_xml(
+            const std::string& xml,
+            ReplierQos& qos,
+            const std::string& profile_name = "") const;
+
     ReturnCode_t get_requester_qos_from_profile(
             const std::string& profile_name,
             RequesterQos& qos) const;
+
+    ReturnCode_t get_requester_qos_from_xml(
+            const std::string& xml,
+            RequesterQos& qos,
+            const std::string& profile_name = "") const;
 
     /* TODO
        bool get_discovered_participants(

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.hpp
@@ -407,9 +407,17 @@ public:
             const std::string& profile_name,
             TopicQos& qos) const;
 
+    ReturnCode_t get_topic_qos_from_profile(
+            const std::string& profile_name,
+            TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type) const;
+
     ReturnCode_t get_topic_qos_from_xml(
             const std::string& xml,
             TopicQos& qos,
+            std::string& topic_name,
+            std::string& topic_data_type,
             const std::string& profile_name = "") const;
 
     ReturnCode_t get_replier_qos_from_profile(

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -237,6 +237,14 @@ ReturnCode_t Publisher::get_datawriter_qos_from_profile(
     return impl_->get_datawriter_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t Publisher::get_datawriter_qos_from_profile(
+        const std::string& profile_name,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_datawriter_qos_from_profile(profile_name, qos, topic_name);
+}
+
 ReturnCode_t Publisher::get_datawriter_qos_from_xml(
         const std::string& xml,
         DataWriterQos& qos,

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -248,6 +248,14 @@ ReturnCode_t Publisher::get_datawriter_qos_from_profile(
 ReturnCode_t Publisher::get_datawriter_qos_from_xml(
         const std::string& xml,
         DataWriterQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_datawriter_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t Publisher::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
         std::string& topic_name,
         const std::string& profile_name) const
 {

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -247,6 +247,21 @@ ReturnCode_t Publisher::get_datawriter_qos_from_profile(
 
 ReturnCode_t Publisher::get_datawriter_qos_from_xml(
         const std::string& xml,
+        DataWriterQos& qos) const
+{
+    return impl_->get_datawriter_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t Publisher::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_datawriter_qos_from_xml(xml, qos, topic_name);
+}
+
+ReturnCode_t Publisher::get_datawriter_qos_from_xml(
+        const std::string& xml,
         DataWriterQos& qos,
         const std::string& profile_name) const
 {
@@ -260,6 +275,21 @@ ReturnCode_t Publisher::get_datawriter_qos_from_xml(
         const std::string& profile_name) const
 {
     return impl_->get_datawriter_qos_from_xml(xml, qos, topic_name, profile_name);
+}
+
+ReturnCode_t Publisher::get_default_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos) const
+{
+    return impl_->get_default_datawriter_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t Publisher::get_default_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_default_datawriter_qos_from_xml(xml, qos, topic_name);
 }
 
 } // namespace dds

--- a/src/cpp/fastdds/publisher/Publisher.cpp
+++ b/src/cpp/fastdds/publisher/Publisher.cpp
@@ -237,6 +237,15 @@ ReturnCode_t Publisher::get_datawriter_qos_from_profile(
     return impl_->get_datawriter_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t Publisher::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name,
+        const std::string& profile_name) const
+{
+    return impl_->get_datawriter_qos_from_xml(xml, qos, topic_name, profile_name);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -474,6 +474,23 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
+        const std::string& profile_name,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr, false))
+    {
+        qos = default_datawriter_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
         const std::string& xml,
         DataWriterQos& qos,

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -486,6 +486,31 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
 
 ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
         const std::string& xml,
+        DataWriterQos& qos) const
+{
+    std::string _topic_name;
+    return get_datawriter_qos_from_xml(xml, qos, _topic_name);
+}
+
+ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_datawriter_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
+        const std::string& xml,
         DataWriterQos& qos,
         const std::string& profile_name) const
 {
@@ -499,8 +524,39 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
         std::string& topic_name,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(PUBLISHER, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::PublisherAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_datawriter_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t PublisherImpl::get_default_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos) const
+{
+    std::string _topic_name;
+    return get_default_datawriter_qos_from_xml(xml, qos, _topic_name);
+}
+
+ReturnCode_t PublisherImpl::get_default_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_publisher_attributes_from_xml(xml, attr, true))
     {
         qos = default_datawriter_qos_;
         utils::set_qos_from_attributes(qos, attr);

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -463,15 +463,8 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
         const std::string& profile_name,
         DataWriterQos& qos) const
 {
-    xmlparser::PublisherAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fillPublisherAttributes(profile_name, attr, false))
-    {
-        qos = default_datawriter_qos_;
-        utils::set_qos_from_attributes(qos, attr);
-        return RETCODE_OK;
-    }
-
-    return RETCODE_BAD_PARAMETER;
+    std::string _topic_name;
+    return get_datawriter_qos_from_profile(profile_name, qos, _topic_name);
 }
 
 ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
@@ -489,6 +482,15 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
     }
 
     return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        const std::string& profile_name) const
+{
+    std::string _topic_name;
+    return get_datawriter_qos_from_xml(xml, qos, _topic_name, profile_name);
 }
 
 ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(

--- a/src/cpp/fastdds/publisher/PublisherImpl.cpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.cpp
@@ -474,6 +474,24 @@ ReturnCode_t PublisherImpl::get_datawriter_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t PublisherImpl::get_datawriter_qos_from_xml(
+        const std::string& xml,
+        DataWriterQos& qos,
+        std::string& topic_name,
+        const std::string& profile_name) const
+{
+    xmlparser::PublisherAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_publisher_attributes_from_xml(xml, attr, profile_name))
+    {
+        qos = default_datawriter_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t PublisherImpl::copy_from_topic_qos(
         DataWriterQos& writer_qos,
         const TopicQos& topic_qos)

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -169,6 +169,12 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
+    ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            std::string& topic_name,
+            const std::string& profile_name = "") const;
+
     ReturnCode_t static copy_from_topic_qos(
             DataWriterQos& writer_qos,
             const TopicQos& topic_qos);

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -177,6 +177,11 @@ public:
     ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,
+            const std::string& profile_name = "") const;
+
+    ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
             std::string& topic_name,
             const std::string& profile_name = "") const;
 

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -169,6 +169,11 @@ public:
             const std::string& profile_name,
             DataWriterQos& qos) const;
 
+    ReturnCode_t get_datawriter_qos_from_profile(
+            const std::string& profile_name,
+            DataWriterQos& qos,
+            std::string& topic_name) const;
+
     ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,

--- a/src/cpp/fastdds/publisher/PublisherImpl.hpp
+++ b/src/cpp/fastdds/publisher/PublisherImpl.hpp
@@ -176,14 +176,32 @@ public:
 
     ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
+            DataWriterQos& qos) const;
+
+    ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
             DataWriterQos& qos,
-            const std::string& profile_name = "") const;
+            std::string& topic_name) const;
+
+    ReturnCode_t get_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            const std::string& profile_name) const;
 
     ReturnCode_t get_datawriter_qos_from_xml(
             const std::string& xml,
             DataWriterQos& qos,
             std::string& topic_name,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos) const;
+
+    ReturnCode_t get_default_datawriter_qos_from_xml(
+            const std::string& xml,
+            DataWriterQos& qos,
+            std::string& topic_name) const;
 
     ReturnCode_t static copy_from_topic_qos(
             DataWriterQos& writer_qos,

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -229,6 +229,14 @@ ReturnCode_t Subscriber::get_datareader_qos_from_profile(
 ReturnCode_t Subscriber::get_datareader_qos_from_xml(
         const std::string& xml,
         DataReaderQos& qos,
+        const std::string& profile_name) const
+{
+    return impl_->get_datareader_qos_from_xml(xml, qos, profile_name);
+}
+
+ReturnCode_t Subscriber::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
         std::string& topic_name,
         const std::string& profile_name) const
 {

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -228,6 +228,21 @@ ReturnCode_t Subscriber::get_datareader_qos_from_profile(
 
 ReturnCode_t Subscriber::get_datareader_qos_from_xml(
         const std::string& xml,
+        DataReaderQos& qos) const
+{
+    return impl_->get_datareader_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t Subscriber::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_datareader_qos_from_xml(xml, qos, topic_name);
+}
+
+ReturnCode_t Subscriber::get_datareader_qos_from_xml(
+        const std::string& xml,
         DataReaderQos& qos,
         const std::string& profile_name) const
 {
@@ -241,6 +256,21 @@ ReturnCode_t Subscriber::get_datareader_qos_from_xml(
         const std::string& profile_name) const
 {
     return impl_->get_datareader_qos_from_xml(xml, qos, topic_name, profile_name);
+}
+
+ReturnCode_t Subscriber::get_default_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos) const
+{
+    return impl_->get_default_datareader_qos_from_xml(xml, qos);
+}
+
+ReturnCode_t Subscriber::get_default_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_default_datareader_qos_from_xml(xml, qos, topic_name);
 }
 
 ReturnCode_t Subscriber::copy_from_topic_qos(

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -218,6 +218,15 @@ ReturnCode_t Subscriber::get_datareader_qos_from_profile(
     return impl_->get_datareader_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t Subscriber::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name,
+        const std::string& profile_name) const
+{
+    return impl_->get_datareader_qos_from_xml(xml, qos, topic_name, profile_name);
+}
+
 ReturnCode_t Subscriber::copy_from_topic_qos(
         DataReaderQos& reader_qos,
         const TopicQos& topic_qos)

--- a/src/cpp/fastdds/subscriber/Subscriber.cpp
+++ b/src/cpp/fastdds/subscriber/Subscriber.cpp
@@ -218,6 +218,14 @@ ReturnCode_t Subscriber::get_datareader_qos_from_profile(
     return impl_->get_datareader_qos_from_profile(profile_name, qos);
 }
 
+ReturnCode_t Subscriber::get_datareader_qos_from_profile(
+        const std::string& profile_name,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    return impl_->get_datareader_qos_from_profile(profile_name, qos, topic_name);
+}
+
 ReturnCode_t Subscriber::get_datareader_qos_from_xml(
         const std::string& xml,
         DataReaderQos& qos,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -436,6 +436,23 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
+        const std::string& profile_name,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr, false))
+    {
+        qos = default_datareader_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
         const std::string& xml,
         DataReaderQos& qos,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -448,6 +448,31 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
 
 ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
         const std::string& xml,
+        DataReaderQos& qos) const
+{
+    std::string _topic_name;
+    return get_datareader_qos_from_xml(xml, qos, _topic_name);
+}
+
+ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, false))
+    {
+        qos = default_datareader_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
+        const std::string& xml,
         DataReaderQos& qos,
         const std::string& profile_name) const
 {
@@ -461,8 +486,39 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
         std::string& topic_name,
         const std::string& profile_name) const
 {
+    if (profile_name.empty())
+    {
+        EPROSIMA_LOG_ERROR(SUBSCRIBER, "Provided profile name must be non-empty");
+        return RETCODE_BAD_PARAMETER;
+    }
+
     xmlparser::SubscriberAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, profile_name))
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, true, profile_name))
+    {
+        qos = default_datareader_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t SubscriberImpl::get_default_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos) const
+{
+    std::string _topic_name;
+    return get_default_datareader_qos_from_xml(xml, qos, _topic_name);
+}
+
+ReturnCode_t SubscriberImpl::get_default_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_default_subscriber_attributes_from_xml(xml, attr, true))
     {
         qos = default_datareader_qos_;
         utils::set_qos_from_attributes(qos, attr);

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -425,15 +425,8 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
         const std::string& profile_name,
         DataReaderQos& qos) const
 {
-    xmlparser::SubscriberAttributes attr;
-    if (XMLP_ret::XML_OK == XMLProfileManager::fillSubscriberAttributes(profile_name, attr, false))
-    {
-        qos = default_datareader_qos_;
-        utils::set_qos_from_attributes(qos, attr);
-        return RETCODE_OK;
-    }
-
-    return RETCODE_BAD_PARAMETER;
+    std::string _topic_name;
+    return get_datareader_qos_from_profile(profile_name, qos, _topic_name);
 }
 
 ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
@@ -451,6 +444,15 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
     }
 
     return RETCODE_BAD_PARAMETER;
+}
+
+ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        const std::string& profile_name) const
+{
+    std::string _topic_name;
+    return get_datareader_qos_from_xml(xml, qos, _topic_name, profile_name);
 }
 
 ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.cpp
@@ -436,6 +436,24 @@ ReturnCode_t SubscriberImpl::get_datareader_qos_from_profile(
     return RETCODE_BAD_PARAMETER;
 }
 
+ReturnCode_t SubscriberImpl::get_datareader_qos_from_xml(
+        const std::string& xml,
+        DataReaderQos& qos,
+        std::string& topic_name,
+        const std::string& profile_name) const
+{
+    xmlparser::SubscriberAttributes attr;
+    if (XMLP_ret::XML_OK == XMLProfileManager::fill_subscriber_attributes_from_xml(xml, attr, profile_name))
+    {
+        qos = default_datareader_qos_;
+        utils::set_qos_from_attributes(qos, attr);
+        topic_name = attr.topic.getTopicName();
+        return RETCODE_OK;
+    }
+
+    return RETCODE_BAD_PARAMETER;
+}
+
 ReturnCode_t SubscriberImpl::copy_from_topic_qos(
         DataReaderQos& reader_qos,
         const TopicQos& topic_qos)

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -147,6 +147,12 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
+    ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            std::string& topic_name,
+            const std::string& profile_name = "") const;
+
     ReturnCode_t static copy_from_topic_qos(
             DataReaderQos& reader_qos,
             const TopicQos& topic_qos);

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -154,14 +154,32 @@ public:
 
     ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
+            DataReaderQos& qos) const;
+
+    ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
             DataReaderQos& qos,
-            const std::string& profile_name = "") const;
+            std::string& topic_name) const;
+
+    ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            const std::string& profile_name) const;
 
     ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,
             std::string& topic_name,
-            const std::string& profile_name = "") const;
+            const std::string& profile_name) const;
+
+    ReturnCode_t get_default_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos) const;
+
+    ReturnCode_t get_default_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
+            std::string& topic_name) const;
 
     ReturnCode_t static copy_from_topic_qos(
             DataReaderQos& reader_qos,

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -155,6 +155,11 @@ public:
     ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,
+            const std::string& profile_name = "") const;
+
+    ReturnCode_t get_datareader_qos_from_xml(
+            const std::string& xml,
+            DataReaderQos& qos,
             std::string& topic_name,
             const std::string& profile_name = "") const;
 

--- a/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
+++ b/src/cpp/fastdds/subscriber/SubscriberImpl.hpp
@@ -147,6 +147,11 @@ public:
             const std::string& profile_name,
             DataReaderQos& qos) const;
 
+    ReturnCode_t get_datareader_qos_from_profile(
+            const std::string& profile_name,
+            DataReaderQos& qos,
+            std::string& topic_name) const;
+
     ReturnCode_t get_datareader_qos_from_xml(
             const std::string& xml,
             DataReaderQos& qos,

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -162,8 +162,9 @@ XMLP_ret fill_attributes_from_xml(
             if (profile_name != "")
             {
                 node_att_map_cit_t it = node->getAttributes().find(PROFILE_NAME);
-                if (it != node->getAttributes().end() && it->second != profile_name)
+                if (it == node->getAttributes().end() || it->second != profile_name)
                 {
+                    // No profile name in this node, or different than the one requested
                     continue;
                 }
             }

--- a/src/cpp/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/xmlparser/XMLProfileManager.cpp
@@ -64,6 +64,7 @@ struct AttributesTraits<ParticipantAttributes>
     {
         return "Participant";
     }
+
 };
 
 template<>
@@ -77,6 +78,7 @@ struct AttributesTraits<PublisherAttributes>
     {
         return "Publisher";
     }
+
 };
 
 template<>
@@ -90,6 +92,7 @@ struct AttributesTraits<SubscriberAttributes>
     {
         return "Subscriber";
     }
+
 };
 
 template<>
@@ -103,6 +106,7 @@ struct AttributesTraits<TopicAttributes>
     {
         return "Topic";
     }
+
 };
 
 template<>
@@ -116,6 +120,7 @@ struct AttributesTraits<RequesterAttributes>
     {
         return "Requester";
     }
+
 };
 
 template<>
@@ -129,6 +134,7 @@ struct AttributesTraits<ReplierAttributes>
     {
         return "Replier";
     }
+
 };
 
 template <typename AttributesType>
@@ -210,11 +216,11 @@ XMLP_ret fill_attributes_from_xml(
     std::reference_wrapper<up_base_node_t> node_to_process = root_node;
     if (fulfill_xsd)
     {
-        if (NodeType::ROOT == root_node ->getType())
+        if (NodeType::ROOT == root_node->getType())
         {
             for (auto&& child: root_node->getChildren())
             {
-                if (NodeType::PROFILES == child ->getType())
+                if (NodeType::PROFILES == child->getType())
                 {
                     node_to_process = child;
                     break;
@@ -246,14 +252,15 @@ XMLP_ret fill_attributes_from_xml(
         bool fulfill_xsd,
         const std::string& profile_name)
 {
-    auto node_filter = [&profile_name](typename AttributesTraits<AttributesType>::NodePtrType node) -> bool {
-        if (!profile_name.empty())
-        {
-            auto it = node->getAttributes().find(PROFILE_NAME);
-            return (it != node->getAttributes().end() && it->second == profile_name);
-        }
-        return true;
-    };
+    auto node_filter = [&profile_name](typename AttributesTraits<AttributesType>::NodePtrType node) -> bool
+            {
+                if (!profile_name.empty())
+                {
+                    auto it = node->getAttributes().find(PROFILE_NAME);
+                    return (it != node->getAttributes().end() && it->second == profile_name);
+                }
+                return true;
+            };
     return fill_attributes_from_xml(xml, atts, node_filter, fulfill_xsd);
 }
 
@@ -263,10 +270,11 @@ XMLP_ret fill_default_attributes_from_xml(
         AttributesType& atts,
         bool fulfill_xsd)
 {
-    auto node_filter = [](typename AttributesTraits<AttributesType>::NodePtrType node) -> bool {
-        auto it = node->getAttributes().find(DEFAULT_PROF);
-        return (it != node->getAttributes().end() && it->second == "true");
-    };
+    auto node_filter = [](typename AttributesTraits<AttributesType>::NodePtrType node) -> bool
+            {
+                auto it = node->getAttributes().find(DEFAULT_PROF);
+                return (it != node->getAttributes().end() && it->second == "true");
+            };
     return fill_attributes_from_xml(xml, atts, node_filter, fulfill_xsd);
 }
 

--- a/src/cpp/xmlparser/XMLProfileManager.h
+++ b/src/cpp/xmlparser/XMLProfileManager.h
@@ -140,14 +140,21 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillParticipantAttributes(
             const std::string& profile_name,
             fastdds::xmlparser::ParticipantAttributes& atts,
             bool log_error = true);
 
+    /**
+     * Search for the first participant profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_participant_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::ParticipantAttributes& atts,
@@ -180,14 +187,21 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillPublisherAttributes(
             const std::string& profile_name,
             fastdds::xmlparser::PublisherAttributes& atts,
             bool log_error = true);
 
+    /**
+     * Search for the first publisher profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_publisher_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::PublisherAttributes& atts,
@@ -201,14 +215,21 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found.
-     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillSubscriberAttributes(
             const std::string& profile_name,
             fastdds::xmlparser::SubscriberAttributes& atts,
             bool log_error = true);
 
+    /**
+     * Search for the first subscriber profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_subscriber_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::SubscriberAttributes& atts,
@@ -237,6 +258,13 @@ public:
             const std::string& profile_name,
             TopicAttributes& atts);
 
+    /**
+     * Search for the first topic profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_topic_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::TopicAttributes& atts,
@@ -265,6 +293,13 @@ public:
             const std::string& profile_name,
             fastdds::xmlparser::RequesterAttributes& atts);
 
+    /**
+     * Search for the first requester profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_requester_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::RequesterAttributes& atts,
@@ -280,6 +315,13 @@ public:
             const std::string& profile_name,
             fastdds::xmlparser::ReplierAttributes& atts);
 
+    /**
+     * Search for the first replier profile found in the given XML (or the one specified) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
     static XMLP_ret fill_replier_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::ReplierAttributes& atts,

--- a/src/cpp/xmlparser/XMLProfileManager.h
+++ b/src/cpp/xmlparser/XMLProfileManager.h
@@ -149,16 +149,30 @@ public:
             bool log_error = true);
 
     /**
-     * Search for the first participant profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first participant profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_participant_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::ParticipantAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default participant profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_participant_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::ParticipantAttributes& atts,
+            bool fulfill_xsd);
 
     //!Fills participant_attributes with the default values.
     static void getDefaultParticipantAttributes(
@@ -196,16 +210,30 @@ public:
             bool log_error = true);
 
     /**
-     * Search for the first publisher profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first publisher profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_publisher_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::PublisherAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default publisher profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_publisher_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::PublisherAttributes& atts,
+            bool fulfill_xsd);
 
     //!Fills publisher_attributes with the default values.
     static void getDefaultPublisherAttributes(
@@ -224,16 +252,30 @@ public:
             bool log_error = true);
 
     /**
-     * Search for the first subscriber profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first subscriber profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_subscriber_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::SubscriberAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default subscriber profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_subscriber_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::SubscriberAttributes& atts,
+            bool fulfill_xsd);
 
     //!Fills subscriber_attributes with the default values.
     static void getDefaultSubscriberAttributes(
@@ -259,16 +301,30 @@ public:
             TopicAttributes& atts);
 
     /**
-     * Search for the first topic profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first topic profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_topic_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::TopicAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default topic profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_topic_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::TopicAttributes& atts,
+            bool fulfill_xsd);
 
     //!Fills topic_attributes with the default values.
     static void getDefaultTopicAttributes(
@@ -294,16 +350,30 @@ public:
             fastdds::xmlparser::RequesterAttributes& atts);
 
     /**
-     * Search for the first requester profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first requester profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_requester_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::RequesterAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default requester profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_requester_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::RequesterAttributes& atts,
+            bool fulfill_xsd);
 
     /**
      * Search for the profile specified and fill the structure.
@@ -316,16 +386,30 @@ public:
             fastdds::xmlparser::ReplierAttributes& atts);
 
     /**
-     * Search for the first replier profile found in the given XML (or the one specified) and fill the structure.
+     * Search for the first replier profile found in the provided XML (or the one specified) and fill the structure.
      * @param xml Raw XML string containing the profile to be used to fill the structure.
      * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
      * @param profile_name Name for the profile to be used to fill the structure. Empty by default (first one found).
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fill_replier_attributes_from_xml(
             const std::string& xml,
             fastdds::xmlparser::ReplierAttributes& atts,
+            bool fulfill_xsd,
             const std::string& profile_name = "");
+
+    /**
+     * Search for the default replier profile found in the provided XML (if there is) and fill the structure.
+     * @param xml Raw XML string containing the profile to be used to fill the structure.
+     * @param atts Structure to be filled.
+     * @param fulfill_xsd Whether the given \c xml should fulfill the XSD schema.
+     * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
+     */
+    static XMLP_ret fill_default_replier_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::ReplierAttributes& atts,
+            bool fulfill_xsd);
 
     /**
      * Deletes the XMLProfileManager instance.

--- a/src/cpp/xmlparser/XMLProfileManager.h
+++ b/src/cpp/xmlparser/XMLProfileManager.h
@@ -148,6 +148,11 @@ public:
             fastdds::xmlparser::ParticipantAttributes& atts,
             bool log_error = true);
 
+    static XMLP_ret fill_participant_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::ParticipantAttributes& atts,
+            const std::string& profile_name = "");
+
     //!Fills participant_attributes with the default values.
     static void getDefaultParticipantAttributes(
             fastdds::xmlparser::ParticipantAttributes& participant_attributes);
@@ -183,6 +188,11 @@ public:
             fastdds::xmlparser::PublisherAttributes& atts,
             bool log_error = true);
 
+    static XMLP_ret fill_publisher_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::PublisherAttributes& atts,
+            const std::string& profile_name = "");
+
     //!Fills publisher_attributes with the default values.
     static void getDefaultPublisherAttributes(
             fastdds::xmlparser::PublisherAttributes& publisher_attributes);
@@ -198,6 +208,11 @@ public:
             const std::string& profile_name,
             fastdds::xmlparser::SubscriberAttributes& atts,
             bool log_error = true);
+
+    static XMLP_ret fill_subscriber_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::SubscriberAttributes& atts,
+            const std::string& profile_name = "");
 
     //!Fills subscriber_attributes with the default values.
     static void getDefaultSubscriberAttributes(
@@ -222,6 +237,11 @@ public:
             const std::string& profile_name,
             TopicAttributes& atts);
 
+    static XMLP_ret fill_topic_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::TopicAttributes& atts,
+            const std::string& profile_name = "");
+
     //!Fills topic_attributes with the default values.
     static void getDefaultTopicAttributes(
             TopicAttributes& topic_attributes);
@@ -245,6 +265,11 @@ public:
             const std::string& profile_name,
             fastdds::xmlparser::RequesterAttributes& atts);
 
+    static XMLP_ret fill_requester_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::RequesterAttributes& atts,
+            const std::string& profile_name = "");
+
     /**
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
@@ -254,6 +279,11 @@ public:
     static XMLP_ret fillReplierAttributes(
             const std::string& profile_name,
             fastdds::xmlparser::ReplierAttributes& atts);
+
+    static XMLP_ret fill_replier_attributes_from_xml(
+            const std::string& xml,
+            fastdds::xmlparser::ReplierAttributes& atts,
+            const std::string& profile_name = "");
 
     /**
      * Deletes the XMLProfileManager instance.

--- a/src/cpp/xmlparser/XMLProfileManager.h
+++ b/src/cpp/xmlparser/XMLProfileManager.h
@@ -140,7 +140,7 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults @c true.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillParticipantAttributes(
@@ -182,7 +182,7 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param qos Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults @c true.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillDomainParticipantFactoryQos(
@@ -201,7 +201,7 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults @c true.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillPublisherAttributes(
@@ -243,7 +243,7 @@ public:
      * Search for the profile specified and fill the structure.
      * @param profile_name Name for the profile to be used to fill the structure.
      * @param atts Structure to be filled.
-     * @param log_error Flag to log an error if the profile_name is not found. Defaults true.
+     * @param log_error Flag to log an error if the profile_name is not found. Defaults @c true.
      * @return XMLP_ret::XML_OK on success, XMLP_ret::XML_ERROR in other case.
      */
     static XMLP_ret fillSubscriberAttributes(

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -479,6 +479,14 @@ public:
         return RETCODE_OK;
     }
 
+    ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& /*xml*/,
+            PublisherQos& /*qos*/,
+            const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
     ReturnCode_t set_default_subscriber_qos(
             const SubscriberQos& /*qos*/)
     {
@@ -493,6 +501,14 @@ public:
     ReturnCode_t get_subscriber_qos_from_profile(
             const std::string& /*profile_name*/,
             SubscriberQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& /*xml*/,
+            SubscriberQos& /*qos*/,
+            const std::string& /*profile_name*/) const
     {
         return RETCODE_OK;
     }
@@ -515,6 +531,33 @@ public:
         return RETCODE_OK;
     }
 
+    ReturnCode_t get_topic_qos_from_profile(
+            const std::string& /*profile_name*/,
+            TopicQos& /*qos*/,
+            std::string& /*topic_name*/,
+            std::string& /*topic_data_type*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& /*xml*/,
+            TopicQos& /*qos*/,
+            const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& /*xml*/,
+            TopicQos& /*qos*/,
+            std::string& /*topic_name*/,
+            std::string& /*topic_data_type*/,
+            const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
     ReturnCode_t get_replier_qos_from_profile(
             const std::string& /*profile_name*/,
             ReplierQos& /*qos*/) const
@@ -522,9 +565,25 @@ public:
         return RETCODE_OK;
     }
 
+    ReturnCode_t get_replier_qos_from_xml(
+            const std::string& /*xml*/,
+            ReplierQos& /*qos*/,
+            const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
     ReturnCode_t get_requester_qos_from_profile(
             const std::string& /*profile_name*/,
             RequesterQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_requester_qos_from_xml(
+            const std::string& /*xml*/,
+            RequesterQos& /*qos*/,
+            const std::string& /*profile_name*/) const
     {
         return RETCODE_OK;
     }

--- a/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
+++ b/test/mock/dds/DomainParticipantImpl/fastdds/domain/DomainParticipantImpl.hpp
@@ -481,8 +481,22 @@ public:
 
     ReturnCode_t get_publisher_qos_from_xml(
             const std::string& /*xml*/,
+            PublisherQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_publisher_qos_from_xml(
+            const std::string& /*xml*/,
             PublisherQos& /*qos*/,
             const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_default_publisher_qos_from_xml(
+            const std::string& /*xml*/,
+            PublisherQos& /*qos*/) const
     {
         return RETCODE_OK;
     }
@@ -507,8 +521,22 @@ public:
 
     ReturnCode_t get_subscriber_qos_from_xml(
             const std::string& /*xml*/,
+            SubscriberQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_subscriber_qos_from_xml(
+            const std::string& /*xml*/,
             SubscriberQos& /*qos*/,
             const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_default_subscriber_qos_from_xml(
+            const std::string& /*xml*/,
+            SubscriberQos& /*qos*/) const
     {
         return RETCODE_OK;
     }
@@ -542,6 +570,22 @@ public:
 
     ReturnCode_t get_topic_qos_from_xml(
             const std::string& /*xml*/,
+            TopicQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& /*xml*/,
+            TopicQos& /*qos*/,
+            std::string& /*topic_name*/,
+            std::string& /*topic_data_type*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_topic_qos_from_xml(
+            const std::string& /*xml*/,
             TopicQos& /*qos*/,
             const std::string& /*profile_name*/) const
     {
@@ -558,8 +602,31 @@ public:
         return RETCODE_OK;
     }
 
+    ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& /*xml*/,
+            TopicQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_default_topic_qos_from_xml(
+            const std::string& /*xml*/,
+            TopicQos& /*qos*/,
+            std::string& /*topic_name*/,
+            std::string& /*topic_data_type*/) const
+    {
+        return RETCODE_OK;
+    }
+
     ReturnCode_t get_replier_qos_from_profile(
             const std::string& /*profile_name*/,
+            ReplierQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_replier_qos_from_xml(
+            const std::string& /*xml*/,
             ReplierQos& /*qos*/) const
     {
         return RETCODE_OK;
@@ -573,6 +640,13 @@ public:
         return RETCODE_OK;
     }
 
+    ReturnCode_t get_default_replier_qos_from_xml(
+            const std::string& /*xml*/,
+            ReplierQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
     ReturnCode_t get_requester_qos_from_profile(
             const std::string& /*profile_name*/,
             RequesterQos& /*qos*/) const
@@ -582,8 +656,22 @@ public:
 
     ReturnCode_t get_requester_qos_from_xml(
             const std::string& /*xml*/,
+            RequesterQos& /*qos*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_requester_qos_from_xml(
+            const std::string& /*xml*/,
             RequesterQos& /*qos*/,
             const std::string& /*profile_name*/) const
+    {
+        return RETCODE_OK;
+    }
+
+    ReturnCode_t get_default_requester_qos_from_xml(
+            const std::string& /*xml*/,
+            RequesterQos& /*qos*/) const
     {
         return RETCODE_OK;
     }

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -41,6 +41,7 @@ target_compile_definitions(ParticipantTests PRIVATE
 target_include_directories(ParticipantTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
+    ${PROJECT_SOURCE_DIR}/test/utils
     )
 target_link_libraries(ParticipantTests fastdds fastcdr foonathan_memory
     GTest::gmock

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -767,10 +767,10 @@ TEST(ParticipantTests, GetParticipantQosFromXml)
         DomainParticipantFactory::get_instance()->get_participant_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     DomainParticipantQos qos_empty_profile;
     EXPECT_EQ(
-        DomainParticipantFactory::get_instance()->get_participant_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        DomainParticipantFactory::get_instance()->get_participant_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile
@@ -808,12 +808,10 @@ TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
         profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     DomainParticipantExtendedQos qos_empty_profile;
     EXPECT_EQ(
-        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_xml(complete_xml, qos_empty_profile,
-        ""),
-        RETCODE_OK);
+        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_xml(complete_xml, qos_empty_profile), RETCODE_OK);
 
     // Check they correspond to the same profile
     // NOTE: test_participant_profile is assumed to be the first participant profile in the XML file
@@ -2094,10 +2092,10 @@ TEST(ParticipantTests, GetSubscriberQosFromXml)
         participant->get_subscriber_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     SubscriberQos qos_empty_profile;
     EXPECT_EQ(
-        participant->get_subscriber_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        participant->get_subscriber_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile
@@ -2192,10 +2190,10 @@ TEST(ParticipantTests, GetPublisherQosFromXml)
         participant->get_publisher_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     PublisherQos qos_empty_profile;
     EXPECT_EQ(
-        participant->get_publisher_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        participant->get_publisher_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile
@@ -2262,10 +2260,10 @@ TEST(ParticipantTests, GetReplierQosFromXml)
         participant->get_replier_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     ReplierQos qos_empty_profile;
     EXPECT_EQ(
-        participant->get_replier_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        participant->get_replier_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile
@@ -2332,10 +2330,10 @@ TEST(ParticipantTests, GetRequesterQosFromXml)
         participant->get_requester_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     RequesterQos qos_empty_profile;
     EXPECT_EQ(
-        participant->get_requester_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        participant->get_requester_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile
@@ -2505,10 +2503,10 @@ TEST(ParticipantTests, GetTopicQosFromXml)
         participant->get_topic_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     TopicQos qos_empty_profile;
     EXPECT_EQ(
-        participant->get_topic_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        participant->get_topic_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -874,7 +874,19 @@ TEST(ParticipantTests, GetDefaultParticipantExtendedQosFromXml)
         RETCODE_OK);
 
     // NOTE: cannot load profiles file and compare with default value as
-    // DomainParticipantFactory::get_default_participant_extended_qos is currently unavailable
+    // DomainParticipantFactory::get_default_participant_extended_qos is currently unavailable. However, we will
+    // instead load the profile we know is the default one and compare with it.
+
+    // Load profiles from XML file and get default QoS (knowing its profile name)
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    DomainParticipantExtendedQos default_qos_from_profile;
+    EXPECT_EQ(
+        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_profile("test_default_participant_profile",
+        default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
 }
 
 TEST(ParticipantTests, DeleteDomainParticipant)
@@ -2123,6 +2135,12 @@ TEST(ParticipantTests, GetSubscriberQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2168,6 +2186,12 @@ TEST(ParticipantTests, GetDefaultSubscriberQosFromXml)
     const std::string xml_filename("test_xml_profile.xml");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
@@ -2255,6 +2279,12 @@ TEST(ParticipantTests, GetPublisherQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2300,6 +2330,12 @@ TEST(ParticipantTests, GetDefaultPublisherQosFromXml)
     const std::string xml_filename("test_xml_profile.xml");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
@@ -2359,6 +2395,12 @@ TEST(ParticipantTests, GetReplierQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2405,6 +2447,12 @@ TEST(ParticipantTests, GetDefaultReplierQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2417,7 +2465,19 @@ TEST(ParticipantTests, GetDefaultReplierQosFromXml)
         RETCODE_OK);
 
     // NOTE: cannot load profiles file and compare with default value as
-    // DomainParticipant::get_default_replier_qos is currently unavailable
+    // DomainParticipant::get_default_replier_qos is currently unavailable. However, we will
+    // instead load the profile we know is the default one and compare with it.
+
+    // Load profiles from XML file and get default QoS (knowing its profile name)
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    ReplierQos default_qos_from_profile;
+    EXPECT_EQ(
+        participant->get_replier_qos_from_profile("test_replier_profile",
+        default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
 
     // Clean up
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
@@ -2452,6 +2512,12 @@ TEST(ParticipantTests, GetRequesterQosFromXml)
     const std::string profile_name("test_requester_profile");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
@@ -2499,6 +2565,12 @@ TEST(ParticipantTests, GetDefaultRequesterQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2511,7 +2583,19 @@ TEST(ParticipantTests, GetDefaultRequesterQosFromXml)
         RETCODE_OK);
 
     // NOTE: cannot load profiles file and compare with default value as
-    // DomainParticipant::get_default_requester_qos is currently unavailable
+    // DomainParticipant::get_default_requester_qos is currently unavailable. However, we will
+    // instead load the profile we know is the default one and compare with it.
+
+    // Load profiles from XML file and get default QoS (knowing its profile name)
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    RequesterQos default_qos_from_profile;
+    EXPECT_EQ(
+        participant->get_requester_qos_from_profile("test_requester_profile",
+        default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
 
     // Clean up
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
@@ -2650,6 +2734,12 @@ TEST(ParticipantTests, GetTopicQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
@@ -2695,6 +2785,12 @@ TEST(ParticipantTests, GetDefaultTopicQosFromXml)
     const std::string xml_filename("test_xml_profile.xml");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -837,7 +837,8 @@ TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
     // Get QoS without providing profile name (gets first one found)
     DomainParticipantExtendedQos qos_empty_profile;
     EXPECT_EQ(
-        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_xml(complete_xml, qos_empty_profile), RETCODE_OK);
+        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_xml(complete_xml,
+        qos_empty_profile), RETCODE_OK);
 
     // Check they correspond to the same profile
     // NOTE: test_participant_profile is assumed to be the first participant profile in the XML file
@@ -870,7 +871,8 @@ TEST(ParticipantTests, GetDefaultParticipantExtendedQosFromXml)
     // Get default QoS from XML
     DomainParticipantExtendedQos default_qos;
     EXPECT_EQ(
-        DomainParticipantFactory::get_instance()->get_default_participant_extended_qos_from_xml(complete_xml, default_qos),
+        DomainParticipantFactory::get_instance()->get_default_participant_extended_qos_from_xml(complete_xml,
+        default_qos),
         RETCODE_OK);
 
     // NOTE: cannot load profiles file and compare with default value as
@@ -881,8 +883,9 @@ TEST(ParticipantTests, GetDefaultParticipantExtendedQosFromXml)
     DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
     DomainParticipantExtendedQos default_qos_from_profile;
     EXPECT_EQ(
-        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_profile("test_default_participant_profile",
-        default_qos_from_profile),
+        DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_profile(
+            "test_default_participant_profile",
+            default_qos_from_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -794,6 +794,32 @@ TEST(ParticipantTests, GetParticipantQosFromXml)
         RETCODE_BAD_PARAMETER);
 }
 
+TEST(ParticipantTests, GetDefaultParticipantQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    // Get default QoS from XML
+    DomainParticipantQos default_qos;
+    EXPECT_EQ(
+        DomainParticipantFactory::get_instance()->get_default_participant_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    DomainParticipantFactory::get_instance()->set_default_participant_qos(PARTICIPANT_QOS_DEFAULT);
+    DomainParticipantQos default_qos_from_profile;
+    EXPECT_EQ(
+        DomainParticipantFactory::get_instance()->get_default_participant_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
+}
+
 TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
 {
     const std::string xml_filename("test_xml_profile.xml");
@@ -833,6 +859,22 @@ TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
         DomainParticipantFactory::get_instance()->get_participant_extended_qos_from_xml(complete_xml, qos,
         "incorrect_profile_name"),
         RETCODE_BAD_PARAMETER);
+}
+
+TEST(ParticipantTests, GetDefaultParticipantExtendedQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    // Get default QoS from XML
+    DomainParticipantExtendedQos default_qos;
+    EXPECT_EQ(
+        DomainParticipantFactory::get_instance()->get_default_participant_extended_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // NOTE: cannot load profiles file and compare with default value as
+    // DomainParticipantFactory::get_default_participant_extended_qos is currently unavailable
 }
 
 TEST(ParticipantTests, DeleteDomainParticipant)
@@ -2121,6 +2163,40 @@ TEST(ParticipantTests, GetSubscriberQosFromXml)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
+TEST(ParticipantTests, GetDefaultSubscriberQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Get default QoS from XML
+    SubscriberQos default_qos;
+    EXPECT_EQ(
+        participant->get_default_subscriber_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    participant->set_default_subscriber_qos(SUBSCRIBER_QOS_DEFAULT);
+    SubscriberQos default_qos_from_profile;
+    EXPECT_EQ(
+        participant->get_default_subscriber_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
+
+    // Clean up
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 TEST(ParticipantTests, CreateSubscriberWithProfile)
 {
     DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_profile.xml");
@@ -2219,6 +2295,40 @@ TEST(ParticipantTests, GetPublisherQosFromXml)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
+TEST(ParticipantTests, GetDefaultPublisherQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Get default QoS from XML
+    PublisherQos default_qos;
+    EXPECT_EQ(
+        participant->get_default_publisher_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    participant->set_default_publisher_qos(PUBLISHER_QOS_DEFAULT);
+    PublisherQos default_qos_from_profile;
+    EXPECT_EQ(
+        participant->get_default_publisher_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
+
+    // Clean up
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 TEST(ParticipantTests, GetReplierProfileQos)
 {
     DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_profile.xml");
@@ -2289,6 +2399,30 @@ TEST(ParticipantTests, GetReplierQosFromXml)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
+TEST(ParticipantTests, GetDefaultReplierQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Get default QoS from XML
+    ReplierQos default_qos;
+    EXPECT_EQ(
+        participant->get_default_replier_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // NOTE: cannot load profiles file and compare with default value as
+    // DomainParticipant::get_default_replier_qos is currently unavailable
+
+    // Clean up
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 TEST(ParticipantTests, GetRequesterProfileQos)
 {
     DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_profile.xml");
@@ -2354,6 +2488,30 @@ TEST(ParticipantTests, GetRequesterQosFromXml)
     EXPECT_EQ(
         participant->get_requester_qos_from_xml(complete_xml, qos, "incorrect_profile_name"),
         RETCODE_BAD_PARAMETER);
+
+    // Clean up
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
+TEST(ParticipantTests, GetDefaultRequesterQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Get default QoS from XML
+    RequesterQos default_qos;
+    EXPECT_EQ(
+        participant->get_default_requester_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // NOTE: cannot load profiles file and compare with default value as
+    // DomainParticipant::get_default_requester_qos is currently unavailable
 
     // Clean up
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
@@ -2527,6 +2685,40 @@ TEST(ParticipantTests, GetTopicQosFromXml)
     EXPECT_EQ(
         participant->get_topic_qos_from_xml(complete_xml, qos, "incorrect_profile_name"),
         RETCODE_BAD_PARAMETER);
+
+    // Clean up
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
+TEST(ParticipantTests, GetDefaultTopicQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Get default QoS from XML
+    TopicQos default_qos;
+    EXPECT_EQ(
+        participant->get_default_topic_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    participant->set_default_topic_qos(TOPIC_QOS_DEFAULT);
+    TopicQos default_qos_from_profile;
+    EXPECT_EQ(
+        participant->get_default_topic_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
 
     // Clean up
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -775,7 +775,7 @@ TEST(ParticipantTests, GetParticipantQosFromXml)
 
     // Check they correspond to the same profile
     // NOTE: test_participant_profile is assumed to be the first participant profile in the XML file
-    check_equivalent_qos(qos, qos_empty_profile);
+    EXPECT_EQ(qos, qos_empty_profile);
 
     // Load profiles from XML file and get QoS given profile name
     DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
@@ -785,7 +785,7 @@ TEST(ParticipantTests, GetParticipantQosFromXml)
         RETCODE_OK);
 
     // Check they correspond to the same profile
-    check_equivalent_qos(qos, qos_from_profile);
+    EXPECT_EQ(qos, qos_from_profile);
 
     // Test return when a non-existent profile is used
     EXPECT_EQ(
@@ -817,7 +817,7 @@ TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
 
     // Check they correspond to the same profile
     // NOTE: test_participant_profile is assumed to be the first participant profile in the XML file
-    check_equivalent_extended_qos(qos, qos_empty_profile);
+    EXPECT_EQ(qos, qos_empty_profile);
 
     // Load profiles from XML file and get QoS given profile name
     DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
@@ -828,7 +828,7 @@ TEST(ParticipantTests, GetParticipantExtendedQosFromXml)
         RETCODE_OK);
 
     // Check they correspond to the same profile
-    check_equivalent_extended_qos(qos, qos_from_profile);
+    EXPECT_EQ(qos, qos_from_profile);
 
     // Test return when a non-existent profile is used
     EXPECT_EQ(

--- a/test/unittest/dds/profiles/test_xml_profile.xml
+++ b/test/unittest/dds/profiles/test_xml_profile.xml
@@ -730,7 +730,7 @@
             </matchedPublishersAllocation>
         </data_reader>
 
-        <topic profile_name = "test_topic_profile">
+        <topic profile_name = "test_topic_profile" is_default_profile="true">
             <historyQos>
                 <kind>KEEP_LAST</kind>
                 <depth>20</depth>
@@ -746,7 +746,8 @@
         <replier profile_name="test_replier_profile"
                 service_name="service_name"
                 request_type="request_type"
-                reply_type="reply_type">
+                reply_type="reply_type"
+                is_default_profile="true">
             <request_topic_name>request_topic_name</request_topic_name>
             <reply_topic_name>reply_topic_name</reply_topic_name>
             <data_writer>
@@ -768,7 +769,8 @@
         <requester profile_name="test_requester_profile"
                 service_name="service_name"
                 request_type="request_type"
-                reply_type="reply_type">
+                reply_type="reply_type"
+                is_default_profile="true">
             <request_topic_name>request_topic_name</request_topic_name>
             <reply_topic_name>reply_topic_name</reply_topic_name>
             <data_writer>

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -321,6 +321,7 @@ target_include_directories(PublisherTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
     ${PROJECT_SOURCE_DIR}/thirdparty/taocpp-pegtl
+    ${PROJECT_SOURCE_DIR}/test/utils
     )
 target_link_libraries(PublisherTests fastdds fastcdr foonathan_memory
     GTest::gmock

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -27,6 +27,8 @@
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.hpp>
 
+#include <FileUtils.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace dds {
@@ -566,6 +568,55 @@ TEST(PublisherTests, GetDataWriterProfileQos)
     ASSERT_EQ(publisher->delete_datawriter(datawriter), RETCODE_OK);
     ASSERT_EQ(participant->delete_publisher(publisher), RETCODE_OK);
     ASSERT_EQ(participant->delete_topic(topic), RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
+TEST(PublisherTests, GetDataWriterQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+    const std::string profile_name("test_publisher_profile");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    // Get QoS given profile name
+    DataWriterQos qos;
+    EXPECT_EQ(
+        publisher->get_datawriter_qos_from_xml(complete_xml, qos, profile_name),
+        RETCODE_OK);
+
+    // Get QoS given profile name with empty profile name (gets first one found)
+    DataWriterQos qos_empty_profile;
+    EXPECT_EQ(
+        publisher->get_datawriter_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    // NOTE: test_publisher_profile is assumed to be the first publisher profile in the XML file
+    EXPECT_EQ(qos, qos_empty_profile);
+
+    // Load profiles from XML file and get QoS given profile name
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    DataWriterQos qos_from_profile;
+    EXPECT_EQ(
+        publisher->get_datawriter_qos_from_profile(profile_name, qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(qos, qos_from_profile);
+
+    // Test return when a non-existent profile is used
+    EXPECT_EQ(
+        publisher->get_datawriter_qos_from_xml(complete_xml, qos, "incorrect_profile_name"),
+        RETCODE_BAD_PARAMETER);
+
+    // Clean up
+    ASSERT_EQ(participant->delete_publisher(publisher), RETCODE_OK);
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -590,10 +590,10 @@ TEST(PublisherTests, GetDataWriterQosFromXml)
         publisher->get_datawriter_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     DataWriterQos qos_empty_profile;
     EXPECT_EQ(
-        publisher->get_datawriter_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        publisher->get_datawriter_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -620,6 +620,42 @@ TEST(PublisherTests, GetDataWriterQosFromXml)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
+TEST(PublisherTests, GetDefaultDataWriterQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    // Get default QoS from XML
+    DataWriterQos default_qos;
+    EXPECT_EQ(
+        publisher->get_default_datawriter_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    publisher->set_default_datawriter_qos(DATAWRITER_QOS_DEFAULT);
+    DataWriterQos default_qos_from_profile;
+    EXPECT_EQ(
+        publisher->get_default_datawriter_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
+
+    // Clean up
+    ASSERT_EQ(participant->delete_publisher(publisher), RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 TEST(PublisherTests, DeletePublisherWithWriters)
 {
     DomainParticipant* participant =

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -578,6 +578,12 @@ TEST(PublisherTests, GetDataWriterQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
@@ -625,6 +631,12 @@ TEST(PublisherTests, GetDefaultDataWriterQosFromXml)
     const std::string xml_filename("test_xml_profile.xml");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);

--- a/test/unittest/dds/subscriber/CMakeLists.txt
+++ b/test/unittest/dds/subscriber/CMakeLists.txt
@@ -73,6 +73,7 @@ target_compile_definitions(SubscriberTests PRIVATE
 target_include_directories(SubscriberTests PRIVATE
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
+    ${PROJECT_SOURCE_DIR}/test/utils
     )
 target_link_libraries(SubscriberTests fastdds fastcdr foonathan_memory
     GTest::gmock

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -644,6 +644,42 @@ TEST(SubscriberTests, GetDataReaderQosFromXml)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
+TEST(PublisherTests, GetDefaultDataReaderQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    // Get default QoS from XML
+    DataReaderQos default_qos;
+    EXPECT_EQ(
+        subscriber->get_default_datareader_qos_from_xml(complete_xml, default_qos),
+        RETCODE_OK);
+
+    // Load profiles from XML file and get default QoS after resetting its value
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    // NOTE: At the time of this writing, the only way to reset the default qos after loading an XML is to do as follows
+    DomainParticipantFactory::get_instance()->load_profiles();
+    subscriber->set_default_datareader_qos(DATAREADER_QOS_DEFAULT);
+    DataReaderQos default_qos_from_profile;
+    EXPECT_EQ(
+        subscriber->get_default_datareader_qos(default_qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(default_qos, default_qos_from_profile);
+
+    // Clean up
+    ASSERT_EQ(participant->delete_subscriber(subscriber), RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 TEST(SubscriberTests, DeleteSubscriberWithReaders)
 {
     DomainParticipant* participant =

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -602,6 +602,12 @@ TEST(SubscriberTests, GetDataReaderQosFromXml)
 
     std::string complete_xml = testing::load_file(xml_filename);
 
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
+
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(participant, nullptr);
@@ -649,6 +655,12 @@ TEST(PublisherTests, GetDefaultDataReaderQosFromXml)
     const std::string xml_filename("test_xml_profile.xml");
 
     std::string complete_xml = testing::load_file(xml_filename);
+
+    // Disable created auxiliar entities to avoid polluting traffic
+    DomainParticipantFactoryQos factory_qos;
+    DomainParticipantFactory::get_instance()->get_qos(factory_qos);
+    factory_qos.entity_factory().autoenable_created_entities = false;
+    DomainParticipantFactory::get_instance()->set_qos(factory_qos);
 
     DomainParticipant* participant =
             DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -614,10 +614,10 @@ TEST(SubscriberTests, GetDataReaderQosFromXml)
         subscriber->get_datareader_qos_from_xml(complete_xml, qos, profile_name),
         RETCODE_OK);
 
-    // Get QoS given profile name with empty profile name (gets first one found)
+    // Get QoS without providing profile name (gets first one found)
     DataReaderQos qos_empty_profile;
     EXPECT_EQ(
-        subscriber->get_datareader_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        subscriber->get_datareader_qos_from_xml(complete_xml, qos_empty_profile),
         RETCODE_OK);
 
     // Check they correspond to the same profile

--- a/test/unittest/dds/subscriber/SubscriberTests.cpp
+++ b/test/unittest/dds/subscriber/SubscriberTests.cpp
@@ -30,6 +30,8 @@
 #include <fastdds/rtps/attributes/PropertyPolicy.hpp>
 #include <fastdds/rtps/history/ReaderHistory.hpp>
 
+#include <FileUtils.hpp>
+
 namespace eprosima {
 namespace fastdds {
 namespace dds {
@@ -590,6 +592,55 @@ TEST(SubscriberTests, GetDataReaderProfileQos)
     ASSERT_EQ(subscriber->delete_datareader(datareader), RETCODE_OK);
     ASSERT_EQ(participant->delete_subscriber(subscriber), RETCODE_OK);
     ASSERT_EQ(participant->delete_topic(topic), RETCODE_OK);
+    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
+TEST(SubscriberTests, GetDataReaderQosFromXml)
+{
+    const std::string xml_filename("test_xml_profile.xml");
+    const std::string profile_name("test_subscriber_profile");
+
+    std::string complete_xml = testing::load_file(xml_filename);
+
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+    Subscriber* subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(subscriber, nullptr);
+
+    // Get QoS given profile name
+    DataReaderQos qos;
+    EXPECT_EQ(
+        subscriber->get_datareader_qos_from_xml(complete_xml, qos, profile_name),
+        RETCODE_OK);
+
+    // Get QoS given profile name with empty profile name (gets first one found)
+    DataReaderQos qos_empty_profile;
+    EXPECT_EQ(
+        subscriber->get_datareader_qos_from_xml(complete_xml, qos_empty_profile, ""),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    // NOTE: test_subscriber_profile is assumed to be the first subscriber profile in the XML file
+    EXPECT_EQ(qos, qos_empty_profile);
+
+    // Load profiles from XML file and get QoS given profile name
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_filename);
+    DataReaderQos qos_from_profile;
+    EXPECT_EQ(
+        subscriber->get_datareader_qos_from_profile(profile_name, qos_from_profile),
+        RETCODE_OK);
+
+    // Check they correspond to the same profile
+    EXPECT_EQ(qos, qos_from_profile);
+
+    // Test return when a non-existent profile is used
+    EXPECT_EQ(
+        subscriber->get_datareader_qos_from_xml(complete_xml, qos, "incorrect_profile_name"),
+        RETCODE_BAD_PARAMETER);
+
+    // Clean up
+    ASSERT_EQ(participant->delete_subscriber(subscriber), RETCODE_OK);
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 

--- a/test/utils/FileUtils.hpp
+++ b/test/utils/FileUtils.hpp
@@ -24,12 +24,14 @@ namespace eprosima {
 namespace fastdds {
 namespace testing {
 
-std::string load_file(const std::string& file_path)
+std::string load_file(
+        const std::string& file_path)
 {
     std::ifstream file(file_path);
 
     // Check if the file was opened successfully
-    if (!file.is_open()) {
+    if (!file.is_open())
+    {
         throw std::runtime_error("Could not open file " + file_path);
     }
 

--- a/test/utils/FileUtils.hpp
+++ b/test/utils/FileUtils.hpp
@@ -1,0 +1,51 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef _TEST_UTILS_FILEUTILS_HPP_
+#define _TEST_UTILS_FILEUTILS_HPP_
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace eprosima {
+namespace fastdds {
+namespace testing {
+
+std::string load_file(const std::string& file_path)
+{
+    std::ifstream file(file_path);
+
+    // Check if the file was opened successfully
+    if (!file.is_open()) {
+        throw std::runtime_error("Could not open file " + file_path);
+    }
+
+    // Use a stringstream to read the file contents into a string
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+
+    // Close the file after reading
+    file.close();
+
+    // Return the string containing the file contents
+    return buffer.str();
+}
+
+} // namespace testing
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // _TEST_UTILS_FILEUTILS_HPP_

--- a/test/utils/FileUtils.hpp
+++ b/test/utils/FileUtils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef _TEST_UTILS_FILEUTILS_HPP_
-#define _TEST_UTILS_FILEUTILS_HPP_
+#ifndef TEST_UTILS__FILEUTILS_HPP
+#define TEST_UTILS__FILEUTILS_HPP
 
 #include <fstream>
 #include <iostream>
@@ -48,4 +48,4 @@ std::string load_file(const std::string& file_path)
 } // namespace fastdds
 } // namespace eprosima
 
-#endif // _TEST_UTILS_FILEUTILS_HPP_
+#endif // TEST_UTILS__FILEUTILS_HPP


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR extends public API with methods meant to fill QoS structures given a raw XML string containing pertinent profile configurations. For each QoS getter from XML there are three method variants:
- `get_X_qos_from_xml` without profile name : the first encountered profile of the expected kind (participant, publisher, etc.) is parsed.
- `get_X_qos_from_xml` given profile name : fills the QoS structure with the profile whose name coincides with the one provided.
- `get_default_X_qos_from_xml`  :  fills the structure with the default profile of the expected kind (participant, publisher, etc.) found in the XML string.

This API extension provides backwards compatibility after having made XMLParser private (done in Fast-DDS 3 release).

Merge after:
- https://github.com/eProsima/Fast-DDS/pull/5295
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/928
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
