### PR TITLE
[21751] Discard changes with big key-only payload and no key hash

### DIFF
--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -877,7 +877,10 @@ bool MessageReceiver::proc_Submsg_Data(
             {
                 if (payload_size <= PARAMETER_KEY_HASH_LENGTH)
                 {
-                    memcpy(ch.instanceHandle.value, &msg->buffer[msg->pos], payload_size);
+                    if (!ch.instanceHandle.isDefined())
+                    {
+                        memcpy(ch.instanceHandle.value, &msg->buffer[msg->pos], payload_size);
+                    }
                 }
                 else
                 {

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -874,7 +874,7 @@ bool MessageReceiver::proc_Submsg_Data(
                 ch.serializedPayload.length = payload_size;
                 ch.serializedPayload.max_size = payload_size;
             }
-            else
+            else // keyFlag would be true since we are inside an if (dataFlag || keyFlag)
             {
                 if (payload_size <= PARAMETER_KEY_HASH_LENGTH)
                 {

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -867,6 +867,7 @@ bool MessageReceiver::proc_Submsg_Data(
         uint32_t next_pos = msg->pos + payload_size;
         if (msg->length >= next_pos && payload_size > 0)
         {
+            FASTDDS_TODO_BEFORE(3, 1, "Pass keyFlag in serializedPayload, and always pass input data upwards");
             if (dataFlag)
             {
                 ch.serializedPayload.data = &msg->buffer[msg->pos];

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -31,8 +31,11 @@ bool change_is_relevant_for_filter(
 {
     bool ret = true;
 
-    if ((change.serializedPayload.data == nullptr) &&
-            ((change.kind == fastdds::rtps::ALIVE) || !change.instanceHandle.isDefined()))
+    // If the change has no payload, it should have an instanceHandle.
+    // This is only allowed for UNREGISTERED and DISPOSED changes, where the instanceHandle is used to identify the
+    // instance to unregister or dispose.
+    if ((nullptr == change.serializedPayload.data) &&
+            ((fastdds::rtps::ALIVE == change.kind) || !change.instanceHandle.isDefined()))
     {
         ret = false;
     }

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -31,6 +31,12 @@ bool change_is_relevant_for_filter(
 {
     bool ret = true;
 
+    if ((change.serializedPayload.data == nullptr) &&
+            ((change.kind == fastdds::rtps::ALIVE) || !change.instanceHandle.isDefined()))
+    {
+        ret = false;
+    }
+
     // Only evaluate filter on ALIVE changes, as UNREGISTERED and DISPOSED are always relevant
     if ((nullptr != filter) && (fastdds::rtps::ALIVE == change.kind) && (!filter->is_relevant(change, reader_guid)))
     {

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -633,6 +634,135 @@ TEST(TransportUDP, MaliciousManipulatedDataOctetsToNextHeaderIgnore)
 
     // Block reader until reception finished or timeout.
     reader.block_for_all();
+}
+
+/**
+ * This is a regression test for redmine issue #21707.
+ */
+TEST(TransportUDP, KeyOnlyBigPayloadIgnored)
+{
+    // Force using UDP transport
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    PubSubWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    struct KeyOnlyBigPayloadDatagram
+    {
+        std::array<char, 4> rtps_id{ {'R', 'T', 'P', 'S'} };
+        std::array<uint8_t, 2> protocol_version{ {2, 3} };
+        std::array<uint8_t, 2> vendor_id{ {0x01, 0x0F} };
+        GuidPrefix_t sender_prefix{};
+
+        struct DataSubMsg
+        {
+            struct Header
+            {
+                uint8_t submessage_id = 0x15;
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint8_t flags = 0x0A; // Serialized key, inline QoS
+#else
+                uint8_t flags = 0x0B; // Serialized key, inline QoS, endianness
+#endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint16_t octets_to_next_header = 0x48;
+                uint16_t extra_flags = 0;
+                uint16_t octets_to_inline_qos = 0x10;
+                EntityId_t reader_id{};
+                EntityId_t writer_id{};
+                SequenceNumber_t sn{ 2 };
+            };
+
+            struct InlineQoS
+            {
+                // PID_STATUS_INFO (unregistered + disposed)
+                struct StatusInfo
+                {
+                    uint16_t pid = 0x0071;
+                    uint16_t length = 0x0004;
+                    std::array<uint8_t, 4> status_value{ {0x00, 0x00, 0x00, 0x03} };
+                };
+                // PID_SENTINEL
+                struct Sentinel
+                {
+                    uint16_t pid = 0x0001;
+                    uint16_t length = 0x0000;
+                };
+
+                StatusInfo status_info;
+                Sentinel sentinel;
+            };
+
+            struct SerializedData
+            {
+                std::array<uint8_t, 2> encapsulation {{0}};
+                std::array<uint8_t, 2> encapsulation_opts {{0}};
+                std::array<uint8_t, 0x24> data {{0}};
+            };
+
+            Header header;
+            InlineQoS qos;
+            SerializedData payload;
+        }
+        data;
+    };
+
+    UDPMessageSender fake_msg_sender;
+
+    // Set common QoS
+    reader.disable_builtin_transport().add_user_transport_to_pparams(udp_transport)
+            .history_depth(10).reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+    writer.history_depth(10).reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+
+    // Set custom reader locator so we can send malicious data to a known location
+    Locator_t reader_locator;
+    ASSERT_TRUE(IPLocator::setIPv4(reader_locator, "127.0.0.1"));
+    reader_locator.port = 7000;
+    reader.add_to_unicast_locator_list("127.0.0.1", 7000);
+
+    // Initialize and wait for discovery
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Send one sample
+    std::list<KeyedHelloWorld> data;
+    KeyedHelloWorld sample;
+    sample.key(0);
+    sample.index(1);
+    sample.message("KeyedHelloWorld 1 (key = 0)");
+    data.push_back(sample);
+    reader.startReception(data);
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+
+    // Wait for the reader to receive the sample
+    reader.block_for_all();
+
+    // Send unregister disposed without PID_KEY_HASH, and long key-only payload
+    {
+        auto writer_guid = writer.datawriter_guid();
+
+        KeyOnlyBigPayloadDatagram malicious_packet{};
+        malicious_packet.sender_prefix = writer_guid.guidPrefix;
+        malicious_packet.data.header.writer_id = writer_guid.entityId;
+        malicious_packet.data.header.reader_id = reader.datareader_guid().entityId;
+        malicious_packet.data.payload.encapsulation[1] = CDR_LE;
+        malicious_packet.data.payload.data.fill(0x00);
+
+        CDRMessage_t msg(0);
+        uint32_t msg_len = static_cast<uint32_t>(sizeof(malicious_packet));
+        msg.init(reinterpret_cast<octet*>(&malicious_packet), msg_len);
+        msg.length = msg_len;
+        msg.pos = msg_len;
+        fake_msg_sender.send(msg, reader_locator);
+    }
+
+    // Wait some time to let the message be processed
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
 }
 
 // Test for ==operator UDPTransportDescriptor is not required as it is an abstract class and in UDPv4 is same method


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

We currently don't have support for key-only payloads bigger than the KEY_HASH length.
Receiving such kind of messages produces a segfault in DataReaderHistory.

This PR adds a regression test reproducing the issue, and fixes it by considering the incoming change as irrelevant.
It has been done this way so it is acknowledged in reliable topics, thus avoiding the offending data to be resent.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
@Mergifyio backport 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
