### PR TITLE
[21710] DataWriter/Reader get_matched_publication/subscription() Test implementation

### DIFF
--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -309,10 +309,10 @@ public:
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
     /**
-     * @brief Fills the provided @ref PublicationBuiltinTopicData with the information of the
+     * @brief Fills the provided fastdds::dds::builtin::PublicationBuiltinTopicData with the information of the
      * writer identified by writer_guid.
      *
-     * @param[out] data @ref PublicationBuiltinTopicData to fill.
+     * @param[out] data fastdds::dds::builtin::PublicationBuiltinTopicData to fill.
      * @param[in] writer_guid GUID of the writer to get the information from.
      * @return True if the writer was found and the data was filled.
      */
@@ -321,10 +321,10 @@ public:
             const GUID_t& writer_guid) const;
 
     /**
-     * @brief Fills the provided @ref SubscriptionBuiltinTopicData with the information of the
+     * @brief Fills the provided fastdds::dds::builtin::SubscriptionBuiltinTopicData with the information of the
      * reader identified by reader_guid.
      *
-     * @param[out] data @ref SubscriptionBuiltinTopicData to fill.
+     * @param[out] data fastdds::dds::builtin::SubscriptionBuiltinTopicData to fill.
      * @param[in] reader_guid GUID of the reader to get the information from.
      * @return True if the reader was found and the data was filled.
      */

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -316,7 +316,7 @@ public:
      * @param[in] writer_guid GUID of the writer to get the information from.
      * @return True if the writer was found and the data was filled.
      */
-    RTPS_DllAPI bool get_publication_info(
+    bool get_publication_info(
             fastdds::dds::builtin::PublicationBuiltinTopicData& data,
             const GUID_t& writer_guid) const;
 
@@ -328,7 +328,7 @@ public:
      * @param[in] reader_guid GUID of the reader to get the information from.
      * @return True if the reader was found and the data was filled.
      */
-    RTPS_DllAPI bool get_subscription_info(
+    bool get_subscription_info(
             fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
             const GUID_t& reader_guid) const;
 

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -309,26 +309,26 @@ public:
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
     /**
-     * @brief Fills the provided PublicationBuiltinTopicData with the information of the
+     * @brief Fills the provided @ref PublicationBuiltinTopicData with the information of the
      * writer identified by writer_guid.
      *
-     * @param[out] data PublicationBuiltinTopicData to fill.
+     * @param[out] data @ref PublicationBuiltinTopicData to fill.
      * @param[in] writer_guid GUID of the writer to get the information from.
      * @return True if the writer was found and the data was filled.
      */
-    bool get_publication_info(
+    RTPS_DllAPI bool get_publication_info(
             fastdds::dds::builtin::PublicationBuiltinTopicData& data,
             const GUID_t& writer_guid) const;
 
     /**
-     * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
+     * @brief Fills the provided @ref SubscriptionBuiltinTopicData with the information of the
      * reader identified by reader_guid.
      *
-     * @param[out] data SubscriptionBuiltinTopicData to fill.
+     * @param[out] data @ref SubscriptionBuiltinTopicData to fill.
      * @param[in] reader_guid GUID of the reader to get the information from.
      * @return True if the reader was found and the data was filled.
      */
-    bool get_subscription_info(
+    RTPS_DllAPI bool get_subscription_info(
             fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
             const GUID_t& reader_guid) const;
 

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -317,8 +317,8 @@ public:
      * @return True if the writer was found and the data was filled.
      */
     bool get_publication_info(
-            const GUID_t& writer_guid,
-            fastdds::dds::builtin::PublicationBuiltinTopicData& data) const;
+            fastdds::dds::builtin::PublicationBuiltinTopicData& data,
+            const GUID_t& writer_guid) const;
 
     /**
      * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
@@ -329,8 +329,8 @@ public:
      * @return True if the reader was found and the data was filled.
      */
     bool get_subscription_info(
-            const GUID_t& reader_guid,
-            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data) const;
+            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
+            const GUID_t& reader_guid) const;
 
 #if HAVE_SECURITY
 

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -54,6 +54,8 @@ namespace dds {
 namespace builtin {
 
 class TypeLookupManager;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 } // namespace builtin
 } // namespace dds
@@ -305,6 +307,30 @@ public:
      * @return A vector with all registered transports' netmask filter information.
      */
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const;
+
+    /**
+     * @brief Fills the provided PublicationBuiltinTopicData with the information of the
+     * writer identified by writer_guid.
+     *
+     * @param[out] data PublicationBuiltinTopicData to fill.
+     * @param[in] writer_guid GUID of the writer to get the information from.
+     * @return True if the writer was found and the data was filled.
+     */
+    bool get_publication_info(
+            const GUID_t& writer_guid,
+            fastdds::dds::builtin::PublicationBuiltinTopicData& data) const;
+
+    /**
+     * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
+     * reader identified by reader_guid.
+     *
+     * @param[out] data SubscriptionBuiltinTopicData to fill.
+     * @param[in] reader_guid GUID of the reader to get the information from.
+     * @return True if the reader was found and the data was filled.
+     */
+    bool get_subscription_info(
+            const GUID_t& reader_guid,
+            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data) const;
 
 #if HAVE_SECURITY
 

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -276,6 +276,15 @@ public:
         data_filter_ = filter;
     }
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    RTPS_DllAPI bool get_matched_guids(
+            std::vector<GUID_t>& guids) const;
+
     /*!
      * @brief Returns there is a clean state with all Writers.
      * It occurs when the Reader received all samples sent by Writers. In other words,

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -282,7 +282,7 @@ public:
      * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
      * @return True if the operation was successful.
      */
-    RTPS_DllAPI bool get_matched_guids(
+    RTPS_DllAPI bool matched_writers_guids(
             std::vector<GUID_t>& guids) const;
 
     /*!

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -323,7 +323,7 @@ public:
      * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
      * @return True if the operation was successful.
      */
-    RTPS_DllAPI bool get_matched_guids(
+    RTPS_DllAPI bool matched_readers_guids(
             std::vector<GUID_t>& guids) const;
 
     /**

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -318,6 +318,15 @@ public:
     }
 
     /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    RTPS_DllAPI bool get_matched_guids(
+            std::vector<GUID_t>& guids) const;
+
+    /**
      * Tries to remove a change waiting a maximum of the provided microseconds.
      * @param max_blocking_time_point Maximum time to wait for.
      * @param lock Lock of the Change list.

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -201,6 +201,20 @@ std::vector<fastdds::rtps::TransportNetmaskFilterInfo> RTPSParticipant::get_netm
     return mp_impl->get_netmask_filter_info();
 }
 
+bool RTPSParticipant::get_publication_info(
+        const GUID_t&,
+        fastdds::dds::builtin::PublicationBuiltinTopicData&) const
+{
+    return false;
+}
+
+bool RTPSParticipant::get_subscription_info(
+        const GUID_t&,
+        fastdds::dds::builtin::SubscriptionBuiltinTopicData&) const
+{
+    return false;
+}
+
 #if HAVE_SECURITY
 
 bool RTPSParticipant::is_security_enabled_for_writer(

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -202,15 +202,15 @@ std::vector<fastdds::rtps::TransportNetmaskFilterInfo> RTPSParticipant::get_netm
 }
 
 bool RTPSParticipant::get_publication_info(
-        const GUID_t&,
-        fastdds::dds::builtin::PublicationBuiltinTopicData&) const
+        fastdds::dds::builtin::PublicationBuiltinTopicData&,
+        const GUID_t&) const
 {
     return false;
 }
 
 bool RTPSParticipant::get_subscription_info(
-        const GUID_t&,
-        fastdds::dds::builtin::SubscriptionBuiltinTopicData&) const
+        fastdds::dds::builtin::SubscriptionBuiltinTopicData&,
+        const GUID_t&) const
 {
     return false;
 }

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -435,6 +435,12 @@ bool RTPSReader::is_sample_valid(
     return true;
 }
 
+bool RTPSReader::get_matched_guids(
+        std::vector<GUID_t>&) const
+{
+    return false;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool RTPSReader::add_statistics_listener(

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -435,7 +435,7 @@ bool RTPSReader::is_sample_valid(
     return true;
 }
 
-bool RTPSReader::get_matched_guids(
+bool RTPSReader::matched_writers_guids(
         std::vector<GUID_t>&) const
 {
     return false;

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -462,6 +462,12 @@ bool RTPSWriter::send_nts(
                    locator_selector.locator_selector.end(), max_blocking_time_point);
 }
 
+bool RTPSWriter::get_matched_guids(
+        std::vector<GUID_t>&) const
+{
+    return false;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool RTPSWriter::add_statistics_listener(

--- a/src/cpp/rtps/writer/RTPSWriter.cpp
+++ b/src/cpp/rtps/writer/RTPSWriter.cpp
@@ -462,7 +462,7 @@ bool RTPSWriter::send_nts(
                    locator_selector.locator_selector.end(), max_blocking_time_point);
 }
 
-bool RTPSWriter::get_matched_guids(
+bool RTPSWriter::matched_readers_guids(
         std::vector<GUID_t>&) const
 {
     return false;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -334,6 +334,12 @@ public:
             return false;
         }
 
+        if (publisher_topicname_.empty())
+        {
+            EPROSIMA_LOG_ERROR(PUBSUBPARTICIPANT, "Publisher topic name not set");
+            return false;
+        }
+
         eprosima::fastdds::dds::Topic* topic =
                 dynamic_cast<eprosima::fastdds::dds::Topic*>(participant_->lookup_topicdescription(
                     publisher_topicname_));
@@ -368,6 +374,12 @@ public:
         }
         if (index >= num_subscribers_)
         {
+            return false;
+        }
+
+        if (subscriber_topicname_.empty())
+        {
+            EPROSIMA_LOG_ERROR(PUBSUBPARTICIPANT, "Subscriber topic name not set");
             return false;
         }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1453,7 +1453,7 @@ public:
         return *this;
     }
 
-    PubSubReader& userData(
+    PubSubReader& user_data(
             std::vector<eprosima::fastrtps::rtps::octet> user_data)
     {
         participant_qos_.user_data() = user_data;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1391,7 +1391,7 @@ public:
         return *this;
     }
 
-    PubSubWriter& userData(
+    PubSubWriter& user_data(
             std::vector<eprosima::fastrtps::rtps::octet> user_data)
     {
         participant_qos_.user_data() = user_data;

--- a/test/blackbox/common/BlackboxTests.cpp
+++ b/test/blackbox/common/BlackboxTests.cpp
@@ -16,9 +16,10 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/rtps/RTPSDomain.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
-#include <fastdds/dds/log/Log.hpp>
 
 #include <thread>
 #include <memory>
@@ -84,6 +85,36 @@ public:
     }
 
 };
+
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::EntityId_t& entity_id)
+{
+    bt_key.value[0] = 0;
+    bt_key.value[1] = 0;
+    bt_key.value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::GuidPrefix_t& guid_prefix)
+{
+    bt_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    bt_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    bt_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
 
 int main(
         int argc,

--- a/test/blackbox/common/BlackboxTests.hpp
+++ b/test/blackbox/common/BlackboxTests.hpp
@@ -46,6 +46,18 @@
 #include <list>
 #include <functional>
 
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace builtin {
+
+struct BuiltinTopicKey_t;
+
+} // namespace builtin
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
 #if HAVE_SECURITY
 extern void blackbox_security_init();
 #endif // if HAVE_SECURITY
@@ -201,5 +213,16 @@ void print_non_received_messages(
 }
 
 /***** End auxiliary lambda function *****/
+
+/****** Auxiliary conversion helpers *******/
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::EntityId_t& entity_id);
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::GuidPrefix_t& guid_prefix);
+
+/****** End Auxiliary conversion helpers *******/
 
 #endif // __BLACKBOX_BLACKBOXTESTS_HPP__

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -934,7 +934,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
     writer.history_depth(100).
-            userData({'a', 'b', 'c', 'd'}).init();
+            user_data({'a', 'b', 'c', 'd'}).init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -385,7 +385,7 @@ TEST_P(PubSubBasic, ReceivedDynamicDataWithNoSizeLimit)
 
     writer.history_depth(100)
             .partition("A").partition("B").partition("C")
-            .userData({'a', 'b', 'c', 'd'}).init();
+            .user_data({'a', 'b', 'c', 'd'}).init();
 
 
     ASSERT_TRUE(writer.isInitialized());
@@ -418,7 +418,7 @@ TEST_P(PubSubBasic, ReceivedDynamicDataWithinSizeLimit)
 
     writer.history_depth(100)
             .partition("A").partition("B").partition("C")
-            .userData({'a', 'b', 'c', 'd'}).init();
+            .user_data({'a', 'b', 'c', 'd'}).init();
 
 
     ASSERT_TRUE(writer.isInitialized());
@@ -452,7 +452,7 @@ TEST_P(PubSubBasic, ReceivedUserDataExceedsSizeLimit)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
     writer.history_depth(100)
-            .userData({'a', 'b', 'c', 'd', 'e', 'f'}).init();
+            .user_data({'a', 'b', 'c', 'd', 'e', 'f'}).init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2706,7 +2706,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(100).
-            userData({ 'a', 'b', 'c', 'd', 'e' }).
+            user_data({ 'a', 'b', 'c', 'd', 'e' }).
             property_policy(pub_part_property_policy).
             entity_property_policy(pub_property_policy).init();
 

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -545,28 +545,9 @@ bool validate_publication_builtin_topic_data(
     auto pub_qos = datawriter.get_publisher()->get_qos();
 
     eprosima::fastdds::dds::builtin::BuiltinTopicKey_t dw_key, part_key;
-    GuidPrefix_t guid_prefix = datawriter.get_publisher()->get_participant()->guid().guidPrefix;
 
-    // This conversions may be included later in utils
-    dw_key.value[0] = 0;
-    dw_key.value[1] = 0;
-    dw_key.value[2] = static_cast<uint32_t>(datawriter.guid().entityId.value[0]) << 24
-            | static_cast<uint32_t>(datawriter.guid().entityId.value[1]) << 16
-            | static_cast<uint32_t>(datawriter.guid().entityId.value[2]) << 8
-            | static_cast<uint32_t>(datawriter.guid().entityId.value[3]);
-
-    part_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[3]);
-    part_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[7]);
-    part_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
-            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
-            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
-            | static_cast<uint32_t>(guid_prefix.value[11]);
+    entity_id_to_builtin_topic_key(dw_key, datawriter.guid().entityId);
+    guid_prefix_to_builtin_topic_key(part_key, datawriter.get_publisher()->get_participant()->guid().guidPrefix);
 
     ret &= (0 == memcmp(pubdata.key.value, dw_key.value, sizeof(eprosima::fastdds::dds::builtin::BuiltinTopicKey_t)));
     ret &=
@@ -585,7 +566,8 @@ bool validate_publication_builtin_topic_data(
     ret &= (pubdata.reliability == dw_qos.reliability());
     ret &= (pubdata.lifespan == dw_qos.lifespan());
     ret &= (
-        0 == memcmp(pubdata.user_data.data(), dw_qos.user_data().data(), pubdata.user_data.size()));
+        (pubdata.user_data.size() == dw_qos.user_data().size()) &&
+        (0 == memcmp(pubdata.user_data.data(), dw_qos.user_data().data(), pubdata.user_data.size())));
     ret &= (pubdata.ownership == dw_qos.ownership());
     ret &= (pubdata.ownership_strength == dw_qos.ownership_strength());
     ret &= (pubdata.destination_order == dw_qos.destination_order());
@@ -600,7 +582,7 @@ bool validate_publication_builtin_topic_data(
 }
 
 /**
- * Refers to DDS-DR-API-GMPD-01 from the test plan.
+ * @test DDS-DR-API-GMPD-01
  *
  * get_matched_publication_data() must return RETCODE_BAD_PARAMETER
  * if the publication is not matched.
@@ -644,7 +626,7 @@ TEST(DDSDataReader, datareader_get_matched_publication_data_bad_parameter)
 }
 
 /**
- * Refers to DDS-DR-API-GMPD-02 from the test plan.
+ * @test DDS-DR-API-GMPD-02
  *
  * The operation must succeed when the publication is matched and correctly
  * retrieve the publication data. Parameterize the test for different transports.
@@ -692,7 +674,7 @@ TEST_P(DDSDataReader, datareader_get_matched_publication_data_correctly_behaves)
 }
 
 /**
- * Refers to DDS-DR-API-GMP-01 from the test plan.
+ * @test DDS-DR-API-GMP-01
  *
  * get_matched_publications() must return RETCODE_OK
  * with an empty list if no DataWriters are matched.
@@ -730,7 +712,7 @@ TEST(DDSDataReader, datareader_get_matched_publications_ok_empty_list)
 }
 
 /**
- * Refers to DDS-DR-API-GMP-02 from the test plan.
+ * @test DDS-DR-API-GMP-02
  *
  * get_matched_publications() must provide the correct list of matched publication handles.
  * Parameterize the test for different transports.
@@ -789,7 +771,7 @@ TEST_P(DDSDataReader, datareader_get_matched_publications_correctly_behaves)
 }
 
 /**
- * Refers to DDS-DR-API-GMP-03 from the test plan.
+ * @test DDS-DR-API-GMP-03
  *
  * The operation must provide the correct list of matched publication handles in multiple
  * participants scenario. Parameterize the test for different transports.

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -544,29 +544,9 @@ bool validate_subscription_builtin_topic_data(
     auto sub_qos = datareader.get_subscriber()->get_qos();
 
     eprosima::fastdds::dds::builtin::BuiltinTopicKey_t dr_key, part_key;
-    eprosima::fastrtps::rtps::GuidPrefix_t part_guid_prefix =
-            datareader.get_subscriber()->get_participant()->guid().guidPrefix;
 
-    // This conversions may be included later in utils
-    dr_key.value[0] = 0;
-    dr_key.value[1] = 0;
-    dr_key.value[2] = static_cast<uint32_t>(datareader.guid().entityId.value[0]) << 24
-            | static_cast<uint32_t>(datareader.guid().entityId.value[1]) << 16
-            | static_cast<uint32_t>(datareader.guid().entityId.value[2]) << 8
-            | static_cast<uint32_t>(datareader.guid().entityId.value[3]);
-
-    part_key.value[0] = static_cast<uint32_t>(part_guid_prefix.value[0]) << 24
-            | static_cast<uint32_t>(part_guid_prefix.value[1]) << 16
-            | static_cast<uint32_t>(part_guid_prefix.value[2]) << 8
-            | static_cast<uint32_t>(part_guid_prefix.value[3]);
-    part_key.value[1] = static_cast<uint32_t>(part_guid_prefix.value[4]) << 24
-            | static_cast<uint32_t>(part_guid_prefix.value[5]) << 16
-            | static_cast<uint32_t>(part_guid_prefix.value[6]) << 8
-            | static_cast<uint32_t>(part_guid_prefix.value[7]);
-    part_key.value[2] = static_cast<uint32_t>(part_guid_prefix.value[8]) << 24
-            | static_cast<uint32_t>(part_guid_prefix.value[9]) << 16
-            | static_cast<uint32_t>(part_guid_prefix.value[10]) << 8
-            | static_cast<uint32_t>(part_guid_prefix.value[11]);
+    entity_id_to_builtin_topic_key(dr_key, datareader.guid().entityId);
+    guid_prefix_to_builtin_topic_key(part_key, datareader.get_subscriber()->get_participant()->guid().guidPrefix);
 
     ret &= (0 == memcmp(subdata.key.value, dr_key.value, sizeof(eprosima::fastdds::dds::builtin::BuiltinTopicKey_t)));
     ret &=
@@ -585,7 +565,8 @@ bool validate_subscription_builtin_topic_data(
     ret &= (subdata.ownership == dr_qos.ownership());
     ret &= (subdata.destination_order == dr_qos.destination_order());
     ret &= (
-        0 == memcmp(subdata.user_data.data(), dr_qos.user_data().data(), subdata.user_data.size()));
+        (subdata.user_data.size() == dr_qos.user_data().size()) &&
+        (0 == memcmp(subdata.user_data.data(), dr_qos.user_data().data(), subdata.user_data.size())));
     // time based filter not implemented
 
     // Subscriber Qos
@@ -598,7 +579,7 @@ bool validate_subscription_builtin_topic_data(
 }
 
 /**
- * Refers to DDS-DW-API-GMSD-01 from the test plan.
+ * @test DDS-DW-API-GMSD-01
  *
  * get_matched_subscription_data() must return RETCODE_BAD_PARAMETER
  * if the subscription is not matched.
@@ -644,7 +625,7 @@ TEST(DDSDataWriter, datawriter_get_matched_subscription_data_bad_parameter)
 }
 
 /**
- * Refers to DDS-DW-API-GMSD-02 from the test plan.
+ * @test DDS-DW-API-GMSD-02
  *
  * The operation must succeed when the subscription is matched and correctly
  * retrieve the publication data. Parameterize the test for different transports.
@@ -694,7 +675,7 @@ TEST_P(DDSDataWriter, datawriter_get_matched_subscription_data_correctly_behaves
 }
 
 /**
- * Refers to DDS-DW-API-GMS-01 from the test plan.
+ * @test DDS-DW-API-GMS-01
  *
  * get_matched_subscriptions() must return RETCODE_OK
  * with an empty list if no DataWriters are matched.
@@ -734,7 +715,7 @@ TEST(DDSDataWriter, datawriter_get_matched_subscriptions_ok_empty_list)
 }
 
 /**
- * Refers to DDS-DW-API-GMS-02 from the test plan.
+ * @test DDS-DW-API-GMS-02
  *
  * get_matched_subscriptions() must provide the correct list of matched subscription handles.
  * Parameterize the test for different transports.
@@ -794,7 +775,7 @@ TEST_P(DDSDataWriter, datawriter_get_matched_subscriptions_correctly_behaves)
 }
 
 /**
- * Refers to DDS-DW-API-GMS-03 from the test plan.
+ * @test DDS-DW-API-GMS-03
  *
  * The operation must provide the correct list of matched subscription handles in multiple
  * participants scenario. Parameterize the test for different transports.

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -34,6 +34,7 @@
 #include <rtps/transport/test_UDPv4Transport.h>
 
 #include "BlackboxTests.hpp"
+#include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
@@ -531,6 +532,306 @@ TEST(DDSDataWriter, datawriter_qos_use_topic_qos)
     // Check that the Qos that are not in common with Topic Qos are correctly set as the default ones,
     // and that the rest of the Qos are left unmodified
     ASSERT_EQ(control_qos, test_qos);
+}
+
+bool validate_subscription_builtin_topic_data(
+        const eprosima::fastdds::dds::builtin::SubscriptionBuiltinTopicData& subdata,
+        const eprosima::fastdds::dds::DataReader& datareader)
+{
+    bool ret = true;
+
+    auto dr_qos = datareader.get_qos();
+    auto pub_qos = datareader.get_subscriber()->get_qos();
+
+    eprosima::fastdds::dds::builtin::BuiltinTopicKey_t dr_key, part_key;
+    eprosima::fastrtps::rtps::GuidPrefix_t part_guid_prefix =
+            datareader.get_subscriber()->get_participant()->guid().guidPrefix;
+
+    // This conversions may be included later in utils
+    dr_key.value[0] = 0;
+    dr_key.value[1] = 0;
+    dr_key.value[2] = static_cast<uint32_t>(datareader.guid().entityId.value[0]) << 24
+            | static_cast<uint32_t>(datareader.guid().entityId.value[1]) << 16
+            | static_cast<uint32_t>(datareader.guid().entityId.value[2]) << 8
+            | static_cast<uint32_t>(datareader.guid().entityId.value[3]);
+
+    part_key.value[0] = static_cast<uint32_t>(part_guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(part_guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(part_guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(part_guid_prefix.value[3]);
+    part_key.value[1] = static_cast<uint32_t>(part_guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(part_guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(part_guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(part_guid_prefix.value[7]);
+    part_key.value[2] = static_cast<uint32_t>(part_guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(part_guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(part_guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(part_guid_prefix.value[11]);
+
+    ret &= (0 == memcmp(subdata.key.value, dr_key.value, sizeof(eprosima::fastdds::dds::builtin::BuiltinTopicKey_t)));
+    ret &=
+            (0 ==
+            memcmp(subdata.participant_key.value, part_key.value,
+            sizeof(eprosima::fastdds::dds::builtin::BuiltinTopicKey_t)));
+    ret &= (subdata.topic_name == datareader.get_topicdescription()->get_name());
+    ret &= (subdata.type_name == datareader.get_topicdescription()->get_type_name());
+
+    // DataReader Qos
+    ret &= (subdata.durability == dr_qos.durability());
+    ret &= (subdata.deadline == dr_qos.deadline());
+    ret &= (subdata.latency_budget == dr_qos.latency_budget());
+    ret &= (subdata.liveliness == dr_qos.liveliness());
+    ret &= (subdata.reliability == dr_qos.reliability());
+    ret &= (subdata.ownership == dr_qos.ownership());
+    ret &= (subdata.destination_order == dr_qos.destination_order());
+    ret &= (subdata.user_data == dr_qos.user_data());
+    // time based filter not implemented
+
+    // Subscriber Qos
+    ret &= (subdata.presentation == pub_qos.presentation());
+    ret &= (subdata.partition == pub_qos.partition());
+    ret &= (subdata.group_data == pub_qos.group_data());
+
+    return ret;
+}
+
+/**
+ * Refers to DDS-DW-API-GMSD-01 from the test plan.
+ *
+ * get_matched_subscription_data() must return RETCODE_BAD_PARAMETER
+ * if the subscription is not matched.
+ */
+TEST(DDSDataWriter, datawriter_get_matched_subscription_data_bad_parameter)
+{
+    using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_2(TEST_TOPIC_NAME);
+
+    eprosima::fastdds::dds::builtin::SubscriptionBuiltinTopicData subdata;
+
+    writer.reliability(BEST_EFFORT_RELIABILITY_QOS)
+            .init();
+
+    reader_1.reliability(RELIABLE_RELIABILITY_QOS)
+            .init();
+    reader_2.ownership_exclusive()
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader_1.isInitialized());
+    ASSERT_TRUE(reader_2.isInitialized());
+
+    // Writer should not be matched with any reader
+    writer.wait_discovery(2, std::chrono::seconds(2));
+
+    ASSERT_TRUE(!writer.is_matched());
+
+    auto& native_writer = writer.get_native_writer();
+
+    InstanceHandle_t r1_handle = reader_1.get_native_reader().get_instance_handle();
+    ReturnCode_t ret = native_writer.get_matched_subscription_data(subdata, r1_handle);
+
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_BAD_PARAMETER);
+
+    InstanceHandle_t r2_handle = reader_2.get_native_reader().get_instance_handle();
+    ret = native_writer.get_matched_subscription_data(subdata, r2_handle);
+
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_BAD_PARAMETER);
+}
+
+/**
+ * Refers to DDS-DW-API-GMSD-02 from the test plan.
+ *
+ * The operation must succeed when the subscription is matched and correctly
+ * retrieve the publication data. Parameterize the test for different transports.
+ */
+TEST_P(DDSDataWriter, datawriter_get_matched_subscription_data_correctly_behaves)
+{
+    using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_2(TEST_TOPIC_NAME);
+
+    eprosima::fastdds::dds::builtin::SubscriptionBuiltinTopicData r1_subdata, r2_subdata;
+
+    writer.init();
+
+    reader_1.init();
+    reader_2.reliability(RELIABLE_RELIABILITY_QOS)
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader_1.isInitialized());
+    ASSERT_TRUE(reader_2.isInitialized());
+
+    // Writer must match with both readers
+    writer.wait_discovery(2, std::chrono::seconds::zero());
+
+    ASSERT_EQ(writer.get_matched(), 2u);
+
+    auto& native_writer = writer.get_native_writer();
+
+    InstanceHandle_t r1_handle = reader_1.get_native_reader().get_instance_handle();
+    ReturnCode_t ret = native_writer.get_matched_subscription_data(r1_subdata, r1_handle);
+
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(validate_subscription_builtin_topic_data(r1_subdata, reader_1.get_native_reader()));
+
+    InstanceHandle_t r2_handle = reader_2.get_native_reader().get_instance_handle();
+    ret = native_writer.get_matched_subscription_data(r2_subdata, r2_handle);
+
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_TRUE(validate_subscription_builtin_topic_data(r2_subdata, reader_2.get_native_reader()));
+}
+
+/**
+ * Refers to DDS-DW-API-GMS-01 from the test plan.
+ *
+ * get_matched_subscriptions() must return RETCODE_OK
+ * with an empty list if no DataWriters are matched.
+ */
+TEST(DDSDataWriter, datawriter_get_matched_subscriptions_ok_empty_list)
+{
+    using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_2(TEST_TOPIC_NAME);
+
+    std::vector<InstanceHandle_t> sub_handles;
+
+    writer.reliability(BEST_EFFORT_RELIABILITY_QOS)
+            .init();
+
+    reader_1.reliability(RELIABLE_RELIABILITY_QOS)
+            .init();
+
+    reader_2.ownership_exclusive()
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader_1.isInitialized());
+    ASSERT_TRUE(reader_2.isInitialized());
+
+    // Writer should not be matched with any reader
+    writer.wait_discovery(2, std::chrono::seconds(2));
+    ASSERT_FALSE(writer.is_matched());
+
+    auto& native_writer = writer.get_native_writer();
+    ReturnCode_t ret = native_writer.get_matched_subscriptions(sub_handles);
+
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(sub_handles.size(), 0u);
+}
+
+/**
+ * Refers to DDS-DW-API-GMS-02 from the test plan.
+ *
+ * get_matched_subscriptions() must provide the correct list of matched subscription handles.
+ * Parameterize the test for different transports.
+ */
+TEST_P(DDSDataWriter, datawriter_get_matched_subscriptions_correctly_behaves)
+{
+    using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+    const size_t num_readers = 5;
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    std::vector<std::unique_ptr<PubSubReader<HelloWorldPubSubType>>> readers;
+    std::vector<InstanceHandle_t> expected_sub_handles;
+    std::vector<InstanceHandle_t> sub_handles;
+
+    readers.reserve(num_readers);
+    sub_handles.reserve(num_readers);
+
+    writer.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    for (size_t i = 0; i < num_readers; ++i)
+    {
+        readers.emplace_back(new PubSubReader<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        readers.back()->init();
+        ASSERT_TRUE(readers.back()->isInitialized());
+        expected_sub_handles.emplace_back(readers.back()->get_native_reader().get_instance_handle());
+    }
+
+    // Wait for discovery
+    writer.wait_discovery(num_readers, std::chrono::seconds::zero());
+    ASSERT_EQ(writer.get_matched(), num_readers);
+
+    auto& native_writer = writer.get_native_writer();
+    ReturnCode_t ret = native_writer.get_matched_subscriptions(sub_handles);
+
+    // Check that the list of matched publication handles is correct
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(sub_handles.size(), num_readers);
+    ASSERT_TRUE(std::is_permutation(sub_handles.begin(), sub_handles.end(), expected_sub_handles.begin()));
+
+    // Remove two readers and check that the list of matched publication handles is updated
+    readers.pop_back();
+    readers.pop_back();
+    expected_sub_handles.pop_back();
+    expected_sub_handles.pop_back();
+
+    // Wait for undiscovery
+    writer.wait_reader_undiscovery(static_cast<unsigned int>(num_readers - 2));
+
+    sub_handles.clear();
+    ret = native_writer.get_matched_subscriptions(sub_handles);
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(sub_handles.size(), static_cast<size_t>(num_readers - 2));
+    ASSERT_TRUE(std::is_permutation(sub_handles.begin(), sub_handles.end(), expected_sub_handles.begin()));
+}
+
+/**
+ * Refers to DDS-DW-API-GMS-03 from the test plan.
+ *
+ * The operation must provide the correct list of matched subscription handles in multiple
+ * participants scenario. Parameterize the test for different transports.
+ */
+TEST_P(DDSDataWriter, datawriter_get_matched_subscriptions_multiple_participants_correctly_behave)
+{
+    using InstanceHandle_t = eprosima::fastrtps::rtps::InstanceHandle_t;
+
+    PubSubParticipant<HelloWorldPubSubType> part_1(1, 1, 1, 1);
+    PubSubParticipant<HelloWorldPubSubType> part_2(1, 1, 1, 1);
+
+    part_1.sub_topic_name(TEST_TOPIC_NAME + "_1");
+    part_2.pub_topic_name(TEST_TOPIC_NAME + "_1");
+
+    ASSERT_TRUE(part_1.init_participant());
+    ASSERT_TRUE(part_1.init_publisher(0));
+    ASSERT_TRUE(part_1.init_subscriber(0));
+
+    ASSERT_TRUE(part_2.init_participant());
+    ASSERT_TRUE(part_2.init_subscriber(0));
+    ASSERT_TRUE(part_2.init_publisher(0));
+
+    part_1.pub_wait_discovery();
+    part_1.sub_wait_discovery();
+
+    part_2.pub_wait_discovery();
+    part_2.sub_wait_discovery();
+
+    auto& writer_p1 = part_1.get_native_writer(0);
+    auto& writer_p2 = part_2.get_native_writer(0);
+
+    std::vector<InstanceHandle_t> sub_handles_p1;
+    std::vector<InstanceHandle_t> sub_handles_p2;
+
+    ReturnCode_t ret = writer_p1.get_matched_subscriptions(sub_handles_p1);
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(sub_handles_p1.size(), 1u);
+    ASSERT_EQ(sub_handles_p1[0], part_2.get_native_reader(0).get_instance_handle());
+
+    ret = writer_p2.get_matched_subscriptions(sub_handles_p2);
+    ASSERT_EQ(ret, ReturnCode_t::RETCODE_OK);
+    ASSERT_EQ(sub_handles_p2.size(), 1u);
+    ASSERT_EQ(sub_handles_p2[0], part_1.get_native_reader(0).get_instance_handle());
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -405,7 +405,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
             .setPublisherIDs(1, 2)
             .setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER)
             .user_data({'V', 'G', 'W', 0x78, 0x73, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x73, 0x5f, 0x67,
-                       0x75, 0x69})
+                        0x75, 0x69})
             .init();
 
     ASSERT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -404,7 +404,7 @@ TEST_P(PersistenceLargeData, PubSubAsReliablePubPersistentWithStaticDiscovery)
             .multicastLocatorList(WriterMulticastLocators)
             .setPublisherIDs(1, 2)
             .setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER)
-            .userData({'V', 'G', 'W', 0x78, 0x73, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x73, 0x5f, 0x67,
+            .user_data({'V', 'G', 'W', 0x78, 0x73, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x73, 0x5f, 0x67,
                        0x75, 0x69})
             .init();
 

--- a/test/blackbox/common/RTPSBlackboxTests.cpp
+++ b/test/blackbox/common/RTPSBlackboxTests.cpp
@@ -21,9 +21,10 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
+#include <fastdds/dds/log/Log.hpp>
 #include <fastrtps/rtps/RTPSDomain.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
-#include <fastdds/dds/log/Log.hpp>
 
 #include <thread>
 #include <memory>
@@ -82,6 +83,36 @@ public:
     }
 
 };
+
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::EntityId_t& entity_id)
+{
+    bt_key.value[0] = 0;
+    bt_key.value[1] = 0;
+    bt_key.value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastrtps::rtps::GuidPrefix_t& guid_prefix)
+{
+    bt_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    bt_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    bt_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
 
 int main(
         int argc,

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -1426,14 +1426,14 @@ TEST_P(RTPS, rtps_participant_get_pubsub_info)
     eprosima::fastdds::dds::builtin::SubscriptionBuiltinTopicData subdata;
 
     // Get publication info from the reader participant and validate it
-    bool ret = reader.get_rtps_participant()->get_publication_info(writer.guid(), pubdata);
+    bool ret = reader.get_rtps_participant()->get_publication_info(pubdata, writer.guid());
     ASSERT_TRUE(ret);
     ASSERT_TRUE(validate_publication_builtin_topic_data(pubdata, writer.get_native_writer(),
             writer.get_topic_attributes(),
             writer.get_writerqos(), reader.get_rtps_participant()->getGuid()));
 
     // Get subscription info from the reader participant and validate it
-    ret = writer.get_rtps_participant()->get_subscription_info(reader.guid(), subdata);
+    ret = writer.get_rtps_participant()->get_subscription_info(subdata, reader.guid());
     ASSERT_TRUE(ret);
     ASSERT_TRUE(validate_subscription_builtin_topic_data(subdata, reader.get_native_reader(),
             reader.get_topic_attributes(),

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -1403,7 +1403,40 @@ bool validate_subscription_builtin_topic_data(
 }
 
 /**
- * Tests get_publication_info() get_subscription_info() RTPSParticipant APIs
+ * Refers to RTPS-PART-API-GSI-GPI-01 from the test plan.
+ */
+TEST(RTPS, rtps_participant_get_pubsub_info_negative)
+{
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(BEST_EFFORT)
+            .init();
+    reader.reliability(RELIABLE)
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery(std::chrono::seconds(1));
+
+    ASSERT_FALSE(writer.get_matched());
+    ASSERT_FALSE(reader.get_matched());
+
+    eprosima::fastdds::dds::builtin::PublicationBuiltinTopicData pubdata;
+    eprosima::fastdds::dds::builtin::SubscriptionBuiltinTopicData subdata;
+
+    // Get publication info from the reader participant and validate it
+    bool ret = reader.get_rtps_participant()->get_publication_info(pubdata, writer.guid());
+    ASSERT_FALSE(ret);
+
+    // Get subscription info from the reader participant and validate it
+    ret = writer.get_rtps_participant()->get_subscription_info(subdata, reader.guid());
+    ASSERT_FALSE(ret);
+}
+
+/**
+ * Refers to RTPS-PART-API-GSI-GPI-02 from the test plan.
  */
 TEST_P(RTPS, rtps_participant_get_pubsub_info)
 {

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -79,7 +79,10 @@ public:
 };
 
 /**
- * Refers to RTPS-READER-API-MWG-01 from the test plan.
+ * @test RTPS-READER-API-MWG-01
+ *
+ * matched_writers_guids() must return true with empty list when the entitiy is not matched.
+ * matched_writers_guids() must return true with a correct list when the entitiy is matched.
  */
 TEST_P(RTPSReaderTests, rtpsreader_matched_writers_guids)
 {

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -1,0 +1,153 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.h>
+#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/log/Log.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+
+using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS
+};
+
+class RTPSReaderTests : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * Tests get_matched_guids() RTPSReader API
+ */
+TEST_P(RTPSReaderTests, rtpsreader_get_matched_guids)
+{
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    reader.reliability(eprosima::fastrtps::rtps::RELIABLE)
+            .init();
+
+    writer.reliability(eprosima::fastrtps::rtps::BEST_EFFORT)
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Expect not to discover
+    reader.wait_discovery(std::chrono::seconds(1));
+    ASSERT_FALSE(reader.get_matched());
+
+    std::vector<GUID_t> matched_guids;
+    auto& native_rtps_reader = reader.get_native_reader();
+    ASSERT_FALSE(native_rtps_reader.get_matched_guids(matched_guids));
+    ASSERT_TRUE(matched_guids.empty());
+
+    writer.destroy();
+    reader.wait_undiscovery();
+
+    const size_t num_matched_writers = 3;
+    std::vector<std::unique_ptr<RTPSWithRegistrationWriter<HelloWorldPubSubType>>> writers;
+    std::vector<GUID_t> expected_matched_guids;
+
+    writers.reserve(num_matched_writers);
+    expected_matched_guids.reserve(num_matched_writers);
+
+    for (size_t i = 0; i < num_matched_writers; ++i)
+    {
+        writers.emplace_back(new RTPSWithRegistrationWriter<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        writers.back()->init();
+        expected_matched_guids.emplace_back(writers.back()->guid());
+    }
+
+    reader.wait_discovery(num_matched_writers, std::chrono::seconds::zero());
+    ASSERT_EQ(num_matched_writers, reader.get_matched());
+    native_rtps_reader.get_matched_guids(matched_guids);
+    ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
+    ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
+            matched_guids.begin()));
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // ifdef INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(RTPSReaderTests,
+        RTPSReaderTests,
+        testing::Values(TRANSPORT, INTRAPROCESS),
+        [](const testing::TestParamInfo<RTPSReaderTests::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+
+        });

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -79,9 +79,9 @@ public:
 };
 
 /**
- * Tests get_matched_guids() RTPSReader API
+ * Tests matched_writers_guids() RTPSReader API
  */
-TEST_P(RTPSReaderTests, rtpsreader_get_matched_guids)
+TEST_P(RTPSReaderTests, rtpsreader_matched_writers_guids)
 {
     RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
@@ -101,7 +101,7 @@ TEST_P(RTPSReaderTests, rtpsreader_get_matched_guids)
 
     std::vector<GUID_t> matched_guids;
     auto& native_rtps_reader = reader.get_native_reader();
-    ASSERT_FALSE(native_rtps_reader.get_matched_guids(matched_guids));
+    ASSERT_FALSE(native_rtps_reader.matched_writers_guids(matched_guids));
     ASSERT_TRUE(matched_guids.empty());
 
     writer.destroy();
@@ -123,7 +123,7 @@ TEST_P(RTPSReaderTests, rtpsreader_get_matched_guids)
 
     reader.wait_discovery(num_matched_writers, std::chrono::seconds::zero());
     ASSERT_EQ(num_matched_writers, reader.get_matched());
-    native_rtps_reader.get_matched_guids(matched_guids);
+    native_rtps_reader.matched_writers_guids(matched_guids);
     ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
     ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
             matched_guids.begin()));

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 /**
- * Tests matched_writers_guids() RTPSReader API
+ * Refers to RTPS-READER-API-MWG-01 from the test plan.
  */
 TEST_P(RTPSReaderTests, rtpsreader_matched_writers_guids)
 {

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -101,7 +101,7 @@ TEST_P(RTPSReaderTests, rtpsreader_matched_writers_guids)
 
     std::vector<GUID_t> matched_guids;
     auto& native_rtps_reader = reader.get_native_reader();
-    ASSERT_FALSE(native_rtps_reader.matched_writers_guids(matched_guids));
+    ASSERT_TRUE(native_rtps_reader.matched_writers_guids(matched_guids));
     ASSERT_TRUE(matched_guids.empty());
 
     writer.destroy();

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -79,7 +79,10 @@ public:
 };
 
 /**
- * Refers to RTPS-WRITER-API-MRG-01 from the test plan.
+ * @test RTPS-WRITER-API-MRG-01
+ *
+ * matched_readers_guids() must return true with empty list when the entitiy is not matched.
+ * matched_readers_guids() must return true with a correct list when the entitiy is matched.
  */
 TEST_P(RTPSWriterTests, rtpswriter_matched_readers_guids)
 {

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -79,9 +79,9 @@ public:
 };
 
 /**
- * Tests get_matched_guids() RTPSWriter API
+ * Tests matched_readers_guids() RTPSWriter API
  */
-TEST_P(RTPSWriterTests, rtpswriter_get_matched_guids)
+TEST_P(RTPSWriterTests, rtpswriter_matched_readers_guids)
 {
     RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
@@ -101,7 +101,7 @@ TEST_P(RTPSWriterTests, rtpswriter_get_matched_guids)
 
     std::vector<GUID_t> matched_guids;
     auto& native_rtps_writer = writer.get_native_writer();
-    ASSERT_FALSE(native_rtps_writer.get_matched_guids(matched_guids));
+    ASSERT_FALSE(native_rtps_writer.matched_readers_guids(matched_guids));
     ASSERT_TRUE(matched_guids.empty());
 
     reader.destroy();
@@ -123,7 +123,7 @@ TEST_P(RTPSWriterTests, rtpswriter_get_matched_guids)
 
     writer.wait_discovery(num_matched_readers, std::chrono::seconds::zero());
     ASSERT_EQ(num_matched_readers, writer.get_matched());
-    native_rtps_writer.get_matched_guids(matched_guids);
+    native_rtps_writer.matched_readers_guids(matched_guids);
     ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
     ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
             matched_guids.begin()));

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -79,7 +79,7 @@ public:
 };
 
 /**
- * Tests matched_readers_guids() RTPSWriter API
+ * Refers to RTPS-WRITER-API-MRG-01 from the test plan.
  */
 TEST_P(RTPSWriterTests, rtpswriter_matched_readers_guids)
 {

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -101,7 +101,7 @@ TEST_P(RTPSWriterTests, rtpswriter_matched_readers_guids)
 
     std::vector<GUID_t> matched_guids;
     auto& native_rtps_writer = writer.get_native_writer();
-    ASSERT_FALSE(native_rtps_writer.matched_readers_guids(matched_guids));
+    ASSERT_TRUE(native_rtps_writer.matched_readers_guids(matched_guids));
     ASSERT_TRUE(matched_guids.empty());
 
     reader.destroy();

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -1,0 +1,153 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.h>
+#include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.h>
+#include <fastdds/rtps/RTPSDomain.h>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.h>
+#include <fastrtps/log/Log.h>
+#include <fastrtps/xmlparser/XMLProfileManager.h>
+
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+
+using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS
+};
+
+class RTPSWriterTests : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        LibrarySettingsAttributes library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                xmlparser::XMLProfileManager::library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * Tests get_matched_guids() RTPSWriter API
+ */
+TEST_P(RTPSWriterTests, rtpswriter_get_matched_guids)
+{
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(eprosima::fastrtps::rtps::BEST_EFFORT)
+            .init();
+
+    reader.reliability(eprosima::fastrtps::rtps::RELIABLE)
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Expect not to discover
+    writer.wait_discovery(std::chrono::seconds(1));
+    ASSERT_FALSE(writer.get_matched());
+
+    std::vector<GUID_t> matched_guids;
+    auto& native_rtps_writer = writer.get_native_writer();
+    ASSERT_FALSE(native_rtps_writer.get_matched_guids(matched_guids));
+    ASSERT_TRUE(matched_guids.empty());
+
+    reader.destroy();
+    writer.wait_undiscovery();
+
+    const size_t num_matched_readers = 3;
+    std::vector<std::unique_ptr<RTPSWithRegistrationReader<HelloWorldPubSubType>>> readers;
+    std::vector<GUID_t> expected_matched_guids;
+
+    readers.reserve(num_matched_readers);
+    expected_matched_guids.reserve(num_matched_readers);
+
+    for (size_t i = 0; i < num_matched_readers; ++i)
+    {
+        readers.emplace_back(new RTPSWithRegistrationReader<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        readers.back()->init();
+        expected_matched_guids.emplace_back(readers.back()->guid());
+    }
+
+    writer.wait_discovery(num_matched_readers, std::chrono::seconds::zero());
+    ASSERT_EQ(num_matched_readers, writer.get_matched());
+    native_rtps_writer.get_matched_guids(matched_guids);
+    ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
+    ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
+            matched_guids.begin()));
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // ifdef INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(RTPSWriterTests,
+        RTPSWriterTests,
+        testing::Values(TRANSPORT, INTRAPROCESS),
+        [](const testing::TestParamInfo<RTPSWriterTests::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+
+        });

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -551,12 +551,12 @@ public:
         return *reader_;
     }
 
-    eprosima::fastrtps::ReaderQos& get_readerqos()
+    const eprosima::fastrtps::ReaderQos& get_readerqos() const
     {
         return reader_qos_;
     }
 
-    eprosima::fastrtps::TopicAttributes& get_topic_attributes()
+    const eprosima::fastrtps::TopicAttributes& get_topic_attributes() const
     {
         return topic_attr_;
     }

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -551,6 +551,21 @@ public:
         return *reader_;
     }
 
+    eprosima::fastrtps::ReaderQos& get_readerqos()
+    {
+        return reader_qos_;
+    }
+
+    eprosima::fastrtps::TopicAttributes& get_topic_attributes()
+    {
+        return topic_attr_;
+    }
+
+    eprosima::fastrtps::rtps::RTPSParticipant* get_rtps_participant()
+    {
+        return participant_;
+    }
+
 private:
 
     void receive_one(

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -578,12 +578,12 @@ public:
         return *writer_;
     }
 
-    eprosima::fastrtps::WriterQos& get_writerqos()
+    const eprosima::fastrtps::WriterQos& get_writerqos() const
     {
         return writer_qos_;
     }
 
-    eprosima::fastrtps::TopicAttributes& get_topic_attributes()
+    const eprosima::fastrtps::TopicAttributes& get_topic_attributes() const
     {
         return topic_attr_;
     }

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -573,6 +573,26 @@ public:
         return writer_->getGuid();
     }
 
+    eprosima::fastrtps::rtps::RTPSWriter& get_native_writer() const
+    {
+        return *writer_;
+    }
+
+    eprosima::fastrtps::WriterQos& get_writerqos()
+    {
+        return writer_qos_;
+    }
+
+    eprosima::fastrtps::TopicAttributes& get_topic_attributes()
+    {
+        return topic_attr_;
+    }
+
+    eprosima::fastrtps::rtps::RTPSParticipant* get_rtps_participant()
+    {
+        return participant_;
+    }
+
 private:
 
     void on_reader_discovery(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -227,15 +227,13 @@ public:
         return {};
     }
 
-    MOCK_METHOD2(
-        get_publication_info, bool(
-            fastdds::dds::builtin::PublicationBuiltinTopicData& data,
-            const GUID_t& writer_guid));
+    MOCK_METHOD(bool, get_publication_info,
+            (fastdds::dds::builtin::PublicationBuiltinTopicData&,
+            const GUID_t&), (const));
 
-    MOCK_METHOD2(
-        get_subscription_info, bool(
-            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
-            const GUID_t& reader_guid));
+    MOCK_METHOD(bool, get_subscription_info,
+            (fastdds::dds::builtin::SubscriptionBuiltinTopicData&,
+            const GUID_t&), (const));
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes()
     {

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -229,13 +229,13 @@ public:
 
     MOCK_METHOD2(
         get_publication_info, bool(
-            const GUID_t& writer_guid,
-            fastdds::dds::builtin::PublicationBuiltinTopicData& data));
+            fastdds::dds::builtin::PublicationBuiltinTopicData& data,
+            const GUID_t& writer_guid));
 
     MOCK_METHOD2(
         get_subscription_info, bool(
-            const GUID_t& writer_guid,
-            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data));
+            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
+            const GUID_t& reader_guid));
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes()
     {

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.h
@@ -49,6 +49,8 @@ namespace dds {
 namespace builtin {
 
 class TypeLookupManager;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 } // namespace builtin
 } // namespace dds
@@ -224,6 +226,16 @@ public:
     {
         return {};
     }
+
+    MOCK_METHOD2(
+        get_publication_info, bool(
+            const GUID_t& writer_guid,
+            fastdds::dds::builtin::PublicationBuiltinTopicData& data));
+
+    MOCK_METHOD2(
+        get_subscription_info, bool(
+            const GUID_t& writer_guid,
+            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data));
 
     const RTPSParticipantAttributes& getRTPSParticipantAttributes()
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the test implementation from the test plan:

`DDS`
* `DataWriter::get_matched_subscriptions()`
* `DataWriter::get_matched_subscription_data()`
* `DataReader::get_matched_publications()`
* `DataReader::get_matched_publication_data()`

`RTPS`
* `RTPSParticipant::get_publication_info()`
* `RTPSParticipant::get_subscription_info()`
* `RTPSReader::matched_writers_guids()` (in the implementation PR, this was changed to pure virtual)
* `RTPSWriter:matched_readers_guids()` (in the implementation PR, this was changed to pure virtual)

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A**  New feature has been added to the `versions.md` file (if applicable).
- **N/A**  New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A**  Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
