### PR TITLE
[21760] Fix memory leak deleting TypeLookupManager

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -101,6 +101,24 @@ TypeLookupManager::~TypeLookupManager()
 
     delete temp_reader_proxy_data_;
     delete temp_writer_proxy_data_;
+
+    for (auto& writer_entry : async_get_type_writer_callbacks_)
+    {
+        // Delete the proxies and remove the entry
+        for (auto& proxy_callback_pair : writer_entry.second)
+        {
+            delete proxy_callback_pair.first;
+        }
+    }
+
+    for (auto& reader_entry : async_get_type_reader_callbacks_)
+    {
+        // Delete the proxies and remove the entry
+        for (auto& proxy_callback_pair : reader_entry.second)
+        {
+            delete proxy_callback_pair.first;
+        }
+    }
 }
 
 bool TypeLookupManager::init(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Asan CI job detects a memory leak when TypeLookupManager is destroyed having still replies to be received. It was detected in eprosima/fast-dds#5109

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- *N/A* Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- *N/A* Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

