### PR TITLE
[17283] Fix issues in Dynamic Network Interfaces

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1707,45 +1707,43 @@ void PDP::local_participant_attributes_update_nts(
     auto participant_data = getLocalParticipantProxyData();
     participant_data->m_userData.data_vec(new_atts.userData);
 
+    // If we are intraprocess only, we do not need to update locators
     bool announce_locators = !mp_RTPSParticipant->is_intraprocess_only();
-    if (!announce_locators)
+    if (announce_locators)
     {
-        // If we are intraprocess only, we do not need to update locators
-        return;
-    }
+        // Clear all locators
+        participant_data->metatraffic_locators.unicast.clear();
+        participant_data->metatraffic_locators.multicast.clear();
+        participant_data->default_locators.unicast.clear();
+        participant_data->default_locators.multicast.clear();
 
-    // Clear all locators
-    participant_data->metatraffic_locators.unicast.clear();
-    participant_data->metatraffic_locators.multicast.clear();
-    participant_data->default_locators.unicast.clear();
-    participant_data->default_locators.multicast.clear();
-
-    // Update default locators
-    for (const Locator_t& loc : new_atts.defaultUnicastLocatorList)
-    {
-        participant_data->default_locators.add_unicast_locator(loc);
-    }
-    for (const Locator_t& loc : new_atts.defaultMulticastLocatorList)
-    {
-        participant_data->default_locators.add_multicast_locator(loc);
-    }
-
-    // Update metatraffic locators
-    for (const auto& locator : new_atts.builtin.metatrafficUnicastLocatorList)
-    {
-        participant_data->metatraffic_locators.add_unicast_locator(locator);
-    }
-    if (!new_atts.builtin.avoid_builtin_multicast || participant_data->metatraffic_locators.unicast.empty())
-    {
-        for (const auto& locator : new_atts.builtin.metatrafficMulticastLocatorList)
+        // Update default locators
+        for (const Locator_t& loc : new_atts.defaultUnicastLocatorList)
         {
-            participant_data->metatraffic_locators.add_multicast_locator(locator);
+            participant_data->default_locators.add_unicast_locator(loc);
         }
-    }
+        for (const Locator_t& loc : new_atts.defaultMulticastLocatorList)
+        {
+            participant_data->default_locators.add_multicast_locator(loc);
+        }
 
-    fastdds::rtps::network::external_locators::add_external_locators(*participant_data,
-            new_atts.builtin.metatraffic_external_unicast_locators,
-            new_atts.default_external_unicast_locators);
+        // Update metatraffic locators
+        for (const auto& locator : new_atts.builtin.metatrafficUnicastLocatorList)
+        {
+            participant_data->metatraffic_locators.add_unicast_locator(locator);
+        }
+        if (!new_atts.builtin.avoid_builtin_multicast || participant_data->metatraffic_locators.unicast.empty())
+        {
+            for (const auto& locator : new_atts.builtin.metatrafficMulticastLocatorList)
+            {
+                participant_data->metatraffic_locators.add_multicast_locator(locator);
+            }
+        }
+
+        fastdds::rtps::network::external_locators::add_external_locators(*participant_data,
+                new_atts.builtin.metatraffic_external_unicast_locators,
+                new_atts.default_external_unicast_locators);
+    }
 }
 
 void PDP::update_endpoint_locators_if_default_nts(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1754,11 +1754,15 @@ void PDP::update_endpoint_locators_if_default_nts(
         const RTPSParticipantAttributes& old_atts,
         const RTPSParticipantAttributes& new_atts)
 {
+    // Check if default locators have changed
     const auto& old_default_unicast = old_atts.defaultUnicastLocatorList;
+    const auto& old_default_multicast = old_atts.defaultMulticastLocatorList;
     const auto& new_default_unicast = new_atts.defaultUnicastLocatorList;
+    const auto& new_default_multicast = new_atts.defaultMulticastLocatorList;
 
     // Early return if there is no change in default unicast locators
-    if (old_default_unicast == new_default_unicast)
+    if ((old_default_unicast == new_default_unicast) &&
+            (old_default_multicast == new_default_multicast))
     {
         return;
     }
@@ -1767,8 +1771,8 @@ void PDP::update_endpoint_locators_if_default_nts(
     EDP* edp = get_edp();
     for (BaseWriter* writer : writers)
     {
-        if (writer->getAttributes().multicastLocatorList.empty() &&
-                writer->getAttributes().unicastLocatorList.empty())
+        if ((old_default_multicast == writer->getAttributes().multicastLocatorList) &&
+                (old_default_unicast == writer->getAttributes().unicastLocatorList))
         {
             WriterProxyData* wdata = nullptr;
             GUID_t participant_guid;
@@ -1787,8 +1791,8 @@ void PDP::update_endpoint_locators_if_default_nts(
     }
     for (BaseReader* reader : readers)
     {
-        if (reader->getAttributes().multicastLocatorList.empty() &&
-                reader->getAttributes().unicastLocatorList.empty())
+        if ((old_default_multicast == reader->getAttributes().multicastLocatorList) &&
+                (old_default_unicast == reader->getAttributes().unicastLocatorList))
         {
             ReaderProxyData* rdata = nullptr;
             GUID_t participant_guid;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1698,6 +1698,37 @@ void PDP::add_builtin_security_attributes(
 
 #endif // HAVE_SECURITY
 
+void PDP::local_participant_attributes_update_nts(
+        const RTPSParticipantAttributes& old_atts,
+        const RTPSParticipantAttributes& new_atts)
+{
+    // Update user data
+    auto local_participant_proxy_data = getLocalParticipantProxyData();
+    local_participant_proxy_data->m_userData.data_vec(new_atts.userData);
+
+    // Update metatraffic locators
+    local_participant_proxy_data->metatraffic_locators.multicast.clear();
+    if (!old_atts.builtin.avoid_builtin_multicast)
+    {
+        for (const auto& locator : new_atts.builtin.metatrafficMulticastLocatorList)
+        {
+            local_participant_proxy_data->metatraffic_locators.add_multicast_locator(locator);
+        }
+    }
+    local_participant_proxy_data->metatraffic_locators.unicast.clear();
+    for (const auto& locator : new_atts.builtin.metatrafficUnicastLocatorList)
+    {
+        local_participant_proxy_data->metatraffic_locators.add_unicast_locator(locator);
+    }
+
+    // Update default locators
+    local_participant_proxy_data->default_locators.unicast.clear();
+    for (const auto& locator : new_atts.defaultUnicastLocatorList)
+    {
+        local_participant_proxy_data->default_locators.add_unicast_locator(locator);
+    }
+}
+
 } /* namespace rtps */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1767,13 +1767,16 @@ void PDP::update_endpoint_locators_if_default_nts(
         return;
     }
 
-    // Update proxies of endpoints with no configured locators
+    // Update proxies of endpoints with default configured locators
     EDP* edp = get_edp();
     for (BaseWriter* writer : writers)
     {
         if ((old_default_multicast == writer->getAttributes().multicastLocatorList) &&
                 (old_default_unicast == writer->getAttributes().unicastLocatorList))
         {
+            writer->getAttributes().multicastLocatorList = new_default_multicast;
+            writer->getAttributes().unicastLocatorList = new_default_unicast;
+
             WriterProxyData* wdata = nullptr;
             GUID_t participant_guid;
             wdata = addWriterProxyData(writer->getGuid(), participant_guid,
@@ -1794,6 +1797,9 @@ void PDP::update_endpoint_locators_if_default_nts(
         if ((old_default_multicast == reader->getAttributes().multicastLocatorList) &&
                 (old_default_unicast == reader->getAttributes().unicastLocatorList))
         {
+            reader->getAttributes().multicastLocatorList = new_default_multicast;
+            reader->getAttributes().unicastLocatorList = new_default_unicast;
+
             ReaderProxyData* rdata = nullptr;
             GUID_t participant_guid;
             rdata = addReaderProxyData(reader->getGuid(), participant_guid,

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -62,6 +62,8 @@
 #endif // if HAVE_SECURITY
 #include <utils/shared_mutex.hpp>
 #include <utils/TimeConversion.hpp>
+#include <rtps/writer/BaseWriter.hpp>
+#include <rtps/reader/BaseReader.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -1744,6 +1746,18 @@ void PDP::local_participant_attributes_update_nts(
     fastdds::rtps::network::external_locators::add_external_locators(*participant_data,
             new_atts.builtin.metatraffic_external_unicast_locators,
             new_atts.default_external_unicast_locators);
+}
+
+void PDP::update_endpoint_locators_if_default_nts(
+        const std::vector<BaseWriter*>& writers,
+        const std::vector<BaseReader*>& readers,
+        const RTPSParticipantAttributes& old_atts,
+        const RTPSParticipantAttributes& new_atts)
+{
+    static_cast<void>(writers);
+    static_cast<void>(readers);
+    static_cast<void>(old_atts);
+    static_cast<void>(new_atts);
 }
 
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -22,13 +22,27 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS_PUBLIC
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
+#include <fastcdr/cdr/fixed_size_string.hpp>
+
+#include <fastdds/dds/core/Time_t.hpp>
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/attributes/ReaderAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/attributes/WriterAttributes.hpp>
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/GuidPrefix_t.hpp>
+#include <fastdds/rtps/common/InstanceHandle.hpp>
+#include <fastdds/rtps/common/LocatorList.hpp>
+#include <fastdds/rtps/common/Types.hpp>
 #include <fastdds/rtps/common/WriteParams.hpp>
 #include <fastdds/rtps/history/IPayloadPool.hpp>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.hpp>
@@ -65,19 +79,11 @@ class TypeIdentifier;
 
 namespace rtps {
 
-class PDPServerListener;
-class PDPEndpoints;
-
-} // namespace rtps
-} // namespace fastdds
-
-namespace fastdds {
-namespace rtps {
-
-class RTPSWriter;
-class RTPSReader;
+class BaseWriter;
+class BaseReader;
 class WriterHistory;
 class ReaderHistory;
+struct RTPSParticipantAllocationAttributes;
 class RTPSParticipantImpl;
 class RTPSParticipantListener;
 class BuiltinProtocols;
@@ -87,6 +93,7 @@ class ReaderProxyData;
 class WriterProxyData;
 class ParticipantProxyData;
 class ReaderListener;
+class PDPEndpoints;
 class PDPListener;
 class PDPServerListener;
 class ITopicPayloadPool;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -494,6 +494,12 @@ public:
     virtual void local_participant_attributes_update_nts(
             const RTPSParticipantAttributes& new_atts);
 
+    virtual void update_endpoint_locators_if_default_nts(
+            const std::vector<BaseWriter*>& writers,
+            const std::vector<BaseReader*>& readers,
+            const RTPSParticipantAttributes& old_atts,
+            const RTPSParticipantAttributes& new_atts);
+
 protected:
 
     //!Pointer to the builtin protocols object.

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -484,6 +484,10 @@ public:
 
 #endif // FASTDDS_STATISTICS
 
+    virtual void local_participant_attributes_update_nts(
+            const RTPSParticipantAttributes& old_atts,
+            const RTPSParticipantAttributes& new_atts);
+
 protected:
 
     //!Pointer to the builtin protocols object.

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -485,7 +485,6 @@ public:
 #endif // FASTDDS_STATISTICS
 
     virtual void local_participant_attributes_update_nts(
-            const RTPSParticipantAttributes& old_atts,
             const RTPSParticipantAttributes& new_atts);
 
 protected:

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1533,6 +1533,12 @@ void RTPSParticipantImpl::update_attributes(
             std::lock_guard<std::recursive_mutex> lock(*pdp->getMutex());
             pdp->local_participant_attributes_update_nts(temp_atts);
 
+            if (local_interfaces_changed && internal_default_locators_)
+            {
+                std::lock_guard<shared_mutex> _(endpoints_list_mutex);
+                pdp->update_endpoint_locators_if_default_nts(m_userWriterList, m_userReaderList, m_att, temp_atts);
+            }
+
             if (local_interfaces_changed)
             {
                 createSenderResources(temp_atts.builtin.metatrafficMulticastLocatorList);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1531,32 +1531,7 @@ void RTPSParticipantImpl::update_attributes(
 
         {
             std::lock_guard<std::recursive_mutex> lock(*pdp->getMutex());
-
-            // Update user data
-            auto local_participant_proxy_data = pdp->getLocalParticipantProxyData();
-            local_participant_proxy_data->m_userData.data_vec(temp_atts.userData);
-
-            // Update metatraffic locators
-            local_participant_proxy_data->metatraffic_locators.multicast.clear();
-            if (!m_att.builtin.avoid_builtin_multicast)
-            {
-                for (const auto& locator : temp_atts.builtin.metatrafficMulticastLocatorList)
-                {
-                    local_participant_proxy_data->metatraffic_locators.add_multicast_locator(locator);
-                }
-            }
-            local_participant_proxy_data->metatraffic_locators.unicast.clear();
-            for (const auto& locator : temp_atts.builtin.metatrafficUnicastLocatorList)
-            {
-                local_participant_proxy_data->metatraffic_locators.add_unicast_locator(locator);
-            }
-
-            // Update default locators
-            local_participant_proxy_data->default_locators.unicast.clear();
-            for (const auto& locator : temp_atts.defaultUnicastLocatorList)
-            {
-                local_participant_proxy_data->default_locators.add_unicast_locator(locator);
-            }
+            pdp->local_participant_attributes_update_nts(m_att, temp_atts);
 
             if (local_interfaces_changed)
             {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1531,7 +1531,7 @@ void RTPSParticipantImpl::update_attributes(
 
         {
             std::lock_guard<std::recursive_mutex> lock(*pdp->getMutex());
-            pdp->local_participant_attributes_update_nts(m_att, temp_atts);
+            pdp->local_participant_attributes_update_nts(temp_atts);
 
             if (local_interfaces_changed)
             {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1445,6 +1445,7 @@ void RTPSParticipantImpl::update_attributes(
     if (internal_metatraffic_locators_)
     {
         LocatorList_t metatraffic_unicast_locator_list = temp_atts.builtin.metatrafficUnicastLocatorList;
+        temp_atts.builtin.metatrafficUnicastLocatorList.clear();
         get_default_metatraffic_locators(temp_atts);
         if (!(metatraffic_unicast_locator_list == temp_atts.builtin.metatrafficUnicastLocatorList))
         {
@@ -1455,6 +1456,7 @@ void RTPSParticipantImpl::update_attributes(
     if (internal_default_locators_)
     {
         LocatorList_t default_unicast_locator_list = temp_atts.defaultUnicastLocatorList;
+        temp_atts.defaultUnicastLocatorList.clear();
         get_default_unicast_locators(temp_atts);
         if (!(default_unicast_locator_list == temp_atts.defaultUnicastLocatorList))
         {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1535,17 +1535,23 @@ void RTPSParticipantImpl::update_attributes(
             local_participant_proxy_data->m_userData.data_vec(temp_atts.userData);
 
             // Update metatraffic locators
-            for (auto locator : temp_atts.builtin.metatrafficMulticastLocatorList)
+            local_participant_proxy_data->metatraffic_locators.multicast.clear();
+            if (!m_att.builtin.avoid_builtin_multicast)
             {
-                local_participant_proxy_data->metatraffic_locators.add_multicast_locator(locator);
+                for (const auto& locator : temp_atts.builtin.metatrafficMulticastLocatorList)
+                {
+                    local_participant_proxy_data->metatraffic_locators.add_multicast_locator(locator);
+                }
             }
-            for (auto locator : temp_atts.builtin.metatrafficUnicastLocatorList)
+            local_participant_proxy_data->metatraffic_locators.unicast.clear();
+            for (const auto& locator : temp_atts.builtin.metatrafficUnicastLocatorList)
             {
                 local_participant_proxy_data->metatraffic_locators.add_unicast_locator(locator);
             }
 
             // Update default locators
-            for (auto locator : temp_atts.defaultUnicastLocatorList)
+            local_participant_proxy_data->default_locators.unicast.clear();
+            for (const auto& locator : temp_atts.defaultUnicastLocatorList)
             {
                 local_participant_proxy_data->default_locators.add_unicast_locator(locator);
             }

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -315,3 +315,7 @@ if(Python3_Interpreter_FOUND)
     endif()
 
 endif()
+
+if(UNIX AND NOT(APPLE) AND NOT(QNXNTO) AND NOT(ANDROID))
+    add_subdirectory(dyn_network)
+endif()

--- a/test/dds/communication/PubSubMain.cpp
+++ b/test/dds/communication/PubSubMain.cpp
@@ -51,7 +51,7 @@ void publisher_run(
         publisher->wait_discovery(wait);
     }
 
-    publisher->run(samples, loops, interval);
+    publisher->run(samples, 0, loops, interval);
 }
 
 int main(
@@ -196,7 +196,7 @@ int main(
         DomainParticipantFactory::get_instance()->load_XML_profiles_file(xml_file);
     }
 
-    SubscriberModule subscriber(publishers, samples, fixed_type, zero_copy);
+    SubscriberModule subscriber(publishers, samples, fixed_type, zero_copy, false, false);
     PublisherModule publisher(exit_on_lost_liveliness, fixed_type, zero_copy);
 
     uint32_t result = 1;
@@ -207,7 +207,7 @@ int main(
 
         if (subscriber.init(seed, magic))
         {
-            result = subscriber.run(notexit, timeout) ? 0 : -1;
+            result = subscriber.run(notexit, 0, timeout) ? 0 : -1;
         }
 
         publisher_thread.join();

--- a/test/dds/communication/PublisherMain.cpp
+++ b/test/dds/communication/PublisherMain.cpp
@@ -50,7 +50,7 @@ int main(
     uint32_t samples = 4;
     uint32_t loops = 0;
     uint32_t interval = 250;
-    uint32_t rescan_interval = 0;
+    uint32_t rescan_interval_seconds = 0;
     std::string magic;
 
     while (arg_count < argc)
@@ -145,7 +145,7 @@ int main(
                 return -1;
             }
 
-            rescan_interval = strtol(argv[arg_count], nullptr, 10);
+            rescan_interval_seconds = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {
@@ -170,7 +170,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples, rescan_interval, loops, interval);
+        publisher.run(samples, rescan_interval_seconds, loops, interval);
         return 0;
     }
 

--- a/test/dds/communication/PublisherMain.cpp
+++ b/test/dds/communication/PublisherMain.cpp
@@ -29,9 +29,10 @@ using namespace eprosima::fastdds::dds;
  * --seed <int>
  * --wait <int>
  * --samples <int>
+ * --interval <int>
  * --magic <str>
  * --xmlfile <path>
- * --interval <int>
+ * --rescan <int>
  */
 
 int main(
@@ -47,6 +48,7 @@ int main(
     char* xml_file = nullptr;
     uint32_t samples = 4;
     uint32_t interval = 250;
+    uint32_t rescan_interval = 0;
     std::string magic;
 
     while (arg_count < argc)
@@ -122,6 +124,16 @@ int main(
             }
 
             xml_file = argv[arg_count];
+        }
+        else if (strcmp(argv[arg_count], "--rescan") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--rescan expects a parameter" << std::endl;
+                return -1;
+            }
+
+            rescan_interval = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {

--- a/test/dds/communication/PublisherMain.cpp
+++ b/test/dds/communication/PublisherMain.cpp
@@ -158,7 +158,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples, 0, interval);
+        publisher.run(samples, rescan_interval, 0, interval);
         return 0;
     }
 

--- a/test/dds/communication/PublisherMain.cpp
+++ b/test/dds/communication/PublisherMain.cpp
@@ -29,6 +29,7 @@ using namespace eprosima::fastdds::dds;
  * --seed <int>
  * --wait <int>
  * --samples <int>
+ * --loops <int>
  * --interval <int>
  * --magic <str>
  * --xmlfile <path>
@@ -47,6 +48,7 @@ int main(
     uint32_t wait = 0;
     char* xml_file = nullptr;
     uint32_t samples = 4;
+    uint32_t loops = 0;
     uint32_t interval = 250;
     uint32_t rescan_interval = 0;
     std::string magic;
@@ -94,6 +96,16 @@ int main(
             }
 
             samples = strtol(argv[arg_count], nullptr, 10);
+        }
+        else if (strcmp(argv[arg_count], "--loops") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--loops expects a parameter" << std::endl;
+                return -1;
+            }
+
+            loops = strtol(argv[arg_count], nullptr, 10);
         }
         else if (strcmp(argv[arg_count], "--interval") == 0)
         {
@@ -158,7 +170,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples, rescan_interval, 0, interval);
+        publisher.run(samples, rescan_interval, loops, interval);
         return 0;
     }
 

--- a/test/dds/communication/PublisherModule.cpp
+++ b/test/dds/communication/PublisherModule.cpp
@@ -134,12 +134,29 @@ void PublisherModule::wait_discovery(
 
 void PublisherModule::run(
         uint32_t samples,
+        const uint32_t rescan_interval,
         const uint32_t loops,
         uint32_t interval)
 {
     uint32_t current_loop = 0;
     uint16_t index = 1;
     void* sample = nullptr;
+
+    std::thread net_rescan_thread([this, rescan_interval]()
+            {
+                if (rescan_interval > 0)
+                {
+                    auto interval = std::chrono::seconds(rescan_interval);
+                    while (run_)
+                    {
+                        std::this_thread::sleep_for(interval);
+                        if (run_)
+                        {
+                            participant_->set_qos(participant_->get_qos());
+                        }
+                    }
+                }
+            });
 
     while (run_ && (loops == 0 || loops > current_loop))
     {
@@ -187,6 +204,9 @@ void PublisherModule::run(
 
         std::this_thread::sleep_for(std::chrono::milliseconds(interval));
     }
+
+    run_ = false;
+    net_rescan_thread.join();
 }
 
 void PublisherModule::on_publication_matched(

--- a/test/dds/communication/PublisherModule.hpp
+++ b/test/dds/communication/PublisherModule.hpp
@@ -19,8 +19,10 @@
 #ifndef TEST_DDS_COMMUNICATION_PUBLISHERMODULE_HPP
 #define TEST_DDS_COMMUNICATION_PUBLISHERMODULE_HPP
 
-#include <mutex>
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <mutex>
 
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -42,8 +44,8 @@ public:
 
     PublisherModule(
             bool exit_on_lost_liveliness,
-            bool fixed_type = false,
-            bool zero_copy = false)
+            bool fixed_type,
+            bool zero_copy)
         : exit_on_lost_liveliness_(exit_on_lost_liveliness)
         , fixed_type_(zero_copy || fixed_type) // If zero copy active, fixed type is required
         , zero_copy_(zero_copy)
@@ -83,8 +85,9 @@ public:
 
     void run(
             uint32_t samples,
-            uint32_t loops = 0,
-            uint32_t interval = 250);
+            const uint32_t rescan_interval,
+            uint32_t loops,
+            uint32_t interval);
 
 private:
 
@@ -96,7 +99,7 @@ private:
     bool exit_on_lost_liveliness_ = false;
     bool fixed_type_ = false;
     bool zero_copy_ = false;
-    bool run_ = true;
+    std::atomic_bool run_{true};
     DomainParticipant* participant_ = nullptr;
     TypeSupport type_;
     Publisher* publisher_ = nullptr;

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -51,7 +51,7 @@ int main(
     uint32_t samples = 4;
     uint32_t publishers = 1;
     uint32_t timeout = 86400000; // 24 h in ms
-    uint32_t rescan_interval = 0;
+    uint32_t rescan_interval_seconds = 0;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -145,7 +145,7 @@ int main(
                 return -1;
             }
 
-            rescan_interval = strtol(argv[arg_count], nullptr, 10);
+            rescan_interval_seconds = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {
@@ -165,7 +165,7 @@ int main(
 
     if (subscriber.init(seed, magic))
     {
-        return subscriber.run(notexit, rescan_interval, timeout) ? 0 : -1;
+        return subscriber.run(notexit, rescan_interval_seconds, timeout) ? 0 : -1;
     }
 
     return -1;

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -165,7 +165,7 @@ int main(
 
     if (subscriber.init(seed, magic))
     {
-        return subscriber.run(notexit, timeout) ? 0 : -1;
+        return subscriber.run(notexit, rescan_interval, timeout) ? 0 : -1;
     }
 
     return -1;

--- a/test/dds/communication/SubscriberMain.cpp
+++ b/test/dds/communication/SubscriberMain.cpp
@@ -26,13 +26,15 @@ using namespace eprosima::fastdds::dds;
  * --notexit
  * --fixed_type
  * --zero_copy
+ * --succeed_on_timeout
  * --seed <int>
  * --samples <int>
  * --magic <str>
+ * --timeout <int>
  * --xmlfile <path>
  * --publishers <int>
- * --succeed_on_timeout
- * --timeout <int>
+ * --die_on_data_received
+ * --rescan <int>
  */
 
 int main(
@@ -49,6 +51,7 @@ int main(
     uint32_t samples = 4;
     uint32_t publishers = 1;
     uint32_t timeout = 86400000; // 24 h in ms
+    uint32_t rescan_interval = 0;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -133,6 +136,16 @@ int main(
         else if (strcmp(argv[arg_count], "--die_on_data_received") == 0)
         {
             die_on_data_received = true;
+        }
+        else if (strcmp(argv[arg_count], "--rescan") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--rescan expects a parameter" << std::endl;
+                return -1;
+            }
+
+            rescan_interval = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {

--- a/test/dds/communication/SubscriberModule.hpp
+++ b/test/dds/communication/SubscriberModule.hpp
@@ -19,10 +19,11 @@
 #ifndef TEST_COMMUNICATION_SUBSCRIBER_HPP
 #define TEST_COMMUNICATION_SUBSCRIBER_HPP
 
-#include <mutex>
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <map>
-#include <chrono>
+#include <mutex>
 
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -45,10 +46,10 @@ public:
     SubscriberModule(
             const uint32_t publishers,
             const uint32_t max_number_samples,
-            bool fixed_type = false,
-            bool zero_copy = false,
-            bool succeed_on_timeout = false,
-            bool die_on_data_received = false)
+            bool fixed_type,
+            bool zero_copy,
+            bool succeed_on_timeout,
+            bool die_on_data_received)
         : publishers_(publishers)
         , max_number_samples_(max_number_samples)
         , fixed_type_(zero_copy || fixed_type) // If zero copy active, fixed type is required
@@ -89,10 +90,12 @@ public:
 
     bool run(
             bool notexit,
-            uint32_t timeout = 86400000);
+            const uint32_t rescan_interval,
+            uint32_t timeout);
 
     bool run_for(
             bool notexit,
+            const uint32_t rescan_interval,
             const std::chrono::milliseconds& timeout);
 
 private:
@@ -106,7 +109,7 @@ private:
     std::map<eprosima::fastdds::rtps::GUID_t, uint32_t> number_samples_;
     bool fixed_type_ = false;
     bool zero_copy_ = false;
-    bool run_ = true;
+    std::atomic_bool run_{true};
     bool succeed_on_timeout_ = false;
     DomainParticipant* participant_ = nullptr;
     TypeSupport type_;

--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -13,9 +13,6 @@
 # limitations under the License.
 message(STATUS "Configuring dynamic network interfaces tests")
 
-# Find Python3
-# find_package(Python3 COMPONENTS Interpreter REQUIRED)
-
 # Find docker
 find_program(DOCKER_EXECUTABLE docker)
 if(NOT DOCKER_EXECUTABLE)

--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -53,22 +53,12 @@ if(NOT (TINYXML2_FROM_SOURCE OR TINYXML2_FROM_THIRDPARTY))
     set(TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH ":${CMAKE_INSTALL_PREFIX}/${DATA_INSTALL_DIR}/fastdds")
 endif()
 
+configure_file(Dockerfile
+               ${CMAKE_CURRENT_BINARY_DIR}/Dockerfile @ONLY)
 configure_file(dynamic_interfaces.compose.yml
-                ${CMAKE_CURRENT_BINARY_DIR}/dynamic_interfaces.compose.yml @ONLY)
+               ${CMAKE_CURRENT_BINARY_DIR}/dynamic_interfaces.compose.yml @ONLY)
 configure_file(launch_subscriber.bash
-                ${CMAKE_CURRENT_BINARY_DIR}/launch_subscriber.bash @ONLY)
-
-## # Find all pytest files for testing
-## file(GLOB examples_python_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.py)
-## 
-## # Configure the pytest files, and add a test for each one
-## foreach(example_test ${examples_python_tests})
-##     get_filename_component(example_name ${example_test} NAME_WE)
-##     string(REPLACE "test_" "" example_name "${example_name}")
-##     message(STATUS "  Configuring example test: ${example_name}")
-##     configure_file(${example_test}
-##                    ${CMAKE_CURRENT_BINARY_DIR}/${example_name}/${example_test} @ONLY)
-##     add_test(NAME example_tests.${example_name}
-##              COMMAND ${Python3_EXECUTABLE} -m pytest -vrP
-##              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example_name})
-## endforeach()
+               ${CMAKE_CURRENT_BINARY_DIR}/launch_subscriber.bash @ONLY)
+add_test(NAME dds.communication.dynamic_interfaces
+         COMMAND ${DOCKER_EXECUTABLE} compose -f ${CMAKE_CURRENT_BINARY_DIR}/dynamic_interfaces.compose.yml up
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -1,0 +1,74 @@
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+message(STATUS "Configuring dynamic network interfaces tests")
+
+# Find Python3
+# find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+# Find docker
+find_program(DOCKER_EXECUTABLE docker)
+if(NOT DOCKER_EXECUTABLE)
+    message(FATAL_ERROR "Docker not found")
+endif()
+
+set(SHELL_EXECUTABLE "")
+set(TINYXML2_LIB_DIR_COMPOSE_VOLUME "")
+set(TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH "")
+
+# Linux configurations
+if(UNIX AND NOT(APPLE) AND NOT(QNXNTO) AND NOT(ANDROID))
+    # Find bash
+    find_program(BASH_EXECUTABLE bash)
+    if(NOT BASH_EXECUTABLE)
+        message(FATAL_ERROR "bash not found")
+    endif()
+
+    set(SHELL_EXECUTABLE ${BASH_EXECUTABLE})
+
+# Windows configurations
+elseif(WIN32)
+    # We don't know which docker image to use for Windows yet
+    message(FATAL_ERROR "Windows not supported yet")
+
+# Unsupported platform
+else()
+    message(FATAL_ERROR "Unsupported platform")
+endif()
+
+# Configure TinyXML2 library path if installed in user library path
+if(NOT (TINYXML2_FROM_SOURCE OR TINYXML2_FROM_THIRDPARTY))
+    get_filename_component(TINYXML2_LIB_DIR ${TINYXML2_LIBRARY} DIRECTORY)
+    set(TINYXML2_LIB_DIR_COMPOSE_VOLUME "- ${TINYXML2_LIB_DIR}:${CMAKE_INSTALL_PREFIX}/${DATA_INSTALL_DIR}/fastdds:ro")
+    set(TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH ":${CMAKE_INSTALL_PREFIX}/${DATA_INSTALL_DIR}/fastdds")
+endif()
+
+configure_file(dynamic_interfaces.compose.yml
+                ${CMAKE_CURRENT_BINARY_DIR}/dynamic_interfaces.compose.yml @ONLY)
+configure_file(launch_subscriber.bash
+                ${CMAKE_CURRENT_BINARY_DIR}/launch_subscriber.bash @ONLY)
+
+## # Find all pytest files for testing
+## file(GLOB examples_python_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.py)
+## 
+## # Configure the pytest files, and add a test for each one
+## foreach(example_test ${examples_python_tests})
+##     get_filename_component(example_name ${example_test} NAME_WE)
+##     string(REPLACE "test_" "" example_name "${example_name}")
+##     message(STATUS "  Configuring example test: ${example_name}")
+##     configure_file(${example_test}
+##                    ${CMAKE_CURRENT_BINARY_DIR}/${example_name}/${example_test} @ONLY)
+##     add_test(NAME example_tests.${example_name}
+##              COMMAND ${Python3_EXECUTABLE} -m pytest -vrP
+##              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example_name})
+## endforeach()

--- a/test/dds/communication/dyn_network/Dockerfile
+++ b/test/dds/communication/dyn_network/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tag, branch, or commit in github.com/eProsima/DDS-Suite
+ARG ubuntu_version=22.04
+FROM ubuntu:$ubuntu_version AS ubuntu-net-tools
+
+# Needed for a dependency that forces to set timezone
+ENV TZ=Europe/Madrid
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Avoids using interactions during building
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install apt dependencies
+RUN apt-get update && apt-get install --yes net-tools && rm -rf /var/lib/apt/lists/*

--- a/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
+++ b/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
@@ -1,0 +1,42 @@
+# Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+version: "3"
+
+services:
+  publisher:
+    image: ubuntu:22.04
+    volumes:
+      - @PROJECT_BINARY_DIR@:@PROJECT_BINARY_DIR@
+      - @fastcdr_LIB_DIR@:@fastcdr_LIB_DIR@
+      @TINYXML2_LIB_DIR_COMPOSE_VOLUME@
+    environment:
+      LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
+      EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
+    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher@FILE_EXTENSION@ --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10"
+
+  subscriber:
+    build: .
+    image: ubuntu-net-tools:22.04
+    privileged: true
+    volumes:
+      - @PROJECT_BINARY_DIR@:@PROJECT_BINARY_DIR@
+      - @fastcdr_LIB_DIR@:@fastcdr_LIB_DIR@
+      @TINYXML2_LIB_DIR_COMPOSE_VOLUME@
+    environment:
+      LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
+      EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
+    working_dir: @PROJECT_BINARY_DIR@/test/dds/communication
+    command: @SHELL_EXECUTABLE@ "dyn_network/launch_subscriber.bash"
+    depends_on:
+      - publisher

--- a/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
+++ b/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
       EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
-    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --seed 0 --magic T"
+    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --loops 1 --seed 0 --magic T"
 
   subscriber:
     build: .

--- a/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
+++ b/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
       EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
-    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --loops 1 --seed 0 --magic T"
+    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --wait 1 --samples 10 --loops 1 --seed 0 --magic T"
 
   subscriber:
     build: .

--- a/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
+++ b/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
       EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
-    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10"
+    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --seed 0 --magic T"
 
   subscriber:
     build: .

--- a/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
+++ b/test/dds/communication/dyn_network/dynamic_interfaces.compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       LD_LIBRARY_PATH: @PROJECT_BINARY_DIR@/src/cpp:@fastcdr_LIB_DIR@@TINYXML2_LIB_DIR_COMPOSE_LD_LIBRARY_PATH@
       EXAMPLE_DIR: @PROJECT_BINARY_DIR@/test/dds/communication
-    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher@FILE_EXTENSION@ --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10"
+    command: @SHELL_EXECUTABLE@ -c "$${EXAMPLE_DIR}/DDSCommunicationPublisher --xmlfile $${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10"
 
   subscriber:
     build: .

--- a/test/dds/communication/dyn_network/launch_subscriber.bash
+++ b/test/dds/communication/dyn_network/launch_subscriber.bash
@@ -1,0 +1,9 @@
+echo "Putting down eth0 interface..."
+ifconfig eth0 down
+echo "Launching subscriber..."
+${EXAMPLE_DIR}/DDSCommunicationSubscriber --xmlfile ${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --rescan 2 &
+echo "Subscriber launched. Waiting 2 seconds and bring up eth0 interface..."
+sleep 2s
+ifconfig eth0 up
+echo "eth0 interface is up. Waiting 3s for the matching to occur..."
+sleep 3s

--- a/test/dds/communication/dyn_network/launch_subscriber.bash
+++ b/test/dds/communication/dyn_network/launch_subscriber.bash
@@ -1,9 +1,33 @@
+# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+# Note: This script is intended to be used in a privileged container, since it requires to bring down and up the eth0 interface.
+
 echo "Putting down eth0 interface..."
 ifconfig eth0 down
+
 echo "Launching subscriber..."
 ${EXAMPLE_DIR}/DDSCommunicationSubscriber --xmlfile ${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --seed 0 --magic T --rescan 2 &
-echo "Subscriber launched. Waiting 2 seconds and bring up eth0 interface..."
+subs_pid=$!
+echo "Subscriber launched."
+
+echo "Waiting 2 seconds and bring up eth0 interface..."
 sleep 2s
 ifconfig eth0 up
-echo "eth0 interface is up. Waiting 3s for the matching to occur..."
-sleep 3s
+echo "eth0 interface is up."
+
+echo "Waiting 3s for the subscriber (process id $subs_pid) to finish..."
+wait $subs_pid

--- a/test/dds/communication/dyn_network/launch_subscriber.bash
+++ b/test/dds/communication/dyn_network/launch_subscriber.bash
@@ -1,7 +1,7 @@
 echo "Putting down eth0 interface..."
 ifconfig eth0 down
 echo "Launching subscriber..."
-${EXAMPLE_DIR}/DDSCommunicationSubscriber --xmlfile ${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --rescan 2 &
+${EXAMPLE_DIR}/DDSCommunicationSubscriber --xmlfile ${EXAMPLE_DIR}/simple_reliable_profile.xml --samples 10 --seed 0 --magic T --rescan 2 &
 echo "Subscriber launched. Waiting 2 seconds and bring up eth0 interface..."
 sleep 2s
 ifconfig eth0 up

--- a/test/dds/communication/security/PublisherMain.cpp
+++ b/test/dds/communication/security/PublisherMain.cpp
@@ -47,7 +47,7 @@ int main(
     char* xml_file = nullptr;
     uint32_t samples = 4;
     uint32_t interval = 250;
-    uint32_t rescan_interval = 0;
+    uint32_t rescan_interval_seconds = 0;
     std::string magic;
 
     while (arg_count < argc)
@@ -132,7 +132,7 @@ int main(
                 return -1;
             }
 
-            rescan_interval = strtol(argv[arg_count], nullptr, 10);
+            rescan_interval_seconds = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {
@@ -157,7 +157,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples, rescan_interval, 0, interval);
+        publisher.run(samples, rescan_interval_seconds, 0, interval);
         return 0;
     }
 

--- a/test/dds/communication/security/PublisherMain.cpp
+++ b/test/dds/communication/security/PublisherMain.cpp
@@ -28,9 +28,10 @@ using namespace eprosima::fastdds::dds;
  * --seed <int>
  * --wait <int>
  * --samples <int>
+ * --interval <int>
  * --magic <str>
  * --xmlfile <path>
- * --interval <int>
+ * --rescan <int>
  */
 
 int main(
@@ -46,6 +47,7 @@ int main(
     char* xml_file = nullptr;
     uint32_t samples = 4;
     uint32_t interval = 250;
+    uint32_t rescan_interval = 0;
     std::string magic;
 
     while (arg_count < argc)
@@ -121,6 +123,16 @@ int main(
             }
 
             xml_file = argv[arg_count];
+        }
+        else if (strcmp(argv[arg_count], "--rescan") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--rescan expects a parameter" << std::endl;
+                return -1;
+            }
+
+            rescan_interval = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {

--- a/test/dds/communication/security/PublisherMain.cpp
+++ b/test/dds/communication/security/PublisherMain.cpp
@@ -157,7 +157,7 @@ int main(
             publisher.wait_discovery(wait);
         }
 
-        publisher.run(samples, 0, interval);
+        publisher.run(samples, rescan_interval, 0, interval);
         return 0;
     }
 

--- a/test/dds/communication/security/PublisherModule.cpp
+++ b/test/dds/communication/security/PublisherModule.cpp
@@ -134,12 +134,29 @@ void PublisherModule::wait_discovery(
 
 void PublisherModule::run(
         uint32_t samples,
+        const uint32_t rescan_interval,
         const uint32_t loops,
         uint32_t interval)
 {
     uint32_t current_loop = 0;
     uint16_t index = 1;
     void* sample = nullptr;
+
+    std::thread net_rescan_thread([this, rescan_interval]()
+            {
+                if (rescan_interval > 0)
+                {
+                    auto interval = std::chrono::seconds(rescan_interval);
+                    while (run_)
+                    {
+                        std::this_thread::sleep_for(interval);
+                        if (run_)
+                        {
+                            participant_->set_qos(participant_->get_qos());
+                        }
+                    }
+                }
+            });
 
     while (run_ && (loops == 0 || loops > current_loop))
     {
@@ -187,6 +204,9 @@ void PublisherModule::run(
 
         std::this_thread::sleep_for(std::chrono::milliseconds(interval));
     }
+
+    run_ = false;
+    net_rescan_thread.join();
 }
 
 void PublisherModule::on_publication_matched(

--- a/test/dds/communication/security/PublisherModule.hpp
+++ b/test/dds/communication/security/PublisherModule.hpp
@@ -19,8 +19,9 @@
 #ifndef TEST_DDS_COMMUNICATION_PUBLISHERMODULE_HPP
 #define TEST_DDS_COMMUNICATION_PUBLISHERMODULE_HPP
 
-#include <mutex>
+#include <atomic>
 #include <condition_variable>
+#include <mutex>
 
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -42,8 +43,8 @@ public:
 
     PublisherModule(
             bool exit_on_lost_liveliness,
-            bool fixed_type = false,
-            bool zero_copy = false)
+            bool fixed_type,
+            bool zero_copy)
         : exit_on_lost_liveliness_(exit_on_lost_liveliness)
         , fixed_type_(zero_copy || fixed_type) // If zero copy active, fixed type is required
         , zero_copy_(zero_copy)
@@ -84,8 +85,9 @@ public:
 
     void run(
             uint32_t samples,
-            uint32_t loops = 0,
-            uint32_t interval = 250);
+            const uint32_t rescan_interval,
+            uint32_t loops,
+            uint32_t interval);
 
 private:
 
@@ -97,7 +99,7 @@ private:
     bool exit_on_lost_liveliness_ = false;
     bool fixed_type_ = false;
     bool zero_copy_ = false;
-    bool run_ = true;
+    std::atomic_bool run_ {true};
     DomainParticipant* participant_ = nullptr;
     TypeSupport type_;
     Publisher* publisher_ = nullptr;

--- a/test/dds/communication/security/SubscriberMain.cpp
+++ b/test/dds/communication/security/SubscriberMain.cpp
@@ -46,7 +46,7 @@ int main(
     uint32_t seed = 7800;
     uint32_t samples = 4;
     uint32_t publishers = 1;
-    uint32_t rescan_interval = 0;
+    uint32_t rescan_interval_seconds = 0;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -126,7 +126,7 @@ int main(
                 return -1;
             }
 
-            rescan_interval = strtol(argv[arg_count], nullptr, 10);
+            rescan_interval_seconds = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {
@@ -146,7 +146,7 @@ int main(
 
     if (subscriber.init(seed, magic))
     {
-        return subscriber.run(notexit, rescan_interval) ? 0 : -1;
+        return subscriber.run(notexit, rescan_interval_seconds) ? 0 : -1;
     }
 
     return -1;

--- a/test/dds/communication/security/SubscriberMain.cpp
+++ b/test/dds/communication/security/SubscriberMain.cpp
@@ -30,6 +30,8 @@ using namespace eprosima::fastdds::dds;
  * --magic <str>
  * --xmlfile <path>
  * --publishers <int>
+ * --die_on_data_received
+ * --rescan <int>
  */
 
 int main(
@@ -44,6 +46,7 @@ int main(
     uint32_t seed = 7800;
     uint32_t samples = 4;
     uint32_t publishers = 1;
+    uint32_t rescan_interval = 0;
     char* xml_file = nullptr;
     std::string magic;
 
@@ -114,6 +117,16 @@ int main(
         else if (strcmp(argv[arg_count], "--die_on_data_received") == 0)
         {
             die_on_data_received = true;
+        }
+        else if (strcmp(argv[arg_count], "--rescan") == 0)
+        {
+            if (++arg_count >= argc)
+            {
+                std::cout << "--rescan expects a parameter" << std::endl;
+                return -1;
+            }
+
+            rescan_interval = strtol(argv[arg_count], nullptr, 10);
         }
         else
         {

--- a/test/dds/communication/security/SubscriberMain.cpp
+++ b/test/dds/communication/security/SubscriberMain.cpp
@@ -146,7 +146,7 @@ int main(
 
     if (subscriber.init(seed, magic))
     {
-        return subscriber.run(notexit) ? 0 : -1;
+        return subscriber.run(notexit, rescan_interval) ? 0 : -1;
     }
 
     return -1;

--- a/test/dds/communication/security/SubscriberModule.cpp
+++ b/test/dds/communication/security/SubscriberModule.cpp
@@ -130,16 +130,34 @@ bool SubscriberModule::init(
 }
 
 bool SubscriberModule::run(
-        bool notexit)
+        bool notexit,
+        const uint32_t rescan_interval)
 {
-    return run_for(notexit, std::chrono::hours(24));
+    return run_for(notexit, rescan_interval, std::chrono::hours(24));
 }
 
 bool SubscriberModule::run_for(
         bool notexit,
+        const uint32_t rescan_interval,
         const std::chrono::milliseconds& timeout)
 {
     bool returned_value = false;
+
+    std::thread net_rescan_thread([this, rescan_interval]()
+            {
+                if (rescan_interval > 0)
+                {
+                    auto interval = std::chrono::seconds(rescan_interval);
+                    while (run_)
+                    {
+                        std::this_thread::sleep_for(interval);
+                        if (run_)
+                        {
+                            participant_->set_qos(participant_->get_qos());
+                        }
+                    }
+                }
+            });
 
     while (notexit && run_)
     {
@@ -183,6 +201,9 @@ bool SubscriberModule::run_for(
         std::cout << "ERROR: detected more than " << publishers_ << " publishers" << std::endl;
         returned_value = false;
     }
+
+    run_ = false;
+    net_rescan_thread.join();
 
     return returned_value;
 }

--- a/test/dds/communication/security/SubscriberModule.hpp
+++ b/test/dds/communication/security/SubscriberModule.hpp
@@ -19,10 +19,11 @@
 #ifndef TEST_COMMUNICATION_SUBSCRIBER_HPP
 #define TEST_COMMUNICATION_SUBSCRIBER_HPP
 
-#include <mutex>
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <map>
-#include <chrono>
+#include <mutex>
 
 #include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -44,9 +45,9 @@ public:
     SubscriberModule(
             const uint32_t publishers,
             const uint32_t max_number_samples,
-            bool fixed_type = false,
-            bool zero_copy = false,
-            bool die_on_data_received = false)
+            bool fixed_type,
+            bool zero_copy,
+            bool die_on_data_received)
         : publishers_(publishers)
         , max_number_samples_(max_number_samples)
         , fixed_type_(zero_copy || fixed_type) // If zero copy active, fixed type is required
@@ -85,10 +86,12 @@ public:
             const std::string& magic);
 
     bool run(
-            bool notexit);
+            bool notexit,
+            const uint32_t rescan_interval);
 
     bool run_for(
             bool notexit,
+            const uint32_t rescan_interval,
             const std::chrono::milliseconds& timeout);
 
 private:
@@ -102,7 +105,7 @@ private:
     std::map<eprosima::fastdds::rtps::GUID_t, uint32_t> number_samples_;
     bool fixed_type_ = false;
     bool zero_copy_ = false;
-    bool run_ = true;
+    std::atomic_bool run_{true};
     DomainParticipant* participant_ = nullptr;
     TypeSupport type_;
     Subscriber* subscriber_ = nullptr;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds a regression test based in Ubuntu containers for one long standing issue with dynamic network interfaces that was preventing communication when a participant was created with no network interfaces available.

It fixes the issue by correctly updating the locators on the proxy data of the participant, and all its readers or writers created with the default locators.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
