### PR TITLE
[21711] DataWriter/Reader `get_matched_publication/subscription...()` Feature implementation

### DIFF
--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -517,9 +517,9 @@ public:
      *
      * @param[out] subscription_data subscription data struct
      * @param subscription_handle InstanceHandle_t of the subscription
-     * @return RETCODE_OK
+     * @return RETCODE_BAD_PARAMETER if the DataWriter is not matched with
+     * the given subscription handle, RETCODE_OK otherwise.
      *
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscription_data(
             builtin::SubscriptionBuiltinTopicData& subscription_data,
@@ -529,13 +529,16 @@ public:
      * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
      *
      * @param[out] subscription_handles Vector where the InstanceHandle_t are returned
-     * @return RETCODE_OK
+     * @return RETCODE_OK if the operation succeeds.
      *
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscriptions(
             std::vector<InstanceHandle_t>& subscription_handles) const;
-
+    /**
+     * @note User is responsible for the memory deallocation of the returned vector.
+     */
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::get_matched_subscriptions()",
             "In favor of version using std::vector<fastrtps::rtps::InstanceHandle_t>.")

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -536,12 +536,13 @@ public:
      */
     RTPS_DllAPI ReturnCode_t get_matched_subscriptions(
             std::vector<InstanceHandle_t>& subscription_handles) const;
-    /**
-     * @note User is responsible for the memory deallocation of the returned vector.
-     */
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
     FASTDDS_DEPRECATED_UNTIL(3, "eprosima::fastdds::dds:DataWriter::get_matched_subscriptions()",
             "In favor of version using std::vector<fastrtps::rtps::InstanceHandle_t>.")
+    /**
+     * @note User is responsible for the memory deallocation of the returned vector.
+     */
     RTPS_DllAPI ReturnCode_t get_matched_subscriptions(
             std::vector<InstanceHandle_t*>& subscription_handles) const;
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/include/fastdds/dds/subscriber/DataReader.hpp
+++ b/include/fastdds/dds/subscriber/DataReader.hpp
@@ -977,9 +977,9 @@ public:
      *
      * @param[out] publication_data publication data struct
      * @param publication_handle InstanceHandle_t of the publication
-     * @return RETCODE_OK
+     * @return RETCODE_BAD_PARAMETER if the DataReader is not matched with
+     * the given publication handle, RETCODE_OK otherwise.
      *
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
      */
     RTPS_DllAPI ReturnCode_t get_matched_publication_data(
             builtin::PublicationBuiltinTopicData& publication_data,
@@ -989,9 +989,10 @@ public:
      * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
      *
      * @param[out] publication_handles Vector where the InstanceHandle_t are returned
-     * @return RETCODE_OK
+     * @return RETCODE_OK if the operation succeeds.
      *
-     * @warning Not supported yet. Currently returns RETCODE_UNSUPPORTED
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
      */
     RTPS_DllAPI ReturnCode_t get_matched_publications(
             std::vector<InstanceHandle_t>& publication_handles) const;

--- a/include/fastdds/rtps/participant/RTPSParticipant.h
+++ b/include/fastdds/rtps/participant/RTPSParticipant.h
@@ -309,10 +309,10 @@ public:
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
     /**
-     * @brief Fills the provided fastdds::dds::builtin::PublicationBuiltinTopicData with the information of the
+     * @brief Fills the provided publication data with the information of the
      * writer identified by writer_guid.
      *
-     * @param[out] data fastdds::dds::builtin::PublicationBuiltinTopicData to fill.
+     * @param[out] data publication data to fill.
      * @param[in] writer_guid GUID of the writer to get the information from.
      * @return True if the writer was found and the data was filled.
      */
@@ -321,10 +321,10 @@ public:
             const GUID_t& writer_guid) const;
 
     /**
-     * @brief Fills the provided fastdds::dds::builtin::SubscriptionBuiltinTopicData with the information of the
+     * @brief Fills the provided subscription discovery data with the information of the
      * reader identified by reader_guid.
      *
-     * @param[out] data fastdds::dds::builtin::SubscriptionBuiltinTopicData to fill.
+     * @param[out] data subscription discovery data to fill.
      * @param[in] reader_guid GUID of the reader to get the information from.
      * @return True if the reader was found and the data was filled.
      */

--- a/include/fastdds/rtps/reader/RTPSReader.h
+++ b/include/fastdds/rtps/reader/RTPSReader.h
@@ -282,8 +282,8 @@ public:
      * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
      * @return True if the operation was successful.
      */
-    RTPS_DllAPI bool matched_writers_guids(
-            std::vector<GUID_t>& guids) const;
+    RTPS_DllAPI virtual bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const = 0;
 
     /*!
      * @brief Returns there is a clean state with all Writers.

--- a/include/fastdds/rtps/reader/StatefulReader.h
+++ b/include/fastdds/rtps/reader/StatefulReader.h
@@ -328,6 +328,15 @@ public:
             WriterProxy* writer,
             bool mark_as_read = true) override;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const override;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/include/fastdds/rtps/reader/StatelessReader.h
+++ b/include/fastdds/rtps/reader/StatelessReader.h
@@ -253,6 +253,15 @@ public:
             WriterProxy* writer,
             bool mark_as_read = true) override;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const override;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/include/fastdds/rtps/writer/RTPSWriter.h
+++ b/include/fastdds/rtps/writer/RTPSWriter.h
@@ -323,8 +323,8 @@ public:
      * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
      * @return True if the operation was successful.
      */
-    RTPS_DllAPI bool matched_readers_guids(
-            std::vector<GUID_t>& guids) const;
+    RTPS_DllAPI virtual bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const = 0;
 
     /**
      * Tries to remove a change waiting a maximum of the provided microseconds.

--- a/include/fastdds/rtps/writer/StatefulWriter.h
+++ b/include/fastdds/rtps/writer/StatefulWriter.h
@@ -448,6 +448,15 @@ public:
         return locator_selector_async_;
     }
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const override;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -241,6 +241,15 @@ public:
         return locator_selector_;
     }
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const override;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -203,6 +203,7 @@ set(${PROJECT_NAME}_source_files
     rtps/builtin/liveliness/WLP.cpp
     rtps/builtin/liveliness/WLPListener.cpp
     rtps/builtin/data/ParticipantProxyData.cpp
+    rtps/builtin/data/ProxyDataConverters.cpp
     rtps/builtin/data/WriterProxyData.cpp
     rtps/builtin/data/ReaderProxyData.cpp
     rtps/flowcontrol/ThroughputControllerDescriptor.cpp

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -302,32 +302,19 @@ ReturnCode_t DataWriter::get_matched_subscription_data(
         builtin::SubscriptionBuiltinTopicData& subscription_data,
         const InstanceHandle_t& subscription_handle) const
 {
-    static_cast<void> (subscription_data);
-    static_cast<void> (subscription_handle);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_subscription_data(subscription_data, subscription_handle);
-     */
+    return impl_->get_matched_subscription_data(subscription_data, subscription_handle);
 }
 
 ReturnCode_t DataWriter::get_matched_subscriptions(
         std::vector<InstanceHandle_t>& subscription_handles) const
 {
-    static_cast<void> (subscription_handles);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_subscription_data(subscription_handles);
-     */
+    return impl_->get_matched_subscriptions(subscription_handles);
 }
 
 ReturnCode_t DataWriter::get_matched_subscriptions(
         std::vector<InstanceHandle_t*>& subscription_handles) const
 {
-    static_cast<void> (subscription_handles);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_subscription_data(subscription_handles);
-     */
+    return impl_->get_matched_subscriptions(subscription_handles);
 }
 
 ReturnCode_t DataWriter::clear_history(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -2262,7 +2262,7 @@ ReturnCode_t DataWriterImpl::get_matched_subscriptions(
     {
         for (const GUID_t& guid : matched_reader_guids)
         {
-            subscription_handles.push_back(InstanceHandle_t(guid));
+            subscription_handles.emplace_back(InstanceHandle_t(guid));
         }
         ret = ReturnCode_t::RETCODE_OK;
     }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -389,6 +389,34 @@ public:
     void filter_is_being_removed(
             const char* filter_class_name);
 
+    /**
+     * @brief Retrieves in a subscription associated with the DataWriter
+     *
+     * @param[out] subscription_data subscription data struct
+     * @param subscription_handle InstanceHandle_t of the subscription
+     * @return RETCODE_BAD_PARAMETER if the DataWriter is not matched with
+     * the given subscription handle, RETCODE_OK otherwise.
+     *
+     */
+    ReturnCode_t get_matched_subscription_data(
+            builtin::SubscriptionBuiltinTopicData& subscription_data,
+            const InstanceHandle_t& subscription_handle) const;
+
+    /**
+     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     *
+     * @param[out] subscription_handles Vector where the InstanceHandle_t are returned
+     * @return RETCODE_OK if the operation succeeds.
+     *
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
+     */
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t>& subscription_handles) const;
+
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t*>& subscription_handles) const;
+
 protected:
 
     using IChangePool = eprosima::fastrtps::rtps::IChangePool;

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -395,22 +395,13 @@ ReturnCode_t DataReader::get_matched_publication_data(
         builtin::PublicationBuiltinTopicData& publication_data,
         const fastrtps::rtps::InstanceHandle_t& publication_handle) const
 {
-    static_cast<void> (publication_data);
-    static_cast<void> (publication_handle);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_publication_data(publication_data, publication_handle);
-     */
+    return impl_->get_matched_publication_data(publication_data, publication_handle);
 }
 
 ReturnCode_t DataReader::get_matched_publications(
         std::vector<InstanceHandle_t>& publication_handles) const
 {
-    static_cast<void> (publication_handles);
-    return ReturnCode_t::RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_publication_data(publication_handles);
-     */
+    return impl_->get_matched_publications(publication_handles);
 }
 
 ReadCondition* DataReader::create_readcondition(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1232,7 +1232,7 @@ ReturnCode_t DataReaderImpl::get_matched_publications(
     {
         for (const GUID_t& guid : matched_writers_guids)
         {
-            publication_handles.push_back(InstanceHandle_t(guid));
+            publication_handles.emplace_back(InstanceHandle_t(guid));
         }
         ret = ReturnCode_t::RETCODE_OK;
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -75,6 +75,12 @@ class ReadConditionImpl;
 
 } // namespace detail
 
+namespace builtin {
+
+struct PublicationBuiltinTopicData;
+
+} // namespace builtin
+
 /**
  * Class DataReader, contains the actual implementation of the behaviour of the Subscriber.
  *  @ingroup FASTDDS_MODULE
@@ -236,6 +242,31 @@ public:
 
     ReturnCode_t get_subscription_matched_status(
             SubscriptionMatchedStatus& status);
+
+    /**
+     * @brief Retrieves in a publication associated with the DataWriter
+     *
+     * @param[out] publication_data publication data struct
+     * @param publication_handle InstanceHandle_t of the publication
+     * @return RETCODE_BAD_PARAMETER if the DataReader is not matched with
+     * the given publication handle, RETCODE_OK otherwise.
+     *
+     */
+    ReturnCode_t get_matched_publication_data(
+            builtin::PublicationBuiltinTopicData& publication_data,
+            const fastrtps::rtps::InstanceHandle_t& publication_handle) const;
+
+    /**
+     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     *
+     * @param[out] publication_handles Vector where the InstanceHandle_t are returned
+     * @return RETCODE_OK if the operation succeeds.
+     *
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
+     */
+    ReturnCode_t get_matched_publications(
+            std::vector<InstanceHandle_t>& publication_handles) const;
 
     ReturnCode_t get_requested_deadline_missed_status(
             fastrtps::RequestedDeadlineMissedStatus& status);

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
@@ -1,0 +1,232 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ProxyDataConverters.cpp
+ */
+
+#include <rtps/builtin/data/ProxyDataConverters.hpp>
+
+#include <cstdint>
+
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
+#include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
+#include <fastdds/dds/publisher/qos/WriterQos.hpp>
+#include <fastdds/dds/subscriber/qos/ReaderQos.hpp>
+#include <fastdds/rtps/common/Guid.h>
+#include <fastdds/rtps/common/GuidPrefix_t.hpp>
+#include <fastdds/rtps/common/InstanceHandle.h>
+#include <fastdds/rtps/builtin/data/ParticipantProxyData.h>
+#include <fastdds/rtps/builtin/data/ReaderProxyData.h>
+#include <fastdds/rtps/builtin/data/WriterProxyData.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+using namespace fastdds::dds::builtin;
+
+void from_proxy_to_builtin(
+        const EntityId_t& entity_id,
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& builtin_key)
+{
+    builtin_key.value[0] = 0;
+    builtin_key.value[1] = 0;
+    builtin_key.value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void from_proxy_to_builtin(
+        const GuidPrefix_t& guid_prefix,
+        eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& dds_key)
+{
+    dds_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    dds_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    dds_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
+
+void from_builtin_to_proxy(
+        const eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& dds_key,
+        EntityId_t& entity_id)
+{
+    entity_id.value[0] = static_cast<uint8_t>((dds_key.value[2] >> 24) & 0xFF);
+    entity_id.value[1] = static_cast<uint8_t>((dds_key.value[2] >> 16) & 0xFF);
+    entity_id.value[2] = static_cast<uint8_t>((dds_key.value[2] >> 8) & 0xFF);
+    entity_id.value[3] = static_cast<uint8_t>(dds_key.value[2] & 0xFF);
+}
+
+void from_builtin_to_proxy(
+        const eprosima::fastdds::dds::builtin::BuiltinTopicKey_t& dds_key,
+        GuidPrefix_t& guid_prefix)
+{
+    guid_prefix.value[0] = static_cast<uint8_t>((dds_key.value[0] >> 24) & 0xFF);
+    guid_prefix.value[1] = static_cast<uint8_t>((dds_key.value[0] >> 16) & 0xFF);
+    guid_prefix.value[2] = static_cast<uint8_t>((dds_key.value[0] >> 8) & 0xFF);
+    guid_prefix.value[3] = static_cast<uint8_t>(dds_key.value[0] & 0xFF);
+
+    guid_prefix.value[4] = static_cast<uint8_t>((dds_key.value[1] >> 24) & 0xFF);
+    guid_prefix.value[5] = static_cast<uint8_t>((dds_key.value[1] >> 16) & 0xFF);
+    guid_prefix.value[6] = static_cast<uint8_t>((dds_key.value[1] >> 8) & 0xFF);
+    guid_prefix.value[7] = static_cast<uint8_t>(dds_key.value[1] & 0xFF);
+
+    guid_prefix.value[8] = static_cast<uint8_t>((dds_key.value[2] >> 24) & 0xFF);
+    guid_prefix.value[9] = static_cast<uint8_t>((dds_key.value[2] >> 16) & 0xFF);
+    guid_prefix.value[10] = static_cast<uint8_t>((dds_key.value[2] >> 8) & 0xFF);
+    guid_prefix.value[11] = static_cast<uint8_t>(dds_key.value[2] & 0xFF);
+}
+
+void from_proxy_to_builtin(
+        const ParticipantProxyData& proxy_data,
+        ParticipantBuiltinTopicData& builtin_data)
+{
+    from_proxy_to_builtin(proxy_data.m_guid.guidPrefix, builtin_data.key);
+
+    builtin_data.user_data = proxy_data.m_userData;
+}
+
+void from_proxy_to_builtin(
+        const ReaderProxyData& proxy_data,
+        SubscriptionBuiltinTopicData& builtin_data)
+{
+    from_proxy_to_builtin(proxy_data.guid().entityId, builtin_data.key);
+    from_proxy_to_builtin(proxy_data.guid().guidPrefix, builtin_data.participant_key);
+
+    builtin_data.topic_name = proxy_data.topicName();
+    builtin_data.type_name = proxy_data.typeName();
+    builtin_data.durability = proxy_data.m_qos.m_durability;
+    builtin_data.deadline = proxy_data.m_qos.m_deadline;
+    builtin_data.latency_budget = proxy_data.m_qos.m_latencyBudget;
+    builtin_data.liveliness = proxy_data.m_qos.m_liveliness;
+    builtin_data.reliability = proxy_data.m_qos.m_reliability;
+    builtin_data.ownership = proxy_data.m_qos.m_ownership;
+    builtin_data.destination_order = proxy_data.m_qos.m_destinationOrder;
+    builtin_data.user_data = proxy_data.m_qos.m_userData;
+    builtin_data.m_timeBasedFilter = proxy_data.m_qos.m_timeBasedFilter;
+
+    // Subscriber Qos
+
+    builtin_data.presentation = proxy_data.m_qos.m_presentation;
+    builtin_data.partition = proxy_data.m_qos.m_partition;
+    builtin_data.topic_data = proxy_data.m_qos.m_topicData;
+    builtin_data.group_data = proxy_data.m_qos.m_groupData;
+}
+
+void from_proxy_to_builtin(
+        const WriterProxyData& proxy_data,
+        PublicationBuiltinTopicData& builtin_data)
+{
+    from_proxy_to_builtin(proxy_data.guid().entityId, builtin_data.key);
+    from_proxy_to_builtin(proxy_data.guid().guidPrefix, builtin_data.participant_key);
+
+    builtin_data.topic_name = proxy_data.topicName();
+    builtin_data.type_name = proxy_data.typeName();
+    builtin_data.durability = proxy_data.m_qos.m_durability;
+    builtin_data.durability_service = proxy_data.m_qos.m_durabilityService;
+    builtin_data.deadline = proxy_data.m_qos.m_deadline;
+    builtin_data.latency_budget = proxy_data.m_qos.m_latencyBudget;
+    builtin_data.liveliness = proxy_data.m_qos.m_liveliness;
+    builtin_data.reliability = proxy_data.m_qos.m_reliability;
+    builtin_data.lifespan = proxy_data.m_qos.m_lifespan;
+    builtin_data.user_data = proxy_data.m_qos.m_userData;
+    builtin_data.ownership = proxy_data.m_qos.m_ownership;
+    builtin_data.ownership_strength = proxy_data.m_qos.m_ownershipStrength;
+    builtin_data.destination_order = proxy_data.m_qos.m_destinationOrder;
+
+    // Publisher Qos
+
+    builtin_data.presentation = proxy_data.m_qos.m_presentation;
+    builtin_data.partition = proxy_data.m_qos.m_partition;
+    builtin_data.topic_data = proxy_data.m_qos.m_topicData;
+    builtin_data.group_data = proxy_data.m_qos.m_groupData;
+}
+
+void from_builtin_to_proxy(
+        const PublicationBuiltinTopicData& builtin_data,
+        WriterProxyData& proxy_data)
+{
+    fastdds::dds::WriterQos qos{};
+
+    from_builtin_to_proxy(builtin_data.participant_key, proxy_data.guid().guidPrefix);
+    from_builtin_to_proxy(builtin_data.key, proxy_data.guid().entityId);
+
+    proxy_data.topicName(builtin_data.topic_name);
+    proxy_data.typeName(builtin_data.type_name);
+
+    qos.m_durability = builtin_data.durability;
+    qos.m_durabilityService = builtin_data.durability_service;
+    qos.m_deadline = builtin_data.deadline;
+    qos.m_latencyBudget = builtin_data.latency_budget;
+    qos.m_liveliness = builtin_data.liveliness;
+    qos.m_reliability = builtin_data.reliability;
+    qos.m_lifespan = builtin_data.lifespan;
+    qos.m_userData = builtin_data.user_data;
+    qos.m_ownership = builtin_data.ownership;
+    qos.m_ownershipStrength = builtin_data.ownership_strength;
+    qos.m_destinationOrder = builtin_data.destination_order;
+
+    qos.m_presentation = builtin_data.presentation;
+    qos.m_partition = builtin_data.partition;
+    qos.m_topicData = builtin_data.topic_data;
+    qos.m_groupData = builtin_data.group_data;
+
+    proxy_data.m_qos.setQos(qos, true);
+}
+
+void from_builtin_to_proxy(
+        const SubscriptionBuiltinTopicData& builtin_data,
+        ReaderProxyData& proxy_data)
+{
+    fastdds::dds::ReaderQos qos{};
+
+    from_builtin_to_proxy(builtin_data.participant_key, proxy_data.guid().guidPrefix);
+    from_builtin_to_proxy(builtin_data.key, proxy_data.guid().entityId);
+
+    proxy_data.topicName(builtin_data.topic_name);
+    proxy_data.typeName(builtin_data.type_name);
+
+    qos.m_durability = builtin_data.durability;
+    qos.m_deadline = builtin_data.deadline;
+    qos.m_latencyBudget = builtin_data.latency_budget;
+    qos.m_liveliness = builtin_data.liveliness;
+    qos.m_reliability = builtin_data.reliability;
+    qos.m_ownership = builtin_data.ownership;
+    qos.m_destinationOrder = builtin_data.destination_order;
+    qos.m_userData = builtin_data.user_data;
+    qos.m_timeBasedFilter = builtin_data.m_timeBasedFilter;
+
+    qos.m_presentation = builtin_data.presentation;
+    qos.m_partition = builtin_data.partition;
+    qos.m_topicData = builtin_data.topic_data;
+    qos.m_groupData = builtin_data.group_data;
+
+    proxy_data.m_qos.setQos(qos, true);
+}
+
+} // namespace rtps
+} // namespace fasrtps
+} // namespace eprosima

--- a/src/cpp/rtps/builtin/data/ProxyDataConverters.hpp
+++ b/src/cpp/rtps/builtin/data/ProxyDataConverters.hpp
@@ -1,0 +1,95 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RTPS_BUILTIN_DATA__PROXYDATACONVERTERS_HPP
+#define RTPS_BUILTIN_DATA__PROXYDATACONVERTERS_HPP
+
+#include <cstdint>
+
+namespace eprosima {
+
+namespace fastdds {
+namespace dds {
+namespace builtin {
+
+struct ParticipantBuiltinTopicData;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
+
+} // builtin
+} // dds
+} // fastdds
+
+namespace fastrtps {
+namespace rtps {
+
+class ParticipantProxyData;
+class ReaderProxyData;
+class WriterProxyData;
+
+/**
+ * Convert a ParticipantProxyData to a ParticipantBuiltinTopicData.
+ *
+ * @param [in]  proxy_data    ParticipantProxyData to convert.
+ * @param [out] builtin_data  ParticipantBuiltinTopicData to fill.
+ */
+void from_proxy_to_builtin(
+        const ParticipantProxyData& proxy_data,
+        fastdds::dds::builtin::ParticipantBuiltinTopicData& builtin_data);
+
+/**
+ * Convert a ReaderProxyData to a SubscriptionBuiltinTopicData.
+ *
+ * @param [in]  proxy_data    ReaderProxyData to convert.
+ * @param [out] builtin_data  SubscriptionBuiltinTopicData to fill.
+ */
+void from_proxy_to_builtin(
+        const ReaderProxyData& proxy_data,
+        fastdds::dds::builtin::SubscriptionBuiltinTopicData& builtin_data);
+
+/**
+ * Convert a WriterProxyData to a PublicationBuiltinTopicData.
+ *
+ * @param [in]  proxy_data    WriterProxyData to convert.
+ * @param [out] builtin_data  PublicationBuiltinTopicData to fill.
+ */
+void from_proxy_to_builtin(
+        const WriterProxyData& proxy_data,
+        fastdds::dds::builtin::PublicationBuiltinTopicData& builtin_data);
+
+/**
+ * Convert a PublicationBuiltinTopicData to a WriterProxyData.
+ *
+ * @param [in]   builtin_data  PublicationBuiltinTopicData to convert.
+ * @param [out]  proxy_data    WriterProxyData to fill.
+ */
+void from_builtin_to_proxy(
+        const fastdds::dds::builtin::PublicationBuiltinTopicData& proxy_data,
+        WriterProxyData& builtin_data);
+
+/**
+ * Convert a SubscriptionBuiltinTopicData to a ReaderProxyData.
+ *
+ * @param [in]   builtin_data  SubscriptionBuiltinTopicData to convert.
+ * @param [out]  proxy_data    ReaderProxyData to fill.
+ */
+void from_builtin_to_proxy(
+        const fastdds::dds::builtin::SubscriptionBuiltinTopicData& builtin_data,
+        ReaderProxyData& proxy_data);
+
+}  // namespace rtps
+}  // namespace fastrtps
+}  // namespace eprosima
+
+#endif // RTPS_BUILTIN_DATA__PROXYDATACONVERTERS_HPP

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -202,17 +202,17 @@ std::vector<fastdds::rtps::TransportNetmaskFilterInfo> RTPSParticipant::get_netm
 }
 
 bool RTPSParticipant::get_publication_info(
-        fastdds::dds::builtin::PublicationBuiltinTopicData&,
-        const GUID_t&) const
+        fastdds::dds::builtin::PublicationBuiltinTopicData& data,
+        const GUID_t& writer_guid) const
 {
-    return false;
+    return mp_impl->get_publication_info(data, writer_guid);
 }
 
 bool RTPSParticipant::get_subscription_info(
-        fastdds::dds::builtin::SubscriptionBuiltinTopicData&,
-        const GUID_t&) const
+        fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
+        const GUID_t& reader_guid) const
 {
-    return false;
+    return mp_impl->get_subscription_info(data, reader_guid);
 }
 
 #if HAVE_SECURITY

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -58,6 +58,7 @@
 #include <fastrtps/utils/Semaphore.h>
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
+#include <rtps/builtin/data/ProxyDataConverters.hpp>
 #include <rtps/builtin/discovery/participant/PDPClient.h>
 #include <rtps/builtin/discovery/participant/PDPServer.hpp>
 #include <rtps/history/BasicPayloadPool.hpp>
@@ -2937,6 +2938,40 @@ bool RTPSParticipantImpl::ignore_reader(
 std::vector<fastdds::rtps::TransportNetmaskFilterInfo> RTPSParticipantImpl::get_netmask_filter_info() const
 {
     return m_network_Factory.netmask_filter_info();
+}
+
+bool RTPSParticipantImpl::get_publication_info(
+        fastdds::dds::builtin::PublicationBuiltinTopicData& data,
+        const GUID_t& writer_guid) const
+{
+    bool ret = false;
+    WriterProxyData wproxy_data(m_att.allocation.locators.max_unicast_locators,
+            m_att.allocation.locators.max_multicast_locators);
+
+    if (mp_builtinProtocols->mp_PDP->lookupWriterProxyData(writer_guid, wproxy_data))
+    {
+        from_proxy_to_builtin(wproxy_data, data);
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool RTPSParticipantImpl::get_subscription_info(
+        fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
+        const GUID_t& reader_guid) const
+{
+    bool ret = false;
+    ReaderProxyData rproxy_data(m_att.allocation.locators.max_unicast_locators,
+            m_att.allocation.locators.max_multicast_locators);
+
+    if (mp_builtinProtocols->mp_PDP->lookupReaderProxyData(reader_guid, rproxy_data))
+    {
+        from_proxy_to_builtin(rproxy_data, data);
+        ret = true;
+    }
+
+    return ret;
 }
 
 #ifdef FASTDDS_STATISTICS

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -91,6 +91,8 @@ namespace dds {
 namespace builtin {
 
 class TypeLookupManager;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 } // namespace builtin
 } // namespace dds
@@ -1127,6 +1129,30 @@ public:
      * @return A vector with all registered transports' netmask filter information.
      */
     std::vector<fastdds::rtps::TransportNetmaskFilterInfo> get_netmask_filter_info() const;
+
+    /**
+     * @brief Fills the provided PublicationBuiltinTopicData with the information of the
+     * writer identified by writer_guid.
+     *
+     * @param[out] data PublicationBuiltinTopicData to fill.
+     * @param[in] writer_guid GUID of the writer to get the information from.
+     * @return True if the writer was found and the data was filled.
+     */
+    bool get_publication_info(
+            fastdds::dds::builtin::PublicationBuiltinTopicData& data,
+            const GUID_t& writer_guid) const;
+
+    /**
+     * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
+     * reader identified by reader_guid.
+     *
+     * @param[out] data SubscriptionBuiltinTopicData to fill.
+     * @param[in] reader_guid GUID of the reader to get the information from.
+     * @return True if the reader was found and the data was filled.
+     */
+    bool get_subscription_info(
+            fastdds::dds::builtin::SubscriptionBuiltinTopicData& data,
+            const GUID_t& reader_guid) const;
 
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(

--- a/src/cpp/rtps/reader/RTPSReader.cpp
+++ b/src/cpp/rtps/reader/RTPSReader.cpp
@@ -435,12 +435,6 @@ bool RTPSReader::is_sample_valid(
     return true;
 }
 
-bool RTPSReader::matched_writers_guids(
-        std::vector<GUID_t>&) const
-{
-    return false;
-}
-
 #ifdef FASTDDS_STATISTICS
 
 bool RTPSReader::add_statistics_listener(

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1499,6 +1499,19 @@ void StatefulReader::change_read_by_user(
     }
 }
 
+bool StatefulReader::matched_writers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    guids.reserve(matched_writers_.size());
+    for (WriterProxy* writer : matched_writers_)
+    {
+        guids.push_back(writer->guid());
+    }
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatefulReader::get_connections(

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -519,6 +519,19 @@ void StatelessReader::change_read_by_user(
 
 }
 
+bool StatelessReader::matched_writers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    guids.reserve(matched_writers_.size());
+    for (const RemoteWriterInfo_t& writer : matched_writers_)
+    {
+        guids.push_back(writer.guid);
+    }
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatelessReader::get_connections(

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -2202,6 +2202,22 @@ DeliveryRetCode StatefulWriter::deliver_sample_nts(
     return ret_code;
 }
 
+bool StatefulWriter::matched_readers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
+            [&guids](const ReaderProxy* reader)
+            {
+                guids.push_back(reader->guid());
+                return false;
+            }
+            );
+
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatefulWriter::get_connections(

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -912,6 +912,21 @@ DeliveryRetCode StatelessWriter::deliver_sample_nts(
     return ret_code;
 }
 
+bool StatelessWriter::matched_readers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
+            [&guids](const ReaderLocator& reader)
+            {
+                guids.push_back(reader.remote_guid());
+                return false;
+            }
+            );
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatelessWriter::get_connections(

--- a/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubWriter.hpp
@@ -1174,7 +1174,7 @@ public:
         return *this;
     }
 
-    PubSubWriter& userData(
+    PubSubWriter& user_data(
             std::vector<eprosima::fastrtps::rtps::octet> user_data)
     {
         participant_attr_.rtps.userData = user_data;

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -177,6 +177,12 @@ public:
         return true;
     }
 
+    virtual bool matched_writers_guids(
+            std::vector<GUID_t>&) const
+    {
+        return true;
+    }
+
     virtual bool isInCleanState()
     {
         return true;

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.h
@@ -180,7 +180,7 @@ public:
     virtual bool matched_writers_guids(
             std::vector<GUID_t>&) const
     {
-        return true;
+        return false;
     }
 
     virtual bool isInCleanState()

--- a/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
+++ b/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.h
@@ -90,6 +90,12 @@ public:
         return false;
     }
 
+    virtual bool matched_readers_guids(
+            std::vector<GUID_t>&) const
+    {
+        return false;
+    }
+
     virtual bool has_been_fully_delivered(
             const SequenceNumber_t& /*seq_num*/) const
     {

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -106,6 +106,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/BuiltinProtocols.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/WriterProxyData.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/database/backup/SharedBackupFunctions.cpp

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1755,9 +1755,7 @@ public:
 /*
  * This test checks that the DataWriter methods defined in the standard not yet implemented in FastDDS return
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. get_matched_subscription_data
- * 2. get_matched_subscriptions
- * 3. lookup_instance
+ * 1. lookup_instance
  */
 TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 {
@@ -1776,15 +1774,6 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 
     DataWriter* data_writer = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
     ASSERT_NE(publisher, nullptr);
-
-    builtin::SubscriptionBuiltinTopicData subscription_data;
-    fastrtps::rtps::InstanceHandle_t subscription_handle;
-    EXPECT_EQ(
-        ReturnCode_t::RETCODE_UNSUPPORTED,
-        data_writer->get_matched_subscription_data(subscription_data, subscription_handle));
-
-    std::vector<InstanceHandle_t> subscription_handles;
-    EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_writer->get_matched_subscriptions(subscription_handles));
 
     EXPECT_EQ(HANDLE_NIL, data_writer->lookup_instance(nullptr /* instance */));
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -2597,11 +2597,9 @@ public:
 /*
  * This test checks that the DataReader methods defined in the standard not yet implemented in FastDDS return
  * ReturnCode_t::RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. get_matched_publication_data
- * 2. create_querycondition
- * 3. get_matched_publications
- * 4. get_key_value
- * 5. wait_for_historical_data
+ * 1. create_querycondition
+ * 2. get_key_value
+ * 3. wait_for_historical_data
  */
 TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
 {
@@ -2621,13 +2619,6 @@ TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
 
     DataReader* data_reader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
     ASSERT_NE(data_reader, nullptr);
-
-    builtin::PublicationBuiltinTopicData publication_data;
-    InstanceHandle_t publication_handle;
-    EXPECT_EQ(
-        ReturnCode_t::RETCODE_UNSUPPORTED,
-        data_reader->get_matched_publication_data(publication_data, publication_handle));
-
     {
         SampleStateMask sample_states = ANY_SAMPLE_STATE;
         ViewStateMask view_states = ANY_VIEW_STATE;
@@ -2643,9 +2634,6 @@ TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
                 query_expression,
                 query_parameters));
     }
-
-    std::vector<InstanceHandle_t> publication_handles;
-    EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_reader->get_matched_publications(publication_handles));
 
     InstanceHandle_t key_handle;
     EXPECT_EQ(ReturnCode_t::RETCODE_UNSUPPORTED, data_reader->get_key_value(nullptr, key_handle));

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -179,6 +179,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/BuiltinProtocols.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/WriterProxyData.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/database/backup/SharedBackupFunctions.cpp
@@ -381,6 +382,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/BuiltinProtocols.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ProxyDataConverters.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/data/WriterProxyData.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/database/backup/SharedBackupFunctions.cpp

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -429,6 +429,25 @@ public:
 
     }
 
+    ReturnCode_t get_matched_subscription_data(
+            builtin::SubscriptionBuiltinTopicData&,
+            const InstanceHandle_t& ) const
+    {
+        return ReturnCode_t::RETCODE_OK;
+    }
+
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t>&) const
+    {
+        return ReturnCode_t::RETCODE_OK;
+    }
+
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t*>&) const
+    {
+        return ReturnCode_t::RETCODE_OK;
+    }
+
     //! Pointer to the associated Data Writer.
     fastrtps::rtps::RTPSWriter* writer_ = nullptr;
     Topic* topic_ = nullptr;

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,12 @@
 Forthcoming
 -----------
 
+* Implementation for:
+  * `DataWriter::get_matched_subscription_data()`
+  * `DataWriter::get_matched_subscriptions()`
+  * `DataReader::get_matched_publication_data()`
+  * `DataReader::get_matched_publications()`
+
 Version 2.14.3
 --------------
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR provides the feature implementation for :

`DDS`
* `DataWriter::get_matched_subscriptions()`
* `DataWriter::get_matched_subscription_data()`
* `DataReader::get_matched_publications()`
* `DataReader::get_matched_publication_data()`

`RTPS`
* `RTPSParticipant::get_publication_info()`
* `RTPSParticipant::get_subscription_info()`
* `RTPSReader::matched_writers_guids()`
* `RTPSWriter::matched_readers_guids()`

In the `2.x` series.
This PR must be merged after
* #5264 

Related PRs
* https://github.com/eProsima/Fast-DDS-python/pull/185

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. API was extended <!-- Public API must not be broken within the same major release. -->
- [X] New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
