### PR TITLE
[21756] Extended Incompatible QoS for Monitor Service Tests implementation

### DIFF
--- a/include/fastdds/statistics/monitorservice_types.idl
+++ b/include/fastdds/statistics/monitorservice_types.idl
@@ -74,19 +74,28 @@ module statistics {
     typedef BaseStatus_s InconsistentTopicStatus_s;
     typedef BaseStatus_s SampleLostStatus_s;
 
+    struct ExtendedIncompatibleQoSStatus_s
+    {
+        detail::GUID_s remote_guid;
+        sequence<unsigned long> current_incompatible_policies;
+    };
+
+    typedef sequence<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
     module StatusKind
     {
         typedef unsigned long StatusKind;
 
-        const StatusKind PROXY              = 0;
-        const StatusKind CONNECTION_LIST    = 1;
-        const StatusKind INCOMPATIBLE_QOS   = 2;
-        const StatusKind INCONSISTENT_TOPIC = 3;
-        const StatusKind LIVELINESS_LOST    = 4;
-        const StatusKind LIVELINESS_CHANGED = 5;
-        const StatusKind DEADLINE_MISSED    = 6;
-        const StatusKind SAMPLE_LOST        = 7;
-        const StatusKind STATUSES_SIZE      = 8;
+        const StatusKind PROXY                     = 0;
+        const StatusKind CONNECTION_LIST           = 1;
+        const StatusKind INCOMPATIBLE_QOS          = 2;
+        const StatusKind INCONSISTENT_TOPIC        = 3;
+        const StatusKind LIVELINESS_LOST           = 4;
+        const StatusKind LIVELINESS_CHANGED        = 5;
+        const StatusKind DEADLINE_MISSED           = 6;
+        const StatusKind SAMPLE_LOST               = 7;
+        const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+        const StatusKind STATUSES_SIZE             = 9;
     }; // module StatusKind
 
     union MonitorServiceData switch(StatusKind::StatusKind)
@@ -107,6 +116,8 @@ module statistics {
             DeadlineMissedStatus_s deadline_missed_status;
         case StatusKind::SAMPLE_LOST:
             SampleLostStatus_s sample_lost_status;
+        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            ExtendedIncompatibleQoSStatusSeq_s extended_incompatible_qos_status;
         case StatusKind::STATUSES_SIZE:
             octet statuses_size;
     };

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -1211,6 +1211,188 @@ typedef BaseStatus_s InconsistentTopicStatus_s;
 
 typedef BaseStatus_s SampleLostStatus_s;
 
+/*!
+ * @brief This class represents the structure ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+ * @ingroup monitorservice_types
+ */
+class ExtendedIncompatibleQoSStatus_s
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return (m_remote_guid == x.m_remote_guid &&
+           m_current_incompatible_policies == x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function copies the value in member remote_guid
+     * @param _remote_guid New value to be copied in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            const detail::GUID_s& _remote_guid)
+    {
+        m_remote_guid = _remote_guid;
+    }
+
+    /*!
+     * @brief This function moves the value in member remote_guid
+     * @param _remote_guid New value to be moved in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            detail::GUID_s&& _remote_guid)
+    {
+        m_remote_guid = std::move(_remote_guid);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member remote_guid
+     * @return Constant reference to member remote_guid
+     */
+    eProsima_user_DllExport const detail::GUID_s& remote_guid() const
+    {
+        return m_remote_guid;
+    }
+
+    /*!
+     * @brief This function returns a reference to member remote_guid
+     * @return Reference to member remote_guid
+     */
+    eProsima_user_DllExport detail::GUID_s& remote_guid()
+    {
+        return m_remote_guid;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be copied in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            const std::vector<uint32_t>& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = _current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function moves the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be moved in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            std::vector<uint32_t>&& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = std::move(_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member current_incompatible_policies
+     * @return Constant reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport const std::vector<uint32_t>& current_incompatible_policies() const
+    {
+        return m_current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function returns a reference to member current_incompatible_policies
+     * @return Reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport std::vector<uint32_t>& current_incompatible_policies()
+    {
+        return m_current_incompatible_policies;
+    }
+
+
+
+private:
+
+    detail::GUID_s m_remote_guid;
+    std::vector<uint32_t> m_current_incompatible_policies;
+
+};
+typedef std::vector<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
 namespace StatusKind {
 
 typedef uint32_t StatusKind;
@@ -1223,7 +1405,8 @@ const StatusKind LIVELINESS_LOST = 4;
 const StatusKind LIVELINESS_CHANGED = 5;
 const StatusKind DEADLINE_MISSED = 6;
 const StatusKind SAMPLE_LOST = 7;
-const StatusKind STATUSES_SIZE = 8;
+const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+const StatusKind STATUSES_SIZE = 9;
 
 } // namespace StatusKind
 /*!
@@ -1296,6 +1479,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1346,6 +1533,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1396,6 +1587,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1448,6 +1643,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1506,6 +1705,10 @@ public:
                                                         break;
 
                                                     case 0x00000009:
+                                                        ret_value = (x.m_extended_incompatible_qos_status == m_extended_incompatible_qos_status);
+                                                        break;
+
+                                                    case 0x0000000a:
                                                         ret_value = (x.m_statuses_size == m_statuses_size);
                                                         break;
 
@@ -1599,8 +1802,15 @@ public:
                             }
                             break;
 
-                        case StatusKind::STATUSES_SIZE:
+                        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                             if (0x00000009 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case StatusKind::STATUSES_SIZE:
+                            if (0x0000000a == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -2050,6 +2260,59 @@ public:
 
 
     /*!
+     * @brief This function copies the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be copied in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            const ExtendedIncompatibleQoSStatusSeq_s& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function moves the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be moved in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            ExtendedIncompatibleQoSStatusSeq_s&& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member extended_incompatible_qos_status
+     * @return Constant reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport const ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status() const
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+    /*!
+     * @brief This function returns a reference to member extended_incompatible_qos_status
+     * @return Reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status()
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+
+    /*!
      * @brief This function sets a value in member statuses_size
      * @param _statuses_size New value for member statuses_size
      */
@@ -2067,7 +2330,7 @@ public:
      */
     eProsima_user_DllExport uint8_t statuses_size() const
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2082,7 +2345,7 @@ public:
      */
     eProsima_user_DllExport uint8_t& statuses_size()
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2248,7 +2511,7 @@ private:
                 return m_sample_lost_status;
             }
 
-            uint8_t& statuses_size_()
+            ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status_()
             {
                 if (0x00000009 != selected_member_)
                 {
@@ -2258,6 +2521,24 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
+                    member_destructor_ = [&]() {m_extended_incompatible_qos_status.~ExtendedIncompatibleQoSStatusSeq_s();};
+                    new(&m_extended_incompatible_qos_status) ExtendedIncompatibleQoSStatusSeq_s();
+
+                }
+
+                return m_extended_incompatible_qos_status;
+            }
+
+            uint8_t& statuses_size_()
+            {
+                if (0x0000000a != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x0000000a;
                     member_destructor_ = nullptr;
                     m_statuses_size = {0};
 
@@ -2279,6 +2560,7 @@ private:
         LivelinessChangedStatus_s m_liveliness_changed_status;
         DeadlineMissedStatus_s m_deadline_missed_status;
         SampleLostStatus_s m_sample_lost_status;
+        ExtendedIncompatibleQoSStatusSeq_s m_extended_incompatible_qos_status;
         uint8_t m_statuses_size;
     };
 

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
@@ -33,6 +33,9 @@ constexpr uint32_t eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize
 
 
 
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize {36UL};
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize {0UL};
+
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize {0UL};
 
@@ -99,6 +102,11 @@ eProsima_user_DllExport void serialize_key(
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
 
 
+
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data);
 
 
 

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
@@ -650,6 +650,108 @@ void serialize_key(
 
 
 
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data,
+        size_t& current_alignment)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.remote_guid(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.current_incompatible_policies(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.remote_guid()
+        << eprosima::fastcdr::MemberId(1) << data.current_incompatible_policies()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.remote_guid();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.current_incompatible_policies();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.remote_guid());
+
+                        scdr << data.current_incompatible_policies();
+
+}
+
+
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -713,8 +815,13 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 data.sample_lost_status(), current_alignment);
                     break;
 
-                case StatusKind::STATUSES_SIZE:
+                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                     calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                                data.extended_incompatible_qos_status(), current_alignment);
+                    break;
+
+                case StatusKind::STATUSES_SIZE:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
                                 data.statuses_size(), current_alignment);
                     break;
 
@@ -777,8 +884,12 @@ eProsima_user_DllExport void serialize(
                     scdr << eprosima::fastcdr::MemberId(8) << data.sample_lost_status();
                     break;
 
+                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                    scdr << eprosima::fastcdr::MemberId(9) << data.extended_incompatible_qos_status();
+                    break;
+
                 case StatusKind::STATUSES_SIZE:
-                    scdr << eprosima::fastcdr::MemberId(9) << data.statuses_size();
+                    scdr << eprosima::fastcdr::MemberId(10) << data.statuses_size();
                     break;
 
         default:
@@ -872,6 +983,14 @@ eProsima_user_DllExport void deserialize(
                                                         break;
                                                     }
 
+                                                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                                                    {
+                                                        eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s extended_incompatible_qos_status_value;
+                                                        data.extended_incompatible_qos_status(std::move(extended_incompatible_qos_status_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
                                                 case StatusKind::STATUSES_SIZE:
                                                     {
                                                         uint8_t statuses_size_value{0};
@@ -919,6 +1038,10 @@ eProsima_user_DllExport void deserialize(
 
                                                 case StatusKind::SAMPLE_LOST:
                                                     dcdr >> data.sample_lost_status();
+                                                    break;
+
+                                                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                                                    dcdr >> data.extended_incompatible_qos_status();
                                                     break;
 
                                                 case StatusKind::STATUSES_SIZE:

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -1124,6 +1124,188 @@ namespace eprosima {
 
 
 
+            ExtendedIncompatibleQoSStatus_sPubSubType::ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                set_name("eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s");
+                uint32_t type_size = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize;
+                type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+                max_serialized_type_size = type_size + 4; /*encapsulation*/
+                is_compute_key_provided = false;
+                uint32_t key_length = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16 ? eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize : 16;
+                key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+                memset(key_buffer_, 0, key_length);
+            }
+
+            ExtendedIncompatibleQoSStatus_sPubSubType::~ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                if (key_buffer_ != nullptr)
+                {
+                    free(key_buffer_);
+                }
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::serialize(
+                    const void* const data,
+                    SerializedPayload_t& payload,
+                    DataRepresentationId_t data_representation)
+            {
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+                payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+                ser.set_encoding_flag(
+                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+                try
+                {
+                    // Serialize encapsulation
+                    ser.serialize_encapsulation();
+                    // Serialize the object.
+                    ser << *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                // Get the serialized length
+                payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+                return true;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::deserialize(
+                    SerializedPayload_t& payload,
+                    void* data)
+            {
+                try
+                {
+                    // Convert DATA to pointer of your type
+                    ExtendedIncompatibleQoSStatus_s* p_type = static_cast<ExtendedIncompatibleQoSStatus_s*>(data);
+
+                    // Object that manages the raw buffer.
+                    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+                    // Object that deserializes the data.
+                    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+                    // Deserialize encapsulation.
+                    deser.read_encapsulation();
+                    payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+                    // Deserialize the object.
+                    deser >> *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            uint32_t ExtendedIncompatibleQoSStatus_sPubSubType::calculate_serialized_size(
+                    const void* const data,
+                    DataRepresentationId_t data_representation)
+            {
+                try
+                {
+                    eprosima::fastcdr::CdrSizeCalculator calculator(
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                    size_t current_alignment {0};
+                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                *static_cast<const ExtendedIncompatibleQoSStatus_s*>(data), current_alignment)) +
+                            4u /*encapsulation*/;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return 0;
+                }
+            }
+
+            void* ExtendedIncompatibleQoSStatus_sPubSubType::create_data()
+            {
+                return reinterpret_cast<void*>(new ExtendedIncompatibleQoSStatus_s());
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::delete_data(
+                    void* data)
+            {
+                delete(reinterpret_cast<ExtendedIncompatibleQoSStatus_s*>(data));
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    SerializedPayload_t& payload,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                ExtendedIncompatibleQoSStatus_s data;
+                if (deserialize(payload, static_cast<void*>(&data)))
+                {
+                    return compute_key(static_cast<void*>(&data), handle, force_md5);
+                }
+
+                return false;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    const void* const data,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+                        eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize);
+
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+                eprosima::fastcdr::serialize_key(ser, *p_type);
+                if (force_md5 || eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
+                {
+                    md5_.init();
+                    md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+                    md5_.finalize();
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = md5_.digest[i];
+                    }
+                }
+                else
+                {
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = key_buffer_[i];
+                    }
+                }
+                return true;
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::register_type_object_representation()
+            {
+                register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_identifiers_);
+            }
+
+
             namespace StatusKind {
             } // namespace StatusKind
 

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
@@ -534,9 +534,92 @@ namespace eprosima
             typedef eprosima::fastdds::statistics::BaseStatus_s LivelinessLostStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s InconsistentTopicStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s SampleLostStatus_s;
+
+            /*!
+             * @brief This class represents the TopicDataType of the type ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+             * @ingroup monitorservice_types
+             */
+            class ExtendedIncompatibleQoSStatus_sPubSubType : public eprosima::fastdds::dds::TopicDataType
+            {
+            public:
+
+                typedef ExtendedIncompatibleQoSStatus_s type;
+
+                eProsima_user_DllExport ExtendedIncompatibleQoSStatus_sPubSubType();
+
+                eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_sPubSubType() override;
+
+                eProsima_user_DllExport bool serialize(
+                        const void* const data,
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool deserialize(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        void* data) override;
+
+                eProsima_user_DllExport uint32_t calculate_serialized_size(
+                        const void* const data,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        const void* const data,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport void* create_data() override;
+
+                eProsima_user_DllExport void delete_data(
+                        void* data) override;
+
+                //Register TypeObject representation in Fast DDS TypeObjectRegistry
+                eProsima_user_DllExport void register_type_object_representation() override;
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+                eProsima_user_DllExport inline bool is_bounded() const override
+                {
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+                eProsima_user_DllExport inline bool is_plain(
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+                {
+                    static_cast<void>(data_representation);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+                eProsima_user_DllExport inline bool construct_sample(
+                        void* memory) const override
+                {
+                    static_cast<void>(memory);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+            private:
+
+                eprosima::fastdds::MD5 md5_;
+                unsigned char* key_buffer_;
+
+            };
+            typedef std::vector<eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;
+
 
 
 

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
@@ -1069,6 +1069,205 @@ void register_SampleLostStatus_s_type_identifier(
     }
 }
 
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatus_s)
+{
+
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatus_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatus_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatus_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatus_s)
+    {
+        StructTypeFlag struct_flags_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatus_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatus_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatus_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatus_s, ann_custom_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string());
+        CompleteStructHeader header_ExtendedIncompatibleQoSStatus_s;
+        header_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ExtendedIncompatibleQoSStatus_s);
+        CompleteStructMemberSeq member_seq_ExtendedIncompatibleQoSStatus_s;
+        {
+            TypeIdentifierPair type_ids_remote_guid;
+            ReturnCode_t return_code_remote_guid {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_remote_guid =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::detail::GUID_s", type_ids_remote_guid);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_remote_guid)
+            {
+                eprosima::fastdds::statistics::detail::register_GUID_s_type_identifier(type_ids_remote_guid);
+            }
+            StructMemberFlag member_flags_remote_guid = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_remote_guid = 0x00000000;
+            bool common_remote_guid_ec {false};
+            CommonStructMember common_remote_guid {TypeObjectUtils::build_common_struct_member(member_id_remote_guid, member_flags_remote_guid, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_remote_guid, common_remote_guid_ec))};
+            if (!common_remote_guid_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure remote_guid member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_remote_guid = "remote_guid";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_remote_guid;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_remote_guid = TypeObjectUtils::build_complete_member_detail(name_remote_guid, member_ann_builtin_remote_guid, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_remote_guid = TypeObjectUtils::build_complete_struct_member(common_remote_guid, detail_remote_guid);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_remote_guid);
+        }
+        {
+            TypeIdentifierPair type_ids_current_incompatible_policies;
+            ReturnCode_t return_code_current_incompatible_policies {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_current_incompatible_policies =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+            {
+                return_code_current_incompatible_policies =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_uint32_t", type_ids_current_incompatible_policies);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_sequence_uint32_t_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_uint32_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, element_identifier_anonymous_sequence_uint32_t_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_uint32_t_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_current_incompatible_policies.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_uint32_t_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_uint32_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint32_t_unbounded, element_flags_anonymous_sequence_uint32_t_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint32_t_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint32_t_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_uint32_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_current_incompatible_policies = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_current_incompatible_policies = 0x00000001;
+            bool common_current_incompatible_policies_ec {false};
+            CommonStructMember common_current_incompatible_policies {TypeObjectUtils::build_common_struct_member(member_id_current_incompatible_policies, member_flags_current_incompatible_policies, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, common_current_incompatible_policies_ec))};
+            if (!common_current_incompatible_policies_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure current_incompatible_policies member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_current_incompatible_policies = "current_incompatible_policies";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_current_incompatible_policies;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_current_incompatible_policies = TypeObjectUtils::build_complete_member_detail(name_current_incompatible_policies, member_ann_builtin_current_incompatible_policies, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_current_incompatible_policies = TypeObjectUtils::build_complete_struct_member(common_current_incompatible_policies, detail_current_incompatible_policies);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_current_incompatible_policies);
+        }
+        CompleteStructType struct_type_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_type(struct_flags_ExtendedIncompatibleQoSStatus_s, header_ExtendedIncompatibleQoSStatus_s, member_seq_ExtendedIncompatibleQoSStatus_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string(), type_ids_ExtendedIncompatibleQoSStatus_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatusSeq_s)
+{
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatusSeq_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatusSeq_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+    {
+        AliasTypeFlag alias_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatusSeq_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatusSeq_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s, type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string());
+        CompleteAliasHeader header_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_header(detail_ExtendedIncompatibleQoSStatusSeq_s);
+        AliasMemberFlag related_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        return_code_ExtendedIncompatibleQoSStatusSeq_s =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+        if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+        {
+            return_code_ExtendedIncompatibleQoSStatusSeq_s =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+            }
+            bool element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec {false};
+            TypeIdentifier* element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec))};
+            if (!element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                return;
+            }
+            EquivalenceKind equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_COMPLETE;
+            if (TK_NONE == type_ids_ExtendedIncompatibleQoSStatusSeq_s.type_identifier2()._d())
+            {
+                equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_BOTH;
+            }
+            CollectionElementFlag element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = 0;
+            PlainCollectionHeader header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded);
+            {
+                SBound bound = 0;
+                PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, bound,
+                            eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded));
+                if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                        TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded already registered in TypeObjectRegistry for a different type.");
+                }
+            }
+        }
+        bool common_ExtendedIncompatibleQoSStatusSeq_s_ec {false};
+        CommonAliasBody common_ExtendedIncompatibleQoSStatusSeq_s {TypeObjectUtils::build_common_alias_body(related_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, common_ExtendedIncompatibleQoSStatusSeq_s_ec))};
+        if (!common_ExtendedIncompatibleQoSStatusSeq_s_ec)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier inconsistent.");
+            return;
+        }
+        eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        ann_custom_ExtendedIncompatibleQoSStatusSeq_s.reset();
+        CompleteAliasBody body_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_body(common_ExtendedIncompatibleQoSStatusSeq_s,
+                member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s);
+        CompleteAliasType alias_type_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_type(alias_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                header_ExtendedIncompatibleQoSStatusSeq_s, body_ExtendedIncompatibleQoSStatusSeq_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_alias_type_object(alias_type_ExtendedIncompatibleQoSStatusSeq_s,
+                    type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string(), type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
 namespace StatusKind {
 void register_StatusKind_type_identifier(
         TypeIdentifierPair& type_ids_StatusKind)
@@ -1478,6 +1677,36 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_MonitorServiceData);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(type_ids_MonitorServiceData);
+            }
+            UnionMemberFlag member_flags_extended_incompatible_qos_status = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_extended_incompatible_qos_status;
+            TypeObjectUtils::add_union_case_label(label_seq_extended_incompatible_qos_status, static_cast<int32_t>(StatusKind::EXTENDED_INCOMPATIBLE_QOS));
+            MemberId member_id_extended_incompatible_qos_status = 0x00000009;
+            bool common_extended_incompatible_qos_status_ec {false};
+            CommonUnionMember common_extended_incompatible_qos_status {TypeObjectUtils::build_common_union_member(member_id_extended_incompatible_qos_status,
+                    member_flags_extended_incompatible_qos_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,
+                        common_extended_incompatible_qos_status_ec), label_seq_extended_incompatible_qos_status)};
+            if (!common_extended_incompatible_qos_status_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union extended_incompatible_qos_status member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_extended_incompatible_qos_status = "extended_incompatible_qos_status";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extended_incompatible_qos_status;
+            ann_custom_MonitorServiceData.reset();
+            CompleteMemberDetail detail_extended_incompatible_qos_status = TypeObjectUtils::build_complete_member_detail(name_extended_incompatible_qos_status, member_ann_builtin_extended_incompatible_qos_status, ann_custom_MonitorServiceData);
+            CompleteUnionMember member_extended_incompatible_qos_status = TypeObjectUtils::build_complete_union_member(common_extended_incompatible_qos_status, detail_extended_incompatible_qos_status);
+            TypeObjectUtils::add_complete_union_member(member_seq_MonitorServiceData, member_extended_incompatible_qos_status);
+        }
+        {
+            return_code_MonitorServiceData =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_byte", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
@@ -1490,7 +1719,7 @@ void register_MonitorServiceData_type_identifier(
                     false, false);
             UnionCaseLabelSeq label_seq_statuses_size;
             TypeObjectUtils::add_union_case_label(label_seq_statuses_size, static_cast<int32_t>(StatusKind::STATUSES_SIZE));
-            MemberId member_id_statuses_size = 0x00000009;
+            MemberId member_id_statuses_size = 0x0000000a;
             bool common_statuses_size_ec {false};
             CommonUnionMember common_statuses_size {TypeObjectUtils::build_common_union_member(member_id_statuses_size,
                     member_flags_statuses_size, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
@@ -192,6 +192,34 @@ eProsima_user_DllExport void register_SampleLostStatus_s_type_identifier(
 
 
 
+/**
+ * @brief Register ExtendedIncompatibleQoSStatus_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+
+
 namespace StatusKind {
 /**
  * @brief Register StatusKind related TypeIdentifier.
@@ -205,6 +233,7 @@ namespace StatusKind {
  */
 eProsima_user_DllExport void register_StatusKind_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
 
 
 

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -228,6 +228,7 @@ public:
     {
         if (!writers_.empty())
         {
+            writer_stat_guids_.pop_back();
             return (eprosima::fastdds::dds::RETCODE_OK == publisher_->delete_datawriter(writers_.back()));
         }
 
@@ -238,6 +239,7 @@ public:
     {
         if (!readers_.empty())
         {
+            reader_stat_guids_.pop_back();
             return (eprosima::fastdds::dds::RETCODE_OK == subscriber_->delete_datareader(readers_.back()));
         }
 

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -1211,6 +1211,188 @@ typedef BaseStatus_s InconsistentTopicStatus_s;
 
 typedef BaseStatus_s SampleLostStatus_s;
 
+/*!
+ * @brief This class represents the structure ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+ * @ingroup monitorservice_types
+ */
+class ExtendedIncompatibleQoSStatus_s
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return (m_remote_guid == x.m_remote_guid &&
+           m_current_incompatible_policies == x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function copies the value in member remote_guid
+     * @param _remote_guid New value to be copied in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            const detail::GUID_s& _remote_guid)
+    {
+        m_remote_guid = _remote_guid;
+    }
+
+    /*!
+     * @brief This function moves the value in member remote_guid
+     * @param _remote_guid New value to be moved in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            detail::GUID_s&& _remote_guid)
+    {
+        m_remote_guid = std::move(_remote_guid);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member remote_guid
+     * @return Constant reference to member remote_guid
+     */
+    eProsima_user_DllExport const detail::GUID_s& remote_guid() const
+    {
+        return m_remote_guid;
+    }
+
+    /*!
+     * @brief This function returns a reference to member remote_guid
+     * @return Reference to member remote_guid
+     */
+    eProsima_user_DllExport detail::GUID_s& remote_guid()
+    {
+        return m_remote_guid;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be copied in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            const std::vector<uint32_t>& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = _current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function moves the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be moved in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            std::vector<uint32_t>&& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = std::move(_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member current_incompatible_policies
+     * @return Constant reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport const std::vector<uint32_t>& current_incompatible_policies() const
+    {
+        return m_current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function returns a reference to member current_incompatible_policies
+     * @return Reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport std::vector<uint32_t>& current_incompatible_policies()
+    {
+        return m_current_incompatible_policies;
+    }
+
+
+
+private:
+
+    detail::GUID_s m_remote_guid;
+    std::vector<uint32_t> m_current_incompatible_policies;
+
+};
+typedef std::vector<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
 namespace StatusKind {
 
 typedef uint32_t StatusKind;
@@ -1223,7 +1405,8 @@ const StatusKind LIVELINESS_LOST = 4;
 const StatusKind LIVELINESS_CHANGED = 5;
 const StatusKind DEADLINE_MISSED = 6;
 const StatusKind SAMPLE_LOST = 7;
-const StatusKind STATUSES_SIZE = 8;
+const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+const StatusKind STATUSES_SIZE = 9;
 
 } // namespace StatusKind
 /*!
@@ -1296,6 +1479,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1346,6 +1533,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1396,6 +1587,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1448,6 +1643,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1506,6 +1705,10 @@ public:
                                                         break;
 
                                                     case 0x00000009:
+                                                        ret_value = (x.m_extended_incompatible_qos_status == m_extended_incompatible_qos_status);
+                                                        break;
+
+                                                    case 0x0000000a:
                                                         ret_value = (x.m_statuses_size == m_statuses_size);
                                                         break;
 
@@ -1599,8 +1802,15 @@ public:
                             }
                             break;
 
-                        case StatusKind::STATUSES_SIZE:
+                        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                             if (0x00000009 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case StatusKind::STATUSES_SIZE:
+                            if (0x0000000a == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -2050,6 +2260,59 @@ public:
 
 
     /*!
+     * @brief This function copies the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be copied in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            const ExtendedIncompatibleQoSStatusSeq_s& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function moves the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be moved in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            ExtendedIncompatibleQoSStatusSeq_s&& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member extended_incompatible_qos_status
+     * @return Constant reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport const ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status() const
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+    /*!
+     * @brief This function returns a reference to member extended_incompatible_qos_status
+     * @return Reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status()
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+
+    /*!
      * @brief This function sets a value in member statuses_size
      * @param _statuses_size New value for member statuses_size
      */
@@ -2067,7 +2330,7 @@ public:
      */
     eProsima_user_DllExport uint8_t statuses_size() const
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2082,7 +2345,7 @@ public:
      */
     eProsima_user_DllExport uint8_t& statuses_size()
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2248,7 +2511,7 @@ private:
                 return m_sample_lost_status;
             }
 
-            uint8_t& statuses_size_()
+            ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status_()
             {
                 if (0x00000009 != selected_member_)
                 {
@@ -2258,6 +2521,24 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
+                    member_destructor_ = [&]() {m_extended_incompatible_qos_status.~ExtendedIncompatibleQoSStatusSeq_s();};
+                    new(&m_extended_incompatible_qos_status) ExtendedIncompatibleQoSStatusSeq_s();
+
+                }
+
+                return m_extended_incompatible_qos_status;
+            }
+
+            uint8_t& statuses_size_()
+            {
+                if (0x0000000a != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x0000000a;
                     member_destructor_ = nullptr;
                     m_statuses_size = {0};
 
@@ -2279,6 +2560,7 @@ private:
         LivelinessChangedStatus_s m_liveliness_changed_status;
         DeadlineMissedStatus_s m_deadline_missed_status;
         SampleLostStatus_s m_sample_lost_status;
+        ExtendedIncompatibleQoSStatusSeq_s m_extended_incompatible_qos_status;
         uint8_t m_statuses_size;
     };
 

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
@@ -33,6 +33,9 @@ constexpr uint32_t eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize
 
 
 
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize {36UL};
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize {0UL};
+
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize {0UL};
 
@@ -99,6 +102,11 @@ eProsima_user_DllExport void serialize_key(
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
 
 
+
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data);
 
 
 

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
@@ -650,6 +650,108 @@ void serialize_key(
 
 
 
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data,
+        size_t& current_alignment)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.remote_guid(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.current_incompatible_policies(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.remote_guid()
+        << eprosima::fastcdr::MemberId(1) << data.current_incompatible_policies()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.remote_guid();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.current_incompatible_policies();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data)
+{
+    using namespace eprosima::fastdds::statistics;
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const eprosima::fastdds::statistics::detail::GUID_s& data);
+
+
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.remote_guid());
+
+                        scdr << data.current_incompatible_policies();
+
+}
+
+
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -713,8 +815,13 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 data.sample_lost_status(), current_alignment);
                     break;
 
-                case StatusKind::STATUSES_SIZE:
+                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                     calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                                data.extended_incompatible_qos_status(), current_alignment);
+                    break;
+
+                case StatusKind::STATUSES_SIZE:
+                    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
                                 data.statuses_size(), current_alignment);
                     break;
 
@@ -777,8 +884,12 @@ eProsima_user_DllExport void serialize(
                     scdr << eprosima::fastcdr::MemberId(8) << data.sample_lost_status();
                     break;
 
+                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                    scdr << eprosima::fastcdr::MemberId(9) << data.extended_incompatible_qos_status();
+                    break;
+
                 case StatusKind::STATUSES_SIZE:
-                    scdr << eprosima::fastcdr::MemberId(9) << data.statuses_size();
+                    scdr << eprosima::fastcdr::MemberId(10) << data.statuses_size();
                     break;
 
         default:
@@ -872,6 +983,14 @@ eProsima_user_DllExport void deserialize(
                                                         break;
                                                     }
 
+                                                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                                                    {
+                                                        eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s extended_incompatible_qos_status_value;
+                                                        data.extended_incompatible_qos_status(std::move(extended_incompatible_qos_status_value));
+                                                        data._d(discriminator);
+                                                        break;
+                                                    }
+
                                                 case StatusKind::STATUSES_SIZE:
                                                     {
                                                         uint8_t statuses_size_value{0};
@@ -919,6 +1038,10 @@ eProsima_user_DllExport void deserialize(
 
                                                 case StatusKind::SAMPLE_LOST:
                                                     dcdr >> data.sample_lost_status();
+                                                    break;
+
+                                                case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+                                                    dcdr >> data.extended_incompatible_qos_status();
                                                     break;
 
                                                 case StatusKind::STATUSES_SIZE:

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -1124,6 +1124,188 @@ namespace eprosima {
 
 
 
+            ExtendedIncompatibleQoSStatus_sPubSubType::ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                set_name("eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s");
+                uint32_t type_size = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize;
+                type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+                max_serialized_type_size = type_size + 4; /*encapsulation*/
+                is_compute_key_provided = false;
+                uint32_t key_length = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16 ? eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize : 16;
+                key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+                memset(key_buffer_, 0, key_length);
+            }
+
+            ExtendedIncompatibleQoSStatus_sPubSubType::~ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                if (key_buffer_ != nullptr)
+                {
+                    free(key_buffer_);
+                }
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::serialize(
+                    const void* const data,
+                    SerializedPayload_t& payload,
+                    DataRepresentationId_t data_representation)
+            {
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+                payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+                ser.set_encoding_flag(
+                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+                try
+                {
+                    // Serialize encapsulation
+                    ser.serialize_encapsulation();
+                    // Serialize the object.
+                    ser << *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                // Get the serialized length
+                payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+                return true;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::deserialize(
+                    SerializedPayload_t& payload,
+                    void* data)
+            {
+                try
+                {
+                    // Convert DATA to pointer of your type
+                    ExtendedIncompatibleQoSStatus_s* p_type = static_cast<ExtendedIncompatibleQoSStatus_s*>(data);
+
+                    // Object that manages the raw buffer.
+                    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+                    // Object that deserializes the data.
+                    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+                    // Deserialize encapsulation.
+                    deser.read_encapsulation();
+                    payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+                    // Deserialize the object.
+                    deser >> *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            uint32_t ExtendedIncompatibleQoSStatus_sPubSubType::calculate_serialized_size(
+                    const void* const data,
+                    DataRepresentationId_t data_representation)
+            {
+                try
+                {
+                    eprosima::fastcdr::CdrSizeCalculator calculator(
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                    size_t current_alignment {0};
+                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                *static_cast<const ExtendedIncompatibleQoSStatus_s*>(data), current_alignment)) +
+                            4u /*encapsulation*/;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return 0;
+                }
+            }
+
+            void* ExtendedIncompatibleQoSStatus_sPubSubType::create_data()
+            {
+                return reinterpret_cast<void*>(new ExtendedIncompatibleQoSStatus_s());
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::delete_data(
+                    void* data)
+            {
+                delete(reinterpret_cast<ExtendedIncompatibleQoSStatus_s*>(data));
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    SerializedPayload_t& payload,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                ExtendedIncompatibleQoSStatus_s data;
+                if (deserialize(payload, static_cast<void*>(&data)))
+                {
+                    return compute_key(static_cast<void*>(&data), handle, force_md5);
+                }
+
+                return false;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    const void* const data,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+                        eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize);
+
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+                eprosima::fastcdr::serialize_key(ser, *p_type);
+                if (force_md5 || eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
+                {
+                    md5_.init();
+                    md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+                    md5_.finalize();
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = md5_.digest[i];
+                    }
+                }
+                else
+                {
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = key_buffer_[i];
+                    }
+                }
+                return true;
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::register_type_object_representation()
+            {
+                register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_identifiers_);
+            }
+
+
             namespace StatusKind {
             } // namespace StatusKind
 

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
@@ -534,9 +534,92 @@ namespace eprosima
             typedef eprosima::fastdds::statistics::BaseStatus_s LivelinessLostStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s InconsistentTopicStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s SampleLostStatus_s;
+
+            /*!
+             * @brief This class represents the TopicDataType of the type ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+             * @ingroup monitorservice_types
+             */
+            class ExtendedIncompatibleQoSStatus_sPubSubType : public eprosima::fastdds::dds::TopicDataType
+            {
+            public:
+
+                typedef ExtendedIncompatibleQoSStatus_s type;
+
+                eProsima_user_DllExport ExtendedIncompatibleQoSStatus_sPubSubType();
+
+                eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_sPubSubType() override;
+
+                eProsima_user_DllExport bool serialize(
+                        const void* const data,
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool deserialize(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        void* data) override;
+
+                eProsima_user_DllExport uint32_t calculate_serialized_size(
+                        const void* const data,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        const void* const data,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport void* create_data() override;
+
+                eProsima_user_DllExport void delete_data(
+                        void* data) override;
+
+                //Register TypeObject representation in Fast DDS TypeObjectRegistry
+                eProsima_user_DllExport void register_type_object_representation() override;
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+                eProsima_user_DllExport inline bool is_bounded() const override
+                {
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+                eProsima_user_DllExport inline bool is_plain(
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+                {
+                    static_cast<void>(data_representation);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+                eProsima_user_DllExport inline bool construct_sample(
+                        void* memory) const override
+                {
+                    static_cast<void>(memory);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+            private:
+
+                eprosima::fastdds::MD5 md5_;
+                unsigned char* key_buffer_;
+
+            };
+            typedef std::vector<eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;
+
 
 
 

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
@@ -1069,6 +1069,205 @@ void register_SampleLostStatus_s_type_identifier(
     }
 }
 
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatus_s)
+{
+
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatus_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatus_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatus_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatus_s)
+    {
+        StructTypeFlag struct_flags_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatus_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatus_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatus_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatus_s, ann_custom_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string());
+        CompleteStructHeader header_ExtendedIncompatibleQoSStatus_s;
+        header_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ExtendedIncompatibleQoSStatus_s);
+        CompleteStructMemberSeq member_seq_ExtendedIncompatibleQoSStatus_s;
+        {
+            TypeIdentifierPair type_ids_remote_guid;
+            ReturnCode_t return_code_remote_guid {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_remote_guid =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::detail::GUID_s", type_ids_remote_guid);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_remote_guid)
+            {
+                eprosima::fastdds::statistics::detail::register_GUID_s_type_identifier(type_ids_remote_guid);
+            }
+            StructMemberFlag member_flags_remote_guid = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_remote_guid = 0x00000000;
+            bool common_remote_guid_ec {false};
+            CommonStructMember common_remote_guid {TypeObjectUtils::build_common_struct_member(member_id_remote_guid, member_flags_remote_guid, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_remote_guid, common_remote_guid_ec))};
+            if (!common_remote_guid_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure remote_guid member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_remote_guid = "remote_guid";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_remote_guid;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_remote_guid = TypeObjectUtils::build_complete_member_detail(name_remote_guid, member_ann_builtin_remote_guid, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_remote_guid = TypeObjectUtils::build_complete_struct_member(common_remote_guid, detail_remote_guid);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_remote_guid);
+        }
+        {
+            TypeIdentifierPair type_ids_current_incompatible_policies;
+            ReturnCode_t return_code_current_incompatible_policies {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_current_incompatible_policies =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+            {
+                return_code_current_incompatible_policies =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_uint32_t", type_ids_current_incompatible_policies);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_sequence_uint32_t_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_uint32_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, element_identifier_anonymous_sequence_uint32_t_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_uint32_t_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_current_incompatible_policies.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_uint32_t_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_uint32_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint32_t_unbounded, element_flags_anonymous_sequence_uint32_t_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint32_t_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint32_t_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_uint32_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_current_incompatible_policies = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_current_incompatible_policies = 0x00000001;
+            bool common_current_incompatible_policies_ec {false};
+            CommonStructMember common_current_incompatible_policies {TypeObjectUtils::build_common_struct_member(member_id_current_incompatible_policies, member_flags_current_incompatible_policies, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, common_current_incompatible_policies_ec))};
+            if (!common_current_incompatible_policies_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure current_incompatible_policies member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_current_incompatible_policies = "current_incompatible_policies";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_current_incompatible_policies;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_current_incompatible_policies = TypeObjectUtils::build_complete_member_detail(name_current_incompatible_policies, member_ann_builtin_current_incompatible_policies, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_current_incompatible_policies = TypeObjectUtils::build_complete_struct_member(common_current_incompatible_policies, detail_current_incompatible_policies);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_current_incompatible_policies);
+        }
+        CompleteStructType struct_type_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_type(struct_flags_ExtendedIncompatibleQoSStatus_s, header_ExtendedIncompatibleQoSStatus_s, member_seq_ExtendedIncompatibleQoSStatus_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string(), type_ids_ExtendedIncompatibleQoSStatus_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatusSeq_s)
+{
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatusSeq_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatusSeq_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+    {
+        AliasTypeFlag alias_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatusSeq_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatusSeq_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s, type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string());
+        CompleteAliasHeader header_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_header(detail_ExtendedIncompatibleQoSStatusSeq_s);
+        AliasMemberFlag related_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        return_code_ExtendedIncompatibleQoSStatusSeq_s =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+        if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+        {
+            return_code_ExtendedIncompatibleQoSStatusSeq_s =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+            }
+            bool element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec {false};
+            TypeIdentifier* element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec))};
+            if (!element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                return;
+            }
+            EquivalenceKind equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_COMPLETE;
+            if (TK_NONE == type_ids_ExtendedIncompatibleQoSStatusSeq_s.type_identifier2()._d())
+            {
+                equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_BOTH;
+            }
+            CollectionElementFlag element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = 0;
+            PlainCollectionHeader header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded);
+            {
+                SBound bound = 0;
+                PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, bound,
+                            eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded));
+                if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                        TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded already registered in TypeObjectRegistry for a different type.");
+                }
+            }
+        }
+        bool common_ExtendedIncompatibleQoSStatusSeq_s_ec {false};
+        CommonAliasBody common_ExtendedIncompatibleQoSStatusSeq_s {TypeObjectUtils::build_common_alias_body(related_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, common_ExtendedIncompatibleQoSStatusSeq_s_ec))};
+        if (!common_ExtendedIncompatibleQoSStatusSeq_s_ec)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier inconsistent.");
+            return;
+        }
+        eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        ann_custom_ExtendedIncompatibleQoSStatusSeq_s.reset();
+        CompleteAliasBody body_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_body(common_ExtendedIncompatibleQoSStatusSeq_s,
+                member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s);
+        CompleteAliasType alias_type_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_type(alias_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                header_ExtendedIncompatibleQoSStatusSeq_s, body_ExtendedIncompatibleQoSStatusSeq_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_alias_type_object(alias_type_ExtendedIncompatibleQoSStatusSeq_s,
+                    type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string(), type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
 namespace StatusKind {
 void register_StatusKind_type_identifier(
         TypeIdentifierPair& type_ids_StatusKind)
@@ -1478,6 +1677,36 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_MonitorServiceData);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(type_ids_MonitorServiceData);
+            }
+            UnionMemberFlag member_flags_extended_incompatible_qos_status = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_extended_incompatible_qos_status;
+            TypeObjectUtils::add_union_case_label(label_seq_extended_incompatible_qos_status, static_cast<int32_t>(StatusKind::EXTENDED_INCOMPATIBLE_QOS));
+            MemberId member_id_extended_incompatible_qos_status = 0x00000009;
+            bool common_extended_incompatible_qos_status_ec {false};
+            CommonUnionMember common_extended_incompatible_qos_status {TypeObjectUtils::build_common_union_member(member_id_extended_incompatible_qos_status,
+                    member_flags_extended_incompatible_qos_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,
+                        common_extended_incompatible_qos_status_ec), label_seq_extended_incompatible_qos_status)};
+            if (!common_extended_incompatible_qos_status_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union extended_incompatible_qos_status member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_extended_incompatible_qos_status = "extended_incompatible_qos_status";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extended_incompatible_qos_status;
+            ann_custom_MonitorServiceData.reset();
+            CompleteMemberDetail detail_extended_incompatible_qos_status = TypeObjectUtils::build_complete_member_detail(name_extended_incompatible_qos_status, member_ann_builtin_extended_incompatible_qos_status, ann_custom_MonitorServiceData);
+            CompleteUnionMember member_extended_incompatible_qos_status = TypeObjectUtils::build_complete_union_member(common_extended_incompatible_qos_status, detail_extended_incompatible_qos_status);
+            TypeObjectUtils::add_complete_union_member(member_seq_MonitorServiceData, member_extended_incompatible_qos_status);
+        }
+        {
+            return_code_MonitorServiceData =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_byte", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
@@ -1490,7 +1719,7 @@ void register_MonitorServiceData_type_identifier(
                     false, false);
             UnionCaseLabelSeq label_seq_statuses_size;
             TypeObjectUtils::add_union_case_label(label_seq_statuses_size, static_cast<int32_t>(StatusKind::STATUSES_SIZE));
-            MemberId member_id_statuses_size = 0x00000009;
+            MemberId member_id_statuses_size = 0x0000000a;
             bool common_statuses_size_ec {false};
             CommonUnionMember common_statuses_size {TypeObjectUtils::build_common_union_member(member_id_statuses_size,
                     member_flags_statuses_size, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
@@ -192,6 +192,34 @@ eProsima_user_DllExport void register_SampleLostStatus_s_type_identifier(
 
 
 
+/**
+ * @brief Register ExtendedIncompatibleQoSStatus_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+
+
 namespace StatusKind {
 /**
  * @brief Register StatusKind related TypeIdentifier.
@@ -205,6 +233,7 @@ namespace StatusKind {
  */
 eProsima_user_DllExport void register_StatusKind_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
 
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR brings the test plan implementation for the `Extended Incompatible QoS` monitor service feature.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
