### PR TITLE
[21745] Fix flow_controllers comparison in DomainParticipantQos equality operator

### DIFF
--- a/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
+++ b/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
@@ -78,25 +78,6 @@ public:
     virtual bool operator ==(
             const DomainParticipantQos& b) const
     {
-        auto compare_flow_controllers = [](const DomainParticipantQos& lhs, const DomainParticipantQos& rhs) -> bool
-                {
-                    const auto& lhs_flow_controllers = lhs.flow_controllers();
-                    const auto& rhs_flow_controllers = rhs.flow_controllers();
-
-                    if (lhs_flow_controllers.size() != rhs_flow_controllers.size())
-                    {
-                        return false;
-                    }
-
-                    return std::equal(lhs_flow_controllers.begin(), lhs_flow_controllers.end(),
-                                    rhs_flow_controllers.begin(),
-                                    [](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& a,
-                                    const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& b)
-                                    {
-                                        return *a == *b;
-                                    });
-                };
-
         return (this->user_data_ == b.user_data()) &&
                (this->entity_factory_ == b.entity_factory()) &&
                (this->allocation_ == b.allocation()) &&
@@ -111,7 +92,7 @@ public:
 #if HAVE_SECURITY
                (this->security_log_thread_ == b.security_log_thread()) &&
 #endif // if HAVE_SECURITY
-               (compare_flow_controllers(*this, b));
+               (compare_flow_controllers(b));
     }
 
     /**
@@ -340,6 +321,15 @@ public:
     {
         return flow_controllers_;
     }
+
+    /**
+     * Compares the flow controllers of two DomainParticipantQos element-wise.
+     *
+     * @param qos The DomainParticipantQos to compare with.
+     * @return true if the flow controllers are the same, false otherwise.
+     */
+    FASTDDS_EXPORTED_API bool compare_flow_controllers(
+            const DomainParticipantQos& qos) const;
 
     /**
      * Getter for FlowControllerDescriptorList

--- a/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
+++ b/include/fastdds/dds/domain/qos/DomainParticipantQos.hpp
@@ -78,6 +78,25 @@ public:
     virtual bool operator ==(
             const DomainParticipantQos& b) const
     {
+        auto compare_flow_controllers = [](const DomainParticipantQos& lhs, const DomainParticipantQos& rhs) -> bool
+                {
+                    const auto& lhs_flow_controllers = lhs.flow_controllers();
+                    const auto& rhs_flow_controllers = rhs.flow_controllers();
+
+                    if (lhs_flow_controllers.size() != rhs_flow_controllers.size())
+                    {
+                        return false;
+                    }
+
+                    return std::equal(lhs_flow_controllers.begin(), lhs_flow_controllers.end(),
+                                    rhs_flow_controllers.begin(),
+                                    [](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& a,
+                                    const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& b)
+                                    {
+                                        return *a == *b;
+                                    });
+                };
+
         return (this->user_data_ == b.user_data()) &&
                (this->entity_factory_ == b.entity_factory()) &&
                (this->allocation_ == b.allocation()) &&
@@ -92,7 +111,7 @@ public:
 #if HAVE_SECURITY
                (this->security_log_thread_ == b.security_log_thread()) &&
 #endif // if HAVE_SECURITY
-               (this->flow_controllers_ == b.flow_controllers());
+               (compare_flow_controllers(*this, b));
     }
 
     /**

--- a/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
+++ b/include/fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp
@@ -58,6 +58,16 @@ struct FlowControllerDescriptor
     //! Thread settings for the sender thread
     ThreadSettings sender_thread;
 
+    bool operator ==(
+            const FlowControllerDescriptor& b) const
+    {
+        return (this->name == b.name) &&
+               (this->scheduler == b.scheduler) &&
+               (this->max_bytes_per_period == b.max_bytes_per_period) &&
+               (this->period_ms == b.period_ms) &&
+               (this->sender_thread == b.sender_thread);
+    }
+
 };
 
 } // namespace rtps

--- a/src/cpp/fastdds/domain/qos/DomainParticipantQos.cpp
+++ b/src/cpp/fastdds/domain/qos/DomainParticipantQos.cpp
@@ -41,6 +41,26 @@ void DomainParticipantQos::setup_transports(
     utils::set_qos_from_attributes(*this, attr);
 }
 
+bool DomainParticipantQos::compare_flow_controllers(
+        const DomainParticipantQos& qos) const
+{
+    const auto& lhs_flow_controllers = flow_controllers();
+    const auto& rhs_flow_controllers = qos.flow_controllers();
+
+    if (lhs_flow_controllers.size() != rhs_flow_controllers.size())
+    {
+        return false;
+    }
+
+    return std::equal(lhs_flow_controllers.begin(), lhs_flow_controllers.end(),
+                   rhs_flow_controllers.begin(),
+                   [](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& a,
+                   const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& b)
+                   {
+                       return *a == *b;
+                   });
+}
+
 } /* namespace dds */
 } /* namespace fastdds */
 } /* namespace eprosima */

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -492,7 +492,34 @@ void check_equivalent_qos(
     ASSERT_EQ(qos_1.wire_protocol(), qos_2.wire_protocol());
     ASSERT_EQ(qos_1.transport(), qos_2.transport());
     ASSERT_EQ(qos_1.name(), qos_2.name());
-    ASSERT_EQ(qos_1.flow_controllers(), qos_2.flow_controllers());
+    ASSERT_EQ(qos_1.builtin_controllers_sender_thread(), qos_2.builtin_controllers_sender_thread());
+    ASSERT_EQ(qos_1.timed_events_thread(), qos_2.timed_events_thread());
+    ASSERT_EQ(qos_1.discovery_server_thread(), qos_2.discovery_server_thread());
+    ASSERT_EQ(qos_1.typelookup_service_thread(), qos_2.typelookup_service_thread());
+#if HAVE_SECURITY
+    ASSERT_EQ(qos_1.security_log_thread(), qos_2.security_log_thread());
+#endif // if HAVE_SECURITY
+
+    auto compare_flow_controllers = [](const DomainParticipantQos& lhs, const DomainParticipantQos& rhs) -> bool
+            {
+                const auto& lhs_flow_controllers = lhs.flow_controllers();
+                const auto& rhs_flow_controllers = rhs.flow_controllers();
+
+                if (lhs_flow_controllers.size() != rhs_flow_controllers.size())
+                {
+                    return false;
+                }
+
+                return std::equal(lhs_flow_controllers.begin(), lhs_flow_controllers.end(),
+                                rhs_flow_controllers.begin(),
+                                [](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& a,
+                                const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& b)
+                                {
+                                    return *a == *b;
+                                });
+            };
+
+    ASSERT_TRUE(compare_flow_controllers(qos_1, qos_2));
 }
 
 void check_participant_with_profile(

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -500,26 +500,7 @@ void check_equivalent_qos(
     ASSERT_EQ(qos_1.security_log_thread(), qos_2.security_log_thread());
 #endif // if HAVE_SECURITY
 
-    auto compare_flow_controllers = [](const DomainParticipantQos& lhs, const DomainParticipantQos& rhs) -> bool
-            {
-                const auto& lhs_flow_controllers = lhs.flow_controllers();
-                const auto& rhs_flow_controllers = rhs.flow_controllers();
-
-                if (lhs_flow_controllers.size() != rhs_flow_controllers.size())
-                {
-                    return false;
-                }
-
-                return std::equal(lhs_flow_controllers.begin(), lhs_flow_controllers.end(),
-                                rhs_flow_controllers.begin(),
-                                [](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& a,
-                                const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& b)
-                                {
-                                    return *a == *b;
-                                });
-            };
-
-    ASSERT_TRUE(compare_flow_controllers(qos_1, qos_2));
+    ASSERT_TRUE(qos_1.compare_flow_controllers(qos_2));
 }
 
 void check_participant_with_profile(

--- a/versions.md
+++ b/versions.md
@@ -2,6 +2,7 @@ Forthcoming
 -----------
 
 * Allow `PERSISTENT_DURABILITY` behaving as `TRANSIENT_DURABILITY`. Fallback to `TRANSIENT_LOCAL_DURABILITY` if no persistence guid is set.
+* Fix DomainParticipantQos equality operator by using the new `DomainParticipantQos::compare_flow_controllers`.
 
 Version v3.0.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
DomainParticipantQos objects contain an attribute of kind `FlowControllerDescriptorList`, which is a vector of `FlowControllerDescriptor` shared pointers. Currently the comparison of two equivalent DomainParticipantQos objects is failing when the elements in this list are not the same (determined by memory address) instead of dereferencing and performing the comparison element-wise. This PR fixes this behaviour.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
