### PR TITLE
[21783] Regenerate types with latest Fast DDS-Gen v4.0.2

### DIFF
--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
@@ -250,15 +250,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_hash == x.m_hash);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_hash == m_hash);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -3090,59 +3099,68 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_no_value == x.m_no_value);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_no_value == m_no_value);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_string_sdefn == x.m_string_sdefn);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_string_sdefn == m_string_sdefn);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_string_ldefn == x.m_string_ldefn);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_string_ldefn == m_string_ldefn);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_seq_sdefn == x.m_seq_sdefn);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_seq_sdefn == m_seq_sdefn);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_seq_ldefn == x.m_seq_ldefn);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_seq_ldefn == m_seq_ldefn);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_array_sdefn == x.m_array_sdefn);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_array_sdefn == m_array_sdefn);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_array_ldefn == x.m_array_ldefn);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_array_ldefn == m_array_ldefn);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_map_sdefn == x.m_map_sdefn);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_map_sdefn == m_map_sdefn);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_map_ldefn == x.m_map_ldefn);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_map_ldefn == m_map_ldefn);
+                                                        break;
 
-                                case 0x0000000a:
-                                    ret_value = (m_sc_component_id == x.m_sc_component_id);
-                                    break;
+                                                    case 0x0000000a:
+                                                        ret_value = (x.m_sc_component_id == m_sc_component_id);
+                                                        break;
 
-                                case 0x0000000b:
-                                    ret_value = (m_equivalence_hash == x.m_equivalence_hash);
-                                    break;
+                                                    case 0x0000000b:
+                                                        ret_value = (x.m_equivalence_hash == m_equivalence_hash);
+                                                        break;
 
-                                case 0x0000000c:
-                                    ret_value = (m_extended_defn == x.m_extended_defn);
-                                    break;
+                                                    case 0x0000000c:
+                                                        ret_value = (x.m_extended_defn == m_extended_defn);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4674,87 +4692,96 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_boolean_value == x.m_boolean_value);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_boolean_value == m_boolean_value);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_byte_value == x.m_byte_value);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_byte_value == m_byte_value);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_int8_value == x.m_int8_value);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_int8_value == m_int8_value);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_uint8_value == x.m_uint8_value);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_uint8_value == m_uint8_value);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_int16_value == x.m_int16_value);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_int16_value == m_int16_value);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_uint_16_value == x.m_uint_16_value);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_uint_16_value == m_uint_16_value);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_int32_value == x.m_int32_value);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_int32_value == m_int32_value);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_uint32_value == x.m_uint32_value);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_uint32_value == m_uint32_value);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_int64_value == x.m_int64_value);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_int64_value == m_int64_value);
+                                                        break;
 
-                                case 0x0000000a:
-                                    ret_value = (m_uint64_value == x.m_uint64_value);
-                                    break;
+                                                    case 0x0000000a:
+                                                        ret_value = (x.m_uint64_value == m_uint64_value);
+                                                        break;
 
-                                case 0x0000000b:
-                                    ret_value = (m_float32_value == x.m_float32_value);
-                                    break;
+                                                    case 0x0000000b:
+                                                        ret_value = (x.m_float32_value == m_float32_value);
+                                                        break;
 
-                                case 0x0000000c:
-                                    ret_value = (m_float64_value == x.m_float64_value);
-                                    break;
+                                                    case 0x0000000c:
+                                                        ret_value = (x.m_float64_value == m_float64_value);
+                                                        break;
 
-                                case 0x0000000d:
-                                    ret_value = (m_float128_value == x.m_float128_value);
-                                    break;
+                                                    case 0x0000000d:
+                                                        ret_value = (x.m_float128_value == m_float128_value);
+                                                        break;
 
-                                case 0x0000000e:
-                                    ret_value = (m_char_value == x.m_char_value);
-                                    break;
+                                                    case 0x0000000e:
+                                                        ret_value = (x.m_char_value == m_char_value);
+                                                        break;
 
-                                case 0x0000000f:
-                                    ret_value = (m_wchar_value == x.m_wchar_value);
-                                    break;
+                                                    case 0x0000000f:
+                                                        ret_value = (x.m_wchar_value == m_wchar_value);
+                                                        break;
 
-                                case 0x00000010:
-                                    ret_value = (m_enumerated_value == x.m_enumerated_value);
-                                    break;
+                                                    case 0x00000010:
+                                                        ret_value = (x.m_enumerated_value == m_enumerated_value);
+                                                        break;
 
-                                case 0x00000011:
-                                    ret_value = (m_string8_value == x.m_string8_value);
-                                    break;
+                                                    case 0x00000011:
+                                                        ret_value = (x.m_string8_value == m_string8_value);
+                                                        break;
 
-                                case 0x00000012:
-                                    ret_value = (m_string16_value == x.m_string16_value);
-                                    break;
+                                                    case 0x00000012:
+                                                        ret_value = (x.m_string16_value == m_string16_value);
+                                                        break;
 
-                                case 0x00000013:
-                                    ret_value = (m_extended_value == x.m_extended_value);
-                                    break;
+                                                    case 0x00000013:
+                                                        ret_value = (x.m_extended_value == m_extended_value);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -20954,55 +20981,64 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_alias_type == x.m_alias_type);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_alias_type == m_alias_type);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_annotation_type == x.m_annotation_type);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_annotation_type == m_annotation_type);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_struct_type == x.m_struct_type);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_struct_type == m_struct_type);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_union_type == x.m_union_type);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_union_type == m_union_type);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_bitset_type == x.m_bitset_type);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_bitset_type == m_bitset_type);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_sequence_type == x.m_sequence_type);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_sequence_type == m_sequence_type);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_array_type == x.m_array_type);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_array_type == m_array_type);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_map_type == x.m_map_type);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_map_type == m_map_type);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_enumerated_type == x.m_enumerated_type);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_enumerated_type == m_enumerated_type);
+                                                        break;
 
-                                case 0x0000000a:
-                                    ret_value = (m_bitmask_type == x.m_bitmask_type);
-                                    break;
+                                                    case 0x0000000a:
+                                                        ret_value = (x.m_bitmask_type == m_bitmask_type);
+                                                        break;
 
-                                case 0x0000000b:
-                                    ret_value = (m_extended_type == x.m_extended_type);
-                                    break;
+                                                    case 0x0000000b:
+                                                        ret_value = (x.m_extended_type == m_extended_type);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -22303,55 +22339,64 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_alias_type == x.m_alias_type);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_alias_type == m_alias_type);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_annotation_type == x.m_annotation_type);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_annotation_type == m_annotation_type);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_struct_type == x.m_struct_type);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_struct_type == m_struct_type);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_union_type == x.m_union_type);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_union_type == m_union_type);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_bitset_type == x.m_bitset_type);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_bitset_type == m_bitset_type);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_sequence_type == x.m_sequence_type);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_sequence_type == m_sequence_type);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_array_type == x.m_array_type);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_array_type == m_array_type);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_map_type == x.m_map_type);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_map_type == m_map_type);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_enumerated_type == x.m_enumerated_type);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_enumerated_type == m_enumerated_type);
+                                                        break;
 
-                                case 0x0000000a:
-                                    ret_value = (m_bitmask_type == x.m_bitmask_type);
-                                    break;
+                                                    case 0x0000000a:
+                                                        ret_value = (x.m_bitmask_type == m_bitmask_type);
+                                                        break;
 
-                                case 0x0000000b:
-                                    ret_value = (m_extended_type == x.m_extended_type);
-                                    break;
+                                                    case 0x0000000b:
+                                                        ret_value = (x.m_extended_type == m_extended_type);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -23409,19 +23454,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_complete == x.m_complete);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_complete == m_complete);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_minimal == x.m_minimal);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_minimal == m_minimal);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
@@ -492,15 +492,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_result == x.m_result);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_result == m_result);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1122,15 +1131,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_result == x.m_result);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_result == m_result);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1408,19 +1426,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_getTypes == x.m_getTypes);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_getTypes == m_getTypes);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_getTypeDependencies == x.m_getTypeDependencies);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_getTypeDependencies == m_getTypeDependencies);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1957,19 +1984,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_getType == x.m_getType);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_getType == m_getType);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_getTypeDependencies == x.m_getTypeDependencies);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_getTypeDependencies == m_getTypeDependencies);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -1465,47 +1465,56 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_entity_proxy == x.m_entity_proxy);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_entity_proxy == m_entity_proxy);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_connection_list == x.m_connection_list);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_connection_list == m_connection_list);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_incompatible_qos_status == x.m_incompatible_qos_status);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_incompatible_qos_status == m_incompatible_qos_status);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_inconsistent_topic_status == x.m_inconsistent_topic_status);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_inconsistent_topic_status == m_inconsistent_topic_status);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_liveliness_lost_status == x.m_liveliness_lost_status);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_liveliness_lost_status == m_liveliness_lost_status);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_liveliness_changed_status == x.m_liveliness_changed_status);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_liveliness_changed_status == m_liveliness_changed_status);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_deadline_missed_status == x.m_deadline_missed_status);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_deadline_missed_status == m_deadline_missed_status);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_sample_lost_status == x.m_sample_lost_status);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_sample_lost_status == m_sample_lost_status);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_statuses_size == x.m_statuses_size);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_statuses_size == m_statuses_size);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/src/cpp/statistics/types/types.hpp
+++ b/src/cpp/statistics/types/types.hpp
@@ -3169,43 +3169,52 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_writer_reader_data == x.m_writer_reader_data);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_writer_reader_data == m_writer_reader_data);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_locator2locator_data == x.m_locator2locator_data);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_locator2locator_data == m_locator2locator_data);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_entity_data == x.m_entity_data);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_entity_data == m_entity_data);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_entity2locator_traffic == x.m_entity2locator_traffic);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_entity2locator_traffic == m_entity2locator_traffic);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_entity_count == x.m_entity_count);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_entity_count == m_entity_count);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_discovery_time == x.m_discovery_time);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_discovery_time == m_discovery_time);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_sample_identity_count == x.m_sample_identity_count);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_sample_identity_count == m_sample_identity_count);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_physical_data == x.m_physical_data);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_physical_data == m_physical_data);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/blackbox/types/core/core_types.hpp
+++ b/test/blackbox/types/core/core_types.hpp
@@ -4268,31 +4268,40 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_heartbeat_submsg == x.m_heartbeat_submsg);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_heartbeat_submsg == m_heartbeat_submsg);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_info_ts_submsg == x.m_info_ts_submsg);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_info_ts_submsg == m_info_ts_submsg);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_info_src_submsg == x.m_info_src_submsg);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_info_src_submsg == m_info_src_submsg);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_info_dst_submsg == x.m_info_dst_submsg);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_info_dst_submsg == m_info_dst_submsg);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_unknown_submsg == x.m_unknown_submsg);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_unknown_submsg == m_unknown_submsg);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -1465,47 +1465,56 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_entity_proxy == x.m_entity_proxy);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_entity_proxy == m_entity_proxy);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_connection_list == x.m_connection_list);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_connection_list == m_connection_list);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_incompatible_qos_status == x.m_incompatible_qos_status);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_incompatible_qos_status == m_incompatible_qos_status);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_inconsistent_topic_status == x.m_inconsistent_topic_status);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_inconsistent_topic_status == m_inconsistent_topic_status);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_liveliness_lost_status == x.m_liveliness_lost_status);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_liveliness_lost_status == m_liveliness_lost_status);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_liveliness_changed_status == x.m_liveliness_changed_status);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_liveliness_changed_status == m_liveliness_changed_status);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_deadline_missed_status == x.m_deadline_missed_status);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_deadline_missed_status == m_deadline_missed_status);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_sample_lost_status == x.m_sample_lost_status);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_sample_lost_status == m_sample_lost_status);
+                                                        break;
 
-                                case 0x00000009:
-                                    ret_value = (m_statuses_size == x.m_statuses_size);
-                                    break;
+                                                    case 0x00000009:
+                                                        ret_value = (x.m_statuses_size == m_statuses_size);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/blackbox/types/statistics/types.hpp
+++ b/test/blackbox/types/statistics/types.hpp
@@ -3169,43 +3169,52 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_writer_reader_data == x.m_writer_reader_data);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_writer_reader_data == m_writer_reader_data);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_locator2locator_data == x.m_locator2locator_data);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_locator2locator_data == m_locator2locator_data);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_entity_data == x.m_entity_data);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_entity_data == m_entity_data);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_entity2locator_traffic == x.m_entity2locator_traffic);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_entity2locator_traffic == m_entity2locator_traffic);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_entity_count == x.m_entity_count);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_entity_count == m_entity_count);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_discovery_time == x.m_discovery_time);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_discovery_time == m_discovery_time);
+                                                        break;
 
-                                case 0x00000007:
-                                    ret_value = (m_sample_identity_count == x.m_sample_identity_count);
-                                    break;
+                                                    case 0x00000007:
+                                                        ret_value = (x.m_sample_identity_count == m_sample_identity_count);
+                                                        break;
 
-                                case 0x00000008:
-                                    ret_value = (m_physical_data == x.m_physical_data);
-                                    break;
+                                                    case 0x00000008:
+                                                        ret_value = (x.m_physical_data == m_physical_data);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/dds-types-test/declarations.hpp
+++ b/test/dds-types-test/declarations.hpp
@@ -470,19 +470,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_case_zero == x.m_case_zero);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_case_zero == m_case_zero);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_case_one == x.m_case_one);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_case_one == m_case_one);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1553,19 +1562,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_case_zero == x.m_case_zero);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_case_zero == m_case_zero);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_case_one == x.m_case_one);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_case_one == m_case_one);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/dds-types-test/external.hpp
+++ b/test/dds-types-test/external.hpp
@@ -3472,23 +3472,32 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_l == x.m_l);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_l == m_l);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_c == x.m_c);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_c == m_c);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_s == x.m_s);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_s == m_s);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4090,23 +4099,32 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_l == x.m_l);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_l == m_l);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_ext == x.m_ext);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_ext == m_ext);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_s == x.m_s);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_s == m_s);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/dds-types-test/helpers/basic_inner_types.hpp
+++ b/test/dds-types-test/helpers/basic_inner_types.hpp
@@ -496,23 +496,32 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_longValue == x.m_longValue);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_longValue == m_longValue);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_floatValue == x.m_floatValue);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_floatValue == m_floatValue);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_shortValue == x.m_shortValue);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_shortValue == m_shortValue);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/dds-types-test/unions.hpp
+++ b/test/dds-types-test/unions.hpp
@@ -169,15 +169,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_a == x.m_a);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_a == m_a);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -428,15 +437,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_b == x.m_b);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_b == m_b);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -687,15 +705,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_c == x.m_c);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_c == m_c);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -946,15 +973,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_d == x.m_d);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_d == m_d);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1205,15 +1241,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_e == x.m_e);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_e == m_e);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1464,15 +1509,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_f == x.m_f);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_f == m_f);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1723,15 +1777,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_g == x.m_g);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_g == m_g);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1982,15 +2045,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_h == x.m_h);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_h == m_h);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -2241,15 +2313,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_i == x.m_i);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_i == m_i);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -2500,15 +2581,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_j == x.m_j);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_j == m_j);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -2759,15 +2849,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_k == x.m_k);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_k == m_k);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -3018,15 +3117,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_l == x.m_l);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_l == m_l);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -3277,15 +3385,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_m == x.m_m);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_m == m_m);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -3536,15 +3653,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_n == x.m_n);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_n == m_n);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -3806,15 +3932,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_o == x.m_o);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_o == m_o);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4076,15 +4211,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_bn == x.m_bn);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_bn == m_bn);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4346,15 +4490,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_bo == x.m_bo);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_bo == m_bo);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4616,15 +4769,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_p == x.m_p);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_p == m_p);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -4875,15 +5037,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_q == x.m_q);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_q == m_q);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -5145,15 +5316,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_r == x.m_r);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_r == m_r);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -5404,15 +5584,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_s == x.m_s);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_s == m_s);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -5674,15 +5863,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_t == x.m_t);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_t == m_t);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -5944,15 +6142,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_u == x.m_u);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_u == m_u);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -6214,15 +6421,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_v == x.m_v);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_v == m_v);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -6484,15 +6700,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_w == x.m_w);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_w == m_w);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -6754,15 +6979,24 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_x == x.m_x);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_x == m_x);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -7040,19 +7274,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -7387,19 +7630,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -7734,19 +7986,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -8081,19 +8342,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -8428,19 +8698,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -8775,19 +9054,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -9126,19 +9414,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -9463,19 +9760,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -9810,19 +10116,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -10157,19 +10472,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -10524,23 +10848,32 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_third == x.m_third);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_third == m_third);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -10937,19 +11270,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -11285,19 +11627,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -11680,31 +12031,40 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_a == x.m_a);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_a == m_a);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_b == x.m_b);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_b == m_b);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_c == x.m_c);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_c == m_c);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_d == x.m_d);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_d == m_d);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_e == x.m_e);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_e == m_e);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -12366,35 +12726,44 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_a == x.m_a);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_a == m_a);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_b == x.m_b);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_b == m_b);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_c == x.m_c);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_c == m_c);
+                                                        break;
 
-                                case 0x00000004:
-                                    ret_value = (m_d == x.m_d);
-                                    break;
+                                                    case 0x00000004:
+                                                        ret_value = (x.m_d == m_d);
+                                                        break;
 
-                                case 0x00000005:
-                                    ret_value = (m_e == x.m_e);
-                                    break;
+                                                    case 0x00000005:
+                                                        ret_value = (x.m_e == m_e);
+                                                        break;
 
-                                case 0x00000006:
-                                    ret_value = (m_f == x.m_f);
-                                    break;
+                                                    case 0x00000006:
+                                                        ret_value = (x.m_f == m_f);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -18530,23 +18899,32 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_a == x.m_a);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_a == m_a);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_b == x.m_b);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_b == m_b);
+                                                        break;
 
-                                case 0x00000003:
-                                    ret_value = (m_c == x.m_c);
-                                    break;
+                                                    case 0x00000003:
+                                                        ret_value = (x.m_c == m_c);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -18939,19 +19317,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_a == x.m_a);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_a == m_a);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_b == x.m_b);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_b == m_b);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_struct.hpp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_struct.hpp
@@ -185,19 +185,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -538,19 +547,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_third == x.m_third);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_third == m_third);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_fourth == x.m_fourth);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_fourth == m_fourth);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveType.hpp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveType.hpp
@@ -860,19 +860,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000010:
-                                    ret_value = (m_first == x.m_first);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000010:
+                                                        ret_value = (x.m_first == m_first);
+                                                        break;
 
-                                case 0x00000011:
-                                    ret_value = (m_second == x.m_second);
-                                    break;
+                                                    case 0x00000011:
+                                                        ret_value = (x.m_second == m_second);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 
@@ -1213,19 +1222,28 @@ public:
     {
         bool ret_value {false};
 
-        if (m__d == x.m__d &&
-                selected_member_ == x.selected_member_)
+        if (x.selected_member_ == selected_member_)
         {
-            switch (selected_member_)
+            if (0x0FFFFFFFu != selected_member_)
             {
-                                case 0x00000001:
-                                    ret_value = (m_third == x.m_third);
-                                    break;
+                if (x.m__d == m__d)
+                {
+                    switch (selected_member_)
+                    {
+                                                    case 0x00000001:
+                                                        ret_value = (x.m_third == m_third);
+                                                        break;
 
-                                case 0x00000002:
-                                    ret_value = (m_fourth == x.m_fourth);
-                                    break;
+                                                    case 0x00000002:
+                                                        ret_value = (x.m_fourth == m_fourth);
+                                                        break;
 
+                    }
+                }
+            }
+            else
+            {
+                ret_value = true;
             }
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR regenerate project types using latest Fast DDS-Gen v4.0.2
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox **N/A** by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox **N/A** with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

