### PR TITLE
[21828] Warn instead of fail when `dds.communication.dynamic_interfaces` cannot be built

### DIFF
--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -29,7 +29,8 @@ if(UNIX AND NOT(APPLE) AND NOT(QNXNTO) AND NOT(ANDROID))
     # Find bash
     find_program(BASH_EXECUTABLE bash)
     if(NOT BASH_EXECUTABLE)
-        message(FATAL_ERROR "bash not found")
+        message(WARNING "bash executable not found. dds.communication.dynamic_interfaces test won't be compiled.")
+        return()
     endif()
 
     set(SHELL_EXECUTABLE ${BASH_EXECUTABLE})
@@ -37,11 +38,12 @@ if(UNIX AND NOT(APPLE) AND NOT(QNXNTO) AND NOT(ANDROID))
 # Windows configurations
 elseif(WIN32)
     # We don't know which docker image to use for Windows yet
-    message(FATAL_ERROR "Windows not supported yet")
-
+    message(WARNING "Windows not supported yet. dds.communication.dynamic_interfaces test won't be compiled.")
+    return()
 # Unsupported platform
 else()
-    message(FATAL_ERROR "Unsupported platform")
+    message(WARNING "Unsupported platform. dds.communication.dynamic_interfaces test won't be compiled.")
+    return()
 endif()
 
 # Configure TinyXML2 library path if installed in user library path

--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -16,7 +16,8 @@ message(STATUS "Configuring dynamic network interfaces tests")
 # Find docker
 find_program(DOCKER_EXECUTABLE docker)
 if(NOT DOCKER_EXECUTABLE)
-    message(FATAL_ERROR "Docker not found")
+    message(WARNING "Docker executable not found. dds.communication.dynamic_interfaces test won't be compiled.")
+    return()
 endif()
 
 set(SHELL_EXECUTABLE "")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

PR #5282 introduces a test which uses `docker`. If `docker` executable is not found launches a FATAL_ERROR. This could happens inside a docker container. This PR fixes this changing the FATAL_ERROR to WARNING.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox *N/A* by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox *N/A* with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- *N/A* Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- *N/A* Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- *N/A* Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- *N/A* New feature has been added to the `versions.md` file (if applicable).
- *N/A* New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- *N/A* Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.

