### PR TITLE
[21808] DataWriter/Reader `get_matched_publication/subscription()` Tests & Feature 3.x

### DIFF
--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -291,6 +291,30 @@ public:
      */
     std::vector<TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
+    /**
+     * @brief Fills the provided publication discovery data with the information of the
+     * writer identified by writer_guid.
+     *
+     * @param[out] data publication discovery data to fill.
+     * @param[in] writer_guid GUID of the writer to get the information from.
+     * @return True if the writer was found and the data was filled.
+     */
+    bool get_publication_info(
+            fastdds::rtps::PublicationBuiltinTopicData& data,
+            const GUID_t& writer_guid) const;
+
+    /**
+     * @brief Fills the provided subscription discovery data with the information of the
+     * reader identified by reader_guid.
+     *
+     * @param[out] data subscription discovery data to fill.
+     * @param[in] reader_guid GUID of the reader to get the information from.
+     * @return True if the reader was found and the data was filled.
+     */
+    bool get_subscription_info(
+            fastdds::rtps::SubscriptionBuiltinTopicData& data,
+            const GUID_t& reader_guid) const;
+
 #if HAVE_SECURITY
 
     /**

--- a/include/fastdds/rtps/reader/RTPSReader.hpp
+++ b/include/fastdds/rtps/reader/RTPSReader.hpp
@@ -142,6 +142,15 @@ public:
             eprosima::fastdds::rtps::IReaderDataFilter* filter) = 0;
 
     /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    FASTDDS_EXPORTED_API virtual bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const = 0;
+
+    /**
      * @brief Read the next unread CacheChange_t from the history.
      *
      * @return A pointer to the first unread CacheChange_t from the history.

--- a/include/fastdds/rtps/writer/RTPSWriter.hpp
+++ b/include/fastdds/rtps/writer/RTPSWriter.hpp
@@ -183,6 +183,15 @@ public:
      */
     FASTDDS_EXPORTED_API virtual bool get_disable_positive_acks() const = 0;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    FASTDDS_EXPORTED_API virtual bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const = 0;
+
 #ifdef FASTDDS_STATISTICS
 
     /**

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -270,22 +270,13 @@ ReturnCode_t DataWriter::get_matched_subscription_data(
         SubscriptionBuiltinTopicData& subscription_data,
         const InstanceHandle_t& subscription_handle) const
 {
-    static_cast<void> (subscription_data);
-    static_cast<void> (subscription_handle);
-    return RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_subscription_data(subscription_data, subscription_handle);
-     */
+    return impl_->get_matched_subscription_data(subscription_data, subscription_handle);
 }
 
 ReturnCode_t DataWriter::get_matched_subscriptions(
         std::vector<InstanceHandle_t>& subscription_handles) const
 {
-    static_cast<void> (subscription_handles);
-    return RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_subscription_data(subscription_handles);
-     */
+    return impl_->get_matched_subscriptions(subscription_handles);
 }
 
 ReturnCode_t DataWriter::clear_history(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -2335,6 +2335,48 @@ void DataWriterImpl::filter_is_being_removed(
     }
 }
 
+ReturnCode_t DataWriterImpl::get_matched_subscription_data(
+        SubscriptionBuiltinTopicData& subscription_data,
+        const InstanceHandle_t& subscription_handle) const
+{
+    ReturnCode_t ret = RETCODE_BAD_PARAMETER;
+    fastdds::rtps::GUID_t reader_guid = iHandle2GUID(subscription_handle);
+
+    if (writer_ && writer_->matched_reader_is_matched(reader_guid))
+    {
+        if (publisher_)
+        {
+            RTPSParticipant* rtps_participant = publisher_->rtps_participant();
+            if (rtps_participant &&
+                    rtps_participant->get_subscription_info(subscription_data, reader_guid))
+            {
+                ret = RETCODE_OK;
+            }
+        }
+    }
+
+    return ret;
+}
+
+ReturnCode_t DataWriterImpl::get_matched_subscriptions(
+        std::vector<InstanceHandle_t>& subscription_handles) const
+{
+    ReturnCode_t ret = RETCODE_ERROR;
+    std::vector<rtps::GUID_t> matched_reader_guids;
+    subscription_handles.clear();
+
+    if (writer_ && writer_->matched_readers_guids(matched_reader_guids))
+    {
+        for (const rtps::GUID_t& guid : matched_reader_guids)
+        {
+            subscription_handles.emplace_back(InstanceHandle_t(guid));
+        }
+        ret = RETCODE_OK;
+    }
+
+    return ret;
+}
+
 bool DataWriterImpl::is_relevant(
         const fastdds::rtps::CacheChange_t& change,
         const fastdds::rtps::GUID_t& reader_guid) const

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -382,6 +382,31 @@ public:
             const char* filter_class_name);
 
     /**
+     * @brief Retrieves in a subscription associated with the DataWriter
+     *
+     * @param[out] subscription_data subscription data struct
+     * @param subscription_handle InstanceHandle_t of the subscription
+     * @return RETCODE_BAD_PARAMETER if the DataWriter is not matched with
+     * the given subscription handle, RETCODE_OK otherwise.
+     *
+     */
+    ReturnCode_t get_matched_subscription_data(
+            SubscriptionBuiltinTopicData& subscription_data,
+            const InstanceHandle_t& subscription_handle) const;
+
+    /**
+     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     *
+     * @param[out] subscription_handles Vector where the InstanceHandle_t are returned
+     * @return RETCODE_OK if the operation succeeds.
+     *
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
+     */
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t>& subscription_handles) const;
+
+    /**
      * Retrieve the publication data discovery information.
      *
      * @param [out] publication_data The publication data discovery information.

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -382,12 +382,12 @@ public:
             const char* filter_class_name);
 
     /**
-     * @brief Retrieves in a subscription associated with the DataWriter
+     * @brief Retrieves in a subscription associated with the @ref DataWriter
      *
      * @param[out] subscription_data subscription data struct
-     * @param subscription_handle InstanceHandle_t of the subscription
-     * @return RETCODE_BAD_PARAMETER if the DataWriter is not matched with
-     * the given subscription handle, RETCODE_OK otherwise.
+     * @param subscription_handle @ref InstanceHandle_t of the subscription
+     * @return @ref RETCODE_BAD_PARAMETER if the DataWriter is not matched with
+     * the given subscription handle, @ref RETCODE_OK otherwise.
      *
      */
     ReturnCode_t get_matched_subscription_data(
@@ -395,12 +395,12 @@ public:
             const InstanceHandle_t& subscription_handle) const;
 
     /**
-     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     * @brief Fills the given vector with the @ref InstanceHandle_t of matched DataReaders
      *
-     * @param[out] subscription_handles Vector where the InstanceHandle_t are returned
-     * @return RETCODE_OK if the operation succeeds.
+     * @param[out] subscription_handles Vector where the @ref InstanceHandle_t are returned
+     * @return @ref RETCODE_OK if the operation succeeds.
      *
-     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     * @note Returning an empty list is not an error, it returns @ref RETCODE_OK.
      *
      */
     ReturnCode_t get_matched_subscriptions(

--- a/src/cpp/fastdds/subscriber/DataReader.cpp
+++ b/src/cpp/fastdds/subscriber/DataReader.cpp
@@ -394,22 +394,13 @@ ReturnCode_t DataReader::get_matched_publication_data(
         PublicationBuiltinTopicData& publication_data,
         const fastdds::rtps::InstanceHandle_t& publication_handle) const
 {
-    static_cast<void> (publication_data);
-    static_cast<void> (publication_handle);
-    return RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_publication_data(publication_data, publication_handle);
-     */
+    return impl_->get_matched_publication_data(publication_data, publication_handle);
 }
 
 ReturnCode_t DataReader::get_matched_publications(
         std::vector<InstanceHandle_t>& publication_handles) const
 {
-    static_cast<void> (publication_handles);
-    return RETCODE_UNSUPPORTED;
-    /*
-       return impl_->get_matched_publication_data(publication_handles);
-     */
+    return impl_->get_matched_publications(publication_handles);
 }
 
 ReadCondition* DataReader::create_readcondition(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1211,6 +1211,48 @@ ReturnCode_t DataReaderImpl::get_subscription_matched_status(
     return RETCODE_OK;
 }
 
+ReturnCode_t DataReaderImpl::get_matched_publication_data(
+        PublicationBuiltinTopicData& publication_data,
+        const InstanceHandle_t& publication_handle) const
+{
+    ReturnCode_t ret = RETCODE_BAD_PARAMETER;
+    fastdds::rtps::GUID_t writer_guid = iHandle2GUID(publication_handle);
+
+    if (reader_ && reader_->matched_writer_is_matched(writer_guid))
+    {
+        if (subscriber_)
+        {
+            RTPSParticipant* rtps_participant = subscriber_->rtps_participant();
+            if (rtps_participant &&
+                    rtps_participant->get_publication_info(publication_data, writer_guid))
+            {
+                ret = RETCODE_OK;
+            }
+        }
+    }
+
+    return ret;
+}
+
+ReturnCode_t DataReaderImpl::get_matched_publications(
+        std::vector<InstanceHandle_t>& publication_handles) const
+{
+    ReturnCode_t ret = RETCODE_ERROR;
+    std::vector<rtps::GUID_t> matched_writers_guids;
+    publication_handles.clear();
+
+    if (reader_ && reader_->matched_writers_guids(matched_writers_guids))
+    {
+        for (const rtps::GUID_t& guid : matched_writers_guids)
+        {
+            publication_handles.emplace_back(InstanceHandle_t(guid));
+        }
+        ret = RETCODE_OK;
+    }
+
+    return ret;
+}
+
 bool DataReaderImpl::deadline_timer_reschedule()
 {
     assert(qos_.deadline().period != dds::c_TimeInfinite);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -238,9 +238,9 @@ public:
      * @brief Retrieves in a publication associated with the DataWriter
      *
      * @param[out] publication_data publication data struct
-     * @param publication_handle InstanceHandle_t of the publication
-     * @return RETCODE_BAD_PARAMETER if the DataReader is not matched with
-     * the given publication handle, RETCODE_OK otherwise.
+     * @param publication_handle @ref InstanceHandle_t of the publication
+     * @return @ref RETCODE_BAD_PARAMETER if the DataReader is not matched with
+     * the given publication handle, @ref RETCODE_OK otherwise.
      *
      */
     ReturnCode_t get_matched_publication_data(
@@ -248,12 +248,12 @@ public:
             const InstanceHandle_t& publication_handle) const;
 
     /**
-     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     * @brief Fills the given vector with the @ref InstanceHandle_t of matched DataReaders
      *
-     * @param[out] publication_handles Vector where the InstanceHandle_t are returned
-     * @return RETCODE_OK if the operation succeeds.
+     * @param[out] publication_handles Vector where the @ref InstanceHandle_t are returned
+     * @return @ref RETCODE_OK if the operation succeeds.
      *
-     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     * @note Returning an empty list is not an error, it returns @ref RETCODE_OK.
      *
      */
     ReturnCode_t get_matched_publications(

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -234,6 +234,31 @@ public:
     ReturnCode_t get_subscription_matched_status(
             SubscriptionMatchedStatus& status);
 
+    /**
+     * @brief Retrieves in a publication associated with the DataWriter
+     *
+     * @param[out] publication_data publication data struct
+     * @param publication_handle InstanceHandle_t of the publication
+     * @return RETCODE_BAD_PARAMETER if the DataReader is not matched with
+     * the given publication handle, RETCODE_OK otherwise.
+     *
+     */
+    ReturnCode_t get_matched_publication_data(
+            rtps::PublicationBuiltinTopicData& publication_data,
+            const InstanceHandle_t& publication_handle) const;
+
+    /**
+     * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
+     *
+     * @param[out] publication_handles Vector where the InstanceHandle_t are returned
+     * @return RETCODE_OK if the operation succeeds.
+     *
+     * @note Returning an empty list is not an error, it returns RETCODE_OK.
+     *
+     */
+    ReturnCode_t get_matched_publications(
+            std::vector<InstanceHandle_t>& publication_handles) const;
+
     ReturnCode_t get_requested_deadline_missed_status(
             RequestedDeadlineMissedStatus& status);
 

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -194,6 +194,20 @@ std::vector<TransportNetmaskFilterInfo> RTPSParticipant::get_netmask_filter_info
     return mp_impl->get_netmask_filter_info();
 }
 
+bool RTPSParticipant::get_publication_info(
+        PublicationBuiltinTopicData& data,
+        const GUID_t& writer_guid) const
+{
+    return mp_impl->get_publication_info(data, writer_guid);
+}
+
+bool RTPSParticipant::get_subscription_info(
+        SubscriptionBuiltinTopicData& data,
+        const GUID_t& reader_guid) const
+{
+    return mp_impl->get_subscription_info(data, reader_guid);
+}
+
 #if HAVE_SECURITY
 
 bool RTPSParticipant::is_security_enabled_for_writer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2791,6 +2791,40 @@ std::vector<TransportNetmaskFilterInfo> RTPSParticipantImpl::get_netmask_filter_
     return m_network_Factory.netmask_filter_info();
 }
 
+bool RTPSParticipantImpl::get_publication_info(
+        PublicationBuiltinTopicData& data,
+        const GUID_t& writer_guid) const
+{
+    bool ret = false;
+    WriterProxyData wproxy_data(m_att.allocation.locators.max_unicast_locators,
+            m_att.allocation.locators.max_multicast_locators);
+
+    if (mp_builtinProtocols->mp_PDP->lookupWriterProxyData(writer_guid, wproxy_data))
+    {
+        from_proxy_to_builtin(wproxy_data, data);
+        ret = true;
+    }
+
+    return ret;
+}
+
+bool RTPSParticipantImpl::get_subscription_info(
+        SubscriptionBuiltinTopicData& data,
+        const GUID_t& reader_guid) const
+{
+    bool ret = false;
+    ReaderProxyData rproxy_data(m_att.allocation.locators.max_unicast_locators,
+            m_att.allocation.locators.max_multicast_locators);
+
+    if (mp_builtinProtocols->mp_PDP->lookupReaderProxyData(reader_guid, rproxy_data))
+    {
+        from_proxy_to_builtin(rproxy_data, data);
+        ret = true;
+    }
+
+    return ret;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool RTPSParticipantImpl::register_in_writer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -1120,6 +1120,30 @@ public:
      */
     std::vector<TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
+    /**
+     * @brief Fills the provided PublicationBuiltinTopicData with the information of the
+     * writer identified by writer_guid.
+     *
+     * @param[out] data PublicationBuiltinTopicData to fill.
+     * @param[in] writer_guid GUID of the writer to get the information from.
+     * @return True if the writer was found and the data was filled.
+     */
+    bool get_publication_info(
+            PublicationBuiltinTopicData& data,
+            const GUID_t& writer_guid) const;
+
+    /**
+     * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
+     * reader identified by reader_guid.
+     *
+     * @param[out] data SubscriptionBuiltinTopicData to fill.
+     * @param[in] reader_guid GUID of the reader to get the information from.
+     * @return True if the reader was found and the data was filled.
+     */
+    bool get_subscription_info(
+            SubscriptionBuiltinTopicData& data,
+            const GUID_t& reader_guid) const;
+
     template <EndpointKind_t kind, octet no_key, octet with_key>
     static bool preprocess_endpoint_attributes(
             const EntityId_t& entity_id,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.h
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.h
@@ -1121,10 +1121,10 @@ public:
     std::vector<TransportNetmaskFilterInfo> get_netmask_filter_info() const;
 
     /**
-     * @brief Fills the provided PublicationBuiltinTopicData with the information of the
+     * @brief Fills the provided @ref PublicationBuiltinTopicData with the information of the
      * writer identified by writer_guid.
      *
-     * @param[out] data PublicationBuiltinTopicData to fill.
+     * @param[out] data @ref PublicationBuiltinTopicData to fill.
      * @param[in] writer_guid GUID of the writer to get the information from.
      * @return True if the writer was found and the data was filled.
      */
@@ -1133,10 +1133,10 @@ public:
             const GUID_t& writer_guid) const;
 
     /**
-     * @brief Fills the provided SubscriptionBuiltinTopicData with the information of the
+     * @brief Fills the provided @ref SubscriptionBuiltinTopicData with the information of the
      * reader identified by reader_guid.
      *
-     * @param[out] data SubscriptionBuiltinTopicData to fill.
+     * @param[out] data @ref SubscriptionBuiltinTopicData to fill.
      * @param[in] reader_guid GUID of the reader to get the information from.
      * @return True if the reader was found and the data was filled.
      */

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1492,6 +1492,19 @@ void StatefulReader::end_sample_access_nts(
     }
 }
 
+bool StatefulReader::matched_writers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    guids.reserve(matched_writers_.size());
+    for (WriterProxy* writer : matched_writers_)
+    {
+        guids.push_back(writer->guid());
+    }
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatefulReader::get_connections(

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1500,7 +1500,7 @@ bool StatefulReader::matched_writers_guids(
     guids.reserve(matched_writers_.size());
     for (WriterProxy* writer : matched_writers_)
     {
-        guids.push_back(writer->guid());
+        guids.emplace_back(writer->guid());
     }
     return true;
 }

--- a/src/cpp/rtps/reader/StatefulReader.hpp
+++ b/src/cpp/rtps/reader/StatefulReader.hpp
@@ -304,6 +304,15 @@ public:
             WriterProxy*& writer,
             bool mark_as_read) override;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const final;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -529,7 +529,7 @@ bool StatelessReader::matched_writers_guids(
     guids.reserve(matched_writers_.size());
     for (const RemoteWriterInfo_t& writer : matched_writers_)
     {
-        guids.push_back(writer.guid);
+        guids.emplace_back(writer.guid);
     }
     return true;
 }

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -521,6 +521,19 @@ void StatelessReader::end_sample_access_nts(
     }
 }
 
+bool StatelessReader::matched_writers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    guids.reserve(matched_writers_.size());
+    for (const RemoteWriterInfo_t& writer : matched_writers_)
+    {
+        guids.push_back(writer.guid);
+    }
+    return true;
+}
+
 #ifdef FASTDDS_STATISTICS
 
 bool StatelessReader::get_connections(

--- a/src/cpp/rtps/reader/StatelessReader.hpp
+++ b/src/cpp/rtps/reader/StatelessReader.hpp
@@ -227,6 +227,15 @@ public:
             WriterProxy*& writer,
             bool mark_as_read) override;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched writers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched writers.
+     * @return True if the operation was successful.
+     */
+    bool matched_writers_guids(
+            std::vector<GUID_t>& guids) const final;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) override;

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1609,10 +1609,12 @@ bool StatefulWriter::matched_readers_guids(
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     guids.clear();
+    guids.reserve(guids.size() + matched_local_readers_.size() + matched_datasharing_readers_.size() +
+            matched_remote_readers_.size());
     for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
             [&guids](const ReaderProxy* reader)
             {
-                guids.push_back(reader->guid());
+                guids.emplace_back(reader->guid());
                 return false;
             }
             );

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1604,6 +1604,22 @@ void StatefulWriter::update_attributes(
     }
 }
 
+bool StatefulWriter::matched_readers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
+            [&guids](const ReaderProxy* reader)
+            {
+                guids.push_back(reader->guid());
+                return false;
+            }
+            );
+
+    return true;
+}
+
 void StatefulWriter::update_positive_acks_times(
         const WriterAttributes& att)
 {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1609,7 +1609,7 @@ bool StatefulWriter::matched_readers_guids(
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     guids.clear();
-    guids.reserve(guids.size() + matched_local_readers_.size() + matched_datasharing_readers_.size() +
+    guids.reserve(matched_local_readers_.size() + matched_datasharing_readers_.size() +
             matched_remote_readers_.size());
     for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
             [&guids](const ReaderProxy* reader)

--- a/src/cpp/rtps/writer/StatefulWriter.hpp
+++ b/src/cpp/rtps/writer/StatefulWriter.hpp
@@ -90,6 +90,15 @@ public:
         return disable_positive_acks_;
     }
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const final;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) final;

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -398,6 +398,21 @@ bool StatelessWriter::get_disable_positive_acks() const
     return false;
 }
 
+bool StatelessWriter::matched_readers_guids(
+        std::vector<GUID_t>& guids) const
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    guids.clear();
+    for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
+            [&guids](const ReaderLocator& reader)
+            {
+                guids.push_back(reader.remote_guid());
+                return false;
+            }
+            );
+    return true;
+}
+
 bool StatelessWriter::try_remove_change(
         const std::chrono::steady_clock::time_point&,
         std::unique_lock<RecursiveTimedMutex>&)

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -403,10 +403,11 @@ bool StatelessWriter::matched_readers_guids(
 {
     std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     guids.clear();
+    guids.reserve(matched_local_readers_.size() + matched_datasharing_readers_.size() + matched_remote_readers_.size());
     for_matched_readers(matched_local_readers_, matched_datasharing_readers_, matched_remote_readers_,
             [&guids](const ReaderLocator& reader)
             {
-                guids.push_back(reader.remote_guid());
+                guids.emplace_back(reader.remote_guid());
                 return false;
             }
             );

--- a/src/cpp/rtps/writer/StatelessWriter.hpp
+++ b/src/cpp/rtps/writer/StatelessWriter.hpp
@@ -97,6 +97,15 @@ public:
 
     bool get_disable_positive_acks() const final;
 
+    /**
+     * @brief Fills the provided vector with the GUIDs of the matched readers.
+     *
+     * @param[out] guids Vector to be filled with the GUIDs of the matched readers.
+     * @return True if the operation was successful.
+     */
+    bool matched_readers_guids(
+            std::vector<GUID_t>& guids) const final;
+
 #ifdef FASTDDS_STATISTICS
     bool get_connections(
             fastdds::statistics::rtps::ConnectionList& connection_list) final;

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -340,6 +340,12 @@ public:
             return false;
         }
 
+        if (publisher_topicname_.empty())
+        {
+            EPROSIMA_LOG_ERROR(PUBSUBPARTICIPANT, "Publisher topic name not set");
+            return false;
+        }
+
         eprosima::fastdds::dds::Topic* topic =
                 dynamic_cast<eprosima::fastdds::dds::Topic*>(participant_->lookup_topicdescription(
                     publisher_topicname_));
@@ -374,6 +380,12 @@ public:
         }
         if (index >= num_subscribers_)
         {
+            return false;
+        }
+
+        if (subscriber_topicname_.empty())
+        {
+            EPROSIMA_LOG_ERROR(PUBSUBPARTICIPANT, "Subscriber topic name not set");
             return false;
         }
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1464,7 +1464,7 @@ public:
         return *this;
     }
 
-    PubSubReader& userData(
+    PubSubReader& user_data(
             std::vector<eprosima::fastdds::rtps::octet> user_data)
     {
         participant_qos_.user_data() = user_data;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1404,7 +1404,7 @@ public:
         return *this;
     }
 
-    PubSubWriter& userData(
+    PubSubWriter& user_data(
             std::vector<eprosima::fastdds::rtps::octet> user_data)
     {
         participant_qos_.user_data() = user_data;

--- a/test/blackbox/common/BlackboxTests.cpp
+++ b/test/blackbox/common/BlackboxTests.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/LibrarySettings.hpp>
@@ -85,6 +86,36 @@ public:
     }
 
 };
+
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::EntityId_t& entity_id)
+{
+    bt_key.value[0] = 0;
+    bt_key.value[1] = 0;
+    bt_key.value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::GuidPrefix_t& guid_prefix)
+{
+    bt_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    bt_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    bt_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
 
 int main(
         int argc,

--- a/test/blackbox/common/BlackboxTests.hpp
+++ b/test/blackbox/common/BlackboxTests.hpp
@@ -47,6 +47,16 @@
 #include <list>
 #include <functional>
 
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+
+struct BuiltinTopicKey_t;
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
 #if HAVE_SECURITY
 extern void blackbox_security_init();
 #endif // if HAVE_SECURITY
@@ -202,5 +212,16 @@ void print_non_received_messages(
 }
 
 /***** End auxiliary lambda function *****/
+
+/****** Auxiliary conversion helpers *******/
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::EntityId_t& entity_id);
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::GuidPrefix_t& guid_prefix);
+
+/****** End Auxiliary conversion helpers *******/
 
 #endif // __BLACKBOX_BLACKBOXTESTS_HPP__

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -933,7 +933,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
     writer.history_depth(100).
-            userData({'a', 'b', 'c', 'd'}).init();
+            user_data({'a', 'b', 'c', 'd'}).init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -384,7 +384,7 @@ TEST_P(PubSubBasic, ReceivedDynamicDataWithNoSizeLimit)
 
     writer.history_depth(100)
             .partition("A").partition("B").partition("C")
-            .userData({'a', 'b', 'c', 'd'}).init();
+            .user_data({'a', 'b', 'c', 'd'}).init();
 
 
     ASSERT_TRUE(writer.isInitialized());
@@ -417,7 +417,7 @@ TEST_P(PubSubBasic, ReceivedDynamicDataWithinSizeLimit)
 
     writer.history_depth(100)
             .partition("A").partition("B").partition("C")
-            .userData({'a', 'b', 'c', 'd'}).init();
+            .user_data({'a', 'b', 'c', 'd'}).init();
 
 
     ASSERT_TRUE(writer.isInitialized());
@@ -451,7 +451,7 @@ TEST_P(PubSubBasic, ReceivedUserDataExceedsSizeLimit)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
     writer.history_depth(100)
-            .userData({'a', 'b', 'c', 'd', 'e', 'f'}).init();
+            .user_data({'a', 'b', 'c', 'd', 'e', 'f'}).init();
 
     ASSERT_TRUE(writer.isInitialized());
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2705,7 +2705,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(100).
-            userData({ 'a', 'b', 'c', 'd', 'e' }).
+            user_data({ 'a', 'b', 'c', 'd', 'e' }).
             property_policy(pub_part_property_policy).
             entity_property_policy(pub_property_policy).init();
 

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -404,8 +404,8 @@ TEST_P(DDSPersistenceTests, PubSubAsReliablePubTransientWithStaticDiscovery)
             .multicastLocatorList(WriterMulticastLocators)
             .setPublisherIDs(1, 2)
             .setManualTopicName(std::string("BlackBox_StaticDiscovery_") + TOPIC_RANDOM_NUMBER)
-            .userData({'V', 'G', 'W', 0x78, 0x73, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x73, 0x5f, 0x67,
-                       0x75, 0x69})
+            .user_data({'V', 'G', 'W', 0x78, 0x73, 0x69, 0x74, 0x65, 0x72, 0x5f, 0x70, 0x65, 0x72, 0x73, 0x5f, 0x67,
+                        0x75, 0x69})
             .init();
 
     ASSERT_TRUE(writer.isInitialized());

--- a/test/blackbox/common/RTPSBlackboxTests.cpp
+++ b/test/blackbox/common/RTPSBlackboxTests.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <thread>
 
+#include <fastdds/dds/builtin/topic/BuiltinTopicKey.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/LibrarySettings.hpp>
 #include <fastdds/rtps/RTPSDomain.hpp>
@@ -80,6 +81,36 @@ public:
     }
 
 };
+
+void entity_id_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::EntityId_t& entity_id)
+{
+    bt_key.value[0] = 0;
+    bt_key.value[1] = 0;
+    bt_key.value[2] = static_cast<uint32_t>(entity_id.value[0]) << 24
+            | static_cast<uint32_t>(entity_id.value[1]) << 16
+            | static_cast<uint32_t>(entity_id.value[2]) << 8
+            | static_cast<uint32_t>(entity_id.value[3]);
+}
+
+void guid_prefix_to_builtin_topic_key(
+        eprosima::fastdds::rtps::BuiltinTopicKey_t& bt_key,
+        const eprosima::fastdds::rtps::GuidPrefix_t& guid_prefix)
+{
+    bt_key.value[0] = static_cast<uint32_t>(guid_prefix.value[0]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[1]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[2]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[3]);
+    bt_key.value[1] = static_cast<uint32_t>(guid_prefix.value[4]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[5]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[6]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[7]);
+    bt_key.value[2] = static_cast<uint32_t>(guid_prefix.value[8]) << 24
+            | static_cast<uint32_t>(guid_prefix.value[9]) << 16
+            | static_cast<uint32_t>(guid_prefix.value[10]) << 8
+            | static_cast<uint32_t>(guid_prefix.value[11]);
+}
 
 int main(
         int argc,

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -1,0 +1,156 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.hpp>
+#include <fastdds/rtps/RTPSDomain.hpp>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
+#include <fastdds/LibrarySettings.hpp>
+
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS
+};
+
+class RTPSReaderTests : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        eprosima::fastdds::LibrarySettings library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = eprosima::fastdds::IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                eprosima::fastdds::rtps::RTPSDomain::set_library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        eprosima::fastdds::LibrarySettings library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = eprosima::fastdds::IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                eprosima::fastdds::rtps::RTPSDomain::set_library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * @test RTPS-READER-API-MWG-01
+ *
+ * matched_writers_guids() must return true with empty list when the entitiy is not matched.
+ * matched_writers_guids() must return true with a correct list when the entitiy is matched.
+ */
+TEST_P(RTPSReaderTests, rtpsreader_matched_writers_guids)
+{
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    reader.reliability(eprosima::fastdds::rtps::RELIABLE)
+            .init();
+
+    writer.reliability(eprosima::fastdds::rtps::BEST_EFFORT)
+            .init();
+
+    ASSERT_TRUE(reader.isInitialized());
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Expect not to discover
+    reader.wait_discovery(std::chrono::seconds(1));
+    ASSERT_FALSE(reader.get_matched());
+
+    std::vector<GUID_t> matched_guids;
+    auto& native_rtps_reader = reader.get_native_reader();
+    ASSERT_TRUE(native_rtps_reader.matched_writers_guids(matched_guids));
+    ASSERT_TRUE(matched_guids.empty());
+
+    writer.destroy();
+    reader.wait_undiscovery();
+
+    const size_t num_matched_writers = 3;
+    std::vector<std::unique_ptr<RTPSWithRegistrationWriter<HelloWorldPubSubType>>> writers;
+    std::vector<GUID_t> expected_matched_guids;
+
+    writers.reserve(num_matched_writers);
+    expected_matched_guids.reserve(num_matched_writers);
+
+    for (size_t i = 0; i < num_matched_writers; ++i)
+    {
+        writers.emplace_back(new RTPSWithRegistrationWriter<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        writers.back()->init();
+        expected_matched_guids.emplace_back(writers.back()->guid());
+    }
+
+    reader.wait_discovery(num_matched_writers, std::chrono::seconds::zero());
+    ASSERT_EQ(num_matched_writers, reader.get_matched());
+    native_rtps_reader.matched_writers_guids(matched_guids);
+    ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
+    ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
+            matched_guids.begin()));
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // ifdef INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(RTPSReaderTests,
+        RTPSReaderTests,
+        testing::Values(TRANSPORT, INTRAPROCESS),
+        [](const testing::TestParamInfo<RTPSReaderTests::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+
+        });

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -1,0 +1,156 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.hpp>
+#include <fastdds/rtps/RTPSDomain.hpp>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
+#include <fastdds/LibrarySettings.hpp>
+
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+enum communication_type
+{
+    TRANSPORT,
+    INTRAPROCESS
+};
+
+class RTPSWriterTests : public testing::TestWithParam<communication_type>
+{
+public:
+
+    void SetUp() override
+    {
+        eprosima::fastdds::LibrarySettings library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = eprosima::fastdds::IntraprocessDeliveryType::INTRAPROCESS_FULL;
+                eprosima::fastdds::rtps::RTPSDomain::set_library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+    void TearDown() override
+    {
+        eprosima::fastdds::LibrarySettings library_settings;
+        switch (GetParam())
+        {
+            case INTRAPROCESS:
+                library_settings.intraprocess_delivery = eprosima::fastdds::IntraprocessDeliveryType::INTRAPROCESS_OFF;
+                eprosima::fastdds::rtps::RTPSDomain::set_library_settings(library_settings);
+                break;
+            case TRANSPORT:
+            default:
+                break;
+        }
+    }
+
+};
+
+/**
+ * @test RTPS-WRITER-API-MRG-01
+ *
+ * matched_readers_guids() must return true with empty list when the entitiy is not matched.
+ * matched_readers_guids() must return true with a correct list when the entitiy is matched.
+ */
+TEST_P(RTPSWriterTests, rtpswriter_matched_readers_guids)
+{
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(eprosima::fastdds::rtps::BEST_EFFORT)
+            .init();
+
+    reader.reliability(eprosima::fastdds::rtps::RELIABLE)
+            .init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Expect not to discover
+    writer.wait_discovery(std::chrono::seconds(1));
+    ASSERT_FALSE(writer.get_matched());
+
+    std::vector<GUID_t> matched_guids;
+    auto& native_rtps_writer = writer.get_native_writer();
+    ASSERT_TRUE(native_rtps_writer.matched_readers_guids(matched_guids));
+    ASSERT_TRUE(matched_guids.empty());
+
+    reader.destroy();
+    writer.wait_undiscovery();
+
+    const size_t num_matched_readers = 3;
+    std::vector<std::unique_ptr<RTPSWithRegistrationReader<HelloWorldPubSubType>>> readers;
+    std::vector<GUID_t> expected_matched_guids;
+
+    readers.reserve(num_matched_readers);
+    expected_matched_guids.reserve(num_matched_readers);
+
+    for (size_t i = 0; i < num_matched_readers; ++i)
+    {
+        readers.emplace_back(new RTPSWithRegistrationReader<HelloWorldPubSubType>(TEST_TOPIC_NAME));
+        readers.back()->init();
+        expected_matched_guids.emplace_back(readers.back()->guid());
+    }
+
+    writer.wait_discovery(num_matched_readers, std::chrono::seconds::zero());
+    ASSERT_EQ(num_matched_readers, writer.get_matched());
+    native_rtps_writer.matched_readers_guids(matched_guids);
+    ASSERT_EQ(expected_matched_guids.size(), matched_guids.size());
+    ASSERT_TRUE(std::is_permutation(expected_matched_guids.begin(), expected_matched_guids.end(),
+            matched_guids.begin()));
+}
+
+#ifdef INSTANTIATE_TEST_SUITE_P
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
+#else
+#define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_CASE_P(x, y, z, w)
+#endif // ifdef INSTANTIATE_TEST_SUITE_P
+
+GTEST_INSTANTIATE_TEST_MACRO(RTPSWriterTests,
+        RTPSWriterTests,
+        testing::Values(TRANSPORT, INTRAPROCESS),
+        [](const testing::TestParamInfo<RTPSWriterTests::ParamType>& info)
+        {
+            switch (info.param)
+            {
+                case INTRAPROCESS:
+                    return "Intraprocess";
+                    break;
+                case TRANSPORT:
+                default:
+                    return "Transport";
+            }
+
+        });

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -602,6 +602,24 @@ public:
         return *reader_;
     }
 
+    const eprosima::fastdds::dds::ReaderQos& get_reader_qos() const
+    {
+        return reader_qos_;
+    }
+
+    eprosima::fastdds::rtps::TopicDescription get_topic_description() const
+    {
+        eprosima::fastdds::rtps::TopicDescription topic_desc;
+        topic_desc.topic_name = sub_builtin_data_.topic_name;
+        topic_desc.type_name = sub_builtin_data_.type_name;
+        return topic_desc;
+    }
+
+    const eprosima::fastdds::rtps::RTPSParticipant* get_rtps_participant() const
+    {
+        return participant_;
+    }
+
 private:
 
     void receive_one(

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -612,6 +612,29 @@ public:
         return writer_->getGuid();
     }
 
+    eprosima::fastdds::rtps::RTPSWriter& get_native_writer() const
+    {
+        return *writer_;
+    }
+
+    const eprosima::fastdds::dds::WriterQos& get_writer_qos() const
+    {
+        return writer_qos_;
+    }
+
+    eprosima::fastdds::rtps::TopicDescription get_topic_description() const
+    {
+        eprosima::fastdds::rtps::TopicDescription topic_desc;
+        topic_desc.topic_name = pub_builtin_data_.topic_name;
+        topic_desc.type_name = pub_builtin_data_.type_name;
+        return topic_desc;
+    }
+
+    const eprosima::fastdds::rtps::RTPSParticipant* get_rtps_participant() const
+    {
+        return participant_;
+    }
+
 private:
 
     void on_reader_discovery(

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -54,6 +54,8 @@ namespace dds {
 namespace builtin {
 
 class TypeLookupManager;
+struct PublicationBuiltinTopicData;
+struct SubscriptionBuiltinTopicData;
 
 } // namespace builtin
 } // namespace dds
@@ -218,6 +220,14 @@ public:
     {
         return attributes_;
     }
+
+    MOCK_METHOD(bool, get_publication_info,
+            (fastdds::rtps::PublicationBuiltinTopicData&,
+            const GUID_t&), (const));
+
+    MOCK_METHOD(bool, get_subscription_info,
+            (fastdds::rtps::SubscriptionBuiltinTopicData&,
+            const GUID_t&), (const));
 
     bool update_attributes(
             const RTPSParticipantAttributes& patt)

--- a/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.hpp
+++ b/test/mock/rtps/RTPSReader/fastdds/rtps/reader/RTPSReader.hpp
@@ -68,6 +68,12 @@ public:
     virtual void assert_writer_liveliness(
             const GUID_t& wguid) = 0;
 
+    virtual bool matched_writers_guids(
+            std::vector<GUID_t>&) const
+    {
+        return false;
+    }
+
     virtual bool is_in_clean_state() = 0;
 
     virtual ReaderListener* get_listener() const = 0;

--- a/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.hpp
+++ b/test/mock/rtps/RTPSWriter/fastdds/rtps/writer/RTPSWriter.hpp
@@ -85,6 +85,12 @@ public:
         return false;
     }
 
+    virtual bool matched_readers_guids(
+            std::vector<GUID_t>&) const
+    {
+        return false;
+    }
+
     virtual bool has_been_fully_delivered(
             const SequenceNumber_t& /*seq_num*/) const
     {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -1733,9 +1733,7 @@ public:
 /*
  * This test checks that the DataWriter methods defined in the standard not yet implemented in FastDDS return
  * RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. get_matched_subscription_data
- * 2. get_matched_subscriptions
- * 3. lookup_instance
+ * 1. lookup_instance
  */
 TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 {
@@ -1754,15 +1752,6 @@ TEST_F(DataWriterUnsupportedTests, UnsupportedDataWriterMethods)
 
     DataWriter* data_writer = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
     ASSERT_NE(publisher, nullptr);
-
-    SubscriptionBuiltinTopicData subscription_data;
-    fastdds::rtps::InstanceHandle_t subscription_handle;
-    EXPECT_EQ(
-        RETCODE_UNSUPPORTED,
-        data_writer->get_matched_subscription_data(subscription_data, subscription_handle));
-
-    std::vector<InstanceHandle_t> subscription_handles;
-    EXPECT_EQ(RETCODE_UNSUPPORTED, data_writer->get_matched_subscriptions(subscription_handles));
 
     EXPECT_EQ(HANDLE_NIL, data_writer->lookup_instance(nullptr /* instance */));
 

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -2623,11 +2623,9 @@ public:
 /*
  * This test checks that the DataReader methods defined in the standard not yet implemented in FastDDS return
  * RETCODE_UNSUPPORTED. The following methods are checked:
- * 1. get_matched_publication_data
- * 2. create_querycondition
- * 3. get_matched_publications
- * 4. get_key_value
- * 5. wait_for_historical_data
+ * 1. create_querycondition
+ * 2. get_key_value
+ * 3. wait_for_historical_data
  */
 TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
 {
@@ -2648,12 +2646,6 @@ TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
     DataReader* data_reader = subscriber->create_datareader(topic, DATAREADER_QOS_DEFAULT);
     ASSERT_NE(data_reader, nullptr);
 
-    PublicationBuiltinTopicData publication_data;
-    InstanceHandle_t publication_handle;
-    EXPECT_EQ(
-        RETCODE_UNSUPPORTED,
-        data_reader->get_matched_publication_data(publication_data, publication_handle));
-
     {
         SampleStateMask sample_states = ANY_SAMPLE_STATE;
         ViewStateMask view_states = ANY_VIEW_STATE;
@@ -2669,9 +2661,6 @@ TEST_F(DataReaderUnsupportedTests, UnsupportedDataReaderMethods)
                 query_expression,
                 query_parameters));
     }
-
-    std::vector<InstanceHandle_t> publication_handles;
-    EXPECT_EQ(RETCODE_UNSUPPORTED, data_reader->get_matched_publications(publication_handles));
 
     InstanceHandle_t key_handle;
     EXPECT_EQ(RETCODE_UNSUPPORTED, data_reader->get_key_value(nullptr, key_handle));

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -423,6 +423,25 @@ public:
 
     }
 
+    ReturnCode_t get_matched_subscription_data(
+            SubscriptionBuiltinTopicData&,
+            const InstanceHandle_t& ) const
+    {
+        return RETCODE_ERROR;
+    }
+
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t>&) const
+    {
+        return RETCODE_ERROR;
+    }
+
+    ReturnCode_t get_matched_subscriptions(
+            std::vector<InstanceHandle_t*>&) const
+    {
+        return RETCODE_ERROR;
+    }
+
     //! Pointer to the associated Data Writer.
     fastdds::rtps::RTPSWriter* writer_ = nullptr;
     Topic* topic_ = nullptr;

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,11 @@
 Forthcoming
 -----------
 
+* Added implementation for:
+  * `DataWriter::get_matched_subscription_data()`
+  * `DataWriter::get_matched_subscriptions()`
+  * `DataReader::get_matched_publication_data()`
+  * `DataReader::get_matched_publications()`
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR is a forward port of #5284, implementing the following APIs

`DDS`
* `DataWriter::get_matched_subscriptions()`
* `DataWriter::get_matched_subscription_data()`
* `DataReader::get_matched_publications()`
* `DataReader::get_matched_publication_data()`

`RTPS`
* `RTPSParticipant::get_publication_info()`
* `RTPSParticipant::get_subscription_info()`
* `RTPSReader::matched_writers_guids()`
* `RTPSWriter::matched_readers_guids()`

In the `3.x` series.

Related PRs:

* https://github.com/eProsima/Fast-DDS-python/pull/188

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [X] New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
