### PR TITLE
Fix cleanup race condition with exclusive and shared lock files

### DIFF
--- a/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
@@ -172,7 +172,8 @@ private:
             bool* was_lock_created)
     {
         int fd = -1;
-        do {
+        do
+        {
             fd = open(file_path.c_str(), O_RDONLY, 0);
 
             if (fd != -1)

--- a/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
@@ -171,30 +171,41 @@ private:
             const std::string& file_path,
             bool* was_lock_created)
     {
-        auto fd = open(file_path.c_str(), O_RDONLY, 0);
+        int fd = -1;
+        do {
+            fd = open(file_path.c_str(), O_RDONLY, 0);
 
-        if (fd != -1)
-        {
-            *was_lock_created = false;
-        }
-        else
-        {
-            *was_lock_created = true;
-            fd = open(file_path.c_str(), O_CREAT | O_RDONLY, 0666);
-        }
+            if (fd != -1)
+            {
+                *was_lock_created = false;
+            }
+            else
+            {
+                *was_lock_created = true;
+                fd = open(file_path.c_str(), O_CREAT | O_RDONLY, 0666);
+            }
 
-        if (fd == -1)
-        {
-            return -1;
-        }
+            if (fd == -1)
+            {
+                return -1;
+            }
 
-        // Lock the file
-        if (0 != flock(fd, LOCK_EX | LOCK_NB))
-        {
-            close(fd);
-            return -1;
-        }
+            // Lock the file
+            if (0 != flock(fd, LOCK_EX | LOCK_NB))
+            {
+                close(fd);
+                return -1;
+            }
 
+            // Check if file was deleted by clean up script between open and lock
+            // if yes, repeat file creation
+            struct stat buffer = {};
+            if (stat(file_path.c_str(), &buffer) != 0 && errno == ENOENT)
+            {
+                close(fd);
+                fd = -1;
+            }
+        } while (fd == -1);
         return fd;
     }
 

--- a/src/cpp/utils/shared_memory/RobustSharedLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustSharedLock.hpp
@@ -237,40 +237,53 @@ private:
             bool* was_lock_created,
             bool* was_lock_released)
     {
-        auto fd = open(file_path.c_str(), O_RDONLY, 0);
+        int fd = -1;
+        do {
+            fd = open(file_path.c_str(), O_RDONLY, 0);
 
-        if (fd != -1)
-        {
-            *was_lock_created = false;
-        }
-        else
-        {
-            *was_lock_created = true;
-            fd = open(file_path.c_str(), O_CREAT | O_RDONLY, 0666);
-        }
-
-        if (was_lock_released != nullptr)
-        {
-            // Lock exclusive
-            if (0 == flock(fd, LOCK_EX | LOCK_NB))
+            if (fd != -1)
             {
-                // Exclusive => shared
-                flock(fd, LOCK_SH | LOCK_NB);
-                *was_lock_released = true;
-                return fd;
+                *was_lock_created = false;
             }
             else
             {
-                *was_lock_released = false;
+                *was_lock_created = true;
+                fd = open(file_path.c_str(), O_CREAT | O_RDONLY, 0666);
             }
-        }
 
-        // Lock shared
-        if (0 != flock(fd, LOCK_SH | LOCK_NB))
-        {
-            close(fd);
-            throw std::runtime_error(("failed to lock " + file_path).c_str());
-        }
+            if (was_lock_released != nullptr)
+            {
+                // Lock exclusive
+                if (0 == flock(fd, LOCK_EX | LOCK_NB))
+                {
+                    // Check if file was deleted by clean up script between open and lock
+                    // if yes, repeat file creation
+                    struct stat buffer = {};
+                    if (stat(file_path.c_str(), &buffer) != 0 && errno == ENOENT)
+                    {
+                        close(fd);
+                        fd = -1;
+                        continue;
+                    }
+
+                    // Exclusive => shared
+                    flock(fd, LOCK_SH | LOCK_NB);
+                    *was_lock_released = true;
+                    return fd;
+                }
+                else
+                {
+                    *was_lock_released = false;
+                }
+            }
+
+            // Lock shared
+            if (0 != flock(fd, LOCK_SH | LOCK_NB))
+            {
+                close(fd);
+                throw std::runtime_error(("failed to lock " + file_path).c_str());
+            }
+        } while (fd == -1);
 
         return fd;
     }

--- a/src/cpp/utils/shared_memory/RobustSharedLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustSharedLock.hpp
@@ -238,7 +238,8 @@ private:
             bool* was_lock_released)
     {
         int fd = -1;
-        do {
+        do
+        {
             fd = open(file_path.c_str(), O_RDONLY, 0);
 
             if (fd != -1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
Since on unix file opening and locking are non-atomic operations (open() system call followed with a flock() call), and [clean.py](https://github.com/eProsima/Fast-DDS/blob/master/tools/fastdds/shm/clean.py) depends on exclusive lockability to in order to decide on zombie file deletion, the following race condition (although rare) exists:

[RobustExclusiveLock.hpp](https://github.com/eProsima/Fast-DDS/blob/master/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp) RobustExclusiveLock::open_and_lock_file calls open() successfully
[clean.py](https://github.com/eProsima/Fast-DDS/blob/master/tools/fastdds/shm/clean.py) opens, successfully locks and deletes the file
[RobustExclusiveLock.hpp](https://github.com/eProsima/Fast-DDS/blob/master/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp) RobustExclusiveLock::open_and_lock_file calls flock() successfully

This leads to the file's creator assuming a successful file creation (the fd is valid and usable), while in reality the file is not accessible anymore since its directory entry has been removed.  A similar situation might be triggered in [obustSharedLock.hpp](https://github.com/eProsima/Fast-DDS/blob/master/src/cpp/utils/shared_memory/RobustSharedLock.hpp).

Verifying the existence of the directory entry with a call to stat() after successfully obtaining the exclusive lock of the file fixes and restarting the open and lock procedure in case the file was removed in between seems to fix the behavior.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
