### PR TITLE
[21696] Fix `SecurityManager` assertion in `Secure DS`

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -946,6 +946,10 @@ bool SecurityManager::on_process_handshake(
                 else
                 {
                     EPROSIMA_LOG_ERROR(SECURITY, "WriterHistory cannot add the CacheChange_t");
+                    // Return the handshake handle
+                    authentication_plugin_->return_handshake_handle(remote_participant_info->handshake_handle_,
+                            exception);
+                    remote_participant_info->handshake_handle_ = nullptr;
                     participant_stateless_message_writer_history_->release_change(change);
                 }
             }
@@ -957,6 +961,9 @@ bool SecurityManager::on_process_handshake(
         }
         else
         {
+            // Return the handshake handle
+            authentication_plugin_->return_handshake_handle(remote_participant_info->handshake_handle_, exception);
+            remote_participant_info->handshake_handle_ = nullptr;
             EPROSIMA_LOG_ERROR(SECURITY, "WriterHistory cannot retrieve a CacheChange_t");
         }
     }

--- a/test/dds/communication/security/CMakeLists.txt
+++ b/test/dds/communication/security/CMakeLists.txt
@@ -390,6 +390,28 @@ if(SECURITY)
                 "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${WIN_PATH}")
         endif()
 
+        add_test(NAME SecureDiscoverServerMultipleClientsHandShakeAssertion
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_secure_ds_pubsub_secure_crypto_communication.py
+            --pub $<TARGET_FILE:CommunicationPublisher>
+            --xml-pub secure_ds_simple_secure_msg_crypto_pub_profile.xml
+            --sub $<TARGET_FILE:CommunicationSubscriber>
+            --xml-sub secure_ds_simple_secure_msg_crypto_sub_profile.xml
+            --samples 100 #not important to receive all samples
+            --servers $<TARGET_FILE:fast-discovery-server>
+            --xml-servers secure_simple_ds_server_profile.xml
+            --n-clients 30
+            --relaunch-clients
+            --validation-method server)
+
+        # Set test with label NoMemoryCheck
+        set_property(TEST SecureDiscoverServerMultipleClientsHandShakeAssertion PROPERTY LABELS "NoMemoryCheck")
+
+        if(WIN32)
+            string(REPLACE ";" "\\;" WIN_PATH "$ENV{PATH}")
+            set_property(TEST SecureDiscoverServerMultipleClientsHandShakeAssertion APPEND PROPERTY ENVIRONMENT
+                "PATH=$<TARGET_FILE_DIR:${PROJECT_NAME}>\\;$<TARGET_FILE_DIR:fastcdr>\\;${WIN_PATH}")
+        endif()
+
     endif()
 
 endif()

--- a/test/dds/communication/security/multiple_secure_ds_pubsub_secure_crypto_communication.py
+++ b/test/dds/communication/security/multiple_secure_ds_pubsub_secure_crypto_communication.py
@@ -18,6 +18,7 @@ import argparse
 import os
 import subprocess
 import sys
+import time
 
 class ParseOptions():
     """Parse arguments."""
@@ -93,9 +94,100 @@ class ParseOptions():
             type=str,
             help='Path to the xml configuration file containing discovery server.'
         )
+        parser.add_argument(
+            '-nc',
+            '--n-clients',
+            type=int,
+            help='Number of pubsub clients to launch (1 of each).'
+        )
+        parser.add_argument(
+            '-rc',
+            '--relaunch-clients',
+            action='store_true',
+            help='Whether to kill clients and relaunch them.'
+        )
+        parser.add_argument(
+            '-vm',
+            '--validation-method',
+            type=str,
+            help='Validation method to use [server, subscriber].'
+        )
 
         return parser.parse_args()
 
+def launch_discovery_server_processes(servers, xml_servers):
+
+    ds_procs = []
+
+    for i in range(0, len(servers)):
+        server_cmd = []
+
+        if not os.path.isfile(servers[i]):
+            print(f'Discovery server executable file does not exists: {servers[i]}')
+            sys.exit(1)
+
+        if not os.access(servers[i], os.X_OK):
+            print(
+                'Discovery server executable does not have execution permissions:'
+                f'{servers[i]}')
+            sys.exit(1)
+
+        server_cmd.append(servers[i])
+        server_cmd.extend(['--xml-file', xml_servers[i]])
+        server_cmd.extend(['--server-id', str(i)])
+
+        ds_proc = subprocess.Popen(server_cmd)
+        print(
+            'Running Discovery Server - commmand:  ',
+            ' '.join(map(str, server_cmd)))
+
+        ds_procs.append(ds_proc)
+
+    return ds_procs
+
+def launch_client_processes(n_clients, pub_command, sub_command):
+
+    pub_procs = []
+    sub_procs = []
+
+    for i in range(0, n_clients):
+        sub_proc = subprocess.Popen(sub_command)
+        print(
+                f'Running Subscriber - commmand:  ',
+                ' '.join(map(str, sub_command)))
+
+        pub_proc = subprocess.Popen(pub_command)
+        print(
+            'Running Publisher - commmand:  ',
+            ' '.join(map(str, pub_command)))
+
+        sub_procs.append(sub_proc)
+        pub_procs.append(pub_proc)
+
+    return sub_procs, pub_procs
+
+def cleanup(pub_procs, sub_procs, ds_procs):
+
+    [sub_proc.kill() for sub_proc in sub_procs]
+    [pub_proc.kill() for pub_proc in pub_procs]
+    [ds_proc.kill() for ds_proc in ds_procs]
+
+def cleanup_clients(pub_procs, sub_procs):
+
+    [sub_proc.kill() for sub_proc in sub_procs]
+    [pub_proc.kill() for pub_proc in pub_procs]
+
+def terminate(ok = True):
+    if ok:
+        try:
+            sys.exit(os.EX_OK)
+        except AttributeError:
+            sys.exit(0)
+    else:
+        try:
+            sys.exit(os.EX_SOFTWARE)
+        except AttributeError:
+            sys.exit(1)
 
 def run(args):
     """
@@ -108,6 +200,8 @@ def run(args):
     """
     pub_command = []
     sub_command = []
+    n_clients = 1
+    relaunch_clients = False
 
     script_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -156,67 +250,48 @@ def run(args):
         pub_command.extend(['--samples', str(args.samples)])
         sub_command.extend(['--samples', str(args.samples)])
 
+    if args.n_clients:
+        n_clients = int(args.n_clients)
+
+    if args.relaunch_clients:
+        relaunch_clients = True
+
     if len(args.servers) != len(args.xml_servers):
         print(
             'Number of servers arguments should be equal to the number of xmls provided.')
         sys.exit(1)
 
-    ds_procs = []
-    for i in range(0, len(args.servers)):
-        server_cmd = []
+    ds_procs = launch_discovery_server_processes(args.servers, args.xml_servers)
 
-        if not os.path.isfile(args.servers[i]):
-            print(f'Discovery server executable file does not exists: {args.servers[i]}')
-            sys.exit(1)
+    sub_procs, pub_procs = launch_client_processes(n_clients, pub_command, sub_command)
 
-        if not os.access(args.servers[i], os.X_OK):
-            print(
-                'Discovery server executable does not have execution permissions:'
-                f'{args.servers[i]}')
-            sys.exit(1)
+    terminate_ok = True
 
-        server_cmd.append(args.servers[i])
-        server_cmd.extend(['--xml-file', args.xml_servers[i]])
-        server_cmd.extend(['--server-id', str(i)])
+    if relaunch_clients:
+        time.sleep(3)
 
-        ds_proc = subprocess.Popen(server_cmd)
-        print(
-            'Running Discovery Server - commmand:  ',
-            ' '.join(map(str, server_cmd)))
+        cleanup_clients(pub_procs, sub_procs)
+        sub_procs, pub_procs = launch_client_processes(n_clients, pub_command, sub_command)
 
-        ds_procs.append(ds_proc)
+        time.sleep(3)
 
-    sub_proc = subprocess.Popen(sub_command)
-    print(
-            f'Running Subscriber - commmand:  ',
-            ' '.join(map(str, sub_command)))
-
-    pub_proc = subprocess.Popen(pub_command)
-    print(
-        'Running Publisher - commmand:  ',
-        ' '.join(map(str, pub_command)))
-
-    try:
-        outs, errs = sub_proc.communicate(timeout=15)
-    except subprocess.TimeoutExpired:
-        print('Subscriber process timed out, terminating...')
-        sub_proc.kill()
-        pub_proc.kill()
-        [ds_proc.kill() for ds_proc in ds_procs]
+    if args.validation_method == 'server':
+        # Check If discovery servers are still running
+        for ds_proc in ds_procs:
+            retcode = ds_proc.poll()
+            if retcode is not None and retcode is not 0:
+                print('Discovery Server process dead, terminating...')
+                terminate_ok = False
+    else:
         try:
-            sys.exit(os.EX_SOFTWARE)
-        except AttributeError:
-            sys.exit(1)
+            for sub_proc in sub_procs:
+                outs, errs = sub_proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            print('Subscriber process timed out, terminating...')
+            terminate_ok = False
 
-
-    pub_proc.kill()
-    ds_proc.kill()
-    [ds_proc.kill() for ds_proc in ds_procs]
-    try:
-        sys.exit(os.EX_OK)
-    except AttributeError:
-        sys.exit(0)
-
+    cleanup(pub_procs, sub_procs, ds_procs)
+    terminate(terminate_ok)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR addresses an assertion triggering in the `SecurityManager` as a consequence of not being able to retrieve a new change for the `participant_stateless_msg_writer`

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
