### PR TITLE
[21841] Extended Incompatible QoS for Monitor Service Feature implementation

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -872,6 +872,14 @@ bool EDP::pairingReader(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && reader->get_listener() != nullptr)
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                auto proxy_observer = mp_PDP->get_proxy_observer();
+                // notify monitor service of a qos incompatibility
+                if (nullptr != proxy_observer)
+                {
+                    proxy_observer->on_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
+                }
+#endif // ifdef FASTDDS_STATISTICS
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -964,6 +972,14 @@ bool EDP::pairingWriter(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && writer->get_listener() != nullptr)
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                auto proxy_observer = mp_PDP->get_proxy_observer();
+                // notify monitor service of a qos incompatibility
+                if (nullptr != proxy_observer)
+                {
+                    proxy_observer->on_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
+                }
+#endif // ifdef FASTDDS_STATISTICS
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -1039,6 +1055,14 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.get_listener() != nullptr)
                         {
                             w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                            auto proxy_observer = mp_PDP->get_proxy_observer();
+                            // notify monitor service of a qos incompatibility
+                            if (nullptr != proxy_observer)
+                            {
+                                proxy_observer->on_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
+                            }
+#endif // ifdef FASTDDS_STATISTICS
                         }
 
                         if (w.matched_reader_is_matched(reader_guid)
@@ -1107,6 +1131,14 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                             w.get_listener() != nullptr)
                             {
                                 w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                                auto proxy_observer = mp_PDP->get_proxy_observer();
+                                // notify monitor service of a qos incompatibility
+                                if (nullptr != proxy_observer)
+                                {
+                                    proxy_observer->on_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
+                                }
+#endif // ifdef FASTDDS_STATISTICS
                             }
 
                             if (w.matched_reader_is_matched(reader_guid)
@@ -1230,6 +1262,14 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.get_listener() != nullptr)
                         {
                             r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                            auto proxy_observer = mp_PDP->get_proxy_observer();
+                            // notify monitor service of a qos incompatibility
+                            if (nullptr != proxy_observer)
+                            {
+                                proxy_observer->on_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
+                            }
+#endif // ifdef FASTDDS_STATISTICS
                         }
 
                         if (r.matched_writer_is_matched(writer_guid)
@@ -1298,6 +1338,14 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                             r.get_listener() != nullptr)
                             {
                                 r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+#ifdef FASTDDS_STATISTICS
+                                auto proxy_observer = mp_PDP->get_proxy_observer();
+                                // notify monitor service of a qos incompatibility
+                                if (nullptr != proxy_observer)
+                                {
+                                    proxy_observer->on_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
+                                }
+#endif // ifdef FASTDDS_STATISTICS
                             }
 
                             if (r.matched_writer_is_matched(writer_guid)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -873,12 +873,7 @@ bool EDP::pairingReader(
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                    auto proxy_observer = mp_PDP->get_proxy_observer();
-                    // notify monitor service of a qos incompatibility
-                    if (nullptr != proxy_observer)
-                    {
-                        proxy_observer->on_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
-                    }
+                    notify_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -973,12 +968,7 @@ bool EDP::pairingWriter(
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                    auto proxy_observer = mp_PDP->get_proxy_observer();
-                    // notify monitor service of a qos incompatibility
-                    if (nullptr != proxy_observer)
-                    {
-                        proxy_observer->on_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
-                    }
+                    notify_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -1056,13 +1046,7 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                         {
                             w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                            auto proxy_observer = mp_PDP->get_proxy_observer();
-                            // notify monitor service of a qos incompatibility
-                            if (nullptr != proxy_observer)
-                            {
-                                proxy_observer->on_incompatible_qos_matching(w.getGuid(), rdata->guid(),
-                                incompatible_qos);
-                            }
+                            notify_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                         }
 
@@ -1133,13 +1117,7 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                             {
                                 w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                                auto proxy_observer = mp_PDP->get_proxy_observer();
-                                // notify monitor service of a qos incompatibility
-                                if (nullptr != proxy_observer)
-                                {
-                                    proxy_observer->on_incompatible_qos_matching(local_writer, rdata.guid(),
-                                    incompatible_qos);
-                                }
+                                notify_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                             }
 
@@ -1265,13 +1243,7 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                         {
                             r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                            auto proxy_observer = mp_PDP->get_proxy_observer();
-                            // notify monitor service of a qos incompatibility
-                            if (nullptr != proxy_observer)
-                            {
-                                proxy_observer->on_incompatible_qos_matching(r.getGuid(), wdata->guid(),
-                                incompatible_qos);
-                            }
+                            notify_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                         }
 
@@ -1342,13 +1314,7 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                             {
                                 r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                                auto proxy_observer = mp_PDP->get_proxy_observer();
-                                // notify monitor service of a qos incompatibility
-                                if (nullptr != proxy_observer)
-                                {
-                                    proxy_observer->on_incompatible_qos_matching(local_reader, wdata.guid(),
-                                    incompatible_qos);
-                                }
+                                notify_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                             }
 
@@ -1423,6 +1389,23 @@ bool EDP::pairing_remote_writer_with_local_reader_after_security(
 }
 
 #endif // if HAVE_SECURITY
+
+#ifdef FASTDDS_STATISTICS
+
+void EDP::notify_incompatible_qos_matching(
+        const GUID_t& local_guid,
+        const GUID_t& remote_guid,
+        const fastdds::dds::PolicyMask& incompatible_qos) const
+{
+    auto proxy_observer = mp_PDP->get_proxy_observer();
+    // notify monitor service of a qos incompatibility
+    if (nullptr != proxy_observer)
+    {
+        proxy_observer->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos);
+    }
+}
+
+#endif // ifdef FASTDDS_STATISTICS
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -873,12 +873,12 @@ bool EDP::pairingReader(
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                auto proxy_observer = mp_PDP->get_proxy_observer();
-                // notify monitor service of a qos incompatibility
-                if (nullptr != proxy_observer)
-                {
-                    proxy_observer->on_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
-                }
+                    auto proxy_observer = mp_PDP->get_proxy_observer();
+                    // notify monitor service of a qos incompatibility
+                    if (nullptr != proxy_observer)
+                    {
+                        proxy_observer->on_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
+                    }
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -973,12 +973,12 @@ bool EDP::pairingWriter(
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                auto proxy_observer = mp_PDP->get_proxy_observer();
-                // notify monitor service of a qos incompatibility
-                if (nullptr != proxy_observer)
-                {
-                    proxy_observer->on_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
-                }
+                    auto proxy_observer = mp_PDP->get_proxy_observer();
+                    // notify monitor service of a qos incompatibility
+                    if (nullptr != proxy_observer)
+                    {
+                        proxy_observer->on_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
+                    }
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -1060,7 +1060,8 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                             // notify monitor service of a qos incompatibility
                             if (nullptr != proxy_observer)
                             {
-                                proxy_observer->on_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
+                                proxy_observer->on_incompatible_qos_matching(w.getGuid(), rdata->guid(),
+                                incompatible_qos);
                             }
 #endif // ifdef FASTDDS_STATISTICS
                         }
@@ -1136,7 +1137,8 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                                 // notify monitor service of a qos incompatibility
                                 if (nullptr != proxy_observer)
                                 {
-                                    proxy_observer->on_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
+                                    proxy_observer->on_incompatible_qos_matching(local_writer, rdata.guid(),
+                                    incompatible_qos);
                                 }
 #endif // ifdef FASTDDS_STATISTICS
                             }
@@ -1267,7 +1269,8 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                             // notify monitor service of a qos incompatibility
                             if (nullptr != proxy_observer)
                             {
-                                proxy_observer->on_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
+                                proxy_observer->on_incompatible_qos_matching(r.getGuid(), wdata->guid(),
+                                incompatible_qos);
                             }
 #endif // ifdef FASTDDS_STATISTICS
                         }
@@ -1343,7 +1346,8 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                                 // notify monitor service of a qos incompatibility
                                 if (nullptr != proxy_observer)
                                 {
-                                    proxy_observer->on_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
+                                    proxy_observer->on_incompatible_qos_matching(local_reader, wdata.guid(),
+                                    incompatible_qos);
                                 }
 #endif // ifdef FASTDDS_STATISTICS
                             }

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -873,7 +873,7 @@ bool EDP::pairingReader(
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                    notify_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
+                    mp_PDP->notify_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -968,7 +968,7 @@ bool EDP::pairingWriter(
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                    notify_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
+                    mp_PDP->notify_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                 }
 
@@ -1046,7 +1046,7 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                         {
                             w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                            notify_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
+                            mp_PDP->notify_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                         }
 
@@ -1117,7 +1117,7 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                             {
                                 w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                                notify_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
+                                mp_PDP->notify_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                             }
 
@@ -1243,7 +1243,7 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                         {
                             r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                            notify_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
+                            mp_PDP->notify_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                         }
 
@@ -1314,7 +1314,7 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                             {
                                 r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
 #ifdef FASTDDS_STATISTICS
-                                notify_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
+                                mp_PDP->notify_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
 #endif // ifdef FASTDDS_STATISTICS
                             }
 
@@ -1389,23 +1389,6 @@ bool EDP::pairing_remote_writer_with_local_reader_after_security(
 }
 
 #endif // if HAVE_SECURITY
-
-#ifdef FASTDDS_STATISTICS
-
-void EDP::notify_incompatible_qos_matching(
-        const GUID_t& local_guid,
-        const GUID_t& remote_guid,
-        const fastdds::dds::PolicyMask& incompatible_qos) const
-{
-    auto proxy_observer = mp_PDP->get_proxy_observer();
-    // notify monitor service of a qos incompatibility
-    if (nullptr != proxy_observer)
-    {
-        proxy_observer->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos);
-    }
-}
-
-#endif // ifdef FASTDDS_STATISTICS
 
 } // namespace rtps
 } // namespace fastdds

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -872,9 +872,7 @@ bool EDP::pairingReader(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && reader->get_listener() != nullptr)
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                     mp_PDP->notify_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -967,9 +965,7 @@ bool EDP::pairingWriter(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && writer->get_listener() != nullptr)
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                     mp_PDP->notify_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -1045,9 +1041,7 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.get_listener() != nullptr)
                         {
                             w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                             mp_PDP->notify_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                         }
 
                         if (w.matched_reader_is_matched(reader_guid)
@@ -1116,9 +1110,7 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                             w.get_listener() != nullptr)
                             {
                                 w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                                 mp_PDP->notify_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                             }
 
                             if (w.matched_reader_is_matched(reader_guid)
@@ -1242,9 +1234,7 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.get_listener() != nullptr)
                         {
                             r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                             mp_PDP->notify_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                         }
 
                         if (r.matched_writer_is_matched(writer_guid)
@@ -1313,9 +1303,7 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                             r.get_listener() != nullptr)
                             {
                                 r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
-#ifdef FASTDDS_STATISTICS
                                 mp_PDP->notify_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
-#endif // ifdef FASTDDS_STATISTICS
                             }
 
                             if (r.matched_writer_is_matched(writer_guid)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -365,6 +365,20 @@ private:
             const WriterProxyData* wdata,
             const ReaderProxyData* rdata) const;
 
+#ifdef FASTDDS_STATISTICS
+    /**
+     * @brief Notify monitor the IProxyObserver implementor about
+     * any incompatible QoS matching between a local and a remote entity.
+     *
+     * @param local_guid GUID of the local entity.
+     * @param remote_guid GUID of the remote entity.
+     * @param incompatible_qos The PolicyMask with the incompatible QoS.
+     */
+    void notify_incompatible_qos_matching(
+            const GUID_t& local_guid,
+            const GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const;
+#endif // ifdef FASTDDS_STATISTICS
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -364,21 +364,6 @@ private:
     bool checkDataRepresentationQos(
             const WriterProxyData* wdata,
             const ReaderProxyData* rdata) const;
-
-#ifdef FASTDDS_STATISTICS
-    /**
-     * @brief Notify monitor the IProxyObserver implementor about
-     * any incompatible QoS matching between a local and a remote entity.
-     *
-     * @param local_guid GUID of the local entity.
-     * @param remote_guid GUID of the remote entity.
-     * @param incompatible_qos The PolicyMask with the incompatible QoS.
-     */
-    void notify_incompatible_qos_matching(
-            const GUID_t& local_guid,
-            const GUID_t& remote_guid,
-            const fastdds::dds::PolicyMask& incompatible_qos) const;
-#endif // ifdef FASTDDS_STATISTICS
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1261,6 +1261,19 @@ void PDP::set_proxy_observer(
     proxy_observer_.store(proxy_observer);
 }
 
+void PDP::notify_incompatible_qos_matching(
+        const GUID_t& local_guid,
+        const GUID_t& remote_guid,
+        const fastdds::dds::PolicyMask& incompatible_qos) const
+{
+    auto proxy_observer = get_proxy_observer();
+    // Notify the IProxyObserver implementor of a qos incompatibility
+    if (nullptr != proxy_observer)
+    {
+        proxy_observer->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos);
+    }
+}
+
 #endif // FASTDDS_STATISTICS
 
 bool PDP::remove_remote_participant(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -808,6 +808,15 @@ bool PDP::removeReaderProxyData(
                     listener->on_reader_discovery(participant, reason, info, should_be_ignored);
                 }
 
+#ifdef FASTDDS_STATISTICS
+                auto proxy_observer = get_proxy_observer();
+                // notify monitor service
+                if (nullptr != proxy_observer)
+                {
+                    proxy_observer->on_remote_proxy_data_removed(pR->guid());
+                }
+#endif // ifdef FASTDDS_STATISTICS
+
                 // Clear reader proxy data and move to pool in order to allow reuse
                 pR->clear();
                 pit->m_readers->erase(rit);
@@ -847,6 +856,15 @@ bool PDP::removeWriterProxyData(
                     from_proxy_to_builtin(*pW, info);
                     listener->on_writer_discovery(participant, status, info, should_be_ignored);
                 }
+
+#ifdef FASTDDS_STATISTICS
+                auto proxy_observer = get_proxy_observer();
+                // notify monitor service
+                if (nullptr != get_proxy_observer())
+                {
+                    proxy_observer->on_remote_proxy_data_removed(pW->guid());
+                }
+#endif // ifdef FASTDDS_STATISTICS
 
                 // Clear writer proxy data and move to pool in order to allow reuse
                 pW->clear();

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1261,19 +1261,6 @@ void PDP::set_proxy_observer(
     proxy_observer_.store(proxy_observer);
 }
 
-void PDP::notify_incompatible_qos_matching(
-        const GUID_t& local_guid,
-        const GUID_t& remote_guid,
-        const fastdds::dds::PolicyMask& incompatible_qos) const
-{
-    auto proxy_observer = get_proxy_observer();
-    // Notify the IProxyObserver implementor of a qos incompatibility
-    if (nullptr != proxy_observer)
-    {
-        proxy_observer->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos);
-    }
-}
-
 #endif // FASTDDS_STATISTICS
 
 bool PDP::remove_remote_participant(
@@ -1775,6 +1762,25 @@ void PDP::local_participant_attributes_update_nts(
                 new_atts.builtin.metatraffic_external_unicast_locators,
                 new_atts.default_external_unicast_locators);
     }
+}
+
+void PDP::notify_incompatible_qos_matching(
+        const GUID_t& local_guid,
+        const GUID_t& remote_guid,
+        const fastdds::dds::PolicyMask& incompatible_qos) const
+{
+#ifdef FASTDDS_STATISTICS
+    auto proxy_observer = get_proxy_observer();
+    // Notify the IProxyObserver implementor of a qos incompatibility
+    if (nullptr != proxy_observer)
+    {
+        proxy_observer->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos);
+    }
+#else
+    static_cast<void>(local_guid);
+    static_cast<void>(remote_guid);
+    static_cast<void>(incompatible_qos);
+#endif // FASTDDS_STATISTICS
 }
 
 void PDP::update_endpoint_locators_if_default_nts(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -475,19 +475,6 @@ public:
         return proxy_observer_.load();
     }
 
-    /**
-     * @brief Notify monitor the IProxyObserver implementor about
-     * any incompatible QoS matching between a local and a remote entity.
-     *
-     * @param local_guid GUID of the local entity.
-     * @param remote_guid GUID of the remote entity.
-     * @param incompatible_qos The PolicyMask with the incompatible QoS.
-     */
-    void notify_incompatible_qos_matching(
-            const GUID_t& local_guid,
-            const GUID_t& remote_guid,
-            const fastdds::dds::PolicyMask& incompatible_qos) const;
-
 #else
     bool get_all_local_proxies(
             std::vector<GUID_t>&) override
@@ -512,6 +499,19 @@ public:
             const std::vector<BaseReader*>& readers,
             const RTPSParticipantAttributes& old_atts,
             const RTPSParticipantAttributes& new_atts);
+
+    /**
+     * @brief Notify monitor the IProxyObserver implementor about
+     * any incompatible QoS matching between a local and a remote entity.
+     *
+     * @param local_guid GUID of the local entity.
+     * @param remote_guid GUID of the remote entity.
+     * @param incompatible_qos The PolicyMask with the incompatible QoS.
+     */
+    void notify_incompatible_qos_matching(
+            const GUID_t& local_guid,
+            const GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const;
 
 protected:
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -470,10 +470,23 @@ public:
     void set_proxy_observer(
             const fastdds::statistics::rtps::IProxyObserver* proxy_observer);
 
-    const fastdds::statistics::rtps::IProxyObserver* get_proxy_observer()
+    const fastdds::statistics::rtps::IProxyObserver* get_proxy_observer() const
     {
         return proxy_observer_.load();
     }
+
+    /**
+     * @brief Notify monitor the IProxyObserver implementor about
+     * any incompatible QoS matching between a local and a remote entity.
+     *
+     * @param local_guid GUID of the local entity.
+     * @param remote_guid GUID of the remote entity.
+     * @param incompatible_qos The PolicyMask with the incompatible QoS.
+     */
+    void notify_incompatible_qos_matching(
+            const GUID_t& local_guid,
+            const GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const;
 
 #else
     bool get_all_local_proxies(

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
@@ -589,6 +589,123 @@ bool MonitorService::spin_queue()
     return re_schedule;
 }
 
+bool MonitorService::on_incompatible_qos_matching(
+        const fastdds::rtps::GUID_t& local_guid,
+        const fastdds::rtps::GUID_t& remote_guid,
+        const fastdds::dds::PolicyMask& incompatible_qos_policies)
+{
+    bool ret = true;
+
+    // Convert the PolicyMask to a vector of policy ids
+    std::vector<uint32_t> incompatible_policies;
+    for (uint32_t id = 1; id < dds::NEXT_QOS_POLICY_ID; ++id)
+    {
+        if (incompatible_qos_policies.test(id))
+        {
+            incompatible_policies.push_back(id);
+        }
+    }
+
+    std::lock_guard<std::mutex> lock(extended_incompatible_qos_mtx_);
+
+    if (!incompatible_policies.empty())
+    {
+        // Check if the local_guid is already in the collection. If not, create a new entry
+        auto local_entity_incompatibilites =
+                extended_incompatible_qos_collection_.insert({local_guid, {}});
+
+        bool first_incompatibility_with_remote = false;
+
+        // Local entity already in the collection (has any incompatible QoS with any remote entity)
+        if (!local_entity_incompatibilites.second)
+        {
+            // Check if the local entitiy already had an incompatibility with this remote entity
+            auto it = std::find_if(
+                local_entity_incompatibilites.first->second.begin(),
+                local_entity_incompatibilites.first->second.end(),
+                [&remote_guid](const ExtendedIncompatibleQoSStatus_s& status)
+                {
+                    return to_fastdds_type(status.remote_guid()) == remote_guid;
+                });
+
+            if (it == local_entity_incompatibilites.first->second.end())
+            {
+                // First incompatibility with that remote entity
+                first_incompatibility_with_remote = true;
+            }
+            else
+            {
+                // Already had an incompatibility with that remote entity.
+                // Update them
+                it->current_incompatible_policies(incompatible_policies);
+                push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+            }
+        }
+        else
+        {
+            // This will be the first incompatibility of this entity
+            first_incompatibility_with_remote = true;
+        }
+
+        if (first_incompatibility_with_remote)
+        {
+            ExtendedIncompatibleQoSStatus_s status;
+            status.remote_guid(to_statistics_type(remote_guid));
+            status.current_incompatible_policies(incompatible_policies);
+            local_entity_incompatibilites.first->second.emplace_back(status);
+            push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+        }
+    }
+    else
+    {
+        // Remove remote guid from the local guid incompatibilities collection
+        auto it = extended_incompatible_qos_collection_.find(local_guid);
+
+        if (it != extended_incompatible_qos_collection_.end())
+        {
+            auto it_remote = std::find_if(
+                it->second.begin(),
+                it->second.end(),
+                [&remote_guid](const ExtendedIncompatibleQoSStatus_s& status)
+                {
+                    return to_fastdds_type(status.remote_guid()) == remote_guid;
+                });
+
+            if (it_remote != it->second.end())
+            {
+                it->second.erase(it_remote);
+                push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+            }
+        }
+    }
+    return ret;
+}
+
+bool MonitorService::on_remote_proxy_data_removed(
+        const fastdds::rtps::GUID_t& removed_proxy_guid)
+{
+    auto& ext_incompatible_qos_collection = extended_incompatible_qos_collection_;
+    std::lock_guard<std::mutex> lock(extended_incompatible_qos_mtx_);
+
+    for (auto& local_entity : ext_incompatible_qos_collection)
+    {
+        auto it = std::find_if(
+            local_entity.second.begin(),
+            local_entity.second.end(),
+            [&removed_proxy_guid](const ExtendedIncompatibleQoSStatus_s& status)
+            {
+                return to_fastdds_type(status.remote_guid()) == removed_proxy_guid;
+            });
+
+        if (it != local_entity.second.end())
+        {
+            local_entity.second.erase(it);
+            push_entity_update(local_entity.first.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+        }
+    }
+    return false;
+}
+
 } // namespace rtps
 } // namespace statistics
 } // namespace fastdds

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.cpp
@@ -589,13 +589,11 @@ bool MonitorService::spin_queue()
     return re_schedule;
 }
 
-bool MonitorService::on_incompatible_qos_matching(
+void MonitorService::on_incompatible_qos_matching(
         const fastdds::rtps::GUID_t& local_guid,
         const fastdds::rtps::GUID_t& remote_guid,
         const fastdds::dds::PolicyMask& incompatible_qos_policies)
 {
-    bool ret = true;
-
     // Convert the PolicyMask to a vector of policy ids
     std::vector<uint32_t> incompatible_policies;
     for (uint32_t id = 1; id < dds::NEXT_QOS_POLICY_ID; ++id)
@@ -678,10 +676,9 @@ bool MonitorService::on_incompatible_qos_matching(
             }
         }
     }
-    return ret;
 }
 
-bool MonitorService::on_remote_proxy_data_removed(
+void MonitorService::on_remote_proxy_data_removed(
         const fastdds::rtps::GUID_t& removed_proxy_guid)
 {
     auto& ext_incompatible_qos_collection = extended_incompatible_qos_collection_;
@@ -703,7 +700,6 @@ bool MonitorService::on_remote_proxy_data_removed(
             push_entity_update(local_entity.first.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
         }
     }
-    return false;
 }
 
 } // namespace rtps

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -71,8 +71,6 @@ class MonitorService
 {
     static constexpr int MIN_TIME_BETWEEN_PUBS_MS = 500;
 
-    friend class MonitorServiceListener;
-
 public:
 
     using endpoint_creator_t = std::function<bool (fastdds::rtps::RTPSWriter**,
@@ -161,6 +159,17 @@ public:
     bool push_entity_update(
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
+
+    inline std::map<fastdds::rtps::GUID_t,
+            ExtendedIncompatibleQoSStatusSeq_s>& get_extended_incompatible_qos_collection()
+    {
+        return extended_incompatible_qos_collection_;
+    }
+
+    inline std::mutex& get_extended_incompatible_qos_mtx()
+    {
+        return extended_incompatible_qos_mtx_;
+    }
 
 private:
 

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -71,6 +71,8 @@ class MonitorService
 {
     static constexpr int MIN_TIME_BETWEEN_PUBS_MS = 500;
 
+    friend class MonitorServiceListener;
+
 public:
 
     using endpoint_creator_t = std::function<bool (fastdds::rtps::RTPSWriter**,
@@ -257,6 +259,13 @@ private:
     endpoint_registrator_t endpoint_registrator_;
 
     MonitorServiceStatusDataPubSubType type_;
+
+    // Stores the current extended incompatible qos status
+    // of local entities with remote entities and their policies.
+    std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
+        extended_incompatible_qos_collection_;
+
+    std::mutex extended_incompatible_qos_mtx_;
 };
 
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -263,7 +263,7 @@ private:
     // Stores the current extended incompatible qos status
     // of local entities with remote entities and their policies.
     std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
-        extended_incompatible_qos_collection_;
+    extended_incompatible_qos_collection_;
 
     std::mutex extended_incompatible_qos_mtx_;
 };

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -168,21 +168,20 @@ public:
      * @param remote_guid The GUID_t identifying the remote entity
      * @param incompatible_qos The PolicyMask with the incompatible QoS
      *
-     * @return Whether processing was successful.
      */
-    bool on_incompatible_qos_matching(
+    void on_incompatible_qos_matching(
             const fastdds::rtps::GUID_t& local_guid,
             const fastdds::rtps::GUID_t& remote_guid,
             const fastdds::dds::PolicyMask& incompatible_qos_policies);
 
     /**
-     * @brief Notifies that a remote proxy
-     * data has been removed. This is interesting to notify proxy removals
-     * independently of the the remote entity being matched or not.
+     * @brief Notifies that a remote proxy data has been removed.
+     * This is interesting to notify proxy removals independently
+     * of the remote entity being matched or not.
      *
-     * @return Wheter the operation was successful.
+     * @param removed_proxy_guid GUID of the removed proxy.
      */
-    bool on_remote_proxy_data_removed(
+    void on_remote_proxy_data_removed(
             const fastdds::rtps::GUID_t& removed_proxy_guid);
 
 private:

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -160,16 +160,30 @@ public:
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
 
-    inline std::map<fastdds::rtps::GUID_t,
-            ExtendedIncompatibleQoSStatusSeq_s>& get_extended_incompatible_qos_collection()
-    {
-        return extended_incompatible_qos_collection_;
-    }
+    /**
+     * @brief Process any updates regarding
+     * remote entities incompatible QoS matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     * @return Whether processing was successful.
+     */
+    bool on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos_policies);
 
-    inline std::mutex& get_extended_incompatible_qos_mtx()
-    {
-        return extended_incompatible_qos_mtx_;
-    }
+    /**
+     * @brief Notifies that a remote proxy
+     * data has been removed. This is interesting to notify proxy removals
+     * independently of the the remote entity being matched or not.
+     *
+     * @return Wheter the operation was successful.
+     */
+    bool on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid);
 
 private:
 

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
@@ -87,32 +87,24 @@ void MonitorServiceListener::on_writer_change_received_by_all(
     static_cast<void>(change);
 }
 
-bool MonitorServiceListener::on_incompatible_qos_matching(
+void MonitorServiceListener::on_incompatible_qos_matching(
         const fastdds::rtps::GUID_t& local_guid,
         const fastdds::rtps::GUID_t& remote_guid,
         const fastdds::dds::PolicyMask& incompatible_qos_policies) const
 {
-    bool ret = false;
-
     if (monitor_srv_)
     {
-        ret = monitor_srv_->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos_policies);
+        monitor_srv_->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos_policies);
     }
-
-    return ret;
 }
 
-bool MonitorServiceListener::on_remote_proxy_data_removed(
+void MonitorServiceListener::on_remote_proxy_data_removed(
         const fastdds::rtps::GUID_t& removed_proxy_guid) const
 {
-    bool ret = false;
-
     if (monitor_srv_)
     {
-        ret = monitor_srv_->on_remote_proxy_data_removed(removed_proxy_guid);
+        monitor_srv_->on_remote_proxy_data_removed(removed_proxy_guid);
     }
-
-    return ret;
 }
 
 } // namespace rtps

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
@@ -92,93 +92,11 @@ bool MonitorServiceListener::on_incompatible_qos_matching(
         const fastdds::rtps::GUID_t& remote_guid,
         const fastdds::dds::PolicyMask& incompatible_qos_policies) const
 {
-    bool ret = true;
-
-    // Convert the PolicyMask to a vector of policy ids
-    std::vector<uint32_t> incompatible_policies;
-    for (uint32_t id = 1; id < dds::NEXT_QOS_POLICY_ID; ++id)
-    {
-        if (incompatible_qos_policies.test(id))
-        {
-            incompatible_policies.push_back(id);
-        }
-    }
+    bool ret = false;
 
     if (monitor_srv_)
     {
-        auto& ext_incompatible_qos_collection = monitor_srv_->get_extended_incompatible_qos_collection();
-        std::lock_guard<std::mutex> lock(monitor_srv_->get_extended_incompatible_qos_mtx());
-
-        if (!incompatible_policies.empty())
-        {
-            // Check if the local_guid is already in the collection. If not, create a new entry
-            auto local_entity_incompatibilites =
-                    ext_incompatible_qos_collection.insert({local_guid, {}});
-
-            bool first_incompatibility_with_remote = false;
-
-            // Local entity already in the collection (has any incompatible QoS with any remote entity)
-            if (!local_entity_incompatibilites.second)
-            {
-                // Check if the local entitiy already had an incompatibility with this remote entity
-                auto it = std::find_if(
-                    local_entity_incompatibilites.first->second.begin(),
-                    local_entity_incompatibilites.first->second.end(),
-                    [&remote_guid](const ExtendedIncompatibleQoSStatus_s& status)
-                    {
-                        return to_fastdds_type(status.remote_guid()) == remote_guid;
-                    });
-
-                if (it == local_entity_incompatibilites.first->second.end())
-                {
-                    // First incompatibility with that remote entity
-                    first_incompatibility_with_remote = true;
-                }
-                else
-                {
-                    // Already had an incompatibility with that remote entity.
-                    // Update them
-                    it->current_incompatible_policies(incompatible_policies);
-                    monitor_srv_->push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
-                }
-            }
-            else
-            {
-                // This will be the first incompatibility of this entity
-                first_incompatibility_with_remote = true;
-            }
-
-            if (first_incompatibility_with_remote)
-            {
-                ExtendedIncompatibleQoSStatus_s status;
-                status.remote_guid(to_statistics_type(remote_guid));
-                status.current_incompatible_policies(incompatible_policies);
-                local_entity_incompatibilites.first->second.emplace_back(status);
-                monitor_srv_->push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
-            }
-        }
-        else
-        {
-            // Remove remote guid from the local guid incompatibilities collection
-            auto it = ext_incompatible_qos_collection.find(local_guid);
-
-            if (it != ext_incompatible_qos_collection.end())
-            {
-                auto it_remote = std::find_if(
-                    it->second.begin(),
-                    it->second.end(),
-                    [&remote_guid](const ExtendedIncompatibleQoSStatus_s& status)
-                    {
-                        return to_fastdds_type(status.remote_guid()) == remote_guid;
-                    });
-
-                if (it_remote != it->second.end())
-                {
-                    it->second.erase(it_remote);
-                    monitor_srv_->push_entity_update(local_guid.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
-                }
-            }
-        }
+        ret = monitor_srv_->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos_policies);
     }
 
     return ret;
@@ -187,26 +105,14 @@ bool MonitorServiceListener::on_incompatible_qos_matching(
 bool MonitorServiceListener::on_remote_proxy_data_removed(
         const fastdds::rtps::GUID_t& removed_proxy_guid) const
 {
-    auto& ext_incompatible_qos_collection = monitor_srv_->get_extended_incompatible_qos_collection();
-    std::lock_guard<std::mutex> lock(monitor_srv_->get_extended_incompatible_qos_mtx());
+    bool ret = false;
 
-    for (auto& local_entity : ext_incompatible_qos_collection)
+    if (monitor_srv_)
     {
-        auto it = std::find_if(
-            local_entity.second.begin(),
-            local_entity.second.end(),
-            [&removed_proxy_guid](const ExtendedIncompatibleQoSStatus_s& status)
-            {
-                return to_fastdds_type(status.remote_guid()) == removed_proxy_guid;
-            });
-
-        if (it != local_entity.second.end())
-        {
-            local_entity.second.erase(it);
-            monitor_srv_->push_entity_update(local_entity.first.entityId, StatusKind::EXTENDED_INCOMPATIBLE_QOS);
-        }
+        ret = monitor_srv_->on_remote_proxy_data_removed(removed_proxy_guid);
     }
-    return false;
+
+    return ret;
 }
 
 } // namespace rtps

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
@@ -64,12 +64,12 @@ public:
             fastdds::rtps::RTPSWriter* writer,
             fastdds::rtps::CacheChange_t* change) override;
 
-    bool on_incompatible_qos_matching(
+    void on_incompatible_qos_matching(
             const fastdds::rtps::GUID_t& local_guid,
             const fastdds::rtps::GUID_t& remote_guid,
             const fastdds::dds::PolicyMask& incompatible_qos) const override;
 
-    bool on_remote_proxy_data_removed(
+    void on_remote_proxy_data_removed(
             const fastdds::rtps::GUID_t& removed_proxy_guid) const override;
 
 protected:

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
@@ -64,6 +64,14 @@ public:
             fastdds::rtps::RTPSWriter* writer,
             fastdds::rtps::CacheChange_t* change) override;
 
+    bool on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const override;
+
+    bool on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid) const override;
+
 protected:
 
     MonitorService* monitor_srv_;

--- a/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
@@ -51,9 +51,8 @@ struct IProxyObserver
      * @param remote_guid The GUID_t identifying the remote entity
      * @param incompatible_qos The PolicyMask with the incompatible QoS
      *
-     * @return Whether the implementor has been properly notified
      */
-    virtual bool on_incompatible_qos_matching(
+    virtual void on_incompatible_qos_matching(
             const fastdds::rtps::GUID_t& local_guid,
             const fastdds::rtps::GUID_t& remote_guid,
             const fastdds::dds::PolicyMask& incompatible_qos) const = 0;
@@ -63,9 +62,9 @@ struct IProxyObserver
      * data has been removed. This is interesting to notify proxy removals
      * independently of the the remote entity being matched or not.
      *
-     * @return If the operation has been properly notified.
+     * @param removed_proxy_guid GUID of the removed proxy.
      */
-    virtual bool on_remote_proxy_data_removed(
+    virtual void on_remote_proxy_data_removed(
             const fastdds::rtps::GUID_t& removed_proxy_guid) const = 0;
 };
 

--- a/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
@@ -20,10 +20,12 @@
 #ifndef _FASTDDS_STATISTICS_MONITOR_SERVICE_INTERFACES_IPROXYOBSERVER_HPP_
 #define _FASTDDS_STATISTICS_MONITOR_SERVICE_INTERFACES_IPROXYOBSERVER_HPP_
 
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 
 namespace eprosima {
 namespace fastdds {
+
 namespace statistics {
 namespace rtps {
 
@@ -41,6 +43,31 @@ struct IProxyObserver
     virtual bool on_local_entity_change(
             const fastdds::rtps::GUID_t& guid,
             bool is_alive) const = 0;
+
+    /**
+     * @brief Interface use to notify about any updates
+     * against remote entities incompatible qos matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     * @return Whether the implementor has been properly notified
+     */
+    virtual bool on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const = 0;
+
+    /**
+     * @brief Method to notify the implementor that a remote proxy
+     * data has been removed. This is interesting to notify proxy removals
+     * independently of the the remote entity being matched or not.
+     *
+     * @return If the operation has been properly notified.
+     */
+    virtual bool on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid) const = 0;
 };
 
 } // rtps

--- a/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
@@ -25,14 +25,13 @@
 
 namespace eprosima {
 namespace fastdds {
-
 namespace statistics {
 namespace rtps {
 
 struct IProxyObserver
 {
     /**
-     * @brief Interface use to notify about any updates
+     * @brief Interface used to notify about any updates
      * on the local entities (updates in the proxy,
      * new matches, unpairs,...)
      *
@@ -45,8 +44,8 @@ struct IProxyObserver
             bool is_alive) const = 0;
 
     /**
-     * @brief Interface use to notify about any updates
-     * against remote entities incompatible qos matching.
+     * @brief Interface used to notify about any updates
+     * regarding remote entities incompatible QoS matching.
      *
      * @param local_guid The GUID_t identifying the local entity
      * @param remote_guid The GUID_t identifying the remote entity

--- a/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
@@ -68,6 +68,10 @@ public:
 
 #ifdef FASTDDS_STATISTICS
     MOCK_METHOD0(get_proxy_observer, const fastdds::statistics::rtps::IProxyObserver*());
+    MOCK_METHOD3(notify_incompatible_qos_matching,
+            void (const GUID_t&,
+            const GUID_t&,
+            const fastdds::dds::PolicyMask&));
 #endif // FASTDDS_STATISTICS
 
     MOCK_METHOD1(assignRemoteEndpoints, void(

--- a/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
@@ -68,10 +68,6 @@ public:
 
 #ifdef FASTDDS_STATISTICS
     MOCK_METHOD0(get_proxy_observer, const fastdds::statistics::rtps::IProxyObserver*());
-    MOCK_METHOD3(notify_incompatible_qos_matching,
-            void (const GUID_t&,
-            const GUID_t&,
-            const fastdds::dds::PolicyMask&));
 #endif // FASTDDS_STATISTICS
 
     MOCK_METHOD1(assignRemoteEndpoints, void(
@@ -92,6 +88,11 @@ public:
             const GUID_t& writer_guid,
             GUID_t& participant_guid,
             std::function<bool(WriterProxyData*, bool, const ParticipantProxyData&)> initializer_func));
+
+    MOCK_METHOD3(notify_incompatible_qos_matching,
+            void (const GUID_t&,
+            const GUID_t&,
+            const fastdds::dds::PolicyMask&));
 
     MOCK_METHOD2(lookupReaderProxyData, bool(
             const GUID_t& reader,

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/StatisticsBase.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/StatisticsBase.hpp
@@ -25,6 +25,8 @@
 #include <set>
 
 #include <fastdds/config.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/Locator.hpp>
 
 #include <statistics/types/types.hpp>
 
@@ -35,25 +37,25 @@ namespace statistics {
 #ifdef FASTDDS_STATISTICS
 
 // auxiliary conversion functions
-detail::Locator_s to_statistics_type(
+inline detail::Locator_s to_statistics_type(
         fastdds::rtps::Locator_t locator)
 {
     return *reinterpret_cast<detail::Locator_s*>(&locator);
 }
 
-fastdds::rtps::Locator_t to_fastdds_type(
+inline fastdds::rtps::Locator_t to_fastdds_type(
         detail::Locator_s locator)
 {
     return *reinterpret_cast<fastdds::rtps::Locator_t*>(&locator);
 }
 
-detail::GUID_s to_statistics_type(
+inline detail::GUID_s to_statistics_type(
         fastdds::rtps::GUID_t guid)
 {
     return *reinterpret_cast<detail::GUID_s*>(&guid);
 }
 
-fastdds::rtps::GUID_t to_fastdds_type(
+inline fastdds::rtps::GUID_t to_fastdds_type(
         detail::GUID_s guid)
 {
     return *reinterpret_cast<fastdds::rtps::GUID_t*>(&guid);

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -58,6 +58,8 @@ class MonitorService
 {
     static constexpr int MIN_TIME_BETWEEN_PUBS_MS = 500;
 
+    friend class MonitorServiceListener;
+
 public:
 
     using endpoint_creator_t = std::function<bool (fastdds::rtps::RTPSWriter**,
@@ -261,6 +263,11 @@ private:
     endpoint_registrator_t endpoint_registrator_;
 
     MonitorServiceStatusDataPubSubType type_;
+
+    std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
+        extended_incompatible_qos_collection_;
+
+    std::mutex extended_incompatible_qos_mtx_;
 };
 
 #endif // FASTDDS_STATISTICS

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -166,16 +166,30 @@ public:
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
 
-    inline std::map<fastdds::rtps::GUID_t,
-            ExtendedIncompatibleQoSStatusSeq_s>& get_extended_incompatible_qos_collection()
-    {
-        return extended_incompatible_qos_collection_;
-    }
+    /**
+     * @brief Process any updates regarding
+     * remote entities incompatible QoS matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     * @return Whether processing was successful.
+     */
+    bool on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos_policies);
 
-    inline std::mutex& get_extended_incompatible_qos_mtx()
-    {
-        return extended_incompatible_qos_mtx_;
-    }
+    /**
+     * @brief Notifies that a remote proxy
+     * data has been removed. This is interesting to notify proxy removals
+     * independently of the the remote entity being matched or not.
+     *
+     * @return Wheter the operation was successful.
+     */
+    bool on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid);
 
 private:
 

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -265,7 +265,7 @@ private:
     MonitorServiceStatusDataPubSubType type_;
 
     std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
-        extended_incompatible_qos_collection_;
+    extended_incompatible_qos_collection_;
 
     std::mutex extended_incompatible_qos_mtx_;
 };

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -174,21 +174,20 @@ public:
      * @param remote_guid The GUID_t identifying the remote entity
      * @param incompatible_qos The PolicyMask with the incompatible QoS
      *
-     * @return Whether processing was successful.
      */
-    bool on_incompatible_qos_matching(
+    void on_incompatible_qos_matching(
             const fastdds::rtps::GUID_t& local_guid,
             const fastdds::rtps::GUID_t& remote_guid,
             const fastdds::dds::PolicyMask& incompatible_qos_policies);
 
     /**
-     * @brief Notifies that a remote proxy
-     * data has been removed. This is interesting to notify proxy removals
-     * independently of the the remote entity being matched or not.
+     * @brief Notifies that a remote proxy data has been removed.
+     * This is interesting to notify proxy removals independently
+     * of the remote entity being matched or not.
      *
-     * @return Wheter the operation was successful.
+     * @param removed_proxy_guid GUID of the removed proxy.
      */
-    bool on_remote_proxy_data_removed(
+    void on_remote_proxy_data_removed(
             const fastdds::rtps::GUID_t& removed_proxy_guid);
 
 private:

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -166,6 +166,17 @@ public:
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
 
+    inline std::map<fastdds::rtps::GUID_t,
+            ExtendedIncompatibleQoSStatusSeq_s>& get_extended_incompatible_qos_collection()
+    {
+        return extended_incompatible_qos_collection_;
+    }
+
+    inline std::mutex& get_extended_incompatible_qos_mtx()
+    {
+        return extended_incompatible_qos_mtx_;
+    }
+
 private:
 
     /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR brings the feature implementation of the `extended incompatible qos` for the monitor service.
This PR must be merged after.

* #5294 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
   - Related documentation PR: eProsima/Fast-DDS-docs#945
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
