### PR TITLE
[21959] Check if `SHM` transport is disabled in `LARGE_DATA` modes

### DIFF
--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -217,6 +217,23 @@ static void setup_transports_udpv6(
     att.userTransports.push_back(descriptor);
 }
 
+static void setup_large_data_shm_transport(
+        RTPSParticipantAttributes& att,
+        const fastdds::rtps::BuiltinTransportsOptions& options)
+{
+#ifdef FASTDDS_SHM_TRANSPORT_DISABLED
+    static_cast<void>(att);
+    EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Trying to configure Large Data transport, " <<
+            "but Fast DDS was built without SHM transport support.");
+#else
+    auto descriptor = create_shm_transport(att, options);
+    att.userTransports.push_back(descriptor);
+
+    auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
+    att.defaultUnicastLocatorList.push_back(shm_loc);
+#endif  // FASTDDS_SHM_TRANSPORT_DISABLED
+}
+
 static void setup_transports_large_data(
         RTPSParticipantAttributes& att,
         bool intraprocess_only,
@@ -224,10 +241,7 @@ static void setup_transports_large_data(
 {
     if (!intraprocess_only)
     {
-        setup_transports_shm(att, options);
-
-        auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
-        att.defaultUnicastLocatorList.push_back(shm_loc);
+        setup_large_data_shm_transport(att, options);
 
         auto tcp_transport = create_tcpv4_transport(att, options);
         att.userTransports.push_back(tcp_transport);
@@ -260,10 +274,7 @@ static void setup_transports_large_datav6(
 {
     if (!intraprocess_only)
     {
-        setup_transports_shm(att, options);
-
-        auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
-        att.defaultUnicastLocatorList.push_back(shm_loc);
+        setup_large_data_shm_transport(att, options);
 
         auto tcp_transport = create_tcpv6_transport(att, options);
         att.userTransports.push_back(tcp_transport);

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -224,8 +224,7 @@ static void setup_transports_large_data(
 {
     if (!intraprocess_only)
     {
-        auto shm_transport = create_shm_transport(att, options);
-        att.userTransports.push_back(shm_transport);
+        setup_transports_shm(att, options);
 
         auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
         att.defaultUnicastLocatorList.push_back(shm_loc);
@@ -261,8 +260,7 @@ static void setup_transports_large_datav6(
 {
     if (!intraprocess_only)
     {
-        auto shm_transport = create_shm_transport(att, options);
-        att.userTransports.push_back(shm_transport);
+        setup_transports_shm(att, options);
 
         auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);
         att.defaultUnicastLocatorList.push_back(shm_loc);

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -224,7 +224,8 @@ static void setup_large_data_shm_transport(
 #ifdef FASTDDS_SHM_TRANSPORT_DISABLED
     static_cast<void>(att);
     EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Trying to configure Large Data transport, " <<
-            "but Fast DDS was built without SHM transport support.");
+            "but Fast DDS was built without SHM transport support. Will use " <<
+            "TCP for communications on the same host.");
 #else
     auto descriptor = create_shm_transport(att, options);
     att.userTransports.push_back(descriptor);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Compilation with `FASTDDS_SHM_TRANSPORT_DISABLED` should properly manage the shm transport in `LARGE_DATA` modes.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
 @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
