### PR TITLE
[22024] Improve `OpenSSL` lifecycle handling

### DIFF
--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -31,6 +31,7 @@
 
 #include <rtps/reader/BaseReader.hpp>
 #include <rtps/reader/LocalReaderPointer.hpp>
+#include <security/OpenSSLInit.hpp>
 #include <rtps/writer/BaseWriter.hpp>
 #include <utils/shared_memory/BoostAtExitRegistry.hpp>
 #include <utils/SystemInfo.hpp>
@@ -285,6 +286,8 @@ private:
     std::shared_ptr<eprosima::detail::BoostAtExitRegistry> boost_singleton_handler_ { eprosima::detail::
                                                                                               BoostAtExitRegistry::
                                                                                               get_instance() };
+
+    std::shared_ptr<security::OpenSSLInit> openssl_singleton_handler_{ security::OpenSSLInit::get_instance() };
 
     std::mutex m_mutex;
 

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -31,10 +31,13 @@
 
 #include <rtps/reader/BaseReader.hpp>
 #include <rtps/reader/LocalReaderPointer.hpp>
-#include <security/OpenSSLInit.hpp>
 #include <rtps/writer/BaseWriter.hpp>
 #include <utils/shared_memory/BoostAtExitRegistry.hpp>
 #include <utils/SystemInfo.hpp>
+
+#if HAVE_SECURITY
+#include <security/OpenSSLInit.hpp>
+#endif // HAVE_SECURITY
 
 #include <fastdds/xtypes/type_representation/TypeObjectRegistry.hpp>
 
@@ -286,8 +289,9 @@ private:
     std::shared_ptr<eprosima::detail::BoostAtExitRegistry> boost_singleton_handler_ { eprosima::detail::
                                                                                               BoostAtExitRegistry::
                                                                                               get_instance() };
-
+#if HAVE_SECURITY
     std::shared_ptr<security::OpenSSLInit> openssl_singleton_handler_{ security::OpenSSLInit::get_instance() };
+#endif // HAVE_SECURITY
 
     std::mutex m_mutex;
 

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -106,7 +106,6 @@ SecurityManager::SecurityManager(
                 participant->get_attributes().allocation.data_limits})
 {
     assert(participant != nullptr);
-    static OpenSSLInit openssl_init;
 }
 
 SecurityManager::~SecurityManager()

--- a/src/cpp/security/OpenSSLInit.hpp
+++ b/src/cpp/security/OpenSSLInit.hpp
@@ -1,3 +1,19 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
 #include <openssl/evp.h>
 #include <openssl/engine.h>
 #include <openssl/rand.h>
@@ -28,12 +44,13 @@ public:
         ERR_remove_thread_state(NULL);
         ENGINE_cleanup();
 #endif // if OPENSSL_VERSION_NUMBER < 0x10000000L
-        RAND_cleanup();
-        CRYPTO_cleanup_all_ex_data();
-        ERR_free_strings();
-        EVP_cleanup();
     }
 
+    static std::shared_ptr<OpenSSLInit> get_instance()
+    {
+        static auto instance = std::make_shared<OpenSSLInit>();
+        return instance;
+    }
 };
 
 } // namespace security

--- a/src/cpp/security/OpenSSLInit.hpp
+++ b/src/cpp/security/OpenSSLInit.hpp
@@ -30,20 +30,13 @@ public:
 
     OpenSSLInit()
     {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-        OpenSSL_add_all_algorithms();
-#endif // if OPENSSL_VERSION_NUMBER < 0x10100000L
+        uint64_t opts = OPENSSL_INIT_NO_ATEXIT;
+        OPENSSL_init_crypto(opts, NULL);
     }
 
     ~OpenSSLInit()
     {
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
-        ERR_remove_state(0);
-        ENGINE_cleanup();
-#elif OPENSSL_VERSION_NUMBER < 0x10100000L
-        ERR_remove_thread_state(NULL);
-        ENGINE_cleanup();
-#endif // if OPENSSL_VERSION_NUMBER < 0x10000000L
+        OPENSSL_cleanup();
     }
 
     static std::shared_ptr<OpenSSLInit> get_instance()
@@ -51,6 +44,7 @@ public:
         static auto instance = std::make_shared<OpenSSLInit>();
         return instance;
     }
+
 };
 
 } // namespace security

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -5191,6 +5191,33 @@ TEST(Security, participant_stateless_secure_writer_pool_change_is_removed_upon_p
     EXPECT_EQ(0u, n_logs);
 }
 
+// Regression test for Redmine issue #22024
+// OpenSSL assertion is not thrown when the library is abruptly finished.
+TEST(Security, openssl_correctly_finishes)
+{
+    // Create
+    PubSubWriter<HelloWorldPubSubType> writer("HelloWorldTopic_openssl_is_correctly_finished");
+    PubSubReader<HelloWorldPubSubType> reader("HelloWorldTopic_openssl_is_correctly_finished");
+
+    const std::string governance_file("governance_helloworld_all_enable.smime");
+    const std::string permissions_file("permissions_helloworld.smime");
+
+    CommonPermissionsConfigure(reader, writer, governance_file, permissions_file);
+
+    reader.init();
+    writer.init();
+
+    ASSERT_TRUE(reader.isInitialized());
+    ASSERT_TRUE(writer.isInitialized());
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Here we force the atexit function from openssl to be abruptly called
+    // i.e in a disordered way
+    // If OpenSSL is not correctly finished, a SIGSEGV will be thrown
+    std::exit(0);
+}
+
 void blackbox_security_init()
 {
     certs_path = std::getenv("CERTS_PATH");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a crash in `OpenSSL` provoked when the `atexit` callback from `openssl` is triggered upon process destruction, making it to trigger a `SIGSEV` on an already released `OpenSSL` resource.

In addition, `OpenSSL` is now a Meyers singleton attached to `RTPSDomainImpl`.

In accordance with [the best practices using OpenSSL](https://developers.redhat.com/articles/2022/10/31/best-practices-application-shutdown-openssl#) and its [documentation](https://docs.openssl.org/master/):
* Initialization is done through `OpenSSL_init_crypto` (available in all versions along with the `OPENSSL_INIT_NO_ATEXIT` option) that makes `atexit` not being registered.
* If `atexit` is not registered, user has to explicitly call `OpenSSL_cleanup()` (also, supported across versions). 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
