### PR TITLE
[21706] Feature: Extended incompatible QoS for monitor service

### DIFF
--- a/include/fastdds/statistics/monitorservice_types.idl
+++ b/include/fastdds/statistics/monitorservice_types.idl
@@ -74,19 +74,28 @@ module statistics {
     typedef BaseStatus_s InconsistentTopicStatus_s;
     typedef BaseStatus_s SampleLostStatus_s;
 
+    struct ExtendedIncompatibleQoSStatus_s
+    {
+        detail::GUID_s remote_guid;
+        sequence<unsigned long> current_incompatible_policies;
+    };
+
+    typedef sequence<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
     module StatusKind
     {
         typedef unsigned long StatusKind;
 
-        const StatusKind PROXY              = 0;
-        const StatusKind CONNECTION_LIST    = 1;
-        const StatusKind INCOMPATIBLE_QOS   = 2;
-        const StatusKind INCONSISTENT_TOPIC = 3;
-        const StatusKind LIVELINESS_LOST    = 4;
-        const StatusKind LIVELINESS_CHANGED = 5;
-        const StatusKind DEADLINE_MISSED    = 6;
-        const StatusKind SAMPLE_LOST        = 7;
-        const StatusKind STATUSES_SIZE      = 8;
+        const StatusKind PROXY                     = 0;
+        const StatusKind CONNECTION_LIST           = 1;
+        const StatusKind INCOMPATIBLE_QOS          = 2;
+        const StatusKind INCONSISTENT_TOPIC        = 3;
+        const StatusKind LIVELINESS_LOST           = 4;
+        const StatusKind LIVELINESS_CHANGED        = 5;
+        const StatusKind DEADLINE_MISSED           = 6;
+        const StatusKind SAMPLE_LOST               = 7;
+        const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+        const StatusKind STATUSES_SIZE             = 9;
     }; // module StatusKind
 
     union MonitorServiceData switch(StatusKind::StatusKind)
@@ -107,6 +116,8 @@ module statistics {
             DeadlineMissedStatus_s deadline_missed_status;
         case StatusKind::SAMPLE_LOST:
             SampleLostStatus_s sample_lost_status;
+        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            ExtendedIncompatibleQoSStatusSeq_s extended_incompatible_qos_status;
         case StatusKind::STATUSES_SIZE:
             octet statuses_size;
     };

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -872,6 +872,7 @@ bool EDP::pairingReader(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && reader->get_listener() != nullptr)
                 {
                     reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
+                    mp_PDP->notify_incompatible_qos_matching(R->getGuid(), wdatait->guid(), incompatible_qos);
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -964,6 +965,7 @@ bool EDP::pairingWriter(
                 if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && writer->get_listener() != nullptr)
                 {
                     writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
+                    mp_PDP->notify_incompatible_qos_matching(W->getGuid(), rdatait->guid(), incompatible_qos);
                 }
 
                 //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->m_guid<<RTPS_DEF<<endl);
@@ -1039,6 +1041,7 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.get_listener() != nullptr)
                         {
                             w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                            mp_PDP->notify_incompatible_qos_matching(w.getGuid(), rdata->guid(), incompatible_qos);
                         }
 
                         if (w.matched_reader_is_matched(reader_guid)
@@ -1107,6 +1110,7 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                             w.get_listener() != nullptr)
                             {
                                 w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                                mp_PDP->notify_incompatible_qos_matching(local_writer, rdata.guid(), incompatible_qos);
                             }
 
                             if (w.matched_reader_is_matched(reader_guid)
@@ -1230,6 +1234,7 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                         if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.get_listener() != nullptr)
                         {
                             r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                            mp_PDP->notify_incompatible_qos_matching(r.getGuid(), wdata->guid(), incompatible_qos);
                         }
 
                         if (r.matched_writer_is_matched(writer_guid)
@@ -1298,6 +1303,7 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                             r.get_listener() != nullptr)
                             {
                                 r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                                mp_PDP->notify_incompatible_qos_matching(local_reader, wdata.guid(), incompatible_qos);
                             }
 
                             if (r.matched_writer_is_matched(writer_guid)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.h
@@ -364,7 +364,6 @@ private:
     bool checkDataRepresentationQos(
             const WriterProxyData* wdata,
             const ReaderProxyData* rdata) const;
-
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -470,7 +470,7 @@ public:
     void set_proxy_observer(
             const fastdds::statistics::rtps::IProxyObserver* proxy_observer);
 
-    const fastdds::statistics::rtps::IProxyObserver* get_proxy_observer()
+    const fastdds::statistics::rtps::IProxyObserver* get_proxy_observer() const
     {
         return proxy_observer_.load();
     }
@@ -499,6 +499,19 @@ public:
             const std::vector<BaseReader*>& readers,
             const RTPSParticipantAttributes& old_atts,
             const RTPSParticipantAttributes& new_atts);
+
+    /**
+     * @brief Notify monitor the IProxyObserver implementor about
+     * any incompatible QoS matching between a local and a remote entity.
+     *
+     * @param local_guid GUID of the local entity.
+     * @param remote_guid GUID of the remote entity.
+     * @param incompatible_qos The PolicyMask with the incompatible QoS.
+     */
+    void notify_incompatible_qos_matching(
+            const GUID_t& local_guid,
+            const GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const;
 
 protected:
 

--- a/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorService.hpp
@@ -160,6 +160,30 @@ public:
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
 
+    /**
+     * @brief Process any updates regarding
+     * remote entities incompatible QoS matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     */
+    void on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos_policies);
+
+    /**
+     * @brief Notifies that a remote proxy data has been removed.
+     * This is interesting to notify proxy removals independently
+     * of the remote entity being matched or not.
+     *
+     * @param removed_proxy_guid GUID of the removed proxy.
+     */
+    void on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid);
+
 private:
 
     /**
@@ -257,6 +281,13 @@ private:
     endpoint_registrator_t endpoint_registrator_;
 
     MonitorServiceStatusDataPubSubType type_;
+
+    // Stores the current extended incompatible qos status
+    // of local entities with remote entities and their policies.
+    std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
+    extended_incompatible_qos_collection_;
+
+    std::mutex extended_incompatible_qos_mtx_;
 };
 
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.cpp
@@ -19,6 +19,7 @@
 #include <statistics/rtps/monitor-service/MonitorServiceListener.hpp>
 
 #include <statistics/rtps/monitor-service/MonitorService.hpp>
+#include <statistics/rtps/StatisticsBase.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -84,6 +85,26 @@ void MonitorServiceListener::on_writer_change_received_by_all(
     //! Do nothing for the moment, no relevant info
     static_cast<void>(writer);
     static_cast<void>(change);
+}
+
+void MonitorServiceListener::on_incompatible_qos_matching(
+        const fastdds::rtps::GUID_t& local_guid,
+        const fastdds::rtps::GUID_t& remote_guid,
+        const fastdds::dds::PolicyMask& incompatible_qos_policies) const
+{
+    if (monitor_srv_)
+    {
+        monitor_srv_->on_incompatible_qos_matching(local_guid, remote_guid, incompatible_qos_policies);
+    }
+}
+
+void MonitorServiceListener::on_remote_proxy_data_removed(
+        const fastdds::rtps::GUID_t& removed_proxy_guid) const
+{
+    if (monitor_srv_)
+    {
+        monitor_srv_->on_remote_proxy_data_removed(removed_proxy_guid);
+    }
 }
 
 } // namespace rtps

--- a/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/MonitorServiceListener.hpp
@@ -64,6 +64,14 @@ public:
             fastdds::rtps::RTPSWriter* writer,
             fastdds::rtps::CacheChange_t* change) override;
 
+    void on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const override;
+
+    void on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid) const override;
+
 protected:
 
     MonitorService* monitor_srv_;

--- a/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
+++ b/src/cpp/statistics/rtps/monitor-service/interfaces/IProxyObserver.hpp
@@ -20,6 +20,7 @@
 #ifndef _FASTDDS_STATISTICS_MONITOR_SERVICE_INTERFACES_IPROXYOBSERVER_HPP_
 #define _FASTDDS_STATISTICS_MONITOR_SERVICE_INTERFACES_IPROXYOBSERVER_HPP_
 
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/common/Guid.hpp>
 
 namespace eprosima {
@@ -30,7 +31,7 @@ namespace rtps {
 struct IProxyObserver
 {
     /**
-     * @brief Interface use to notify about any updates
+     * @brief Interface used to notify about any updates
      * on the local entities (updates in the proxy,
      * new matches, unpairs,...)
      *
@@ -41,6 +42,30 @@ struct IProxyObserver
     virtual bool on_local_entity_change(
             const fastdds::rtps::GUID_t& guid,
             bool is_alive) const = 0;
+
+    /**
+     * @brief Interface used to notify about any updates
+     * regarding remote entities incompatible QoS matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     */
+    virtual void on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos) const = 0;
+
+    /**
+     * @brief Method to notify the implementor that a remote proxy
+     * data has been removed. This is interesting to notify proxy removals
+     * independently of the the remote entity being matched or not.
+     *
+     * @param removed_proxy_guid GUID of the removed proxy.
+     */
+    virtual void on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid) const = 0;
 };
 
 } // rtps

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -1211,6 +1211,188 @@ typedef BaseStatus_s InconsistentTopicStatus_s;
 
 typedef BaseStatus_s SampleLostStatus_s;
 
+/*!
+ * @brief This class represents the structure ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+ * @ingroup monitorservice_types
+ */
+class ExtendedIncompatibleQoSStatus_s
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return (m_remote_guid == x.m_remote_guid &&
+           m_current_incompatible_policies == x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function copies the value in member remote_guid
+     * @param _remote_guid New value to be copied in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            const detail::GUID_s& _remote_guid)
+    {
+        m_remote_guid = _remote_guid;
+    }
+
+    /*!
+     * @brief This function moves the value in member remote_guid
+     * @param _remote_guid New value to be moved in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            detail::GUID_s&& _remote_guid)
+    {
+        m_remote_guid = std::move(_remote_guid);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member remote_guid
+     * @return Constant reference to member remote_guid
+     */
+    eProsima_user_DllExport const detail::GUID_s& remote_guid() const
+    {
+        return m_remote_guid;
+    }
+
+    /*!
+     * @brief This function returns a reference to member remote_guid
+     * @return Reference to member remote_guid
+     */
+    eProsima_user_DllExport detail::GUID_s& remote_guid()
+    {
+        return m_remote_guid;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be copied in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            const std::vector<uint32_t>& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = _current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function moves the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be moved in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            std::vector<uint32_t>&& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = std::move(_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member current_incompatible_policies
+     * @return Constant reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport const std::vector<uint32_t>& current_incompatible_policies() const
+    {
+        return m_current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function returns a reference to member current_incompatible_policies
+     * @return Reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport std::vector<uint32_t>& current_incompatible_policies()
+    {
+        return m_current_incompatible_policies;
+    }
+
+
+
+private:
+
+    detail::GUID_s m_remote_guid;
+    std::vector<uint32_t> m_current_incompatible_policies;
+
+};
+typedef std::vector<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
 namespace StatusKind {
 
 typedef uint32_t StatusKind;
@@ -1223,7 +1405,8 @@ const StatusKind LIVELINESS_LOST = 4;
 const StatusKind LIVELINESS_CHANGED = 5;
 const StatusKind DEADLINE_MISSED = 6;
 const StatusKind SAMPLE_LOST = 7;
-const StatusKind STATUSES_SIZE = 8;
+const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+const StatusKind STATUSES_SIZE = 9;
 
 } // namespace StatusKind
 /*!
@@ -1296,6 +1479,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1346,6 +1533,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1396,6 +1587,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1448,6 +1643,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1506,6 +1705,10 @@ public:
                                                         break;
 
                                                     case 0x00000009:
+                                                        ret_value = (x.m_extended_incompatible_qos_status == m_extended_incompatible_qos_status);
+                                                        break;
+
+                                                    case 0x0000000a:
                                                         ret_value = (x.m_statuses_size == m_statuses_size);
                                                         break;
 
@@ -1599,8 +1802,15 @@ public:
                             }
                             break;
 
-                        case StatusKind::STATUSES_SIZE:
+                        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                             if (0x00000009 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case StatusKind::STATUSES_SIZE:
+                            if (0x0000000a == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -2050,6 +2260,59 @@ public:
 
 
     /*!
+     * @brief This function copies the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be copied in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            const ExtendedIncompatibleQoSStatusSeq_s& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function moves the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be moved in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            ExtendedIncompatibleQoSStatusSeq_s&& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member extended_incompatible_qos_status
+     * @return Constant reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport const ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status() const
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+    /*!
+     * @brief This function returns a reference to member extended_incompatible_qos_status
+     * @return Reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status()
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+
+    /*!
      * @brief This function sets a value in member statuses_size
      * @param _statuses_size New value for member statuses_size
      */
@@ -2067,7 +2330,7 @@ public:
      */
     eProsima_user_DllExport uint8_t statuses_size() const
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2082,7 +2345,7 @@ public:
      */
     eProsima_user_DllExport uint8_t& statuses_size()
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2275,7 +2538,7 @@ private:
                 return m_sample_lost_status;
             }
 
-            uint8_t& statuses_size_()
+            ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status_()
             {
                 if (0x00000009 != selected_member_)
                 {
@@ -2285,6 +2548,28 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_extended_incompatible_qos_status.~ExtendedIncompatibleQoSStatusSeq_s();
+                    };
+                    new(&m_extended_incompatible_qos_status) ExtendedIncompatibleQoSStatusSeq_s();
+
+                }
+
+                return m_extended_incompatible_qos_status;
+            }
+
+            uint8_t& statuses_size_()
+            {
+                if (0x0000000a != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x0000000a;
                     member_destructor_ = nullptr;
                     m_statuses_size = {0};
 
@@ -2306,6 +2591,7 @@ private:
         LivelinessChangedStatus_s m_liveliness_changed_status;
         DeadlineMissedStatus_s m_deadline_missed_status;
         SampleLostStatus_s m_sample_lost_status;
+        ExtendedIncompatibleQoSStatusSeq_s m_extended_incompatible_qos_status;
         uint8_t m_statuses_size;
     };
 

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
@@ -33,6 +33,9 @@ constexpr uint32_t eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize
 
 
 
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize {36UL};
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize {0UL};
+
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize {0UL};
 
@@ -96,6 +99,10 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data);
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -1120,6 +1120,187 @@ namespace eprosima {
                 register_DeadlineMissedStatus_s_type_identifier(type_identifiers_);
             }
 
+            ExtendedIncompatibleQoSStatus_sPubSubType::ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                set_name("eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s");
+                uint32_t type_size = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize;
+                type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+                max_serialized_type_size = type_size + 4; /*encapsulation*/
+                is_compute_key_provided = false;
+                uint32_t key_length = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16 ? eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize : 16;
+                key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+                memset(key_buffer_, 0, key_length);
+            }
+
+            ExtendedIncompatibleQoSStatus_sPubSubType::~ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                if (key_buffer_ != nullptr)
+                {
+                    free(key_buffer_);
+                }
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::serialize(
+                    const void* const data,
+                    SerializedPayload_t& payload,
+                    DataRepresentationId_t data_representation)
+            {
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+                payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+                ser.set_encoding_flag(
+                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+                try
+                {
+                    // Serialize encapsulation
+                    ser.serialize_encapsulation();
+                    // Serialize the object.
+                    ser << *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                // Get the serialized length
+                payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+                return true;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::deserialize(
+                    SerializedPayload_t& payload,
+                    void* data)
+            {
+                try
+                {
+                    // Convert DATA to pointer of your type
+                    ExtendedIncompatibleQoSStatus_s* p_type = static_cast<ExtendedIncompatibleQoSStatus_s*>(data);
+
+                    // Object that manages the raw buffer.
+                    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+                    // Object that deserializes the data.
+                    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+                    // Deserialize encapsulation.
+                    deser.read_encapsulation();
+                    payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+                    // Deserialize the object.
+                    deser >> *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            uint32_t ExtendedIncompatibleQoSStatus_sPubSubType::calculate_serialized_size(
+                    const void* const data,
+                    DataRepresentationId_t data_representation)
+            {
+                try
+                {
+                    eprosima::fastcdr::CdrSizeCalculator calculator(
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                    size_t current_alignment {0};
+                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                *static_cast<const ExtendedIncompatibleQoSStatus_s*>(data), current_alignment)) +
+                            4u /*encapsulation*/;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return 0;
+                }
+            }
+
+            void* ExtendedIncompatibleQoSStatus_sPubSubType::create_data()
+            {
+                return reinterpret_cast<void*>(new ExtendedIncompatibleQoSStatus_s());
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::delete_data(
+                    void* data)
+            {
+                delete(reinterpret_cast<ExtendedIncompatibleQoSStatus_s*>(data));
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    SerializedPayload_t& payload,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                ExtendedIncompatibleQoSStatus_s data;
+                if (deserialize(payload, static_cast<void*>(&data)))
+                {
+                    return compute_key(static_cast<void*>(&data), handle, force_md5);
+                }
+
+                return false;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    const void* const data,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+                        eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize);
+
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+                eprosima::fastcdr::serialize_key(ser, *p_type);
+                if (force_md5 || eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
+                {
+                    md5_.init();
+                    md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+                    md5_.finalize();
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = md5_.digest[i];
+                    }
+                }
+                else
+                {
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = key_buffer_[i];
+                    }
+                }
+                return true;
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::register_type_object_representation()
+            {
+                register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_identifiers_);
+            }
+
             namespace StatusKind {
             } // namespace StatusKind
 

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
@@ -534,6 +534,88 @@ namespace eprosima
             typedef eprosima::fastdds::statistics::BaseStatus_s LivelinessLostStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s InconsistentTopicStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s SampleLostStatus_s;
+
+            /*!
+             * @brief This class represents the TopicDataType of the type ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+             * @ingroup monitorservice_types
+             */
+            class ExtendedIncompatibleQoSStatus_sPubSubType : public eprosima::fastdds::dds::TopicDataType
+            {
+            public:
+
+                typedef ExtendedIncompatibleQoSStatus_s type;
+
+                eProsima_user_DllExport ExtendedIncompatibleQoSStatus_sPubSubType();
+
+                eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_sPubSubType() override;
+
+                eProsima_user_DllExport bool serialize(
+                        const void* const data,
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool deserialize(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        void* data) override;
+
+                eProsima_user_DllExport uint32_t calculate_serialized_size(
+                        const void* const data,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        const void* const data,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport void* create_data() override;
+
+                eProsima_user_DllExport void delete_data(
+                        void* data) override;
+
+                //Register TypeObject representation in Fast DDS TypeObjectRegistry
+                eProsima_user_DllExport void register_type_object_representation() override;
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+                eProsima_user_DllExport inline bool is_bounded() const override
+                {
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+                eProsima_user_DllExport inline bool is_plain(
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+                {
+                    static_cast<void>(data_representation);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+                eProsima_user_DllExport inline bool construct_sample(
+                        void* memory) const override
+                {
+                    static_cast<void>(memory);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+            private:
+
+                eprosima::fastdds::MD5 md5_;
+                unsigned char* key_buffer_;
+
+            };
+            typedef std::vector<eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.cxx
@@ -1069,6 +1069,205 @@ void register_SampleLostStatus_s_type_identifier(
     }
 }
 
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatus_s)
+{
+
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatus_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatus_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatus_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatus_s)
+    {
+        StructTypeFlag struct_flags_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatus_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatus_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatus_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatus_s, ann_custom_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string());
+        CompleteStructHeader header_ExtendedIncompatibleQoSStatus_s;
+        header_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ExtendedIncompatibleQoSStatus_s);
+        CompleteStructMemberSeq member_seq_ExtendedIncompatibleQoSStatus_s;
+        {
+            TypeIdentifierPair type_ids_remote_guid;
+            ReturnCode_t return_code_remote_guid {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_remote_guid =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::detail::GUID_s", type_ids_remote_guid);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_remote_guid)
+            {
+                eprosima::fastdds::statistics::detail::register_GUID_s_type_identifier(type_ids_remote_guid);
+            }
+            StructMemberFlag member_flags_remote_guid = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_remote_guid = 0x00000000;
+            bool common_remote_guid_ec {false};
+            CommonStructMember common_remote_guid {TypeObjectUtils::build_common_struct_member(member_id_remote_guid, member_flags_remote_guid, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_remote_guid, common_remote_guid_ec))};
+            if (!common_remote_guid_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure remote_guid member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_remote_guid = "remote_guid";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_remote_guid;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_remote_guid = TypeObjectUtils::build_complete_member_detail(name_remote_guid, member_ann_builtin_remote_guid, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_remote_guid = TypeObjectUtils::build_complete_struct_member(common_remote_guid, detail_remote_guid);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_remote_guid);
+        }
+        {
+            TypeIdentifierPair type_ids_current_incompatible_policies;
+            ReturnCode_t return_code_current_incompatible_policies {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_current_incompatible_policies =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+            {
+                return_code_current_incompatible_policies =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_uint32_t", type_ids_current_incompatible_policies);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_sequence_uint32_t_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_uint32_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, element_identifier_anonymous_sequence_uint32_t_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_uint32_t_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_current_incompatible_policies.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_uint32_t_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_uint32_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint32_t_unbounded, element_flags_anonymous_sequence_uint32_t_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint32_t_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint32_t_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_uint32_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_current_incompatible_policies = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_current_incompatible_policies = 0x00000001;
+            bool common_current_incompatible_policies_ec {false};
+            CommonStructMember common_current_incompatible_policies {TypeObjectUtils::build_common_struct_member(member_id_current_incompatible_policies, member_flags_current_incompatible_policies, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, common_current_incompatible_policies_ec))};
+            if (!common_current_incompatible_policies_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure current_incompatible_policies member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_current_incompatible_policies = "current_incompatible_policies";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_current_incompatible_policies;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_current_incompatible_policies = TypeObjectUtils::build_complete_member_detail(name_current_incompatible_policies, member_ann_builtin_current_incompatible_policies, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_current_incompatible_policies = TypeObjectUtils::build_complete_struct_member(common_current_incompatible_policies, detail_current_incompatible_policies);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_current_incompatible_policies);
+        }
+        CompleteStructType struct_type_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_type(struct_flags_ExtendedIncompatibleQoSStatus_s, header_ExtendedIncompatibleQoSStatus_s, member_seq_ExtendedIncompatibleQoSStatus_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string(), type_ids_ExtendedIncompatibleQoSStatus_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatusSeq_s)
+{
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatusSeq_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatusSeq_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+    {
+        AliasTypeFlag alias_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatusSeq_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatusSeq_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s, type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string());
+        CompleteAliasHeader header_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_header(detail_ExtendedIncompatibleQoSStatusSeq_s);
+        AliasMemberFlag related_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        return_code_ExtendedIncompatibleQoSStatusSeq_s =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+        if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+        {
+            return_code_ExtendedIncompatibleQoSStatusSeq_s =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+            }
+            bool element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec {false};
+            TypeIdentifier* element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec))};
+            if (!element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                return;
+            }
+            EquivalenceKind equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_COMPLETE;
+            if (TK_NONE == type_ids_ExtendedIncompatibleQoSStatusSeq_s.type_identifier2()._d())
+            {
+                equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_BOTH;
+            }
+            CollectionElementFlag element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = 0;
+            PlainCollectionHeader header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded);
+            {
+                SBound bound = 0;
+                PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, bound,
+                            eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded));
+                if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                        TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded already registered in TypeObjectRegistry for a different type.");
+                }
+            }
+        }
+        bool common_ExtendedIncompatibleQoSStatusSeq_s_ec {false};
+        CommonAliasBody common_ExtendedIncompatibleQoSStatusSeq_s {TypeObjectUtils::build_common_alias_body(related_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, common_ExtendedIncompatibleQoSStatusSeq_s_ec))};
+        if (!common_ExtendedIncompatibleQoSStatusSeq_s_ec)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier inconsistent.");
+            return;
+        }
+        eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        ann_custom_ExtendedIncompatibleQoSStatusSeq_s.reset();
+        CompleteAliasBody body_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_body(common_ExtendedIncompatibleQoSStatusSeq_s,
+                member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s);
+        CompleteAliasType alias_type_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_type(alias_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                header_ExtendedIncompatibleQoSStatusSeq_s, body_ExtendedIncompatibleQoSStatusSeq_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_alias_type_object(alias_type_ExtendedIncompatibleQoSStatusSeq_s,
+                    type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string(), type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
 namespace StatusKind {
 void register_StatusKind_type_identifier(
         TypeIdentifierPair& type_ids_StatusKind)
@@ -1478,6 +1677,36 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_MonitorServiceData);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(type_ids_MonitorServiceData);
+            }
+            UnionMemberFlag member_flags_extended_incompatible_qos_status = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_extended_incompatible_qos_status;
+            TypeObjectUtils::add_union_case_label(label_seq_extended_incompatible_qos_status, static_cast<int32_t>(StatusKind::EXTENDED_INCOMPATIBLE_QOS));
+            MemberId member_id_extended_incompatible_qos_status = 0x00000009;
+            bool common_extended_incompatible_qos_status_ec {false};
+            CommonUnionMember common_extended_incompatible_qos_status {TypeObjectUtils::build_common_union_member(member_id_extended_incompatible_qos_status,
+                    member_flags_extended_incompatible_qos_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,
+                        common_extended_incompatible_qos_status_ec), label_seq_extended_incompatible_qos_status)};
+            if (!common_extended_incompatible_qos_status_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union extended_incompatible_qos_status member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_extended_incompatible_qos_status = "extended_incompatible_qos_status";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extended_incompatible_qos_status;
+            ann_custom_MonitorServiceData.reset();
+            CompleteMemberDetail detail_extended_incompatible_qos_status = TypeObjectUtils::build_complete_member_detail(name_extended_incompatible_qos_status, member_ann_builtin_extended_incompatible_qos_status, ann_custom_MonitorServiceData);
+            CompleteUnionMember member_extended_incompatible_qos_status = TypeObjectUtils::build_complete_union_member(common_extended_incompatible_qos_status, detail_extended_incompatible_qos_status);
+            TypeObjectUtils::add_complete_union_member(member_seq_MonitorServiceData, member_extended_incompatible_qos_status);
+        }
+        {
+            return_code_MonitorServiceData =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_byte", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
@@ -1490,7 +1719,7 @@ void register_MonitorServiceData_type_identifier(
                     false, false);
             UnionCaseLabelSeq label_seq_statuses_size;
             TypeObjectUtils::add_union_case_label(label_seq_statuses_size, static_cast<int32_t>(StatusKind::STATUSES_SIZE));
-            MemberId member_id_statuses_size = 0x00000009;
+            MemberId member_id_statuses_size = 0x0000000a;
             bool common_statuses_size_ec {false};
             CommonUnionMember common_statuses_size {TypeObjectUtils::build_common_union_member(member_id_statuses_size,
                     member_flags_statuses_size, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
@@ -192,6 +192,34 @@ eProsima_user_DllExport void register_SampleLostStatus_s_type_identifier(
 
 
 
+/**
+ * @brief Register ExtendedIncompatibleQoSStatus_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+
+
 namespace StatusKind {
 /**
  * @brief Register StatusKind related TypeIdentifier.

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -228,6 +228,7 @@ public:
     {
         if (!writers_.empty())
         {
+            writer_stat_guids_.pop_back();
             return (eprosima::fastdds::dds::RETCODE_OK == publisher_->delete_datawriter(writers_.back()));
         }
 
@@ -238,6 +239,7 @@ public:
     {
         if (!readers_.empty())
         {
+            reader_stat_guids_.pop_back();
             return (eprosima::fastdds::dds::RETCODE_OK == subscriber_->delete_datareader(readers_.back()));
         }
 
@@ -501,6 +503,28 @@ struct SampleValidator
     {
     }
 
+    void update_processed_msgs(
+            std::list<MonitorServiceType::type>::iterator& it,
+            std::list<MonitorServiceType::type>& expected_msgs,
+            std::atomic<size_t>& processed_count,
+            std::condition_variable& cv,
+            bool& was_expected)
+    {
+        was_expected = false;
+
+        if (it != expected_msgs.end())
+        {
+            was_expected = true;
+            expected_msgs.erase(it);
+            ++processed_count;
+            cv.notify_one();
+        }
+        else if (assert_on_non_expected_msgs_)
+        {
+            ASSERT_TRUE(false);
+        }
+    }
+
     std::bitset<statistics::StatusKind::STATUSES_SIZE> validation_mask;
     bool assert_on_non_expected_msgs_;
 
@@ -686,7 +710,10 @@ struct ProxySampleValidator : public SampleValidator
                                 data.local_entity() == elem.local_entity();
                             });
 
-            if (it == total_msgs.end())
+            bool msgs_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msgs_was_expected);
+            // If this proxy is not expected, avoid further processing and return
+            if (!msgs_was_expected)
             {
                 std::cout << "Unexpected proxy " << statistics::to_fastdds_type(data.local_entity()) <<
                     data.status_kind() << std::endl;
@@ -694,8 +721,6 @@ struct ProxySampleValidator : public SampleValidator
             }
 
             GUID_t guid = statistics::to_fastdds_type(data.local_entity());
-
-            bool valid_entity = true;
 
             if (!data.value().entity_proxy().empty())
             {
@@ -734,7 +759,6 @@ struct ProxySampleValidator : public SampleValidator
                 }
                 else
                 {
-                    valid_entity = false;
                     EPROSIMA_LOG_ERROR(BBTestsMonitorService, "Invalid entity guid " << guid);
                 }
             }
@@ -742,13 +766,6 @@ struct ProxySampleValidator : public SampleValidator
             {
                 std::cout << "Received Entity disposal of entity "
                           << statistics::to_fastdds_type(data.local_entity()) << std::endl;
-            }
-
-            if (valid_entity)
-            {
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
             }
         }
         else if (validation_mask[statistics::StatusKind::PROXY])
@@ -763,13 +780,8 @@ struct ProxySampleValidator : public SampleValidator
             std::cout << "Received unregistration of instance "
                       << info.instance_handle << std::endl;
 
-            if (assert_on_non_expected_msgs_)
-            {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
-            }
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
 
@@ -875,13 +887,8 @@ struct ConnectionListSampleValidator : public SampleValidator
                                 return false;
                             });
 
-            if (assert_on_non_expected_msgs_)
-            {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
-            }
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
 
@@ -909,13 +916,8 @@ struct IncompatibleQoSSampleValidator : public SampleValidator
                                 == elem.value().incompatible_qos_status().last_policy_id());
                             });
 
-            if (assert_on_non_expected_msgs_)
-            {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
-            }
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
 
             std::cout << "Received QoS Incompatibility on local_entity "
                       << statistics::to_fastdds_type(data.local_entity())
@@ -951,10 +953,10 @@ struct LivelinessLostSampleValidator : public SampleValidator
             if (assert_on_non_expected_msgs_)
             {
                 ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
             }
+
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
 
             std::cout << "Received QoS Incompatibility on local_entity "
                       << statistics::to_fastdds_type(data.local_entity())
@@ -992,13 +994,8 @@ struct LivelinessChangedSampleValidator : public SampleValidator
                       << "\n\tNot Alive Count: " << data.value().liveliness_changed_status().not_alive_count()
                       << std::endl;
 
-            if (assert_on_non_expected_msgs_)
-            {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
-            }
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
 
@@ -1036,13 +1033,8 @@ struct DeadlineMissedSampleValidator : public SampleValidator
                       << "\n\tTotal Count: " << data.value().deadline_missed_status().total_count()
                       << std::endl;
 
-            if (assert_on_non_expected_msgs_)
-            {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
-            }
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
 
@@ -1075,13 +1067,52 @@ struct SampleLostSampleValidator : public SampleValidator
                       << std::endl;
 
 
-            if (assert_on_non_expected_msgs_)
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
+        }
+    }
+
+};
+
+struct ExtendedIncompatibleQoSValidator : public SampleValidator
+{
+    void validate(
+            SampleInfo& info,
+            MonitorServiceType::type& data,
+            std::list<MonitorServiceType::type>& total_msgs,
+            std::atomic<size_t>& processed_count,
+            std::condition_variable& cv)
+    {
+        if (validation_mask[statistics::StatusKind::EXTENDED_INCOMPATIBLE_QOS]
+                && info.valid_data
+                && info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE)
+        {
+            auto it = std::find_if(total_msgs.begin(), total_msgs.end(),
+                            [&](const MonitorServiceType::type& elem)
+                            {
+                                return (data.status_kind() == elem.status_kind()) &&
+                                (data.local_entity() == elem.local_entity()) &&
+                                (data.value().extended_incompatible_qos_status() ==
+                                elem.value().extended_incompatible_qos_status());
+                            });
+
+            std::cout << "Received Extended Incompatible QoS on local_entity "
+                      << statistics::to_fastdds_type(data.local_entity());
+
+            for (auto& incompatibility : data.value().extended_incompatible_qos_status())
             {
-                ASSERT_NE(it, total_msgs.end());
-                total_msgs.erase(it);
-                ++processed_count;
-                cv.notify_one();
+                std::cout << "\n\tAgainst remote GUID: " << statistics::to_fastdds_type(incompatibility.remote_guid())
+                          << "\n\tIncom. policies: ";
+                for (auto& policy : incompatibility.current_incompatible_policies())
+                {
+                    std::cout << "\n\t\tPolicy: " << policy;
+                }
             }
+
+            std::cout << std::endl;
+
+            bool msg_was_expected = false;
+            update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
 
@@ -1142,6 +1173,12 @@ void validator_selector(
         case statistics::StatusKind::SAMPLE_LOST:
         {
             auto sample_validator = static_cast<SampleLostSampleValidator*>(validator);
+            sample_validator->validate(info, data, total_msgs, processed_count, cv);
+            break;
+        }
+        case statistics::StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+        {
+            auto sample_validator = static_cast<ExtendedIncompatibleQoSValidator*>(validator);
             sample_validator->validate(info, data, total_msgs, processed_count, cv);
             break;
         }
@@ -1474,7 +1511,9 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_qos_incompatibility_status)
 
     //! Setup
     MonitorServiceParticipant MSP;
-    MonitorServiceConsumer MSC(validation_mask);
+    //! We may receive EXTENDED_INCOMPATIBLE_QOS samples as well
+    //! prevent them from being validated
+    MonitorServiceConsumer MSC(validation_mask, false);
 
     //! Procedure
     MSC.init_monitor_service_reader();
@@ -2008,6 +2047,133 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_enable_disable_enable)
 }
 
 /**
+ * Refers to DDS-MS-SIMPLE-11 from the test plan.
+ *
+ * A pair of MSPs correctly notify MSC with proper extended QoS incompatibility
+ * after creating a pair of reader/writer sharing the same topic with an incompatible
+ * configuration.
+ */
+TEST(DDSMonitorServiceTest, monitor_service_simple_extended_incompatible_qos)
+{
+#ifdef FASTDDS_STATISTICS
+    using namespace eprosima::fastdds::statistics;
+
+    //! Validate PROXY samples
+    //! Validate EXTENDED_INCOMPATIBLE_QOS samples
+    std::bitset<statistics::StatusKind::STATUSES_SIZE> validation_mask;
+    validation_mask[statistics::StatusKind::PROXY] = true;
+    validation_mask[statistics::StatusKind::EXTENDED_INCOMPATIBLE_QOS] = true;
+
+    //! Setup
+    MonitorServiceParticipant MSP;
+    //! We will receive extra msgs such as instance unregistrations but we are not interested in
+    //! them in this test, so we set assert_on_non_expected_msgs to false
+    MonitorServiceConsumer MSC(validation_mask, false);
+
+    //! Procedure
+    MSP.setup();
+
+    MSC.init_monitor_service_reader();
+    MSP.enable_monitor_service();
+
+    DataReaderQos dr_qos;
+    DataWriterQos dw_qos;
+
+    dr_qos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    dw_qos.reliability().kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;
+
+    MSP.create_and_add_writer(dw_qos);
+    MSP.create_and_add_reader(dr_qos);
+
+    std::list<MonitorServiceType::type> expected_msgs;
+
+    // Expected messages for the new entities discovering
+    MonitorServiceType::type participant_proxy_msg, entity_proxy_msg, endpoint_ext_incmpqos_msg;
+
+    participant_proxy_msg.status_kind(StatusKind::PROXY);
+    participant_proxy_msg.local_entity(MSP.get_participant_guid());
+
+    expected_msgs.push_back(participant_proxy_msg);
+
+    entity_proxy_msg.status_kind(StatusKind::PROXY);
+    StatisticsGUIDList w_guids = MSP.get_writer_guids();
+    StatisticsGUIDList r_guids = MSP.get_reader_guids();
+
+    ASSERT_EQ(w_guids.size(), 1);
+    entity_proxy_msg.local_entity(w_guids.back());
+    expected_msgs.push_back(entity_proxy_msg);
+
+    ASSERT_EQ(r_guids.size(), 1);
+    entity_proxy_msg.local_entity(r_guids.back());
+    expected_msgs.push_back(entity_proxy_msg);
+
+    // Expected messages for the extended qos incompatibilities
+    endpoint_ext_incmpqos_msg.status_kind(StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+    endpoint_ext_incmpqos_msg.local_entity(w_guids.back());
+
+    // Writer extended incompatibility for reliability
+    statistics::ExtendedIncompatibleQoSStatusSeq_s ext_incompatible_qos_seq;
+    statistics::ExtendedIncompatibleQoSStatus_s ext_incompatible_qos;
+    std::vector<uint32_t> incompatible_policies;
+
+    ext_incompatible_qos.remote_guid(r_guids.back());
+    incompatible_policies.push_back(RELIABILITY_QOS_POLICY_ID);
+    ext_incompatible_qos.current_incompatible_policies(incompatible_policies);
+    ext_incompatible_qos_seq.push_back(ext_incompatible_qos);
+    endpoint_ext_incmpqos_msg.value().extended_incompatible_qos_status(ext_incompatible_qos_seq);
+    expected_msgs.push_back(endpoint_ext_incmpqos_msg);
+
+    // Reader extended incompatibility for reliability
+    r_guids = MSP.get_reader_guids();
+    ASSERT_EQ(r_guids.size(), 1);
+    endpoint_ext_incmpqos_msg.local_entity(r_guids.back());
+    ext_incompatible_qos_seq.at(0).remote_guid(w_guids.back());
+    endpoint_ext_incmpqos_msg.value().extended_incompatible_qos_status(ext_incompatible_qos_seq);
+    expected_msgs.push_back(endpoint_ext_incmpqos_msg);
+
+    MSC.start_reception(expected_msgs);
+
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(3)), expected_msgs.size());
+    expected_msgs.clear();
+
+    // When the reader is destroyed, the MSP's writer should notify
+    // with an empty extended incompatible qos list. Add it to
+    // the expected messages
+    MonitorServiceType::type empty_ext_incmpqos_msg;
+    empty_ext_incmpqos_msg.status_kind(StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+    empty_ext_incmpqos_msg.local_entity(w_guids.back());
+    empty_ext_incmpqos_msg.value().extended_incompatible_qos_status(statistics::ExtendedIncompatibleQoSStatusSeq_s());
+    expected_msgs.push_back(empty_ext_incmpqos_msg);
+
+    // Additionally, we should receive an empty proxy status kind for the reader
+    // meaning that the reader has been disposed
+    MonitorServiceType::type reader_disposal_msg;
+    reader_disposal_msg.local_entity(r_guids.back());
+    expected_msgs.push_back(reader_disposal_msg);
+
+    MSC.start_reception(expected_msgs);
+
+    MSP.delete_reader();
+
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(3)), expected_msgs.size());
+    expected_msgs.clear();
+
+    dr_qos.reliability().kind = eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;
+    MSP.create_and_add_reader(dr_qos);
+
+    // Expect only the new reader's discovery proxy one
+    r_guids = MSP.get_reader_guids();
+    ASSERT_EQ(r_guids.size(), 1);
+    entity_proxy_msg.local_entity(r_guids.back());
+    expected_msgs.push_back(entity_proxy_msg);
+
+    MSC.start_reception(expected_msgs);
+
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(3)), expected_msgs.size());
+#endif //FASTDDS_STATISTICS
+}
+
+/**
  * Refers to DDS-MS-ADV-01 from the test plan.
  *
  * A MSC shall correctly receive the corresponding proxies from different MSPs.
@@ -2175,7 +2341,9 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_single_late_joiner)
     size_t n_participants = 3;
     std::vector<MonitorServiceParticipant> MSPs;
     MSPs.resize(n_participants);
-    MonitorServiceConsumer MSC(validation_mask);
+    //! We may receive EXTENDED_INCOMPATIBLE_QOS samples as well
+    //! prevent them from being validated
+    MonitorServiceConsumer MSC(validation_mask, false);
 
     //! Procedure
     std::list<MonitorServiceType::type> expected_msgs;
@@ -2295,6 +2463,190 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_multiple_late_joiners)
         //! The assertion checking whether the on_data_availble() was called is assumed in the following one
         ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(3)), expected_msgs.size());
     }
+#endif //FASTDDS_STATISTICS
+}
+
+/**
+ * Refers to DDS-MS-ADV-05 from the test plan.
+ *
+ * Multiple MSPs notifiy MSC with the correct extended QoS incompatibilities. 4 MSPs
+ * are created, one with a writer and the others with one an incompatible qos reader
+ * in the same topic. It is checked that the MSC receives the corresponding extended
+ * incompatibility notifications.
+ */
+
+void add_extended_incompatible_policy(
+        std::list<MonitorServiceType::type>& expected_msgs,
+        const statistics::detail::GUID_s& source_entity_guid,
+        const std::vector<std::pair<statistics::detail::GUID_s,
+        std::vector<uint32_t>>>& remote_entity_guids_and_policies)
+{
+    MonitorServiceType::type endpoint_ext_incmpqos_msg;
+    StatisticsGUIDList r_guids;
+    statistics::ExtendedIncompatibleQoSStatusSeq_s ext_incompatible_qos_seq;
+    statistics::ExtendedIncompatibleQoSStatus_s ext_incompatible_qos;
+
+    endpoint_ext_incmpqos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::EXTENDED_INCOMPATIBLE_QOS);
+    endpoint_ext_incmpqos_msg.local_entity(source_entity_guid);
+
+    for (const auto& remote_entity_guid_and_policies : remote_entity_guids_and_policies)
+    {
+        ext_incompatible_qos.remote_guid(remote_entity_guid_and_policies.first);
+        ext_incompatible_qos.current_incompatible_policies(remote_entity_guid_and_policies.second);
+        ext_incompatible_qos_seq.push_back(ext_incompatible_qos);
+    }
+
+    endpoint_ext_incmpqos_msg.value().extended_incompatible_qos_status(ext_incompatible_qos_seq);
+    expected_msgs.push_back(endpoint_ext_incmpqos_msg);
+}
+
+TEST(DDSMonitorServiceTest, monitor_service_advanced_extended_incompatible_qos)
+{
+#ifdef FASTDDS_STATISTICS
+
+    //! Validate EXTENDED_INCOMPATIBLE_QOS and PROXY samples only
+    std::bitset<statistics::StatusKind::STATUSES_SIZE> validation_mask;
+    //! In this test we will only expect the disposal proxy samples, not discovery ones
+    validation_mask[statistics::StatusKind::PROXY] = true;
+    validation_mask[statistics::StatusKind::EXTENDED_INCOMPATIBLE_QOS] = true;
+
+    //! Setup
+    size_t n_participants = 4;
+    std::vector<MonitorServiceParticipant> MSPs;
+    MSPs.resize(n_participants);
+    //! By validating PROXY we will receive extra msgs such as discovery proxies or instance unregistrations
+    //! (We are only interested in the disposals from the PROXY status kind)
+    //! but we are not interested in them in this test, so we set assert_on_non_expected_msgs to false
+    MonitorServiceConsumer MSC(validation_mask, false);
+    MSC.init_monitor_service_reader();
+
+    //! Procedure
+    std::list<MonitorServiceType::type> expected_msgs;
+
+    size_t idx = 0;
+    statistics::detail::GUID_s w_guid;
+    for (auto& MSP : MSPs)
+    {
+        MSP.setup();
+        MSP.enable_monitor_service();
+
+        switch (idx)
+        {
+            case 0:
+            {
+                DataWriterQos dw_qos;
+                dw_qos.durability().kind = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS;
+
+                MSP.create_and_add_writer(dw_qos);
+
+                ASSERT_EQ(MSP.get_writer_guids().size(), 1);
+                w_guid = MSP.get_writer_guids().back();
+
+                break;
+            }
+            case 1:
+            {
+                DataReaderQos dr_qos;
+                dr_qos.durability().kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+
+                MSP.create_and_add_reader(dr_qos);
+
+                //! Add extended qos incompatibilities
+                //! for the reader (reader -> writer)
+                add_extended_incompatible_policy(
+                    expected_msgs,
+                    MSP.get_reader_guids().back(),
+                    {{w_guid, {DURABILITY_QOS_POLICY_ID}}}
+                    );
+
+                break;
+            }
+            case 2:
+            {
+                DataReaderQos dr_qos;
+                dr_qos.liveliness().kind = eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+
+                MSP.create_and_add_reader(dr_qos);
+
+                //! Add extended qos incompatibilities
+                //! for the reader (reader -> writer)
+                add_extended_incompatible_policy(
+                    expected_msgs,
+                    MSP.get_reader_guids().back(),
+                    {{w_guid, {LIVELINESS_QOS_POLICY_ID}}}
+                    );
+
+                break;
+            }
+            case 3:
+            {
+                DataReaderQos dr_qos;
+                dr_qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
+
+                MSP.create_and_add_reader(dr_qos);
+
+                //! Add extended qos incompatibilities
+                //! for the reader (reader -> writer)
+                add_extended_incompatible_policy(
+                    expected_msgs,
+                    MSP.get_reader_guids().back(),
+                    {{w_guid, {OWNERSHIP_QOS_POLICY_ID}}}
+                    );
+
+                break;
+            }
+        }
+
+        idx++;
+    }
+
+    //! Finally, add the extended incompatibility for the writer
+    //! Note: we may receive intermediate incompatibility messages like
+    //!      {MSPs[1].get_reader_guids().back(), {DURABILITY_QOS_POLICY_ID}},
+    //! and
+    //!      {MSPs[1].get_reader_guids().back(), {DURABILITY_QOS_POLICY_ID}},
+    //!      {MSPs[2].get_reader_guids().back(), {LIVELINESS_QOS_POLICY_ID}},
+    //! but the important thing is that we receive the folowing one
+    add_extended_incompatible_policy(
+        expected_msgs,
+        w_guid,
+    {
+        {MSPs[1].get_reader_guids().back(), {DURABILITY_QOS_POLICY_ID}},
+        {MSPs[2].get_reader_guids().back(), {LIVELINESS_QOS_POLICY_ID}},
+        {MSPs[3].get_reader_guids().back(), {OWNERSHIP_QOS_POLICY_ID}}});
+
+    MSC.start_reception(expected_msgs);
+
+    //! Assertions
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(5)), expected_msgs.size());
+
+    expected_msgs.clear();
+
+    //! Now we are about to remove readers, prepare the expected messages.
+    //! Empty extended incompatible qos lists
+    add_extended_incompatible_policy(
+        expected_msgs,
+        w_guid,
+        {});
+
+    //! readers disposals
+    for (size_t i = 1; i < n_participants; i++)
+    {
+        MonitorServiceType::type reader_disposal_msg;
+        reader_disposal_msg.local_entity(MSPs[i].get_reader_guids().back());
+        expected_msgs.push_back(reader_disposal_msg);
+    }
+
+    MSC.start_reception(expected_msgs);
+
+    for (size_t i = 1; i < n_participants; i++)
+    {
+        MSPs[i].delete_reader();
+    }
+
+    //! Assertions
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(5)), expected_msgs.size());
+
 #endif //FASTDDS_STATISTICS
 }
 

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -1211,6 +1211,188 @@ typedef BaseStatus_s InconsistentTopicStatus_s;
 
 typedef BaseStatus_s SampleLostStatus_s;
 
+/*!
+ * @brief This class represents the structure ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+ * @ingroup monitorservice_types
+ */
+class ExtendedIncompatibleQoSStatus_s
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_s()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            const ExtendedIncompatibleQoSStatus_s& x)
+    {
+
+                    m_remote_guid = x.m_remote_guid;
+
+                    m_current_incompatible_policies = x.m_current_incompatible_policies;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ExtendedIncompatibleQoSStatus_s that will be copied.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatus_s& operator =(
+            ExtendedIncompatibleQoSStatus_s&& x) noexcept
+    {
+
+        m_remote_guid = std::move(x.m_remote_guid);
+        m_current_incompatible_policies = std::move(x.m_current_incompatible_policies);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return (m_remote_guid == x.m_remote_guid &&
+           m_current_incompatible_policies == x.m_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ExtendedIncompatibleQoSStatus_s object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ExtendedIncompatibleQoSStatus_s& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function copies the value in member remote_guid
+     * @param _remote_guid New value to be copied in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            const detail::GUID_s& _remote_guid)
+    {
+        m_remote_guid = _remote_guid;
+    }
+
+    /*!
+     * @brief This function moves the value in member remote_guid
+     * @param _remote_guid New value to be moved in member remote_guid
+     */
+    eProsima_user_DllExport void remote_guid(
+            detail::GUID_s&& _remote_guid)
+    {
+        m_remote_guid = std::move(_remote_guid);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member remote_guid
+     * @return Constant reference to member remote_guid
+     */
+    eProsima_user_DllExport const detail::GUID_s& remote_guid() const
+    {
+        return m_remote_guid;
+    }
+
+    /*!
+     * @brief This function returns a reference to member remote_guid
+     * @return Reference to member remote_guid
+     */
+    eProsima_user_DllExport detail::GUID_s& remote_guid()
+    {
+        return m_remote_guid;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be copied in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            const std::vector<uint32_t>& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = _current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function moves the value in member current_incompatible_policies
+     * @param _current_incompatible_policies New value to be moved in member current_incompatible_policies
+     */
+    eProsima_user_DllExport void current_incompatible_policies(
+            std::vector<uint32_t>&& _current_incompatible_policies)
+    {
+        m_current_incompatible_policies = std::move(_current_incompatible_policies);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member current_incompatible_policies
+     * @return Constant reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport const std::vector<uint32_t>& current_incompatible_policies() const
+    {
+        return m_current_incompatible_policies;
+    }
+
+    /*!
+     * @brief This function returns a reference to member current_incompatible_policies
+     * @return Reference to member current_incompatible_policies
+     */
+    eProsima_user_DllExport std::vector<uint32_t>& current_incompatible_policies()
+    {
+        return m_current_incompatible_policies;
+    }
+
+
+
+private:
+
+    detail::GUID_s m_remote_guid;
+    std::vector<uint32_t> m_current_incompatible_policies;
+
+};
+typedef std::vector<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
 namespace StatusKind {
 
 typedef uint32_t StatusKind;
@@ -1223,7 +1405,8 @@ const StatusKind LIVELINESS_LOST = 4;
 const StatusKind LIVELINESS_CHANGED = 5;
 const StatusKind DEADLINE_MISSED = 6;
 const StatusKind SAMPLE_LOST = 7;
-const StatusKind STATUSES_SIZE = 8;
+const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+const StatusKind STATUSES_SIZE = 9;
 
 } // namespace StatusKind
 /*!
@@ -1296,6 +1479,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1346,6 +1533,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1396,6 +1587,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = x.m_extended_incompatible_qos_status;
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = x.m_statuses_size;
                             break;
 
@@ -1448,6 +1643,10 @@ public:
                             break;
 
                         case 0x00000009:
+                            extended_incompatible_qos_status_() = std::move(x.m_extended_incompatible_qos_status);
+                            break;
+
+                        case 0x0000000a:
                             statuses_size_() = std::move(x.m_statuses_size);
                             break;
 
@@ -1506,6 +1705,10 @@ public:
                                                         break;
 
                                                     case 0x00000009:
+                                                        ret_value = (x.m_extended_incompatible_qos_status == m_extended_incompatible_qos_status);
+                                                        break;
+
+                                                    case 0x0000000a:
                                                         ret_value = (x.m_statuses_size == m_statuses_size);
                                                         break;
 
@@ -1599,8 +1802,15 @@ public:
                             }
                             break;
 
-                        case StatusKind::STATUSES_SIZE:
+                        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
                             if (0x00000009 == selected_member_)
+                            {
+                                valid_discriminator = true;
+                            }
+                            break;
+
+                        case StatusKind::STATUSES_SIZE:
+                            if (0x0000000a == selected_member_)
                             {
                                 valid_discriminator = true;
                             }
@@ -2050,6 +2260,59 @@ public:
 
 
     /*!
+     * @brief This function copies the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be copied in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            const ExtendedIncompatibleQoSStatusSeq_s& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function moves the value in member extended_incompatible_qos_status
+     * @param _extended_incompatible_qos_status New value to be moved in member extended_incompatible_qos_status
+     */
+    eProsima_user_DllExport void extended_incompatible_qos_status(
+            ExtendedIncompatibleQoSStatusSeq_s&& _extended_incompatible_qos_status)
+    {
+        extended_incompatible_qos_status_() = _extended_incompatible_qos_status;
+        m__d = StatusKind::EXTENDED_INCOMPATIBLE_QOS;
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member extended_incompatible_qos_status
+     * @return Constant reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport const ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status() const
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+    /*!
+     * @brief This function returns a reference to member extended_incompatible_qos_status
+     * @return Reference to member extended_incompatible_qos_status
+     * @exception eprosima::fastcdr::exception::BadParamException This exception is thrown if the requested union member is not the current selection.
+     */
+    eProsima_user_DllExport ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status()
+    {
+        if (0x00000009 != selected_member_)
+        {
+            throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
+        }
+
+        return m_extended_incompatible_qos_status;
+    }
+
+
+    /*!
      * @brief This function sets a value in member statuses_size
      * @param _statuses_size New value for member statuses_size
      */
@@ -2067,7 +2330,7 @@ public:
      */
     eProsima_user_DllExport uint8_t statuses_size() const
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2082,7 +2345,7 @@ public:
      */
     eProsima_user_DllExport uint8_t& statuses_size()
     {
-        if (0x00000009 != selected_member_)
+        if (0x0000000a != selected_member_)
         {
             throw eprosima::fastcdr::exception::BadParamException("This member has not been selected");
         }
@@ -2275,7 +2538,7 @@ private:
                 return m_sample_lost_status;
             }
 
-            uint8_t& statuses_size_()
+            ExtendedIncompatibleQoSStatusSeq_s& extended_incompatible_qos_status_()
             {
                 if (0x00000009 != selected_member_)
                 {
@@ -2285,6 +2548,28 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_extended_incompatible_qos_status.~ExtendedIncompatibleQoSStatusSeq_s();
+                    };
+                    new(&m_extended_incompatible_qos_status) ExtendedIncompatibleQoSStatusSeq_s();
+
+                }
+
+                return m_extended_incompatible_qos_status;
+            }
+
+            uint8_t& statuses_size_()
+            {
+                if (0x0000000a != selected_member_)
+                {
+                    if (member_destructor_)
+                    {
+                        member_destructor_();
+                    }
+
+                    selected_member_ = 0x0000000a;
                     member_destructor_ = nullptr;
                     m_statuses_size = {0};
 
@@ -2306,6 +2591,7 @@ private:
         LivelinessChangedStatus_s m_liveliness_changed_status;
         DeadlineMissedStatus_s m_deadline_missed_status;
         SampleLostStatus_s m_sample_lost_status;
+        ExtendedIncompatibleQoSStatusSeq_s m_extended_incompatible_qos_status;
         uint8_t m_statuses_size;
     };
 

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
@@ -33,6 +33,9 @@ constexpr uint32_t eprosima_fastdds_statistics_BaseStatus_s_max_key_cdr_typesize
 
 
 
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize {36UL};
+constexpr uint32_t eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize {0UL};
+
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_cdr_typesize {24UL};
 constexpr uint32_t eprosima_fastdds_statistics_DeadlineMissedStatus_s_max_key_cdr_typesize {0UL};
 
@@ -96,6 +99,10 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s& data);
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -1120,6 +1120,187 @@ namespace eprosima {
                 register_DeadlineMissedStatus_s_type_identifier(type_identifiers_);
             }
 
+            ExtendedIncompatibleQoSStatus_sPubSubType::ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                set_name("eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s");
+                uint32_t type_size = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_cdr_typesize;
+                type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+                max_serialized_type_size = type_size + 4; /*encapsulation*/
+                is_compute_key_provided = false;
+                uint32_t key_length = eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16 ? eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize : 16;
+                key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+                memset(key_buffer_, 0, key_length);
+            }
+
+            ExtendedIncompatibleQoSStatus_sPubSubType::~ExtendedIncompatibleQoSStatus_sPubSubType()
+            {
+                if (key_buffer_ != nullptr)
+                {
+                    free(key_buffer_);
+                }
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::serialize(
+                    const void* const data,
+                    SerializedPayload_t& payload,
+                    DataRepresentationId_t data_representation)
+            {
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+                payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+                ser.set_encoding_flag(
+                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+                try
+                {
+                    // Serialize encapsulation
+                    ser.serialize_encapsulation();
+                    // Serialize the object.
+                    ser << *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                // Get the serialized length
+                payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+                return true;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::deserialize(
+                    SerializedPayload_t& payload,
+                    void* data)
+            {
+                try
+                {
+                    // Convert DATA to pointer of your type
+                    ExtendedIncompatibleQoSStatus_s* p_type = static_cast<ExtendedIncompatibleQoSStatus_s*>(data);
+
+                    // Object that manages the raw buffer.
+                    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+                    // Object that deserializes the data.
+                    eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+                    // Deserialize encapsulation.
+                    deser.read_encapsulation();
+                    payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+                    // Deserialize the object.
+                    deser >> *p_type;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            uint32_t ExtendedIncompatibleQoSStatus_sPubSubType::calculate_serialized_size(
+                    const void* const data,
+                    DataRepresentationId_t data_representation)
+            {
+                try
+                {
+                    eprosima::fastcdr::CdrSizeCalculator calculator(
+                        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                        eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                    size_t current_alignment {0};
+                    return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                                *static_cast<const ExtendedIncompatibleQoSStatus_s*>(data), current_alignment)) +
+                            4u /*encapsulation*/;
+                }
+                catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+                {
+                    return 0;
+                }
+            }
+
+            void* ExtendedIncompatibleQoSStatus_sPubSubType::create_data()
+            {
+                return reinterpret_cast<void*>(new ExtendedIncompatibleQoSStatus_s());
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::delete_data(
+                    void* data)
+            {
+                delete(reinterpret_cast<ExtendedIncompatibleQoSStatus_s*>(data));
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    SerializedPayload_t& payload,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                ExtendedIncompatibleQoSStatus_s data;
+                if (deserialize(payload, static_cast<void*>(&data)))
+                {
+                    return compute_key(static_cast<void*>(&data), handle, force_md5);
+                }
+
+                return false;
+            }
+
+            bool ExtendedIncompatibleQoSStatus_sPubSubType::compute_key(
+                    const void* const data,
+                    InstanceHandle_t& handle,
+                    bool force_md5)
+            {
+                if (!is_compute_key_provided)
+                {
+                    return false;
+                }
+
+                const ExtendedIncompatibleQoSStatus_s* p_type = static_cast<const ExtendedIncompatibleQoSStatus_s*>(data);
+
+                // Object that manages the raw buffer.
+                eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+                        eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize);
+
+                // Object that serializes the data.
+                eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+                ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+                eprosima::fastcdr::serialize_key(ser, *p_type);
+                if (force_md5 || eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_max_key_cdr_typesize > 16)
+                {
+                    md5_.init();
+                    md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+                    md5_.finalize();
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = md5_.digest[i];
+                    }
+                }
+                else
+                {
+                    for (uint8_t i = 0; i < 16; ++i)
+                    {
+                        handle.value[i] = key_buffer_[i];
+                    }
+                }
+                return true;
+            }
+
+            void ExtendedIncompatibleQoSStatus_sPubSubType::register_type_object_representation()
+            {
+                register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_identifiers_);
+            }
+
             namespace StatusKind {
             } // namespace StatusKind
 

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
@@ -534,6 +534,88 @@ namespace eprosima
             typedef eprosima::fastdds::statistics::BaseStatus_s LivelinessLostStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s InconsistentTopicStatus_s;
             typedef eprosima::fastdds::statistics::BaseStatus_s SampleLostStatus_s;
+
+            /*!
+             * @brief This class represents the TopicDataType of the type ExtendedIncompatibleQoSStatus_s defined by the user in the IDL file.
+             * @ingroup monitorservice_types
+             */
+            class ExtendedIncompatibleQoSStatus_sPubSubType : public eprosima::fastdds::dds::TopicDataType
+            {
+            public:
+
+                typedef ExtendedIncompatibleQoSStatus_s type;
+
+                eProsima_user_DllExport ExtendedIncompatibleQoSStatus_sPubSubType();
+
+                eProsima_user_DllExport ~ExtendedIncompatibleQoSStatus_sPubSubType() override;
+
+                eProsima_user_DllExport bool serialize(
+                        const void* const data,
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool deserialize(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        void* data) override;
+
+                eProsima_user_DllExport uint32_t calculate_serialized_size(
+                        const void* const data,
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport bool compute_key(
+                        const void* const data,
+                        eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                        bool force_md5 = false) override;
+
+                eProsima_user_DllExport void* create_data() override;
+
+                eProsima_user_DllExport void delete_data(
+                        void* data) override;
+
+                //Register TypeObject representation in Fast DDS TypeObjectRegistry
+                eProsima_user_DllExport void register_type_object_representation() override;
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+                eProsima_user_DllExport inline bool is_bounded() const override
+                {
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+                eProsima_user_DllExport inline bool is_plain(
+                        eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+                {
+                    static_cast<void>(data_representation);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+            #ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+                eProsima_user_DllExport inline bool construct_sample(
+                        void* memory) const override
+                {
+                    static_cast<void>(memory);
+                    return false;
+                }
+
+            #endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+            private:
+
+                eprosima::fastdds::MD5 md5_;
+                unsigned char* key_buffer_;
+
+            };
+            typedef std::vector<eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.cxx
@@ -1069,6 +1069,205 @@ void register_SampleLostStatus_s_type_identifier(
     }
 }
 
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatus_s)
+{
+
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatus_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatus_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatus_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatus_s)
+    {
+        StructTypeFlag struct_flags_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatus_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatus_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatus_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatus_s, ann_custom_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string());
+        CompleteStructHeader header_ExtendedIncompatibleQoSStatus_s;
+        header_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ExtendedIncompatibleQoSStatus_s);
+        CompleteStructMemberSeq member_seq_ExtendedIncompatibleQoSStatus_s;
+        {
+            TypeIdentifierPair type_ids_remote_guid;
+            ReturnCode_t return_code_remote_guid {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_remote_guid =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::detail::GUID_s", type_ids_remote_guid);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_remote_guid)
+            {
+                eprosima::fastdds::statistics::detail::register_GUID_s_type_identifier(type_ids_remote_guid);
+            }
+            StructMemberFlag member_flags_remote_guid = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_remote_guid = 0x00000000;
+            bool common_remote_guid_ec {false};
+            CommonStructMember common_remote_guid {TypeObjectUtils::build_common_struct_member(member_id_remote_guid, member_flags_remote_guid, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_remote_guid, common_remote_guid_ec))};
+            if (!common_remote_guid_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure remote_guid member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_remote_guid = "remote_guid";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_remote_guid;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_remote_guid = TypeObjectUtils::build_complete_member_detail(name_remote_guid, member_ann_builtin_remote_guid, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_remote_guid = TypeObjectUtils::build_complete_struct_member(common_remote_guid, detail_remote_guid);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_remote_guid);
+        }
+        {
+            TypeIdentifierPair type_ids_current_incompatible_policies;
+            ReturnCode_t return_code_current_incompatible_policies {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_current_incompatible_policies =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+            {
+                return_code_current_incompatible_policies =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "_uint32_t", type_ids_current_incompatible_policies);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_current_incompatible_policies)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
+                    return;
+                }
+                bool element_identifier_anonymous_sequence_uint32_t_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_uint32_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, element_identifier_anonymous_sequence_uint32_t_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_uint32_t_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_current_incompatible_policies.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_uint32_t_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_uint32_t_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_uint32_t_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint32_t_unbounded, element_flags_anonymous_sequence_uint32_t_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_uint32_t_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_uint32_t_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_uint32_t_unbounded", type_ids_current_incompatible_policies))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_uint32_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_current_incompatible_policies = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_current_incompatible_policies = 0x00000001;
+            bool common_current_incompatible_policies_ec {false};
+            CommonStructMember common_current_incompatible_policies {TypeObjectUtils::build_common_struct_member(member_id_current_incompatible_policies, member_flags_current_incompatible_policies, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_current_incompatible_policies, common_current_incompatible_policies_ec))};
+            if (!common_current_incompatible_policies_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure current_incompatible_policies member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_current_incompatible_policies = "current_incompatible_policies";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_current_incompatible_policies;
+            ann_custom_ExtendedIncompatibleQoSStatus_s.reset();
+            CompleteMemberDetail detail_current_incompatible_policies = TypeObjectUtils::build_complete_member_detail(name_current_incompatible_policies, member_ann_builtin_current_incompatible_policies, ann_custom_ExtendedIncompatibleQoSStatus_s);
+            CompleteStructMember member_current_incompatible_policies = TypeObjectUtils::build_complete_struct_member(common_current_incompatible_policies, detail_current_incompatible_policies);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ExtendedIncompatibleQoSStatus_s, member_current_incompatible_policies);
+        }
+        CompleteStructType struct_type_ExtendedIncompatibleQoSStatus_s = TypeObjectUtils::build_complete_struct_type(struct_flags_ExtendedIncompatibleQoSStatus_s, header_ExtendedIncompatibleQoSStatus_s, member_seq_ExtendedIncompatibleQoSStatus_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ExtendedIncompatibleQoSStatus_s, type_name_ExtendedIncompatibleQoSStatus_s.to_string(), type_ids_ExtendedIncompatibleQoSStatus_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        TypeIdentifierPair& type_ids_ExtendedIncompatibleQoSStatusSeq_s)
+{
+    ReturnCode_t return_code_ExtendedIncompatibleQoSStatusSeq_s {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ExtendedIncompatibleQoSStatusSeq_s =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+    {
+        AliasTypeFlag alias_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        QualifiedTypeName type_name_ExtendedIncompatibleQoSStatusSeq_s = "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ExtendedIncompatibleQoSStatusSeq_s;
+        CompleteTypeDetail detail_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s, type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string());
+        CompleteAliasHeader header_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_header(detail_ExtendedIncompatibleQoSStatusSeq_s);
+        AliasMemberFlag related_flags_ExtendedIncompatibleQoSStatusSeq_s = 0;
+        return_code_ExtendedIncompatibleQoSStatusSeq_s =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+        if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+        {
+            return_code_ExtendedIncompatibleQoSStatusSeq_s =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatus_s", type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_ExtendedIncompatibleQoSStatusSeq_s)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatus_s_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s);
+            }
+            bool element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec {false};
+            TypeIdentifier* element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec))};
+            if (!element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                return;
+            }
+            EquivalenceKind equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_COMPLETE;
+            if (TK_NONE == type_ids_ExtendedIncompatibleQoSStatusSeq_s.type_identifier2()._d())
+            {
+                equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = EK_BOTH;
+            }
+            CollectionElementFlag element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = 0;
+            PlainCollectionHeader header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, element_flags_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded);
+            {
+                SBound bound = 0;
+                PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded, bound,
+                            eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded));
+                if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                        TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded", type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "anonymous_sequence_eprosima_fastdds_statistics_ExtendedIncompatibleQoSStatus_s_unbounded already registered in TypeObjectRegistry for a different type.");
+                }
+            }
+        }
+        bool common_ExtendedIncompatibleQoSStatusSeq_s_ec {false};
+        CommonAliasBody common_ExtendedIncompatibleQoSStatusSeq_s {TypeObjectUtils::build_common_alias_body(related_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ExtendedIncompatibleQoSStatusSeq_s, common_ExtendedIncompatibleQoSStatusSeq_s_ec))};
+        if (!common_ExtendedIncompatibleQoSStatusSeq_s_ec)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier inconsistent.");
+            return;
+        }
+        eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s;
+        ann_custom_ExtendedIncompatibleQoSStatusSeq_s.reset();
+        CompleteAliasBody body_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_body(common_ExtendedIncompatibleQoSStatusSeq_s,
+                member_ann_builtin_ExtendedIncompatibleQoSStatusSeq_s, ann_custom_ExtendedIncompatibleQoSStatusSeq_s);
+        CompleteAliasType alias_type_ExtendedIncompatibleQoSStatusSeq_s = TypeObjectUtils::build_complete_alias_type(alias_flags_ExtendedIncompatibleQoSStatusSeq_s,
+                header_ExtendedIncompatibleQoSStatusSeq_s, body_ExtendedIncompatibleQoSStatusSeq_s);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_alias_type_object(alias_type_ExtendedIncompatibleQoSStatusSeq_s,
+                    type_name_ExtendedIncompatibleQoSStatusSeq_s.to_string(), type_ids_ExtendedIncompatibleQoSStatusSeq_s))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
 namespace StatusKind {
 void register_StatusKind_type_identifier(
         TypeIdentifierPair& type_ids_StatusKind)
@@ -1478,6 +1677,36 @@ void register_MonitorServiceData_type_identifier(
         {
             return_code_MonitorServiceData =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::statistics::ExtendedIncompatibleQoSStatusSeq_s", type_ids_MonitorServiceData);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
+            {
+                eprosima::fastdds::statistics::register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(type_ids_MonitorServiceData);
+            }
+            UnionMemberFlag member_flags_extended_incompatible_qos_status = TypeObjectUtils::build_union_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false);
+            UnionCaseLabelSeq label_seq_extended_incompatible_qos_status;
+            TypeObjectUtils::add_union_case_label(label_seq_extended_incompatible_qos_status, static_cast<int32_t>(StatusKind::EXTENDED_INCOMPATIBLE_QOS));
+            MemberId member_id_extended_incompatible_qos_status = 0x00000009;
+            bool common_extended_incompatible_qos_status_ec {false};
+            CommonUnionMember common_extended_incompatible_qos_status {TypeObjectUtils::build_common_union_member(member_id_extended_incompatible_qos_status,
+                    member_flags_extended_incompatible_qos_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,
+                        common_extended_incompatible_qos_status_ec), label_seq_extended_incompatible_qos_status)};
+            if (!common_extended_incompatible_qos_status_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Union extended_incompatible_qos_status member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_extended_incompatible_qos_status = "extended_incompatible_qos_status";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extended_incompatible_qos_status;
+            ann_custom_MonitorServiceData.reset();
+            CompleteMemberDetail detail_extended_incompatible_qos_status = TypeObjectUtils::build_complete_member_detail(name_extended_incompatible_qos_status, member_ann_builtin_extended_incompatible_qos_status, ann_custom_MonitorServiceData);
+            CompleteUnionMember member_extended_incompatible_qos_status = TypeObjectUtils::build_complete_union_member(common_extended_incompatible_qos_status, detail_extended_incompatible_qos_status);
+            TypeObjectUtils::add_complete_union_member(member_seq_MonitorServiceData, member_extended_incompatible_qos_status);
+        }
+        {
+            return_code_MonitorServiceData =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_byte", type_ids_MonitorServiceData);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_MonitorServiceData)
@@ -1490,7 +1719,7 @@ void register_MonitorServiceData_type_identifier(
                     false, false);
             UnionCaseLabelSeq label_seq_statuses_size;
             TypeObjectUtils::add_union_case_label(label_seq_statuses_size, static_cast<int32_t>(StatusKind::STATUSES_SIZE));
-            MemberId member_id_statuses_size = 0x00000009;
+            MemberId member_id_statuses_size = 0x0000000a;
             bool common_statuses_size_ec {false};
             CommonUnionMember common_statuses_size {TypeObjectUtils::build_common_union_member(member_id_statuses_size,
                     member_flags_statuses_size, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_MonitorServiceData,

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
@@ -192,6 +192,34 @@ eProsima_user_DllExport void register_SampleLostStatus_s_type_identifier(
 
 
 
+/**
+ * @brief Register ExtendedIncompatibleQoSStatus_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatus_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register ExtendedIncompatibleQoSStatusSeq_s related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ExtendedIncompatibleQoSStatusSeq_s_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+
+
 namespace StatusKind {
 /**
  * @brief Register StatusKind related TypeIdentifier.

--- a/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
+++ b/test/mock/rtps/PDP/rtps/builtin/discovery/participant/PDP.h
@@ -89,6 +89,11 @@ public:
             GUID_t& participant_guid,
             std::function<bool(WriterProxyData*, bool, const ParticipantProxyData&)> initializer_func));
 
+    MOCK_METHOD3(notify_incompatible_qos_matching,
+            void (const GUID_t&,
+            const GUID_t&,
+            const fastdds::dds::PolicyMask&));
+
     MOCK_METHOD2(lookupReaderProxyData, bool(
             const GUID_t& reader,
             ReaderProxyData& rdata));

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/StatisticsBase.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/StatisticsBase.hpp
@@ -25,6 +25,8 @@
 #include <set>
 
 #include <fastdds/config.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/Locator.hpp>
 
 #include <statistics/types/types.hpp>
 
@@ -35,25 +37,25 @@ namespace statistics {
 #ifdef FASTDDS_STATISTICS
 
 // auxiliary conversion functions
-detail::Locator_s to_statistics_type(
+inline detail::Locator_s to_statistics_type(
         fastdds::rtps::Locator_t locator)
 {
     return *reinterpret_cast<detail::Locator_s*>(&locator);
 }
 
-fastdds::rtps::Locator_t to_fastdds_type(
+inline fastdds::rtps::Locator_t to_fastdds_type(
         detail::Locator_s locator)
 {
     return *reinterpret_cast<fastdds::rtps::Locator_t*>(&locator);
 }
 
-detail::GUID_s to_statistics_type(
+inline detail::GUID_s to_statistics_type(
         fastdds::rtps::GUID_t guid)
 {
     return *reinterpret_cast<detail::GUID_s*>(&guid);
 }
 
-fastdds::rtps::GUID_t to_fastdds_type(
+inline fastdds::rtps::GUID_t to_fastdds_type(
         detail::GUID_s guid)
 {
     return *reinterpret_cast<fastdds::rtps::GUID_t*>(&guid);

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -58,6 +58,8 @@ class MonitorService
 {
     static constexpr int MIN_TIME_BETWEEN_PUBS_MS = 500;
 
+    friend class MonitorServiceListener;
+
 public:
 
     using endpoint_creator_t = std::function<bool (fastdds::rtps::RTPSWriter**,
@@ -164,6 +166,30 @@ public:
             const fastdds::rtps::EntityId_t& entity_id,
             const uint32_t& status_id);
 
+    /**
+     * @brief Process any updates regarding
+     * remote entities incompatible QoS matching.
+     *
+     * @param local_guid The GUID_t identifying the local entity
+     * @param remote_guid The GUID_t identifying the remote entity
+     * @param incompatible_qos The PolicyMask with the incompatible QoS
+     *
+     */
+    void on_incompatible_qos_matching(
+            const fastdds::rtps::GUID_t& local_guid,
+            const fastdds::rtps::GUID_t& remote_guid,
+            const fastdds::dds::PolicyMask& incompatible_qos_policies);
+
+    /**
+     * @brief Notifies that a remote proxy data has been removed.
+     * This is interesting to notify proxy removals independently
+     * of the remote entity being matched or not.
+     *
+     * @param removed_proxy_guid GUID of the removed proxy.
+     */
+    void on_remote_proxy_data_removed(
+            const fastdds::rtps::GUID_t& removed_proxy_guid);
+
 private:
 
     /**
@@ -261,6 +287,11 @@ private:
     endpoint_registrator_t endpoint_registrator_;
 
     MonitorServiceStatusDataPubSubType type_;
+
+    std::map<fastdds::rtps::GUID_t, ExtendedIncompatibleQoSStatusSeq_s>
+    extended_incompatible_qos_collection_;
+
+    std::mutex extended_incompatible_qos_mtx_;
 };
 
 #endif // FASTDDS_STATISTICS

--- a/versions.md
+++ b/versions.md
@@ -6,6 +6,7 @@ Forthcoming
   * `DataWriter::get_matched_subscriptions()`
   * `DataReader::get_matched_publication_data()`
   * `DataReader::get_matched_publications()`
+* Added ``Extended Incompatible QoS`` feature for monitor service.
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the `Extended incompatible QoS for monitor service` feature.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [X] New feature has been added to the `versions.md` file (if applicable).
- [X] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#947
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
