### PR TITLE
[21698] Add -v or --version to cli command tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,8 +610,6 @@ if(INSTALL_TOOLS)
       )
 endif()
 
-install(FILES "${CMAKE_SOURCE_DIR}/package.xml" DESTINATION "${CMAKE_INSTALL_PREFIX}")
-
 if(BUILD_DOCUMENTATION)
 
     # Instalation of doxygen files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,8 @@ if(INSTALL_TOOLS)
       )
 endif()
 
+install(FILES "${CMAKE_SOURCE_DIR}/package.xml" DESTINATION "${CMAKE_INSTALL_PREFIX}")
+
 if(BUILD_DOCUMENTATION)
 
     # Instalation of doxygen files

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <name>fastdds</name>
   <version>3.1.0</version>
   <description>
-     *eprosima Fast DDS* is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard. *eProsima Fast DDS* expose an API to access directly the RTPS protocol, giving the user full access to the protocol internals.
+  eProsima Fast DDS is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard. eProsima Fast DDS expose an API to access directly the RTPS protocol, giving the user full access to the protocol internals.
   </description>
   <maintainer email="raulsanchezmateos@eprosima.com">Raul Sanchez Mateos</maintainer>
   <maintainer email="miguelcompany@eprosima.com">Miguel Company</maintainer>

--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -26,6 +26,7 @@ if(Python3_Interpreter_FOUND)
 
     set(TESTS
         test_fastdds_installed
+        test_fastdds_version
         test_fastdds_discovery
         test_ros_discovery
         test_fastdds_shm

--- a/test/system/tools/fastdds/tests.py
+++ b/test/system/tools/fastdds/tests.py
@@ -98,7 +98,7 @@ def test_fastdds_installed(install_path):
 
 def test_fastdds_version(install_path):
     """Test that fastdds version is printed correctly."""
-    args = ' -v'
+    args = '-v'
     ret = subprocess.call(cmd(install_path, args=args), shell=True)
     if 0 != ret:
         print('test_fastdds_version FAILED')
@@ -205,6 +205,8 @@ if __name__ == '__main__':
     tests = {
         'test_fastdds_installed':
         lambda: test_fastdds_installed(fastdds_tool_path),
+        'test_fastdds_version':
+        lambda: test_fastdds_version(fastdds_tool_path),
         'test_fastdds_discovery': lambda: test_fastdds_discovery(
             fastdds_tool_path, setup_script_path),
         'test_ros_discovery':

--- a/test/system/tools/fastdds/tests.py
+++ b/test/system/tools/fastdds/tests.py
@@ -96,6 +96,13 @@ def test_fastdds_installed(install_path):
         print('test_fastdds_installed FAILED')
         sys.exit(ret)
 
+def test_fastdds_version(install_path):
+    """Test that fastdds version is printed correctly."""
+    args = ' -v'
+    ret = subprocess.call(cmd(install_path, args=args), shell=True)
+    if 0 != ret:
+        print('test_fastdds_version FAILED')
+        sys.exit(ret)
 
 def test_fastdds_shm(install_path):
     """Test that shm command runs."""

--- a/tools/fastdds/discovery/parser.py
+++ b/tools/fastdds/discovery/parser.py
@@ -54,7 +54,6 @@ class Parser:
                     (len(argv) == 1 and argv[0] == '--help')
                ):
                 print(self.__edit_tool_help(result.stdout))
-                
             elif (
                 (len(argv) == 1 and argv[0] == '-v') or 
                 (len(argv) == 1 and argv[0] == '--version')

--- a/tools/fastdds/discovery/parser.py
+++ b/tools/fastdds/discovery/parser.py
@@ -54,6 +54,14 @@ class Parser:
                     (len(argv) == 1 and argv[0] == '--help')
                ):
                 print(self.__edit_tool_help(result.stdout))
+                
+            elif (
+                (len(argv) == 1 and argv[0] == '-v') or 
+                (len(argv) == 1 and argv[0] == '--version')
+                ):
+                result = subprocess.run([tool_path, '-v'])
+                if result.returncode != 0:
+                    sys.exit(result.returncode)
             else:
                 # Call the tool
                 result = subprocess.run([tool_path] + argv)

--- a/tools/fastdds/fastdds.py
+++ b/tools/fastdds/fastdds.py
@@ -44,6 +44,7 @@ optional arguments:
 import argparse
 import pathlib
 import sys
+import textwrap
 import xml.etree.ElementTree as ET
 
 from discovery.parser import Parser as DiscoveryParser
@@ -91,15 +92,15 @@ class FastDDSParser:
                 getattr(self, args.command)()
         elif args.version:
             parents_path = list(pathlib.Path(__file__).parent.resolve().parents)
-            matching_paths = [p for p in parents_path if p.name == 'fastdds'][0]
-            p = matching_paths / 'package.xml'
-            tree = ET.parse(p)
+            path_to_package_xml = [p for p in parents_path if p.name == 'fastdds'][0] / 'package.xml'
+            tree = ET.parse(path_to_package_xml)
             root = tree.getroot()
             name = 'Fast DDS'
             version = root.find('version').text
-            description = root.find('description').text.strip('*')
-            print('{} version: {}'.format(name, version))
-            print(description)
+            description = root.find('description').text.replace('*', '')
+            print(f"\n\033[1m{name} version: {version}\033[0m\n")
+            print("\033[1mDescription:\033[0m\n")
+            print(textwrap.fill(description, width=120, subsequent_indent="    ") + "\n")
         else:
             parser.print_help()
 

--- a/tools/fastdds/fastdds.py
+++ b/tools/fastdds/fastdds.py
@@ -42,10 +42,7 @@ optional arguments:
 """
 
 import argparse
-import pathlib
 import sys
-import textwrap
-import xml.etree.ElementTree as ET
 
 from discovery.parser import Parser as DiscoveryParser
 

--- a/tools/fastdds/fastdds.py
+++ b/tools/fastdds/fastdds.py
@@ -42,7 +42,9 @@ optional arguments:
 """
 
 import argparse
+import pathlib
 import sys
+import xml.etree.ElementTree as ET
 
 from discovery.parser import Parser as DiscoveryParser
 
@@ -78,6 +80,7 @@ class FastDDSParser:
         parser.add_argument('command',
                             nargs='?',
                             help='Command to run')
+        parser.add_argument('-v', '--version', action='store_true', help='Print Fast DDS version')
 
         args = parser.parse_args(sys.argv[1:2])
 
@@ -86,6 +89,17 @@ class FastDDSParser:
                 print('Invalid command')
             else:
                 getattr(self, args.command)()
+        elif args.version:
+            parents_path = list(pathlib.Path(__file__).parent.resolve().parents)
+            matching_paths = [p for p in parents_path if p.name == 'fastdds'][0]
+            p = matching_paths / 'package.xml'
+            tree = ET.parse(p)
+            root = tree.getroot()
+            name = 'Fast DDS'
+            version = root.find('version').text
+            description = root.find('description').text.strip('*')
+            print('{} version: {}'.format(name, version))
+            print(description)
         else:
             parser.print_help()
 
@@ -121,7 +135,6 @@ class FastDDSParser:
             XMLParser(sys.argv[2:])
         except ImportError:
             sys.exit(1)
-
 
 if __name__ == '__main__':
 

--- a/tools/fastdds/fastdds.py
+++ b/tools/fastdds/fastdds.py
@@ -91,16 +91,7 @@ class FastDDSParser:
             else:
                 getattr(self, args.command)()
         elif args.version:
-            parents_path = list(pathlib.Path(__file__).parent.resolve().parents)
-            path_to_package_xml = [p for p in parents_path if p.name == 'fastdds'][0] / 'package.xml'
-            tree = ET.parse(path_to_package_xml)
-            root = tree.getroot()
-            name = 'Fast DDS'
-            version = root.find('version').text
-            description = root.find('description').text.replace('*', '')
-            print(f"\n\033[1m{name} version: {version}\033[0m\n")
-            print("\033[1mDescription:\033[0m\n")
-            print(textwrap.fill(description, width=120, subsequent_indent="    ") + "\n")
+            DiscoveryParser(['-v'])
         else:
             parser.print_help()
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -113,7 +113,7 @@ int fastdds_discovery_server(
     // Show version if asked to
     if (options[VERSION])
     {
-        std::cout <<  "Fast DDS version: " << FASTDDS_VERSION_STR << std::endl;
+        std::cout << "Fast DDS version: " << FASTDDS_VERSION_STR << std::endl;
         return 0;
     }
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "server.h"
+#include <fastdds/config.hpp>
 
 #include <condition_variable>
 #include <csignal>
@@ -106,6 +107,13 @@ int fastdds_discovery_server(
     {
         option::printUsage(std::cout, usage);
         std::cout << EXAMPLES << std::endl;
+        return 0;
+    }
+
+    // Show version if asked to
+    if (options[VERSION])
+    {
+        std::cout <<  "FastDDS version: " << FASTDDS_VERSION_STR << std::endl;
         return 0;
     }
 

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -113,7 +113,7 @@ int fastdds_discovery_server(
     // Show version if asked to
     if (options[VERSION])
     {
-        std::cout <<  "FastDDS version: " << FASTDDS_VERSION_STR << std::endl;
+        std::cout <<  "Fast DDS version: " << FASTDDS_VERSION_STR << std::endl;
         return 0;
     }
 

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -64,7 +64,7 @@ const option::Descriptor usage[] = {
       "  -h  \t--help        Produce help message.\n" },
 
     { VERSION,   0, "v",  "version",      Arg::None,
-      "  -v  \t--version     Show FastDDS version information.\n" },
+      "  -v  \t--version     Show Fast DDS version information.\n" },
 
     { UDPADDRESS, 0, "l", "udp-address",   Arg::OptionalAny,
       "  -l \t--udp-address IPv4/IPv6 address chosen to listen the clients. Defaults\n"

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -62,7 +62,7 @@ const option::Descriptor usage[] = {
 
     { HELP,      0, "h",  "help",         Arg::None,
       "  -h  \t--help        Produce help message.\n" },
-    
+
     { VERSION,   0, "v",  "version",      Arg::None,
       "  -v  \t--version     Show FastDDS version information.\n" },
 

--- a/tools/fds/server.h
+++ b/tools/fds/server.h
@@ -25,6 +25,7 @@ enum  optionIndex
 {
     UNKNOWN,
     HELP,
+    VERSION,
     SERVERID,
     UDPADDRESS,
     UDP_PORT,
@@ -61,6 +62,9 @@ const option::Descriptor usage[] = {
 
     { HELP,      0, "h",  "help",         Arg::None,
       "  -h  \t--help        Produce help message.\n" },
+    
+    { VERSION,   0, "v",  "version",      Arg::None,
+      "  -v  \t--version     Show FastDDS version information.\n" },
 
     { UDPADDRESS, 0, "l", "udp-address",   Arg::OptionalAny,
       "  -l \t--udp-address IPv4/IPv6 address chosen to listen the clients. Defaults\n"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->
Modify the cli command tool to provide the version of the installed Fast DDS. Modify CMakeLists.txt in fastdds repository to export 'package.xml' to install directory.
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [X] The PR has a milestone assigned.
- [X] The title and description correctly express the PR's purpose.
- [X] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
