### PR TITLE
[22056] Fix TCP discovery server locators translation (backport #5382)

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1174,7 +1174,6 @@ bool SecurityManager::create_participant_stateless_message_reader()
         ratt.endpoint.multicastLocatorList = pattr.builtin.metatrafficMulticastLocatorList;
     }
     ratt.endpoint.unicastLocatorList = pattr.builtin.metatrafficUnicastLocatorList;
-    ratt.endpoint.remoteLocatorList = pattr.builtin.initialPeersList;
     ratt.endpoint.external_unicast_locators = pattr.builtin.metatraffic_external_unicast_locators;
     ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
     ratt.matched_writers_allocation = pattr.allocation.participants;
@@ -1274,7 +1273,6 @@ bool SecurityManager::create_participant_volatile_message_secure_writer()
     watt.endpoint.unicastLocatorList = pattr.builtin.metatrafficUnicastLocatorList;
     watt.endpoint.external_unicast_locators = pattr.builtin.metatraffic_external_unicast_locators;
     watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.endpoint.remoteLocatorList = pattr.builtin.initialPeersList;
     watt.endpoint.security_attributes().is_submessage_protected = true;
     watt.endpoint.security_attributes().plugin_endpoint_attributes =
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
@@ -1327,7 +1325,6 @@ bool SecurityManager::create_participant_volatile_message_secure_reader()
     ratt.endpoint.unicastLocatorList = pattr.builtin.metatrafficUnicastLocatorList;
     ratt.endpoint.external_unicast_locators = pattr.builtin.metatraffic_external_unicast_locators;
     ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.remoteLocatorList = pattr.builtin.initialPeersList;
     ratt.endpoint.security_attributes().is_submessage_protected = true;
     ratt.endpoint.security_attributes().plugin_endpoint_attributes =
             PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -239,7 +239,7 @@ public:
     virtual ~TCPTransportInterface();
 
     //! Stores the binding between the given locator and the given TCP socket. Server side.
-    void bind_socket(
+    ResponseCode bind_socket(
             std::shared_ptr<TCPChannelResource>&);
 
     //! Removes the listening socket for the specified port.
@@ -525,6 +525,16 @@ public:
      */
     void send_channel_pending_logical_ports(
             std::shared_ptr<TCPChannelResource>& channel);
+
+    /**
+     * Method to check if a locator contains an interface that belongs to the same host.
+     * If it occurs, @c locNames will be updated with the list of interfaces of the host.
+     * @param [in]     locator Locator to check.
+     * @param [in,out] locNames Vector of interfaces to be updated.
+     */
+    void is_own_interface(
+            const Locator& locator,
+            std::vector<fastdds::rtps::IPFinder::info_IP>& locNames) const;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -458,7 +458,7 @@ ResponseCode RTCPMessageManager::processBindConnectionRequest(
 
     if (RETCODE_OK == code)
     {
-        mTransport->bind_socket(channel);
+        code = mTransport->bind_socket(channel);
     }
 
     sendData(channel, BIND_CONNECTION_RESPONSE, transaction_id, &payload, code);

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -304,6 +304,8 @@ int fastdds_discovery_server(
     // Retrieve first TCP port
     option::Option* pO_tcp_port = options[TCP_PORT];
 
+    bool udp_server_initialized = (pOp != nullptr) || (pO_port != nullptr);
+
     /**
      * A locator has been initialized previously in [0.0.0.0] address using either the DEFAULT_ROS2_SERVER_PORT or the
      * port number set in the CLI. This locator must be used:
@@ -318,6 +320,7 @@ int fastdds_discovery_server(
         // Add default locator in cases a) and b)
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.clear();
         participantQos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator4);
+        udp_server_initialized = true;
     }
     else if (nullptr == pOp && nullptr != pO_port)
     {
@@ -569,6 +572,7 @@ int fastdds_discovery_server(
     }
 
     fastdds::rtps::GuidPrefix_t guid_prefix = participantQos.wire_protocol().prefix;
+    participantQos.transport().use_builtin_transports = udp_server_initialized || options[XML_FILE] != nullptr;
 
     // Create the server
     int return_value = 0;


### PR DESCRIPTION
## Description

This PR is a partial backport of https://github.com/eProsima/Fast-DDS/pull/5382, which fixes a bug where a TCP client connecting to `localhost` is unable to identify the locator of a TCP discovery server with a custom GUID listening on `any`. This causes the client to create two different channels for the same connection, where the latest can never be reached. The reason is that the server's locator is not considered from the same host due to its custom GUID. Hence, the server transforms the client's locator into `localhost` but the client does not do the same with the server's locator.

The proposed fix is to create a new entry into the `channel_resources_` map for each local interface available. In this way, every locator with local address will reuse the same TCP channel, instead of creating a new one. Any new attempt of creating a new channel will be rejected by the server if the address was previously added.

@Mergifyio backport 3.0.x 2.14.x 2.10.x

## Contributor Checklist

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally. Related tests: https://github.com/eProsima/Discovery-Server/pull/108
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
