### PR TITLE
[22280] New property to select preferred key agreement algorithm

### DIFF
--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -1052,7 +1052,7 @@ ValidationResult_t PKIDH::validate_local_identity(
         password = &empty_password;
     }
 
-    std::string key_agreement_algorithm = DH_2048_256;
+    std::string key_agreement_algorithm = ECDH_prime256v1;
     std::string* key_agreement_property =
             PropertyPolicyHelper::find_property(auth_properties, "preferred_key_agreement");
     if (nullptr != key_agreement_property)

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -1061,7 +1061,7 @@ ValidationResult_t PKIDH::validate_local_identity(
             {DH_2048_256, DH_2048_256},
             {ECDH_prime256v1, ECDH_prime256v1},
             {"ECDH", ECDH_prime256v1},
-            {"RSA", DH_2048_256}
+            {"DH", DH_2048_256}
         };
 
         key_agreement_algorithm = "";

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -55,6 +55,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <utility>
 
 #define S1(x) #x
 #define S2(x) S1(x)
@@ -1051,8 +1052,39 @@ ValidationResult_t PKIDH::validate_local_identity(
         password = &empty_password;
     }
 
+    std::string key_agreement_algorithm = DH_2048_256;
+    std::string* key_agreement_property =
+            PropertyPolicyHelper::find_property(auth_properties, "preferred_key_agreement");
+    if (nullptr != key_agreement_property)
+    {
+        const std::pair<std::string, std::string> key_agreement_allowed_values[] = {
+            {DH_2048_256, DH_2048_256},
+            {ECDH_prime256v1, ECDH_prime256v1},
+            {"ECDH", ECDH_prime256v1},
+            {"RSA", DH_2048_256}
+        };
+
+        key_agreement_algorithm = "";
+        for (const auto& allowed_value : key_agreement_allowed_values)
+        {
+            if (key_agreement_property->compare(allowed_value.first) == 0)
+            {
+                key_agreement_algorithm = allowed_value.second;
+                break;
+            }
+        }
+
+        if (key_agreement_algorithm.empty())
+        {
+            exception = _SecurityException_("Invalid key agreement algorithm '" + *key_agreement_property + "'");
+            EMERGENCY_SECURITY_LOGGING("PKIDH", exception.what());
+            return ValidationResult_t::VALIDATION_FAILED;
+        }
+    }
+
     PKIIdentityHandle* ih = &PKIIdentityHandle::narrow(*get_identity_handle(exception));
 
+    (*ih)->kagree_alg_ = key_agreement_algorithm;
     (*ih)->store_ = load_identity_ca(*identity_ca, (*ih)->there_are_crls_, (*ih)->sn, (*ih)->algo,
                     exception);
 
@@ -1266,7 +1298,6 @@ ValidationResult_t PKIDH::begin_handshake_request(
     bproperty.propagate(true);
     (*handshake_handle_aux)->handshake_message_.binary_properties().push_back(std::move(bproperty));
 
-    // TODO(Ricardo) Only support right now DH+MODP-2048-256
     // c.kagree_algo.
     bproperty.name("c.kagree_algo");
     bproperty.value().assign(lih->kagree_alg_.begin(),
@@ -1636,7 +1667,6 @@ ValidationResult_t PKIDH::begin_handshake_reply(
     bproperty.propagate(true);
     (*handshake_handle_aux)->handshake_message_.binary_properties().push_back(std::move(bproperty));
 
-    // TODO(Ricardo) Only support right now DH+MODP-2048-256
     // c.kagree_algo.
     bproperty.name("c.kagree_algo");
     bproperty.value().assign((*handshake_handle_aux)->kagree_alg_.begin(),

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -51,7 +51,7 @@ enum communication_type
 
 enum class key_agree_alg
 {
-    RSA,
+    DH,
     ECDH
 };
 
@@ -125,8 +125,8 @@ public:
         fill_basic_pub_auth(policy);
         switch (std::get<1>(GetParam()))
         {
-            case key_agree_alg::RSA:
-                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "RSA");
+            case key_agree_alg::DH:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "DH");
                 break;
 
             case key_agree_alg::ECDH:
@@ -142,8 +142,8 @@ public:
         fill_basic_sub_auth(policy);
         switch (std::get<1>(GetParam()))
         {
-            case key_agree_alg::RSA:
-                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "RSA");
+            case key_agree_alg::DH:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "DH");
                 break;
             case key_agree_alg::ECDH:
             default:
@@ -4568,11 +4568,11 @@ GTEST_INSTANTIATE_TEST_MACRO(Security,
         Security,
         testing::Combine(
             testing::Values(TRANSPORT, INTRAPROCESS, DATASHARING),
-            testing::Values(key_agree_alg::RSA, key_agree_alg::ECDH)),
+            testing::Values(key_agree_alg::DH, key_agree_alg::ECDH)),
         [](const testing::TestParamInfo<Security::ParamType>& info)
         {
             std::string alg;
-            alg = std::get<1>(info.param) == key_agree_alg::RSA ? "RSA_" : "ECDH_";
+            alg = (std::get<1>(info.param) == key_agree_alg::DH) ? "DH_" : "ECDH_";
 
             switch (std::get<0>(info.param))
             {

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -874,8 +874,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_rtps_ok_same_participant)
 {
     PubSubWriterReader<HelloWorldPubSubType> wreader(TEST_TOPIC_NAME);
 
-    PropertyPolicy pub_property_policy, sub_property_policy,
-            property_policy;
+    PropertyPolicy property_policy;
 
     fill_pub_auth(property_policy);
     property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
@@ -1120,7 +1119,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1170,7 +1169,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1254,7 +1253,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1304,7 +1303,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1352,7 +1351,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1410,7 +1409,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1466,7 +1465,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
@@ -1516,7 +1515,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3018,7 +3018,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     std::string permissions_file("permissions_helloworld.smime");
 
     //!Lambda for configuring publisher participant qos and security properties
-    auto secure_participant_pub_configurator = [this, &governance_file,
+    auto secure_participant_pub_configurator = [&governance_file,
                     &permissions_file](const std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>& part,
                     const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
@@ -3048,7 +3048,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
             };
     //!Lambda for configuring subscriber participant qos and security properties
-    auto secure_participant_sub_configurator = [this, &governance_file,
+    auto secure_participant_sub_configurator = [&governance_file,
                     &permissions_file](const std::shared_ptr<PubSubReader<HelloWorldPubSubType>>& part,
                     const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -58,25 +58,25 @@ enum class key_agree_alg
 static void fill_basic_pub_auth(
         PropertyPolicy& policy)
 {
-    policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    policy.properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem");
 }
 
 static void fill_basic_sub_auth(
         PropertyPolicy& policy)
 {
-    policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    policy.properties().emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainsubcert.pem");
+    policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainsubkey.pem");
 }
 
 class Security : public testing::TestWithParam<std::tuple<communication_type, key_agree_alg>>
@@ -669,8 +669,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -679,8 +678,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -727,8 +725,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -737,8 +734,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -787,8 +783,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -797,8 +792,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -835,8 +829,7 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_basic_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -846,8 +839,7 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_basic_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -884,8 +876,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_rtps_ok_same_participant)
             property_policy;
 
     fill_pub_auth(property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     wreader.pub_history_depth(10).sub_history_depth(10).sub_reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
@@ -917,8 +908,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -927,8 +917,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -965,8 +954,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -976,8 +964,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1013,8 +1000,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1023,8 +1009,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1069,8 +1054,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
     PropertyPolicy pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1080,8 +1064,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1126,8 +1109,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1137,8 +1119,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1177,8 +1158,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1189,8 +1169,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1228,8 +1207,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_submessage_ok_same_partici
             property_policy;
 
     fill_pub_auth(pub_property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
@@ -1265,8 +1243,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1276,8 +1253,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1316,8 +1292,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1328,8 +1303,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1367,8 +1341,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1378,8 +1351,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1426,8 +1398,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1438,8 +1409,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1485,8 +1455,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1496,8 +1465,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1536,8 +1504,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1548,8 +1515,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1587,8 +1553,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
             property_policy;
 
     fill_pub_auth(property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
@@ -1622,8 +1587,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     PropertyPolicy pub_property_policy, sub_property_policy, property_policy;
 
     fill_pub_auth(property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
@@ -1659,8 +1623,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1670,8 +1633,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1710,8 +1672,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(10).
@@ -1722,8 +1683,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     writer.history_depth(10).
@@ -1761,8 +1721,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1772,8 +1731,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1820,8 +1778,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     reader.history_depth(5).
@@ -1832,8 +1789,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
     // When doing fragmentation, it is necessary to have some degree of
@@ -1879,8 +1835,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1892,8 +1847,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1934,8 +1888,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1948,8 +1901,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1989,8 +1941,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2002,8 +1953,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2044,8 +1994,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2058,8 +2007,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2099,8 +2047,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2112,8 +2059,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2162,8 +2108,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2176,8 +2121,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2226,8 +2170,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
             pub_property_policy, sub_property_policy;
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2240,8 +2183,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
     ASSERT_TRUE(reader.isInitialized());
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2289,8 +2231,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
             pub_property_policy, sub_property_policy;
 
     fill_pub_auth(pub_part_property_policy);
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2303,8 +2244,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     ASSERT_TRUE(writer.isInitialized());
 
     fill_sub_auth(sub_part_property_policy);
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_part_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2356,8 +2296,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2375,8 +2314,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
         ASSERT_TRUE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2424,8 +2362,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2441,8 +2378,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
         ASSERT_FALSE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2467,8 +2403,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
 
         PropertyPolicy pub_property_policy;
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2490,8 +2425,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
 
         PropertyPolicy sub_property_policy;
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2537,8 +2471,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2554,8 +2487,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         ASSERT_FALSE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2581,8 +2513,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2600,8 +2531,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         ASSERT_TRUE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2650,8 +2580,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2667,8 +2596,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         ASSERT_FALSE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2694,8 +2622,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         PropertyPolicy pub_property_policy, sub_property_policy;
 
         fill_sub_auth(sub_property_policy);
-        sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         sub_property_policy.properties().emplace_back(Property(
@@ -2714,8 +2641,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
         ASSERT_TRUE(reader.isInitialized());
 
         fill_pub_auth(pub_property_policy);
-        pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                "builtin.AES-GCM-GMAC"));
+        pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                 "builtin.Access-Permissions"));
         pub_property_policy.properties().emplace_back(Property(
@@ -2765,8 +2691,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
     // Prepare subscriptions security properties
     PropertyPolicy sub_property_policy;
     fill_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     sub_property_policy.properties().emplace_back(Property(
@@ -2793,8 +2718,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
     // Prepare publication security properties
     PropertyPolicy pub_property_policy;
     fill_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     pub_property_policy.properties().emplace_back(Property(
@@ -2873,8 +2797,7 @@ void prepare_pkcs11_nodes(
             "file://" + std::string(certs_path) + "/mainsubcert.pem"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
             reader_private_key_url));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     sub_property_policy.properties().emplace_back(Property(
@@ -2897,8 +2820,7 @@ void prepare_pkcs11_nodes(
             "file://" + std::string(certs_path) + "/mainpubcert.pem"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
             writer_private_key_url));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     pub_property_policy.properties().emplace_back(Property(
@@ -3008,8 +2930,7 @@ static void CommonPermissionsConfigure(
 {
     PropertyPolicy sub_property_policy(extra_properties);
     fill_basic_sub_auth(sub_property_policy);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -3031,8 +2952,7 @@ static void CommonPermissionsConfigure(
     PropertyPolicy pub_property_policy(extra_properties);
 
     fill_basic_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -3107,8 +3027,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
                 fill_pub_auth(property_policy);
 
-                property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                        "builtin.AES-GCM-GMAC"));
+                property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
                 property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                         "builtin.Access-Permissions"));
                 property_policy.properties().emplace_back(Property(
@@ -3137,8 +3056,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
                 PropertyPolicy property_policy;
 
                 fill_sub_auth(property_policy);
-                property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-                        "builtin.AES-GCM-GMAC"));
+                property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
                 property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
                         "builtin.Access-Permissions"));
                 property_policy.properties().emplace_back(Property(
@@ -3223,8 +3141,7 @@ TEST(Security, AllowUnauthenticatedParticipants_EntityCreationFailsIfRTPSProtect
     PropertyPolicy property_policy;
 
     fill_basic_sub_auth(property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     property_policy.properties().emplace_back(Property(
@@ -3259,8 +3176,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoSecureParticipantsWithDiffere
             "file://" + std::string(certs_path) + "/othersubcert.pem"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
             "file://" + std::string(certs_path) + "/othersubkey.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -3277,8 +3193,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoSecureParticipantsWithDiffere
     ASSERT_TRUE(reader.isInitialized());
 
     fill_basic_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -3334,8 +3249,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoParticipantsDifferentCertific
             "file://" + std::string(certs_path) + "/othersubcert.pem"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
             "file://" + std::string(certs_path) + "/othersubkey.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    sub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -3353,8 +3267,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoParticipantsDifferentCertific
     ASSERT_TRUE(reader.isInitialized());
 
     fill_basic_pub_auth(pub_property_policy);
-    pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    pub_property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
             "builtin.Access-Permissions"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions_ca",
@@ -4358,8 +4271,7 @@ TEST(Security, ValidateAuthenticationHandshakePropertiesParsing)
     PropertyPolicy property_policy;
 
     fill_basic_sub_auth(property_policy);
-    property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
-            "builtin.AES-GCM-GMAC"));
+    property_policy.properties().emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
 
     // max_handshake_requests out of bounds
     property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.max_handshake_requests",

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -3018,7 +3018,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     //!Lambda for configuring publisher participant qos and security properties
     auto secure_participant_pub_configurator = [this, &governance_file,
                     &permissions_file](const std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>& part,
-            const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
+                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
                 part->lease_duration(3, 1);
                 part->disable_builtin_transport().add_user_transport_to_pparams(transport_interface);
@@ -3048,7 +3048,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     //!Lambda for configuring subscriber participant qos and security properties
     auto secure_participant_sub_configurator = [this, &governance_file,
                     &permissions_file](const std::shared_ptr<PubSubReader<HelloWorldPubSubType>>& part,
-            const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
+                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
                 part->lease_duration(3, 1);
                 part->disable_builtin_transport().add_user_transport_to_pparams(transport_interface);

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -119,6 +119,23 @@ public:
         }
     }
 
+    void fill_pub_auth(
+            PropertyPolicy& policy)
+    {
+        fill_basic_pub_auth(policy);
+        switch (std::get<1>(GetParam()))
+        {
+            case key_agree_alg::RSA:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "RSA");
+                break;
+
+            case key_agree_alg::ECDH:
+            default:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "ECDH");
+                break;
+        }
+    }
+
 };
 
 class SecurityPkcs : public ::testing::Test
@@ -280,7 +297,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
 
     writer.history_depth(10).
             property_policy(pub_property_policy).init();
@@ -314,7 +331,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok_same_participan
 
     PropertyPolicy property_policy;
 
-    fill_basic_pub_auth(property_policy);
+    fill_pub_auth(property_policy);
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
     wreader.pub_history_depth(10);
@@ -350,7 +367,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
 
         ASSERT_TRUE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
 
         writer.history_depth(10).
                 property_policy(pub_property_policy).init();
@@ -406,7 +423,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
     writer.disable_builtin_transport();
     writer.add_user_transport_to_pparams(testTransport);
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
 
     writer.history_depth(10).
             property_policy(pub_property_policy).init();
@@ -591,7 +608,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_ensure_same_guid_reconnection)
 
     // Prepare participant properties
     PropertyPolicy property_policy;
-    fill_basic_pub_auth(property_policy);
+    fill_pub_auth(property_policy);
 
     // Create the participant being checked
     PubSubWriter<HelloWorldPubSubType> main_participant("HelloWorldTopic");
@@ -645,7 +662,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -703,7 +720,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -763,7 +780,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -850,7 +867,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_rtps_ok_same_participant)
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    fill_basic_pub_auth(property_policy);
+    fill_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -893,7 +910,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -942,7 +959,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -989,7 +1006,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1046,7 +1063,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1103,7 +1120,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1155,7 +1172,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1194,7 +1211,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_submessage_ok_same_partici
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1242,7 +1259,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1294,7 +1311,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1344,7 +1361,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1404,7 +1421,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1462,7 +1479,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1514,7 +1531,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1553,7 +1570,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    fill_basic_pub_auth(property_policy);
+    fill_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1588,7 +1605,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
 
     PropertyPolicy pub_property_policy, sub_property_policy, property_policy;
 
-    fill_basic_pub_auth(property_policy);
+    fill_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1636,7 +1653,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1688,7 +1705,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1738,7 +1755,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1798,7 +1815,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1858,7 +1875,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1914,7 +1931,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1968,7 +1985,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2024,7 +2041,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2078,7 +2095,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2142,7 +2159,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2206,7 +2223,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
 
     ASSERT_TRUE(reader.isInitialized());
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2255,7 +2272,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_pub_auth(pub_part_property_policy);
+    fill_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2341,7 +2358,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         ASSERT_TRUE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2407,7 +2424,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         ASSERT_FALSE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2433,7 +2450,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
         std::string permissions_file("permissions_helloworld.smime");
 
         PropertyPolicy pub_property_policy;
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2520,7 +2537,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2566,7 +2583,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         ASSERT_TRUE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2633,7 +2650,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2680,7 +2697,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         ASSERT_TRUE(reader.isInitialized());
 
-        fill_basic_pub_auth(pub_property_policy);
+        fill_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2759,7 +2776,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
     // Prepare publication security properties
     PropertyPolicy pub_property_policy;
-    fill_basic_pub_auth(pub_property_policy);
+    fill_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3063,7 +3080,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     std::string permissions_file("permissions_helloworld.smime");
 
     //!Lambda for configuring publisher participant qos and security properties
-    auto secure_participant_pub_configurator = [&governance_file,
+    auto secure_participant_pub_configurator = [this, &governance_file,
                     &permissions_file](const std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>& part,
             const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
@@ -3072,7 +3089,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
                 PropertyPolicy property_policy;
 
-                fill_basic_pub_auth(property_policy);
+                fill_pub_auth(property_policy);
 
                 property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                         "builtin.AES-GCM-GMAC"));

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -59,6 +59,18 @@ static void fill_basic_pub_auth(
             "file://" + std::string(certs_path) + "/mainpubkey.pem"));
 }
 
+static void fill_basic_sub_auth(
+        PropertyPolicy& policy)
+{
+    policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+}
+
 class Security : public testing::TestWithParam<communication_type>
 {
 public:
@@ -252,14 +264,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
 
     reader.history_depth(10).
             reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -352,15 +357,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
         PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
         PropertyPolicy sub_property_policy;
-
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
 
         reader.history_depth(10).
                 reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -384,14 +381,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
 
     reader.history_depth(10).
             reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -637,14 +627,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -702,14 +685,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -769,14 +745,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -824,14 +793,7 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -913,14 +875,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -968,14 +923,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1023,14 +971,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1086,14 +1027,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1150,14 +1084,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1208,14 +1135,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1303,14 +1223,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1361,14 +1274,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1419,14 +1325,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1485,14 +1384,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1551,14 +1443,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1609,14 +1494,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1739,14 +1617,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1797,14 +1668,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1855,14 +1719,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1921,14 +1778,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1987,14 +1837,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2049,14 +1892,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2111,14 +1947,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2173,14 +2002,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2235,14 +2057,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2305,14 +2120,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2376,14 +2184,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2460,14 +2261,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
 
     ASSERT_TRUE(writer.isInitialized());
 
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2520,14 +2314,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2595,14 +2382,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2668,14 +2448,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
         ASSERT_TRUE(publishers.init_publisher(1u));
 
         PropertyPolicy sub_property_policy;
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2722,14 +2495,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2773,14 +2539,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2849,14 +2608,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2900,14 +2652,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-        sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+        fill_basic_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2978,14 +2723,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
     // Prepare subscriptions security properties
     PropertyPolicy sub_property_policy;
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3228,14 +2966,7 @@ static void CommonPermissionsConfigure(
         const PropertyPolicy& extra_properties)
 {
     PropertyPolicy sub_property_policy(extra_properties);
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    sub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3364,10 +3095,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
                 PropertyPolicy property_policy;
 
-                property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                        "builtin.PKI-DH"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                        "file://" + std::string(certs_path) + "/maincacert.pem"));
+                fill_basic_sub_auth(property_policy);
                 property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                         "builtin.AES-GCM-GMAC"));
                 property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3375,10 +3103,6 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
                 property_policy.properties().emplace_back(Property(
                             "dds.sec.access.builtin.Access-Permissions.permissions_ca",
                             "file://" + std::string(certs_path) + "/maincacert.pem"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                        "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                        "file://" + std::string(certs_path) + "/mainsubkey.pem"));
                 property_policy.properties().emplace_back(Property(
                             "dds.sec.access.builtin.Access-Permissions.governance",
                             "file://" + std::string(certs_path) + "/" + governance_file));
@@ -3457,14 +3181,7 @@ TEST(Security, AllowUnauthenticatedParticipants_EntityCreationFailsIfRTPSProtect
 
     PropertyPolicy property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -4599,14 +4316,7 @@ TEST(Security, ValidateAuthenticationHandshakePropertiesParsing)
 
     PropertyPolicy property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainsubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainsubkey.pem"));
+    fill_basic_sub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -47,6 +47,18 @@ enum communication_type
     DATASHARING
 };
 
+static void fill_basic_pub_auth(
+        PropertyPolicy& policy)
+{
+    policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
+    policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+}
+
 class Security : public testing::TestWithParam<communication_type>
 {
 public:
@@ -255,14 +267,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
 
     writer.history_depth(10).
             property_policy(pub_property_policy).init();
@@ -296,14 +301,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok_same_participan
 
     PropertyPolicy property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
 
     wreader.sub_history_depth(10).sub_reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
     wreader.pub_history_depth(10);
@@ -339,14 +337,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
 
         ASSERT_TRUE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
 
         writer.history_depth(10).
                 property_policy(pub_property_policy).init();
@@ -417,14 +408,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
     writer.disable_builtin_transport();
     writer.add_user_transport_to_pparams(testTransport);
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
 
     writer.history_depth(10).
             property_policy(pub_property_policy).init();
@@ -537,13 +521,7 @@ TEST(Security, BuiltinAuthenticationPlugin_second_participant_creation_loop)
 
     // Prepare participant properties
     PropertyPolicy property_policy;
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
 
     // Create the participant being checked
     PubSubReader<HelloWorldPubSubType> main_participant("HelloWorldTopic");
@@ -615,13 +593,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_ensure_same_guid_reconnection)
 
     // Prepare participant properties
     PropertyPolicy property_policy;
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
 
     // Create the participant being checked
     PubSubWriter<HelloWorldPubSubType> main_participant("HelloWorldTopic");
@@ -682,14 +654,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -754,14 +719,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -828,14 +786,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -891,14 +842,7 @@ TEST(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -936,14 +880,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_rtps_ok_same_participant)
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -993,14 +930,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1056,14 +986,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1117,14 +1040,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1188,14 +1104,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1259,14 +1168,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1325,14 +1227,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1371,14 +1266,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_submessage_ok_same_partici
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1433,14 +1321,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1499,14 +1380,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1563,14 +1437,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1637,14 +1504,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1709,14 +1569,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1775,14 +1628,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1821,14 +1667,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
     PropertyPolicy pub_property_policy, sub_property_policy,
             property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1863,13 +1702,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_payload_ok_same_participan
 
     PropertyPolicy pub_property_policy, sub_property_policy, property_policy;
 
-    property_policy.properties().emplace_back(Property("dds.sec.auth.plugin", "builtin.PKI-DH"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(property_policy);
     property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1924,14 +1757,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1990,14 +1816,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2054,14 +1873,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2128,14 +1940,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -2202,14 +2007,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2272,14 +2070,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2340,14 +2131,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2410,14 +2194,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2478,14 +2255,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2556,14 +2326,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2634,14 +2397,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2690,14 +2446,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_part_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_part_property_policy);
     pub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2797,14 +2546,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         ASSERT_TRUE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2877,14 +2619,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         ASSERT_FALSE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2910,14 +2645,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
         std::string permissions_file("permissions_helloworld.smime");
 
         PropertyPolicy pub_property_policy;
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3018,14 +2746,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3078,14 +2799,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         ASSERT_TRUE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3159,14 +2873,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
                 property_policy(sub_property_policy).init();
         ASSERT_FALSE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3220,14 +2927,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         ASSERT_TRUE(reader.isInitialized());
 
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                "builtin.PKI-DH"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                "file://" + std::string(certs_path) + "/maincacert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-        pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+        fill_basic_pub_auth(pub_property_policy);
         pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3313,14 +3013,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
     // Prepare publication security properties
     PropertyPolicy pub_property_policy;
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3565,14 +3258,7 @@ static void CommonPermissionsConfigure(
 {
     PropertyPolicy pub_property_policy(extra_properties);
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3640,17 +3326,15 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     //!Lambda for configuring publisher participant qos and security properties
     auto secure_participant_pub_configurator = [&governance_file,
                     &permissions_file](const std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>& part,
-                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
+            const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
                 part->lease_duration(3, 1);
                 part->disable_builtin_transport().add_user_transport_to_pparams(transport_interface);
 
                 PropertyPolicy property_policy;
 
-                property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-                        "builtin.PKI-DH"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-                        "file://" + std::string(certs_path) + "/maincacert.pem"));
+                fill_basic_pub_auth(property_policy);
+
                 property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                         "builtin.AES-GCM-GMAC"));
                 property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3658,10 +3342,6 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
                 property_policy.properties().emplace_back(Property(
                             "dds.sec.access.builtin.Access-Permissions.permissions_ca",
                             "file://" + std::string(certs_path) + "/maincacert.pem"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-                        "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-                property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-                        "file://" + std::string(certs_path) + "/mainpubkey.pem"));
                 property_policy.properties().emplace_back(Property(
                             "dds.sec.access.builtin.Access-Permissions.governance",
                             "file://" + std::string(certs_path) + "/" + governance_file));
@@ -3677,7 +3357,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
     //!Lambda for configuring subscriber participant qos and security properties
     auto secure_participant_sub_configurator = [&governance_file,
                     &permissions_file](const std::shared_ptr<PubSubReader<HelloWorldPubSubType>>& part,
-                    const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
+            const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
                 part->lease_duration(3, 1);
                 part->disable_builtin_transport().add_user_transport_to_pparams(transport_interface);
@@ -3838,14 +3518,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoSecureParticipantsWithDiffere
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3921,14 +3594,7 @@ TEST(Security, AllowUnauthenticatedParticipants_TwoParticipantsDifferentCertific
 
     ASSERT_TRUE(reader.isInitialized());
 
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.plugin",
-            "builtin.PKI-DH"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_ca",
-            "file://" + std::string(certs_path) + "/maincacert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.identity_certificate",
-            "file://" + std::string(certs_path) + "/mainpubcert.pem"));
-    pub_property_policy.properties().emplace_back(Property("dds.sec.auth.builtin.PKI-DH.private_key",
-            "file://" + std::string(certs_path) + "/mainpubkey.pem"));
+    fill_basic_pub_auth(pub_property_policy);
     pub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     pub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -60,14 +60,18 @@ static void fill_pub_auth(
             "file://" + std::string(certs_path) + "/mainpubkey.pem");
 
     // Select the key agreement algorithm based on process id
-    switch (static_cast<uint32_t>(GET_PID()) % 3u)
+    switch (static_cast<uint32_t>(GET_PID()) % 4u)
     {
-        // Force DH
+        // Automatic selection
         case 1u:
+            policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "AUTO");
+            break;
+        // Force DH
+        case 2u:
             policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "DH");
             break;
         // Force ECDH
-        case 2u:
+        case 3u:
             policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "ECDH");
             break;
         // Leave default
@@ -89,14 +93,18 @@ static void fill_sub_auth(
             "file://" + std::string(certs_path) + "/mainsubkey.pem");
 
     // Select the key agreement algorithm based on process id
-    switch (static_cast<uint32_t>(GET_PID()) % 3u)
+    switch (static_cast<uint32_t>(GET_PID()) % 4u)
     {
-        // Force DH
+        // Automatic selection
         case 1u:
+            policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "AUTO");
+            break;
+        // Force DH
+        case 2u:
             policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "DH");
             break;
         // Force ECDH
-        case 2u:
+        case 3u:
             policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "ECDH");
             break;
         // Leave default

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -136,6 +136,22 @@ public:
         }
     }
 
+    void fill_sub_auth(
+            PropertyPolicy& policy)
+    {
+        fill_basic_sub_auth(policy);
+        switch (std::get<1>(GetParam()))
+        {
+            case key_agree_alg::RSA:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "RSA");
+                break;
+            case key_agree_alg::ECDH:
+            default:
+                policy.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "ECDH");
+                break;
+        }
+    }
+
 };
 
 class SecurityPkcs : public ::testing::Test
@@ -289,7 +305,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
 
     reader.history_depth(10).
             reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -382,7 +398,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_validation_fail)
         PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
         PropertyPolicy sub_property_policy;
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
 
         reader.history_depth(10).
                 reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -406,7 +422,7 @@ TEST_P(Security, BuiltinAuthenticationPlugin_PKIDH_lossy_conditions)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
 
     reader.history_depth(10).
             reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).
@@ -652,7 +668,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -710,7 +726,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_transport_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -770,7 +786,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_shm_udp_transport_ok)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -900,7 +916,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_large_string)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -948,7 +964,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_large_string
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -996,7 +1012,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_rtps_data300kb)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1052,7 +1068,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_rtps_data300kb)
 
     PropertyPolicy pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1109,7 +1125,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1160,7 +1176,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1248,7 +1264,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_larg
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1299,7 +1315,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_large_
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1350,7 +1366,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_submessage_data
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1409,7 +1425,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_submessage_data30
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
@@ -1468,7 +1484,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1519,7 +1535,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1642,7 +1658,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_large_s
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1693,7 +1709,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_large_str
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1744,7 +1760,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_payload_data300
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1803,7 +1819,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_payload_data300kb
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
@@ -1862,7 +1878,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1917,7 +1933,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_ok)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -1972,7 +1988,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_large_strin
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2027,7 +2043,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_large_string)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2082,7 +2098,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_besteffort_all_data300kb)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2145,7 +2161,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb)
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2209,7 +2225,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_reliable_all_data300kb_mix
     PropertyPolicy pub_part_property_policy, sub_part_property_policy,
             pub_property_policy, sub_property_policy;
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2286,7 +2302,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
 
     ASSERT_TRUE(writer.isInitialized());
 
-    fill_basic_sub_auth(sub_part_property_policy);
+    fill_sub_auth(sub_part_property_policy);
     sub_part_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_part_property_policy.properties().emplace_back("rtps.participant.rtps_protection_kind", "ENCRYPT");
@@ -2339,7 +2355,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2407,7 +2423,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_governance_rule_o
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2473,7 +2489,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_multiple_endpoint
         ASSERT_TRUE(publishers.init_publisher(1u));
 
         PropertyPolicy sub_property_policy;
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2520,7 +2536,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2564,7 +2580,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2633,7 +2649,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2677,7 +2693,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
         PropertyPolicy pub_property_policy, sub_property_policy;
 
-        fill_basic_sub_auth(sub_property_policy);
+        fill_sub_auth(sub_property_policy);
         sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                 "builtin.AES-GCM-GMAC"));
         sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -2748,7 +2764,7 @@ TEST_P(Security, BuiltinAuthenticationAndAccessAndCryptoPlugin_Permissions_valid
 
     // Prepare subscriptions security properties
     PropertyPolicy sub_property_policy;
-    fill_basic_sub_auth(sub_property_policy);
+    fill_sub_auth(sub_property_policy);
     sub_property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
             "builtin.AES-GCM-GMAC"));
     sub_property_policy.properties().emplace_back(Property("dds.sec.access.plugin",
@@ -3111,7 +3127,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
             };
     //!Lambda for configuring subscriber participant qos and security properties
-    auto secure_participant_sub_configurator = [&governance_file,
+    auto secure_participant_sub_configurator = [this, &governance_file,
                     &permissions_file](const std::shared_ptr<PubSubReader<HelloWorldPubSubType>>& part,
             const std::shared_ptr<eprosima::fastdds::rtps::TransportDescriptorInterface>& transport_interface)
             {
@@ -3120,7 +3136,7 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
                 PropertyPolicy property_policy;
 
-                fill_basic_sub_auth(property_policy);
+                fill_sub_auth(property_policy);
                 property_policy.properties().emplace_back(Property("dds.sec.crypto.plugin",
                         "builtin.AES-GCM-GMAC"));
                 property_policy.properties().emplace_back(Property("dds.sec.access.plugin",

--- a/test/dds/communication/security/secure_msg_crypto_besteffort_pub_profile.xml
+++ b/test/dds/communication/security/secure_msg_crypto_besteffort_pub_profile.xml
@@ -34,6 +34,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainpubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>ECDH</value>
+                        </property>
                         <!-- Activate DDS:Crypto:AES-GCM-GMAC plugin -->
                         <property>
                             <name>dds.sec.crypto.plugin</name>

--- a/test/dds/communication/security/secure_msg_submsg_crypto_besteffort_pub_profile.xml
+++ b/test/dds/communication/security/secure_msg_submsg_crypto_besteffort_pub_profile.xml
@@ -33,6 +33,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainpubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>DH</value>
+                        </property>
                         <!-- Activate DDS:Crypto:AES-GCM-GMAC plugin -->
                         <property>
                             <name>dds.sec.crypto.plugin</name>

--- a/test/dds/communication/security/secure_msg_submsg_crypto_besteffort_sub_profile.xml
+++ b/test/dds/communication/security/secure_msg_submsg_crypto_besteffort_sub_profile.xml
@@ -33,6 +33,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainsubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>ECDH</value>
+                        </property>
                         <!-- Activate DDS:Crypto:AES-GCM-GMAC plugin -->
                         <property>
                             <name>dds.sec.crypto.plugin</name>

--- a/test/dds/communication/security/secure_submsg_crypto_besteffort_pub_profile.xml
+++ b/test/dds/communication/security/secure_submsg_crypto_besteffort_pub_profile.xml
@@ -33,6 +33,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainpubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>ECDH</value>
+                        </property>
                         <!-- Activate DDS:Crypto:AES-GCM-GMAC plugin -->
                         <property>
                             <name>dds.sec.crypto.plugin</name>

--- a/test/dds/communication/security/secure_submsg_crypto_besteffort_sub_profile.xml
+++ b/test/dds/communication/security/secure_submsg_crypto_besteffort_sub_profile.xml
@@ -33,6 +33,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainsubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>DH</value>
+                        </property>
                         <!-- Activate DDS:Crypto:AES-GCM-GMAC plugin -->
                         <property>
                             <name>dds.sec.crypto.plugin</name>

--- a/test/dds/communication/security/simple_secure_besteffort_pub_profile.xml
+++ b/test/dds/communication/security/simple_secure_besteffort_pub_profile.xml
@@ -26,6 +26,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainpubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>ECDH</value>
+                        </property>
                         <!-- Activate Access:Permissions plugin -->
                         <property>
                             <name>dds.sec.access.plugin</name>

--- a/test/dds/communication/security/simple_secure_besteffort_sub_profile.xml
+++ b/test/dds/communication/security/simple_secure_besteffort_sub_profile.xml
@@ -26,6 +26,10 @@
                             <name>dds.sec.auth.builtin.PKI-DH.private_key</name>
                             <value>file://mainsubkey.pem</value>
                         </property>
+                        <property>
+                            <name>dds.sec.auth.builtin.PKI-DH.preferred_key_agreement</name>
+                            <value>DH</value>
+                        </property>
                         <!-- Activate Access:Permissions plugin -->
                         <property>
                             <name>dds.sec.access.plugin</name>

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -165,6 +165,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
             ValidationResult_t::VALIDATION_FAILED;
 
     participant_attr.properties = get_valid_policy();
+    participant_attr.properties.properties().emplace_back("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", "DH");
 
     result = plugin.validate_local_identity(&local_identity_handle1,
                     adjusted_participant_key1,

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -425,40 +425,40 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_kagree_algo)
     auto test_fn = [this](
         const std::string& alg,
         ValidationResult_t expected_result) -> void
-    {
-        IdentityHandle* local_identity_handle = nullptr;
-        GUID_t adjusted_participant_key;
-        uint32_t domain_id = 0;
-        RTPSParticipantAttributes participant_attr;
-        GUID_t candidate_participant_key;
-        SecurityException exception;
-        ValidationResult_t result = ValidationResult_t::VALIDATION_FAILED;
+            {
+                IdentityHandle* local_identity_handle = nullptr;
+                GUID_t adjusted_participant_key;
+                uint32_t domain_id = 0;
+                RTPSParticipantAttributes participant_attr;
+                GUID_t candidate_participant_key;
+                SecurityException exception;
+                ValidationResult_t result = ValidationResult_t::VALIDATION_FAILED;
 
-        fill_candidate_participant_key(candidate_participant_key);
-        participant_attr.properties = get_valid_policy();
-        participant_attr.properties.properties().emplace_back(
-            Property("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", alg));
-        result = plugin.validate_local_identity(&local_identity_handle,
-            adjusted_participant_key,
-            domain_id,
-            participant_attr,
-            candidate_participant_key,
-            exception);
+                fill_candidate_participant_key(candidate_participant_key);
+                participant_attr.properties = get_valid_policy();
+                participant_attr.properties.properties().emplace_back(
+                    Property("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", alg));
+                result = plugin.validate_local_identity(&local_identity_handle,
+                                adjusted_participant_key,
+                                domain_id,
+                                participant_attr,
+                                candidate_participant_key,
+                                exception);
 
-        ASSERT_TRUE(result == expected_result);
-        if (ValidationResult_t::VALIDATION_OK == result)
-        {
-            ASSERT_TRUE(local_identity_handle != nullptr);
-            check_local_identity_handle(*local_identity_handle);
-            ASSERT_TRUE(adjusted_participant_key != GUID_t::unknown());
-            ASSERT_TRUE(plugin.return_identity_handle(local_identity_handle, exception));
-        }
-        else
-        {
-            ASSERT_TRUE(local_identity_handle == nullptr);
-            ASSERT_TRUE(adjusted_participant_key == GUID_t::unknown());
-        }
-    };
+                ASSERT_TRUE(result == expected_result);
+                if (ValidationResult_t::VALIDATION_OK == result)
+                {
+                    ASSERT_TRUE(local_identity_handle != nullptr);
+                    check_local_identity_handle(*local_identity_handle);
+                    ASSERT_TRUE(adjusted_participant_key != GUID_t::unknown());
+                    ASSERT_TRUE(plugin.return_identity_handle(local_identity_handle, exception));
+                }
+                else
+                {
+                    ASSERT_TRUE(local_identity_handle == nullptr);
+                    ASSERT_TRUE(adjusted_participant_key == GUID_t::unknown());
+                }
+            };
 
     for (const std::string& value : correct_values)
     {

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -402,6 +402,75 @@ void AuthenticationPluginTest::check_shared_secrets(
     ASSERT_TRUE(*sharedsecret_1 == *sharedsecret_2);
 }
 
+TEST_F(AuthenticationPluginTest, validate_local_identity_kagree_algo)
+{
+    const std::string correct_values[] =
+    {
+        "RSA",
+        "ECDH",
+        "DH+MODP-2048-256",
+        "ECDH+prime256v1-CEUM"
+    };
+
+    const std::string wrong_values[] =
+    {
+        "RSA+MODP-2048-256",
+        "ECDH+MODP-2048-256",
+        "DH",
+        "ECDH+prime256v1",
+        "unknown",
+        ""
+    };
+
+    auto test_fn = [this](
+        const std::string& alg,
+        ValidationResult_t expected_result) -> void
+    {
+        IdentityHandle* local_identity_handle = nullptr;
+        GUID_t adjusted_participant_key;
+        uint32_t domain_id = 0;
+        RTPSParticipantAttributes participant_attr;
+        GUID_t candidate_participant_key;
+        SecurityException exception;
+        ValidationResult_t result = ValidationResult_t::VALIDATION_FAILED;
+
+        fill_candidate_participant_key(candidate_participant_key);
+        participant_attr.properties = get_valid_policy();
+        participant_attr.properties.properties().emplace_back(
+            Property("dds.sec.auth.builtin.PKI-DH.preferred_key_agreement", alg));
+        result = plugin.validate_local_identity(&local_identity_handle,
+            adjusted_participant_key,
+            domain_id,
+            participant_attr,
+            candidate_participant_key,
+            exception);
+
+        ASSERT_TRUE(result == expected_result);
+        if (ValidationResult_t::VALIDATION_OK == result)
+        {
+            ASSERT_TRUE(local_identity_handle != nullptr);
+            check_local_identity_handle(*local_identity_handle);
+            ASSERT_TRUE(adjusted_participant_key != GUID_t::unknown());
+            ASSERT_TRUE(plugin.return_identity_handle(local_identity_handle, exception));
+        }
+        else
+        {
+            ASSERT_TRUE(local_identity_handle == nullptr);
+            ASSERT_TRUE(adjusted_participant_key == GUID_t::unknown());
+        }
+    };
+
+    for (const std::string& value : correct_values)
+    {
+        test_fn(value, ValidationResult_t::VALIDATION_OK);
+    }
+
+    for (const std::string& value : wrong_values)
+    {
+        test_fn(value, ValidationResult_t::VALIDATION_FAILED);
+    }
+}
+
 TEST_F(AuthenticationPluginTest, validate_local_identity_validation_ok_with_pwd)
 {
     IdentityHandle* local_identity_handle = nullptr;

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -406,7 +406,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_kagree_algo)
 {
     const std::string correct_values[] =
     {
-        "RSA",
+        "DH",
         "ECDH",
         "DH+MODP-2048-256",
         "ECDH+prime256v1-CEUM"
@@ -416,7 +416,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_kagree_algo)
     {
         "RSA+MODP-2048-256",
         "ECDH+MODP-2048-256",
-        "DH",
+        "RSA",
         "ECDH+prime256v1",
         "unknown",
         ""

--- a/versions.md
+++ b/versions.md
@@ -9,6 +9,7 @@ Forthcoming
 * Added ``Extended Incompatible QoS`` feature for monitor service.
 * Machine UUID added to the Data(p) to check Participants in same host, instead of using GUIDs.
 * Windows ci example testing infrastructure and `hello world` example.
+* New property to configure the preferred key agreement algorithm.
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

[DDS security](https://www.omg.org/spec/DDS-SECURITY/1.1/About-DDS-SECURITY/) specifies the possibility of selecting the key agreement algorithm used to generate the shared secret at the end of the authentication phase.

The Fast DDS [documentation](https://fast-dds.docs.eprosima.com/en/latest/fastdds/security/auth_plugin/auth_plugin.html) indicates that `Elliptic Curve Diffie-Hellman (ECDH)` is used, but this is only the case if a participant from other vendor starts the authentication and proposes that method.

This pull request:
1. Changes the default key agreement algorithm to the one indicated in the documentation
2. Adds a new `dds.sec.auth.builtin.PKI-DH.preferred_key_agreement` property that allows choosing the preferred algorithm to use.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x

We will backport to 3.1.x, but leaving the default value of the new property to the old behavior.
We will then backport from there into 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#963
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
