### PR TITLE
[22285] Fix comparison in `is_update_allowed`

### DIFF
--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -1205,7 +1205,7 @@ bool ReaderProxyData::is_update_allowed(
     if ((m_guid != rdata.m_guid) ||
 #if HAVE_SECURITY
             (security_attributes_ != rdata.security_attributes_) ||
-            (plugin_security_attributes_ != rdata.security_attributes_) ||
+            (plugin_security_attributes_ != rdata.plugin_security_attributes_) ||
 #endif // if HAVE_SECURITY
             (m_typeName != rdata.m_typeName) ||
             (m_topicName != rdata.m_topicName))

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -1217,7 +1217,7 @@ bool WriterProxyData::is_update_allowed(
             (persistence_guid_ != wdata.persistence_guid_) ||
 #if HAVE_SECURITY
             (security_attributes_ != wdata.security_attributes_) ||
-            (plugin_security_attributes_ != wdata.security_attributes_) ||
+            (plugin_security_attributes_ != wdata.plugin_security_attributes_) ||
 #endif // if HAVE_SECURITY
             (m_typeName != wdata.m_typeName) ||
             (m_topicName != wdata.m_topicName))

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -2474,6 +2474,71 @@ TEST(BuiltinDataSerializationTests, deserialization_of_big_parameters)
     }
 }
 
+/*!
+ * This is a regression test for redmine issue #19927
+ *
+ * It checks that proxy data for readers and writers can only be updated if the security attributes are equal.
+ */
+TEST(BuiltinDataSerializationTests, security_attributes_update)
+{
+    // Only if security is enabled
+#if HAVE_SECURITY
+
+    // Test for ReaderProxyData
+    {
+        ReaderProxyData original(max_unicast_locators, max_multicast_locators);
+        original.security_attributes_ = 0x01;
+        original.plugin_security_attributes_ = 0x02;
+
+        ReaderProxyData updated(original);
+        EXPECT_TRUE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_ + 10;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_ + 10;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.plugin_security_attributes_;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_;
+        updated.plugin_security_attributes_ = original.security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+    }
+
+    // Test for WriterProxyData
+    {
+        WriterProxyData original(max_unicast_locators, max_multicast_locators);
+        original.security_attributes_ = 0x01;
+        original.plugin_security_attributes_ = 0x02;
+
+        WriterProxyData updated(original);
+        EXPECT_TRUE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_ + 10;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_ + 10;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.plugin_security_attributes_;
+        updated.plugin_security_attributes_ = original.plugin_security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+
+        updated.security_attributes_ = original.security_attributes_;
+        updated.plugin_security_attributes_ = original.security_attributes_;
+        EXPECT_FALSE(original.is_update_allowed(updated));
+    }
+
+#endif  // HAVE_SECURITY
+}
+
 } // namespace rtps
 } // namespace fastdds
 } // namespace eprosima


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This fixes a bug in the comparison of the security attributes inside `is_update_allowed` of `ReaderProxyData` and `WriterProxyData`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
