### PR TITLE
Regenerate types with Fast DDS-Gen v3.3.1

### DIFF
--- a/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationPubSubTypes.cxx
+++ b/examples/cpp/dds/AdvancedConfigurationExample/AdvancedConfigurationPubSubTypes.cxx
@@ -85,6 +85,11 @@ bool AdvancedConfigurationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/BasicConfigurationExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/BasicConfigurationExample/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/Configurability/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/Configurability/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/ContentFilteredTopicExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/ContentFilteredTopicExample/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/CustomListenerExample/TopicPubSubTypes.cxx
+++ b/examples/cpp/dds/CustomListenerExample/TopicPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool TopicPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/CustomPayloadPoolExample/CustomPayloadPoolDataPubSubTypes.cxx
+++ b/examples/cpp/dds/CustomPayloadPoolExample/CustomPayloadPoolDataPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool CustomPayloadPoolDataPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/DeadlineQoSExample/deadlinepayloadPubSubTypes.cxx
+++ b/examples/cpp/dds/DeadlineQoSExample/deadlinepayloadPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloMsgPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/DisablePositiveACKs/TopicPubSubTypes.cxx
+++ b/examples/cpp/dds/DisablePositiveACKs/TopicPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool TopicPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/DiscoveryServerExample/types/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/Filtering/FilteringExamplePubSubTypes.cxx
+++ b/examples/cpp/dds/Filtering/FilteringExamplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool FilteringExamplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/FlowControlExample/FlowControlExample.h
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExample.h
@@ -183,7 +183,7 @@ public:
 
 private:
 
-    std::array<char, 600000> m_message;
+    std::array<char, 600000> m_message{0};
     char m_wasFast{0};
 
 };

--- a/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.cxx
+++ b/examples/cpp/dds/FlowControlExample/FlowControlExamplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool FlowControlExamplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/HelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleDataSharing/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorld.h
@@ -212,7 +212,7 @@ private:
 
     uint32_t m_index{0};
     std::string m_message;
-    std::array<char, 1024*1024> m_data;
+    std::array<char, 1024*1024> m_data{0};
 
 };
 

--- a/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleSharedMem/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/HelloWorldExampleTCP/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/HistoryKind/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/HistoryKind/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/Keys/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/Keys/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/LateJoiners/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/LateJoiners/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/LifespanQoSExample/LifespanPubSubTypes.cxx
+++ b/examples/cpp/dds/LifespanQoSExample/LifespanPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool LifespanPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/LivelinessQoS/TopicPubSubTypes.cxx
+++ b/examples/cpp/dds/LivelinessQoS/TopicPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool TopicPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/OwnershipStrengthQoSExample/OwnershipStrengthPubSubTypes.cxx
+++ b/examples/cpp/dds/OwnershipStrengthQoSExample/OwnershipStrengthPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool ExampleMessagePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.cxx
+++ b/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool RequestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -273,6 +278,11 @@ bool ReplyTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.h
+++ b/examples/cpp/dds/RequestReplyExample/CalculatorPubSubTypes.h
@@ -93,7 +93,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/examples/cpp/dds/SampleConfig_Controller/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/SampleConfig_Controller/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/SampleConfig_Events/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/SampleConfig_Events/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/SampleConfig_Multimedia/samplePubSubTypes.cxx
+++ b/examples/cpp/dds/SampleConfig_Multimedia/samplePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool samplePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/SecureHelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/StaticHelloWorldExample/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/WriterLoansExample/LoanableHelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool LoanableHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.cxx
+++ b/examples/cpp/dds/ZeroCopyExample/LoanableHelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool LoanableHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -88,6 +88,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -278,6 +283,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -468,6 +478,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -662,6 +677,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -852,6 +872,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1042,6 +1067,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1243,6 +1273,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/src/cpp/statistics/types/typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/typesPubSubTypes.cxx
@@ -87,6 +87,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -277,6 +282,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -467,6 +477,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -657,6 +672,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -847,6 +867,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1037,6 +1062,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1230,6 +1260,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1420,6 +1455,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1610,6 +1650,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1800,6 +1845,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1990,6 +2040,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2180,6 +2235,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2370,6 +2430,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2560,6 +2625,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/blackbox/types/Data1mbPubSubTypes.cxx
+++ b/test/blackbox/types/Data1mbPubSubTypes.cxx
@@ -85,6 +85,11 @@ bool Data1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/Data64kbPubSubTypes.cxx
+++ b/test/blackbox/types/Data64kbPubSubTypes.cxx
@@ -85,6 +85,11 @@ bool Data64kbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/FixedSizedPubSubTypes.cxx
+++ b/test/blackbox/types/FixedSizedPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool FixedSizedPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/HelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/HelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
@@ -85,6 +85,11 @@ bool KeyedData1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool KeyedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/StringTestPubSubTypes.cxx
+++ b/test/blackbox/types/StringTestPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool StringTestPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/TestRegression3361PubSubTypes.cxx
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.cxx
@@ -83,6 +83,11 @@ bool TestRegression3361PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool UnboundedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/statistics/typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/typesPubSubTypes.cxx
@@ -87,6 +87,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -277,6 +282,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -467,6 +477,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -657,6 +672,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -847,6 +867,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1037,6 +1062,11 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                #if FASTCDR_VERSION_MAJOR > 1
+                        ser.set_dds_cdr_options({0,0});
+                #else
+                        ser.setDDSCdrOptions(0);
+                #endif // FASTCDR_VERSION_MAJOR > 1
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1230,6 +1260,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1420,6 +1455,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1610,6 +1650,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1800,6 +1845,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1990,6 +2040,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2180,6 +2235,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2370,6 +2430,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2560,6 +2625,11 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+            #if FASTCDR_VERSION_MAJOR > 1
+                    ser.set_dds_cdr_options({0,0});
+            #else
+                    ser.setDDSCdrOptions(0);
+            #endif // FASTCDR_VERSION_MAJOR > 1
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool AllocTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
@@ -83,6 +83,11 @@ bool StructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -279,6 +284,11 @@ bool ContentFilterTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dynamic_types/idl/BasicPubSubTypes.cxx
+++ b/test/unittest/dynamic_types/idl/BasicPubSubTypes.cxx
@@ -87,6 +87,11 @@ bool EnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -277,6 +282,11 @@ bool AliasStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -467,6 +477,11 @@ bool AliasAliasStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -657,6 +672,11 @@ bool BoolStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -847,6 +867,11 @@ bool OctetStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1037,6 +1062,11 @@ bool ShortStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1227,6 +1257,11 @@ bool LongStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1417,6 +1452,11 @@ bool LongLongStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1607,6 +1647,11 @@ bool UShortStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1797,6 +1842,11 @@ bool ULongStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1987,6 +2037,11 @@ bool ULongLongStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2177,6 +2232,11 @@ bool FloatStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2367,6 +2427,11 @@ bool DoubleStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2557,6 +2622,11 @@ bool LongDoubleStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2747,6 +2817,11 @@ bool CharStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2937,6 +3012,11 @@ bool WCharStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3127,6 +3207,11 @@ bool StringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3317,6 +3402,11 @@ bool WStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3507,6 +3597,11 @@ bool LargeStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3697,6 +3792,11 @@ bool LargeWStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3887,6 +3987,11 @@ bool ArraytStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4079,6 +4184,11 @@ bool ArrayArrayStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4271,6 +4381,11 @@ bool SequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4465,6 +4580,11 @@ bool SequenceSequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4657,6 +4777,11 @@ bool MapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4851,6 +4976,11 @@ bool MapMapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5042,6 +5172,11 @@ bool BitsetStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5232,6 +5367,11 @@ bool StructStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5422,6 +5562,11 @@ bool StructStructStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5624,6 +5769,11 @@ bool SimpleUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5814,6 +5964,11 @@ bool UnionUnionUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6004,6 +6159,11 @@ bool WCharUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dynamic_types/idl/BasicPubSubTypes.h
+++ b/test/unittest/dynamic_types/idl/BasicPubSubTypes.h
@@ -95,7 +95,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -185,7 +185,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -275,7 +275,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/test/unittest/dynamic_types/idl/TestPubSubTypes.cxx
+++ b/test/unittest/dynamic_types/idl/TestPubSubTypes.cxx
@@ -89,6 +89,11 @@ bool BasicStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -291,6 +296,11 @@ bool ComplexStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -489,6 +499,11 @@ bool CompleteStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -679,6 +694,11 @@ bool KeyedStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dynamic_types/idl/new_features_4_2PubSubTypes.cxx
+++ b/test/unittest/dynamic_types/idl/new_features_4_2PubSubTypes.cxx
@@ -83,6 +83,11 @@ bool NewAliasesPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -286,6 +291,11 @@ namespace bitmodule {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+    #if FASTCDR_VERSION_MAJOR > 1
+            ser.set_dds_cdr_options({0,0});
+    #else
+            ser.setDDSCdrOptions(0);
+    #endif // FASTCDR_VERSION_MAJOR > 1
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -476,6 +486,11 @@ namespace bitmodule {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+    #if FASTCDR_VERSION_MAJOR > 1
+            ser.set_dds_cdr_options({0,0});
+    #else
+            ser.setDDSCdrOptions(0);
+    #endif // FASTCDR_VERSION_MAJOR > 1
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -669,6 +684,11 @@ bool StructTestPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/xtypes/idl/TypesPubSubTypes.cxx
+++ b/test/unittest/xtypes/idl/TypesPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool MyEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -273,6 +278,11 @@ bool MyBadEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -465,6 +475,11 @@ bool MyAliasEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -655,6 +670,11 @@ bool BasicStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -845,6 +865,11 @@ bool BasicNamesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1035,6 +1060,11 @@ bool BasicBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1225,6 +1255,11 @@ bool BasicWideStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1415,6 +1450,11 @@ bool BadBasicWideStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1605,6 +1645,11 @@ bool StringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1795,6 +1840,11 @@ bool LargeStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1985,6 +2035,11 @@ bool WStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2175,6 +2230,11 @@ bool LargeWStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2365,6 +2425,11 @@ bool ArrayStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2555,6 +2620,11 @@ bool ArrayStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2745,6 +2815,11 @@ bool ArrayBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2935,6 +3010,11 @@ bool ArrayDimensionsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3125,6 +3205,11 @@ bool ArraySizeStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3317,6 +3402,11 @@ bool SequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3509,6 +3599,11 @@ bool SequenceStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3701,6 +3796,11 @@ bool SequenceBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3893,6 +3993,11 @@ bool SequenceBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4087,6 +4192,11 @@ bool SequenceSequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4281,6 +4391,11 @@ bool SequenceSequenceBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4473,6 +4588,11 @@ bool MapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4665,6 +4785,11 @@ bool MapStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4857,6 +4982,11 @@ bool MapBadKeyStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5049,6 +5179,11 @@ bool MapBadElemStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5241,6 +5376,11 @@ bool MapBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5435,6 +5575,11 @@ bool MapMapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5629,6 +5774,11 @@ bool MapMapBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5839,6 +5989,11 @@ bool SimpleUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6029,6 +6184,11 @@ bool SimpleUnionStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6219,6 +6379,11 @@ bool SimpleUnionNamesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6409,6 +6574,11 @@ bool SimpleTypeUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6599,6 +6769,11 @@ bool SimpleBadUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6789,6 +6964,11 @@ bool SimplBadDiscUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/xtypes/idl/TypesPubSubTypes.h
+++ b/test/unittest/xtypes/idl/TypesPubSubTypes.h
@@ -93,7 +93,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -183,7 +183,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -274,7 +274,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/test/unittest/xtypes/idl/WideEnumPubSubTypes.cxx
+++ b/test/unittest/xtypes/idl/WideEnumPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool MyEnumWideStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -277,6 +282,11 @@ bool SimpleWideUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/xtypes/idl/WideEnumPubSubTypes.h
+++ b/test/unittest/xtypes/idl/WideEnumPubSubTypes.h
@@ -93,7 +93,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED

--- a/test/xtypes/idl/TypesPubSubTypes.cxx
+++ b/test/xtypes/idl/TypesPubSubTypes.cxx
@@ -83,6 +83,11 @@ bool MyEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -273,6 +278,11 @@ bool MyBadEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -465,6 +475,11 @@ bool MyAliasEnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -655,6 +670,11 @@ bool BasicStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -845,6 +865,11 @@ bool BasicNamesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1035,6 +1060,11 @@ bool BasicBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1225,6 +1255,11 @@ bool BasicWideStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1415,6 +1450,11 @@ bool BadBasicWideStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1605,6 +1645,11 @@ bool StringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1795,6 +1840,11 @@ bool LargeStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1985,6 +2035,11 @@ bool WStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2175,6 +2230,11 @@ bool LargeWStringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2365,6 +2425,11 @@ bool ArrayStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2555,6 +2620,11 @@ bool ArrayStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2745,6 +2815,11 @@ bool ArrayBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2935,6 +3010,11 @@ bool ArrayDimensionsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3125,6 +3205,11 @@ bool ArraySizeStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3317,6 +3402,11 @@ bool SequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3509,6 +3599,11 @@ bool SequenceStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3701,6 +3796,11 @@ bool SequenceBadStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3893,6 +3993,11 @@ bool SequenceBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4087,6 +4192,11 @@ bool SequenceSequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4281,6 +4391,11 @@ bool SequenceSequenceBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4473,6 +4588,11 @@ bool MapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4665,6 +4785,11 @@ bool MapStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4857,6 +4982,11 @@ bool MapBadKeyStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5049,6 +5179,11 @@ bool MapBadElemStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5241,6 +5376,11 @@ bool MapBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5435,6 +5575,11 @@ bool MapMapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5629,6 +5774,11 @@ bool MapMapBoundsStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5839,6 +5989,11 @@ bool SimpleUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6029,6 +6184,11 @@ bool SimpleUnionStructEqualPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6219,6 +6379,11 @@ bool SimpleUnionNamesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6409,6 +6574,11 @@ bool SimpleTypeUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6599,6 +6769,11 @@ bool SimpleBadUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6789,6 +6964,11 @@ bool SimplBadDiscUnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+#if FASTCDR_VERSION_MAJOR > 1
+        ser.set_dds_cdr_options({0,0});
+#else
+        ser.setDDSCdrOptions(0);
+#endif // FASTCDR_VERSION_MAJOR > 1
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/xtypes/idl/TypesPubSubTypes.h
+++ b/test/xtypes/idl/TypesPubSubTypes.h
@@ -93,7 +93,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -183,7 +183,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
@@ -274,7 +274,7 @@ public:
 #ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
     eProsima_user_DllExport inline bool is_bounded() const override
     {
-        return false;
+        return true;
     }
 
 #endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- **N/A** The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
