### PR TITLE
[21506] Allow domain names (DNS) when parsing TCP locators XML elements

### DIFF
--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -29,8 +29,8 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
-static const std::regex IPv4_REGEX("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}"
-        "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
+static const std::regex IPv4_REGEX("^(?:(?:0*25[0-5]|0*2[0-4][0-9]|0*[01]?[0-9][0-9]?)\\.){3}"
+        "(?:0*25[0-5]|0*2[0-4][0-9]|0*[01]?[0-9][0-9]?)$");
 static const std::regex IPv6_QUARTET_REGEX("^(?:[A-Fa-f0-9]){0,4}$");
 
 // Factory
@@ -112,23 +112,22 @@ bool IPLocator::setIPv4(
         // Attempt DNS resolution
         auto response = IPLocator::resolveNameDNS(s);
 
-        // Add the first valid IPv4 address that we can find
+        // Use the first valid IPv4 address that we can find
         if (response.first.size() > 0)
         {
             s = response.first.begin()->data();
+            // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+            if (!IPLocator::isIPv4(s))
+            {
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "DNS name [" << ipv4 << "] resolved into wrong IPv4 format: " << s);
+                return false;
+            }
         }
         else
         {
             EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
             return false;
         }
-    }
-
-    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
-    if (!IPLocator::isIPv4(s))
-    {
-        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv4 " << s << " error format. Expected X.X.X.X");
-        return false;
     }
 
     std::stringstream ss(s);
@@ -285,10 +284,16 @@ bool IPLocator::setIPv6(
         // Attempt DNS resolution
         auto response = IPLocator::resolveNameDNS(s);
 
-        // Add the first valid IPv6 address that we can find
+        // Use the first valid IPv6 address that we can find
         if (response.second.size() > 0)
         {
             s = response.second.begin()->data();
+            // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+            if (!IPLocator::isIPv6(s))
+            {
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "DNS name [" << ipv6 << "] resolved into wrong IPv6 format: " << s);
+                return false;
+            }
         }
         else
         {
@@ -296,13 +301,6 @@ bool IPLocator::setIPv6(
                     "IPv6 " << s << " error format. Expected well defined address or valid DNS name");
             return false;
         }
-    }
-
-    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
-    if (!IPLocator::isIPv6(s))
-    {
-        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv6 " << s << " error format.");
-        return false;
     }
 
     LOCATOR_ADDRESS_INVALID(locator.address);
@@ -728,23 +726,22 @@ bool IPLocator::setWan(
         // Attempt DNS resolution
         auto response = IPLocator::resolveNameDNS(s);
 
-        // Add the first valid IPv4 address that we can find
+        // Use the first valid IPv4 address that we can find
         if (response.first.size() > 0)
         {
             s = response.first.begin()->data();
+            // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+            if (!IPLocator::isIPv4(s))
+            {
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "DNS name [" << wan << "] resolved into wrong IPv4 format: " << s);
+                return false;
+            }
         }
         else
         {
             EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
             return false;
         }
-    }
-
-    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
-    if (!IPLocator::isIPv4(s))
-    {
-        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv4 " << s << " error format. Expected X.X.X.X");
-        return false;
     }
 
     std::stringstream ss(s);

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -106,7 +106,32 @@ bool IPLocator::setIPv4(
     // This function do not set address to 0 in case it fails
     // Be careful, do not set all IP to 0 because WAN and LAN could be set beforehand
 
-    std::stringstream ss(ipv4);
+    std::string s(ipv4);
+    if (!IPLocator::isIPv4(s))
+    {
+        // Attempt DNS resolution
+        auto response = IPLocator::resolveNameDNS(s);
+
+        // Add the first valid IPv4 address that we can find
+        if (response.first.size() > 0)
+        {
+            s = response.first.begin()->data();
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
+            return false;
+        }
+    }
+
+    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+    if (!IPLocator::isIPv4(s))
+    {
+        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv4 " << s << " error format. Expected X.X.X.X");
+        return false;
+    }
+
+    std::stringstream ss(s);
     uint32_t a;
     uint32_t b;
     uint32_t c;
@@ -127,7 +152,7 @@ bool IPLocator::setIPv4(
         // If there are more info to read, it fails
         return ss.rdbuf()->in_avail() == 0;
     }
-    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << ipv4 << " error format. Expected X.X.X.X");
+    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X");
     return false;
 }
 
@@ -254,14 +279,34 @@ bool IPLocator::setIPv6(
         return false;
     }
 
-    if (!IPv6isCorrect(ipv6))
+    std::string s(ipv6);
+    if (!IPLocator::isIPv6(s))
     {
-        EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " is not well defined");
+        // Attempt DNS resolution
+        auto response = IPLocator::resolveNameDNS(s);
+
+        // Add the first valid IPv6 address that we can find
+        if (response.second.size() > 0)
+        {
+            s = response.second.begin()->data();
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(IP_LOCATOR,
+                    "IPv6 " << s << " error format. Expected well defined address or valid DNS name");
+            return false;
+        }
+    }
+
+    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+    if (!IPLocator::isIPv6(s))
+    {
+        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv6 " << s << " error format.");
         return false;
     }
 
     LOCATOR_ADDRESS_INVALID(locator.address);
-    uint16_t count = (uint16_t) std::count_if( ipv6.begin(), ipv6.end(), []( char c )
+    uint16_t count = (uint16_t) std::count_if( s.begin(), s.end(), []( char c )
                     {
                         return c == ':';
                     }); // C type cast to avoid Windows warnings
@@ -274,10 +319,10 @@ bool IPLocator::setIPv6(
     size_t aux_prev; // This must be size_t as string::npos could change value depending on size_t size
 
     // Check whether is a zero block and where
-    if (ipv6.front() == ':')
+    if (s.front() == ':')
     {
         // First element equal : -> starts with zeros
-        if (ipv6.back() == ':')
+        if (s.back() == ':')
         {
             // Empty string (correct ipv6 format)
             initial_zeros = 16;
@@ -291,7 +336,7 @@ bool IPLocator::setIPv6(
             initial_zeros = (7 - (count - 2)) * 2;
         }
     }
-    else if (ipv6.back() == ':')
+    else if (s.back() == ':')
     {
         // Last element equal : -> ends with zeros
         // It does not start with :: (previous if)
@@ -300,8 +345,8 @@ bool IPLocator::setIPv6(
     else
     {
         // It does not starts or ends with zeros, but it could have :: in the middle or not have it
-        aux_prev = ipv6.size(); // Aux could be 1 so this number must be unreacheable
-        aux = ipv6.find(':'); // Index of first ':'
+        aux_prev = s.size(); // Aux could be 1 so this number must be unreacheable
+        aux = s.find(':'); // Index of first ':'
 
         // Look for "::" will loop string twice
         // Therefore, we use this loop that will go over less or equal once
@@ -317,13 +362,13 @@ bool IPLocator::setIPv6(
             // Not "::" found, keep searching in next ':'
             position_zeros += 2; // It stores the point where the 0 block is
             aux_prev = aux;
-            aux = ipv6.find(':', aux + 1);
+            aux = s.find(':', aux + 1);
         }
     }
 
     char punct;
     std::stringstream ss;
-    ss << std::hex << ipv6;
+    ss << std::hex << s;
     uint16_t i;
     uint32_t input_aux; // It cannot be uint16_t or we could not find whether the input number is bigger than allowed
 
@@ -343,7 +388,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << s << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -364,7 +409,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
-                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << s << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -386,7 +431,7 @@ bool IPLocator::setIPv6(
             ss >> input_aux >> punct;
             if (input_aux >= 65536)
             {
-                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << s << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -403,7 +448,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << s << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -421,7 +466,7 @@ bool IPLocator::setIPv6(
             ss >> punct >> input_aux;
             if (input_aux >= 65536)
             {
-                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << ipv6 << " has values higher than expected (65536)");
+                EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv6 " << s << " has values higher than expected (65536)");
                 return false;
             }
             locator.address[i++] = octet(input_aux >> 8);
@@ -671,7 +716,38 @@ bool IPLocator::setWan(
         Locator_t& locator,
         const std::string& wan)
 {
-    std::stringstream ss(wan);
+    if (locator.kind != LOCATOR_KIND_TCPv4)
+    {
+        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Trying to set WAN address in a non TCP-IPv4 Locator");
+        return false;
+    }
+
+    std::string s(wan);
+    if (!IPLocator::isIPv4(s))
+    {
+        // Attempt DNS resolution
+        auto response = IPLocator::resolveNameDNS(s);
+
+        // Add the first valid IPv4 address that we can find
+        if (response.first.size() > 0)
+        {
+            s = response.first.begin()->data();
+        }
+        else
+        {
+            EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
+            return false;
+        }
+    }
+
+    // Redundant check for extra security (here a custom regex is used instead of asio's verification)
+    if (!IPLocator::isIPv4(s))
+    {
+        EPROSIMA_LOG_WARNING(IP_LOCATOR, "Resolved IPv4 " << s << " error format. Expected X.X.X.X");
+        return false;
+    }
+
+    std::stringstream ss(s);
     int a, b, c, d; //to store the 4 ints
     char ch; //to temporarily store the '.'
 
@@ -683,6 +759,7 @@ bool IPLocator::setWan(
         locator.address[11] = (octet)d;
         return true;
     }
+    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X");
     return false;
 }
 

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -151,7 +151,7 @@ bool IPLocator::setIPv4(
         // If there are more info to read, it fails
         return ss.rdbuf()->in_avail() == 0;
     }
-    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X");
+    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
     return false;
 }
 
@@ -756,7 +756,7 @@ bool IPLocator::setWan(
         locator.address[11] = (octet)d;
         return true;
     }
-    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X");
+    EPROSIMA_LOG_WARNING(IP_LOCATOR, "IPv4 " << s << " error format. Expected X.X.X.X or valid DNS name");
     return false;
 }
 

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -3069,24 +3069,11 @@ XMLP_ret XMLParser::getXMLLocatorUDPv4(
             {
                 return XMLP_ret::XML_ERROR;
             }
-            // Check whether the address is IPv4
-            if (!IPLocator::isIPv4(s))
+            if (!IPLocator::setIPv4(locator, s))
             {
-                auto response = rtps::IPLocator::resolveNameDNS(s);
-
-                // Add the first valid IPv4 address that we can find
-                if (response.first.size() > 0)
-                {
-                    s = response.first.begin()->data();
-                }
-                else
-                {
-                    EPROSIMA_LOG_ERROR(XMLPARSER,
-                            "DNS server did not return any IPv4 address for: '" << s << "'. Name: " << name);
-                    return XMLP_ret::XML_ERROR;
-                }
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Failed to parse UDPv4 locator's " << ADDRESS << " tag");
+                return XMLP_ret::XML_ERROR;
             }
-            IPLocator::setIPv4(locator, s);
         }
         else
         {
@@ -3142,24 +3129,11 @@ XMLP_ret XMLParser::getXMLLocatorUDPv6(
             {
                 return XMLP_ret::XML_ERROR;
             }
-            // Check whether the address is IPv6
-            if (!IPLocator::isIPv6(s))
+            if (!IPLocator::setIPv6(locator, s))
             {
-                auto response = rtps::IPLocator::resolveNameDNS(s);
-
-                // Add the first valid IPv6 address that we can find
-                if (response.second.size() > 0)
-                {
-                    s = response.second.begin()->data();
-                }
-                else
-                {
-                    EPROSIMA_LOG_ERROR(XMLPARSER,
-                            "DNS server did not return any IPv6 address for: '" << s << "'. Name: " << name);
-                    return XMLP_ret::XML_ERROR;
-                }
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Failed to parse UDPv6 locator's " << ADDRESS << " tag");
+                return XMLP_ret::XML_ERROR;
             }
-            IPLocator::setIPv6(locator, s);
         }
         else
         {
@@ -3230,7 +3204,11 @@ XMLP_ret XMLParser::getXMLLocatorTCPv4(
             {
                 return XMLP_ret::XML_ERROR;
             }
-            IPLocator::setIPv4(locator, s);
+            if (!IPLocator::setIPv4(locator, s))
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Failed to parse TCPv4 locator's " << ADDRESS << " tag");
+                return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, WAN_ADDRESS) == 0)
         {
@@ -3240,7 +3218,11 @@ XMLP_ret XMLParser::getXMLLocatorTCPv4(
             {
                 return XMLP_ret::XML_ERROR;
             }
-            IPLocator::setWan(locator, s);
+            if (!IPLocator::setWan(locator, s))
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Failed to parse TCPv4 locator's " << WAN_ADDRESS << " tag");
+                return XMLP_ret::XML_ERROR;
+            }
         }
         else if (strcmp(name, UNIQUE_LAN_ID) == 0)
         {
@@ -3319,7 +3301,11 @@ XMLP_ret XMLParser::getXMLLocatorTCPv6(
             {
                 return XMLP_ret::XML_ERROR;
             }
-            IPLocator::setIPv6(locator, s);
+            if (!IPLocator::setIPv6(locator, s))
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "Failed to parse TCPv6 locator's " << ADDRESS << " tag");
+                return XMLP_ret::XML_ERROR;
+            }
         }
         else
         {

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -76,6 +76,7 @@ public:
 
     const std::string ipv4_any = "0.0.0.0";
     const std::string ipv4_invalid = "0.0.0.0";
+    const std::string ipv4_invalid_format = "192.168.1.256.1";
     const std::string ipv6_any = "::";
     const std::string ipv6_invalid = "0:0:0:0:0:0:0:0";
 
@@ -161,7 +162,6 @@ TEST_F(IPLocatorTests, setIPv4_from_string)
     {
         // Error cases
         ASSERT_FALSE(IPLocator::setIPv4(locator, "1.1.1.256")); // Too high number
-        ASSERT_FALSE(IPLocator::setIPv4(locator, "1.1.1"));     // Too few args
         ASSERT_FALSE(IPLocator::setIPv4(locator, "1.1.1.1.1")); // Too much args
 
         // Change to IPv6
@@ -1318,8 +1318,8 @@ TEST_F(IPLocatorTests, setIPv4address)
     }
 
     ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7", "9.10.11.12", "13.14.15.16"));
-    ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", "9.10.11", "13.14.15.16"));
-    ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", "9.10.11.12", "13.14.15"));
+    ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", ipv4_invalid_format, "13.14.15.16"));
+    ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", "9.10.11.12", ipv4_invalid_format));
 
     locator.kind = LOCATOR_KIND_TCPv6;
     ASSERT_FALSE(IPLocator::setIPv4address(locator, "1.2.3.4.5.6.7.8", "9.10.11.12", "13.14.15.16"));

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -258,7 +258,7 @@ if(EPROSIMA_TEST_DNS_NOT_SET_UP)
     message(STATUS "Ignoring 'getXMLLocatorDNS*'")
     set(IGNORE_COMMAND "-getXMLLocatorDNS*")
 endif()
-gtest_discover_tests(XMLParserTests)
+gtest_discover_tests(XMLParserTests TEST_FILTER ${IGNORE_COMMAND})
 ######################################  XMLParserTests  ########################################################
 
 #######################################  XMLTreeTests  #########################################################

--- a/test/unittest/xmlparser/CMakeLists.txt
+++ b/test/unittest/xmlparser/CMakeLists.txt
@@ -254,6 +254,10 @@ target_link_libraries(XMLParserTests
 if(QNX)
     target_link_libraries(XMLParserTests socket)
 endif()
+if(EPROSIMA_TEST_DNS_NOT_SET_UP)
+    message(STATUS "Ignoring 'getXMLLocatorDNS*'")
+    set(IGNORE_COMMAND "-getXMLLocatorDNS*")
+endif()
 gtest_discover_tests(XMLParserTests)
 ######################################  XMLParserTests  ########################################################
 

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -308,6 +308,109 @@ TEST_F(XMLParserTests, get_xml_disable_heartbeat_piggyback)
 }
 
 /*
+ * This test checks the parsing of a <udpv4> element from a list of locators.
+ * 1. Correct parsing of a valid element.
+ * 2. Check an empty definition of <port> .
+ * 3. Check an empty definition of <address>.
+ * 4. Check an bad element as a child xml element.
+ */
+TEST_F(XMLParserTests, getXMLLocatorUDPv4)
+{
+
+    uint8_t ident = 1;
+    LocatorList_t list;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <unicastLocatorList>\
+                <locator>\
+                    <udpv4>\
+                        <port>%s</port>\
+                        <address>%s</address>\
+                        %s\
+                    </udpv4>\
+                </locator>\
+            </unicastLocatorList>\
+            ";
+    constexpr size_t xml_len {500};
+    char xml[xml_len];
+
+    // Valid XML
+    snprintf(xml, xml_len, xml_p, "8844", "192.168.1.55", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+    EXPECT_EQ(list.begin()->port, 8844u);
+    EXPECT_EQ(list.begin()->address[12], 192);
+    EXPECT_EQ(list.begin()->address[13], 168);
+    EXPECT_EQ(list.begin()->address[14], 1);
+    EXPECT_EQ(list.begin()->address[15], 55);
+    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_UDPv4);
+
+    // Missing data - port
+    snprintf(xml, xml_len, xml_p, "", "192.168.1.55", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+
+    // Missing data - address
+    snprintf(xml, xml_len, xml_p, "8844", "", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+
+    // Invalid element
+    snprintf(xml, xml_len, xml_p, "8844", "192.168.1.55", "<bad_element></bad_element>");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+}
+
+/*
+ * This test checks the parsing of a <udpv4> element from a list of locators, using DNS resolution.
+ * 1. Correct parsing of a valid element (with address given by domain).
+ */
+TEST_F(XMLParserTests, getXMLLocatorDNSUDPv4)
+{
+
+    uint8_t ident = 1;
+    LocatorList_t list;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <unicastLocatorList>\
+                <locator>\
+                    <udpv4>\
+                        <port>%s</port>\
+                        <address>%s</address>\
+                        %s\
+                    </udpv4>\
+                </locator>\
+            </unicastLocatorList>\
+            ";
+    constexpr size_t xml_len {500};
+    char xml[xml_len];
+
+    // Valid XML
+    snprintf(xml, xml_len, xml_p, "8844", "www.acme.com.test", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+    EXPECT_EQ(list.begin()->port, 8844u);
+    EXPECT_EQ(list.begin()->address[12], 216);
+    EXPECT_EQ(list.begin()->address[13], 58);
+    EXPECT_EQ(list.begin()->address[14], 215);
+    EXPECT_EQ(list.begin()->address[15], 164);
+    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_UDPv4);
+}
+
+/*
  * This test checks the parsing of a <udpv6> element from a list of locators.
  * 1. Correct parsing of a valid element.
  * 2. Check an empty definition of <port> .
@@ -364,6 +467,63 @@ TEST_F(XMLParserTests, getXMLLocatorUDPv6)
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+}
+
+/*
+ * This test checks the parsing of a <udpv6> element from a list of locators, using DNS resolution.
+ * 1. Correct parsing of a valid element (with address given by domain).
+ */
+TEST_F(XMLParserTests, getXMLLocatorDNSUDPv6)
+{
+
+    uint8_t ident = 1;
+    LocatorList_t list;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <unicastLocatorList>\
+                <locator>\
+                    <udpv6>\
+                        <port>%s</port>\
+                        <address>%s</address>\
+                        %s\
+                    </udpv6>\
+                </locator>\
+            </unicastLocatorList>\
+            ";
+    constexpr size_t xml_len {500};
+    char xml[xml_len];
+
+    // Valid XML
+    snprintf(xml, xml_len, xml_p, "8844", "www.acme.com.test", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+    EXPECT_EQ(list.begin()->port, 8844u);
+
+    // <address>
+    Locator_t expected_locator; // auxiliar locator to check the address, disregard port
+    IPLocator::createLocator(LOCATOR_KIND_UDPv6, "2a00:1450:400e:803::2004", 8844, expected_locator);
+    EXPECT_EQ(list.begin()->address[0], expected_locator.address[0]);
+    EXPECT_EQ(list.begin()->address[1], expected_locator.address[1]);
+    EXPECT_EQ(list.begin()->address[2], expected_locator.address[2]);
+    EXPECT_EQ(list.begin()->address[3], expected_locator.address[3]);
+    EXPECT_EQ(list.begin()->address[4], expected_locator.address[4]);
+    EXPECT_EQ(list.begin()->address[5], expected_locator.address[5]);
+    EXPECT_EQ(list.begin()->address[6], expected_locator.address[6]);
+    EXPECT_EQ(list.begin()->address[7], expected_locator.address[7]);
+    EXPECT_EQ(list.begin()->address[8], expected_locator.address[8]);
+    EXPECT_EQ(list.begin()->address[9], expected_locator.address[9]);
+    EXPECT_EQ(list.begin()->address[10], expected_locator.address[10]);
+    EXPECT_EQ(list.begin()->address[11], expected_locator.address[11]);
+    EXPECT_EQ(list.begin()->address[12], expected_locator.address[12]);
+    EXPECT_EQ(list.begin()->address[13], expected_locator.address[13]);
+    EXPECT_EQ(list.begin()->address[14], expected_locator.address[14]);
+    EXPECT_EQ(list.begin()->address[15], expected_locator.address[15]);
+    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_UDPv6);
 }
 
 /*
@@ -474,6 +634,70 @@ TEST_F(XMLParserTests, getXMLLocatorTCPv4)
 }
 
 /*
+ * This test checks the parsing of a <tcpv4> element from a list of locators, using DNS resolution.
+ * 1. Correct parsing of a valid element (with addresses given by domain).
+ */
+TEST_F(XMLParserTests, getXMLLocatorDNSTCPv4)
+{
+
+    uint8_t ident = 1;
+    LocatorList_t list;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <unicastLocatorList>\
+                <locator>\
+                    <tcpv4>\
+                        <physical_port>%s</physical_port>\
+                        <port>%s</port>\
+                        <unique_lan_id>%s</unique_lan_id>\
+                        <wan_address>%s</wan_address>\
+                        <address>%s</address>\
+                        %s\
+                    </tcpv4>\
+                </locator>\
+            </unicastLocatorList>\
+            ";
+    constexpr size_t xml_len {1000};
+    char xml[xml_len];
+
+    // Valid XML
+    snprintf(xml, xml_len, xml_p, "5100", "8844", "192.168.1.1.1.1.2.55", "www.acme.com.test", "localhost", "");
+
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+    EXPECT_EQ(IPLocator::getPhysicalPort(list.begin()->port), 5100u);
+    EXPECT_EQ(IPLocator::getLogicalPort(list.begin()->port), 8844u);
+
+    //<unique_lan_id>
+    EXPECT_EQ(list.begin()->address[0], 192);
+    EXPECT_EQ(list.begin()->address[1], 168);
+    EXPECT_EQ(list.begin()->address[2], 1);
+    EXPECT_EQ(list.begin()->address[3], 1);
+    EXPECT_EQ(list.begin()->address[4], 1);
+    EXPECT_EQ(list.begin()->address[5], 1);
+    EXPECT_EQ(list.begin()->address[6], 2);
+    EXPECT_EQ(list.begin()->address[7], 55);
+
+    //<wan_address>
+    EXPECT_EQ(list.begin()->address[8], 216);
+    EXPECT_EQ(list.begin()->address[9], 58);
+    EXPECT_EQ(list.begin()->address[10], 215);
+    EXPECT_EQ(list.begin()->address[11], 164);
+
+    // <address>
+    EXPECT_EQ(list.begin()->address[12], 127);
+    EXPECT_EQ(list.begin()->address[13], 0);
+    EXPECT_EQ(list.begin()->address[14], 0);
+    EXPECT_EQ(list.begin()->address[15], 1);
+    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_TCPv4);
+}
+
+/*
  * This test checks the parsing of a <tcpv6> element from a list of locators.
  * 1. Correct parsing of a valid element.
  * 2. Check an empty definition of <physical_port> .
@@ -540,6 +764,66 @@ TEST_F(XMLParserTests, getXMLLocatorTCPv6)
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+}
+
+/*
+ * This test checks the parsing of a <tcpv6> element from a list of locators, using DNS resolution.
+ * 1. Correct parsing of a valid element (with address given by domain).
+ */
+TEST_F(XMLParserTests, getXMLLocatorDNSTCPv6)
+{
+
+    uint8_t ident = 1;
+    LocatorList_t list;
+    tinyxml2::XMLDocument xml_doc;
+    tinyxml2::XMLElement* titleElement;
+
+    // Parametrized XML
+    const char* xml_p =
+            "\
+            <unicastLocatorList>\
+                <locator>\
+                    <tcpv6>\
+                        <physical_port>%s</physical_port>\
+                        <port>%s</port>\
+                        <address>%s</address>\
+                        %s\
+                    </tcpv6>\
+                </locator>\
+            </unicastLocatorList>\
+            ";
+    constexpr size_t xml_len {500};
+    char xml[xml_len];
+
+    // Valid XML
+    snprintf(xml, xml_len, xml_p, "5100", "8844", "www.acme.com.test", "");
+
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+    EXPECT_EQ(IPLocator::getPhysicalPort(list.begin()->port), 5100u);
+    EXPECT_EQ(IPLocator::getLogicalPort(list.begin()->port), 8844u);
+
+    // <address>
+    Locator_t expected_locator; // auxiliar locator to check the address, disregard port
+    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "2a00:1450:400e:803::2004", 8844, expected_locator);
+    EXPECT_EQ(list.begin()->address[0], expected_locator.address[0]);
+    EXPECT_EQ(list.begin()->address[1], expected_locator.address[1]);
+    EXPECT_EQ(list.begin()->address[2], expected_locator.address[2]);
+    EXPECT_EQ(list.begin()->address[3], expected_locator.address[3]);
+    EXPECT_EQ(list.begin()->address[4], expected_locator.address[4]);
+    EXPECT_EQ(list.begin()->address[5], expected_locator.address[5]);
+    EXPECT_EQ(list.begin()->address[6], expected_locator.address[6]);
+    EXPECT_EQ(list.begin()->address[7], expected_locator.address[7]);
+    EXPECT_EQ(list.begin()->address[8], expected_locator.address[8]);
+    EXPECT_EQ(list.begin()->address[9], expected_locator.address[9]);
+    EXPECT_EQ(list.begin()->address[10], expected_locator.address[10]);
+    EXPECT_EQ(list.begin()->address[11], expected_locator.address[11]);
+    EXPECT_EQ(list.begin()->address[12], expected_locator.address[12]);
+    EXPECT_EQ(list.begin()->address[13], expected_locator.address[13]);
+    EXPECT_EQ(list.begin()->address[14], expected_locator.address[14]);
+    EXPECT_EQ(list.begin()->address[15], expected_locator.address[15]);
+    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_TCPv6);
 }
 
 /*

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -372,6 +372,7 @@ TEST_F(XMLParserTests, getXMLLocatorUDPv4)
 /*
  * This test checks the parsing of a <udpv4> element from a list of locators, using DNS resolution.
  * 1. Correct parsing of a valid element (with address given by domain).
+ * 2. Check parsing an element with invalid domain name as address fails.
  */
 TEST_F(XMLParserTests, getXMLLocatorDNSUDPv4)
 {
@@ -408,6 +409,12 @@ TEST_F(XMLParserTests, getXMLLocatorDNSUDPv4)
     EXPECT_EQ(list.begin()->address[14], 215);
     EXPECT_EQ(list.begin()->address[15], 164);
     EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_UDPv4);
+
+    // Invalid domain name address
+    snprintf(xml, xml_len, xml_p, "8844", "hopefully.invalid.domain.name", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
 }
 
 /*
@@ -472,6 +479,7 @@ TEST_F(XMLParserTests, getXMLLocatorUDPv6)
 /*
  * This test checks the parsing of a <udpv6> element from a list of locators, using DNS resolution.
  * 1. Correct parsing of a valid element (with address given by domain).
+ * 2. Check parsing an element with invalid domain name as address fails.
  */
 TEST_F(XMLParserTests, getXMLLocatorDNSUDPv6)
 {
@@ -502,28 +510,15 @@ TEST_F(XMLParserTests, getXMLLocatorDNSUDPv6)
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
-    EXPECT_EQ(list.begin()->port, 8844u);
-
-    // <address>
-    Locator_t expected_locator; // auxiliar locator to check the address, disregard port
+    Locator_t expected_locator;
     IPLocator::createLocator(LOCATOR_KIND_UDPv6, "2a00:1450:400e:803::2004", 8844, expected_locator);
-    EXPECT_EQ(list.begin()->address[0], expected_locator.address[0]);
-    EXPECT_EQ(list.begin()->address[1], expected_locator.address[1]);
-    EXPECT_EQ(list.begin()->address[2], expected_locator.address[2]);
-    EXPECT_EQ(list.begin()->address[3], expected_locator.address[3]);
-    EXPECT_EQ(list.begin()->address[4], expected_locator.address[4]);
-    EXPECT_EQ(list.begin()->address[5], expected_locator.address[5]);
-    EXPECT_EQ(list.begin()->address[6], expected_locator.address[6]);
-    EXPECT_EQ(list.begin()->address[7], expected_locator.address[7]);
-    EXPECT_EQ(list.begin()->address[8], expected_locator.address[8]);
-    EXPECT_EQ(list.begin()->address[9], expected_locator.address[9]);
-    EXPECT_EQ(list.begin()->address[10], expected_locator.address[10]);
-    EXPECT_EQ(list.begin()->address[11], expected_locator.address[11]);
-    EXPECT_EQ(list.begin()->address[12], expected_locator.address[12]);
-    EXPECT_EQ(list.begin()->address[13], expected_locator.address[13]);
-    EXPECT_EQ(list.begin()->address[14], expected_locator.address[14]);
-    EXPECT_EQ(list.begin()->address[15], expected_locator.address[15]);
-    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_UDPv6);
+    EXPECT_EQ(*list.begin(), expected_locator);
+
+    // Invalid domain name address
+    snprintf(xml, xml_len, xml_p, "8844", "hopefully.invalid.domain.name", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
 }
 
 /*
@@ -636,6 +631,8 @@ TEST_F(XMLParserTests, getXMLLocatorTCPv4)
 /*
  * This test checks the parsing of a <tcpv4> element from a list of locators, using DNS resolution.
  * 1. Correct parsing of a valid element (with addresses given by domain).
+ * 2. Check parsing an element with invalid domain name as wan address fails.
+ * 3. Check parsing an element with invalid domain name as address fails.
  */
 TEST_F(XMLParserTests, getXMLLocatorDNSTCPv4)
 {
@@ -695,6 +692,20 @@ TEST_F(XMLParserTests, getXMLLocatorDNSTCPv4)
     EXPECT_EQ(list.begin()->address[14], 0);
     EXPECT_EQ(list.begin()->address[15], 1);
     EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_TCPv4);
+
+    // Invalid domain name wan address
+    snprintf(xml, xml_len, xml_p, "5100", "8844", "192.168.1.1.1.1.2.55", "hopefully.invalid.domain.name", "localhost",
+            "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
+
+    // Invalid domain name address
+    snprintf(xml, xml_len, xml_p, "5100", "8844", "192.168.1.1.1.1.2.55", "www.acme.com.test",
+            "hopefully.invalid.domain.name", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
 }
 
 /*
@@ -769,6 +780,7 @@ TEST_F(XMLParserTests, getXMLLocatorTCPv6)
 /*
  * This test checks the parsing of a <tcpv6> element from a list of locators, using DNS resolution.
  * 1. Correct parsing of a valid element (with address given by domain).
+ * 2. Check parsing an element with invalid domain name as address fails.
  */
 TEST_F(XMLParserTests, getXMLLocatorDNSTCPv6)
 {
@@ -801,29 +813,17 @@ TEST_F(XMLParserTests, getXMLLocatorDNSTCPv6)
     ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
     titleElement = xml_doc.RootElement();
     EXPECT_EQ(XMLP_ret::XML_OK, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
-    EXPECT_EQ(IPLocator::getPhysicalPort(list.begin()->port), 5100u);
-    EXPECT_EQ(IPLocator::getLogicalPort(list.begin()->port), 8844u);
+    Locator_t expected_locator;
+    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "2a00:1450:400e:803::2004", 0, expected_locator);
+    IPLocator::setPhysicalPort(expected_locator, 5100u);
+    IPLocator::setLogicalPort(expected_locator, 8844u);
+    EXPECT_EQ(*list.begin(), expected_locator);
 
-    // <address>
-    Locator_t expected_locator; // auxiliar locator to check the address, disregard port
-    IPLocator::createLocator(LOCATOR_KIND_TCPv6, "2a00:1450:400e:803::2004", 8844, expected_locator);
-    EXPECT_EQ(list.begin()->address[0], expected_locator.address[0]);
-    EXPECT_EQ(list.begin()->address[1], expected_locator.address[1]);
-    EXPECT_EQ(list.begin()->address[2], expected_locator.address[2]);
-    EXPECT_EQ(list.begin()->address[3], expected_locator.address[3]);
-    EXPECT_EQ(list.begin()->address[4], expected_locator.address[4]);
-    EXPECT_EQ(list.begin()->address[5], expected_locator.address[5]);
-    EXPECT_EQ(list.begin()->address[6], expected_locator.address[6]);
-    EXPECT_EQ(list.begin()->address[7], expected_locator.address[7]);
-    EXPECT_EQ(list.begin()->address[8], expected_locator.address[8]);
-    EXPECT_EQ(list.begin()->address[9], expected_locator.address[9]);
-    EXPECT_EQ(list.begin()->address[10], expected_locator.address[10]);
-    EXPECT_EQ(list.begin()->address[11], expected_locator.address[11]);
-    EXPECT_EQ(list.begin()->address[12], expected_locator.address[12]);
-    EXPECT_EQ(list.begin()->address[13], expected_locator.address[13]);
-    EXPECT_EQ(list.begin()->address[14], expected_locator.address[14]);
-    EXPECT_EQ(list.begin()->address[15], expected_locator.address[15]);
-    EXPECT_EQ(list.begin()->kind, LOCATOR_KIND_TCPv6);
+    // Invalid domain name address
+    snprintf(xml, xml_len, xml_p, "5100", "8844", "hopefully.invalid.domain.name", "");
+    ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+    titleElement = xml_doc.RootElement();
+    EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::getXMLLocatorList_wrapper(titleElement, list, ident));
 }
 
 /*


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Currently DNS name resolution is only attempted when parsing UDP locators from an XML profile. This PR extends that functionality to TCP locators by moving that logic to `IPLocator::setIPvX(Locator_t& locator, const std::string& ipvx)`.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
