### PR TITLE
[22353] Use correct algorithm strings on PermissionsToken and IdentityToken

### DIFF
--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -59,6 +59,18 @@ namespace rtps {
 
 using namespace security;
 
+/**
+ * @brief Convert a signature algortihm before adding it to a PermissionsToken.
+ *
+ * This methods converts the signature algorithm to the format used in the PermissionsToken.
+ * Depending on the value of the use_legacy parameter, the algorithm will be converted to the legacy format or to the
+ * one specified in the DDS-SEC 1.1 specification.
+ *
+ * @param algorithm The algorithm to convert.
+ * @param use_legacy Whether to use the legacy format or not.
+ *
+ * @return The converted algorithm.
+ */
 static std::string convert_to_token_algo(
         const std::string& algorithm,
         bool use_legacy)
@@ -82,6 +94,16 @@ static std::string convert_to_token_algo(
     return algorithm;
 }
 
+/**
+ * @brief Parse a signature algorithm from a PermissionsToken.
+ *
+ * This method parses a signature algorithm from a PermissionsToken.
+ * It converts the algorithm to the internal (legacy) format used by the library.
+ *
+ * @param algorithm The algorithm to parse.
+ *
+ * @return The parsed algorithm.
+ */
 static std::string parse_token_algo(
         const std::string& algorithm)
 {

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -896,6 +896,18 @@ static bool generate_challenge(
     return returnedValue;
 }
 
+/**
+ * @brief Convert a signature algortihm before adding it to an IdentityToken.
+ *
+ * This methods converts the signature algorithm to the format used in the IdentityToken.
+ * Depending on the value of the use_legacy parameter, the algorithm will be converted to the legacy format or to the
+ * one specified in the DDS-SEC 1.1 specification.
+ *
+ * @param algorithm The algorithm to convert.
+ * @param use_legacy Whether to use the legacy format or not.
+ *
+ * @return The converted algorithm.
+ */
 static std::string convert_to_token_algo(
         const std::string& algorithm,
         bool use_legacy)
@@ -919,6 +931,16 @@ static std::string convert_to_token_algo(
     return algorithm;
 }
 
+/**
+ * @brief Parse a signature algorithm from an IdentityToken.
+ *
+ * This method parses the signature algorithm from an IdentityToken.
+ * It converts the algorithm to the internal (legacy) format used by the library.
+ *
+ * @param algorithm The algorithm to parse.
+ *
+ * @return The parsed algorithm.
+ */
 static std::string parse_token_algo(
         const std::string& algorithm)
 {

--- a/src/cpp/security/authentication/PKIIdentityHandle.h
+++ b/src/cpp/security/authentication/PKIIdentityHandle.h
@@ -33,6 +33,9 @@ namespace security {
 static const char* const RSA_SHA256 = "RSASSA-PSS-SHA256";
 static const char* const ECDSA_SHA256 = "ECDSA-SHA256";
 
+static const char* const RSA_SHA256_FOR_TOKENS = "RSA-2048";
+static const char* const ECDSA_SHA256_FOR_TOKENS = "EC-prime256v1";
+
 static const char* const DH_2048_256 = "DH+MODP-2048-256";
 static const char* const ECDH_prime256v1 = "ECDH+prime256v1-CEUM";
 

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -4548,6 +4548,70 @@ TEST(Security, openssl_correctly_finishes)
     std::exit(0);
 }
 
+// Regression test for Redmine issue #19925
+TEST(Security, legacy_token_algorithms_communicate)
+{
+    auto test_run = [](bool legacy_pub, bool legacy_sub) -> void
+            {
+                // Create
+                PubSubWriter<HelloWorldPubSubType> writer("HelloWorldTopic_legacy_token_algorithms_communicate");
+                PubSubReader<HelloWorldPubSubType> reader("HelloWorldTopic_legacy_token_algorithms_communicate");
+                const std::string governance_file("governance_helloworld_all_enable.smime");
+                const std::string permissions_file("permissions_helloworld.smime");
+
+                // Configure Writer
+                {
+                    PropertyPolicy extra_policy;
+                    const char* value = legacy_pub ? "true" : "false";
+                    auto& properties = extra_policy.properties();
+                    properties.emplace_back(
+                        "dds.sec.auth.builtin.PKI-DH.transmit_algorithms_as_legacy", value);
+                    properties.emplace_back(
+                        "dds.sec.access.builtin.Access-Permissions.transmit_algorithms_as_legacy", value);
+                    CommonPermissionsConfigure(writer, governance_file, permissions_file, extra_policy);
+                }
+
+                // Configure Reader
+                {
+                    PropertyPolicy extra_policy;
+                    const char* value = legacy_sub ? "true" : "false";
+                    auto& properties = extra_policy.properties();
+                    properties.emplace_back(
+                        "dds.sec.auth.builtin.PKI-DH.transmit_algorithms_as_legacy", value);
+                    properties.emplace_back(
+                        "dds.sec.access.builtin.Access-Permissions.transmit_algorithms_as_legacy", value);
+                    CommonPermissionsConfigure(reader, governance_file, permissions_file, extra_policy);
+                }
+
+                // Initialize
+                reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).init();
+                ASSERT_TRUE(reader.isInitialized());
+                writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).init();
+                ASSERT_TRUE(writer.isInitialized());
+
+                // Wait for discovery
+                reader.waitAuthorized();
+                writer.waitAuthorized();
+                reader.wait_discovery();
+                writer.wait_discovery();
+                ASSERT_TRUE(reader.is_matched());
+                ASSERT_TRUE(writer.is_matched());
+
+                // Perform communication
+                auto data = default_helloworld_data_generator(1);
+                reader.startReception(data);
+                writer.send(data);
+                ASSERT_TRUE(data.empty());
+                reader.block_for_all();
+            };
+
+    // Test all possible combinations
+    test_run(false, false);
+    test_run(false, true);
+    test_run(true, false);
+    test_run(true, true);
+}
+
 void blackbox_security_init()
 {
     certs_path = std::getenv("CERTS_PATH");


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR changes the strings transmitted in `dds.cert.algo`, `dds.ca.algo`, and `dds.perm_ca.algo` to the ones
specified in [DDS-SEC-1.1](https://www.omg.org/spec/DDS-SECURITY/1.1/PDF).

In order to provide interoperability with legacy implementations, a new `transmit_algorithms_as_legacy` sub-property has been added to the builtin plugins configuration properties.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#974
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
