### PR TITLE
[22352] Fast DDS Auto DS Mode - Tests

### DIFF
--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1872,6 +1872,11 @@ public:
         return matched_;
     }
 
+    unsigned int get_participants_matched() const
+    {
+        return participant_matched_;
+    }
+
     void set_xml_filename(
             const std::string& name)
     {

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1736,7 +1736,7 @@ public:
         std::cout << "Reader gets discovery result..." << std::endl;
     }
 
-    void setOnDiscoveryFunction(
+    void set_on_discovery_function(
             std::function<bool(const eprosima::fastdds::rtps::ParticipantBuiltinTopicData&,
             eprosima::fastdds::rtps::ParticipantDiscoveryStatus)> f)
     {

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -336,6 +336,8 @@ public:
         , message_receive_count_(0)
         , filter_expression_("")
         , expression_parameters_({})
+        , use_preferred_domain_id_(false)
+        , preferred_domain_id_(0)
     {
         // Load default QoS to permit testing with external XML profile files.
         DomainParticipantFactory::get_instance()->load_profiles();
@@ -427,10 +429,11 @@ public:
                 ASSERT_TRUE(participant_->is_enabled());
             }
         }
+
         if (participant_ == nullptr)
         {
             participant_ = DomainParticipantFactory::get_instance()->create_participant(
-                (uint32_t)GET_PID() % 230,
+                (use_preferred_domain_id_ ? preferred_domain_id_ : (uint32_t)GET_PID() % 230),
                 participant_qos_,
                 &participant_listener_,
                 eprosima::fastdds::dds::StatusMask::none());
@@ -949,6 +952,14 @@ public:
             std::placeholders::_1,
             std::placeholders::_2);
 
+        return *this;
+    }
+
+    PubSubReader& set_domain_id(
+            const uint32_t& domain_id)
+    {
+        use_preferred_domain_id_ = true;
+        preferred_domain_id_ = domain_id;
         return *this;
     }
 
@@ -2223,6 +2234,10 @@ protected:
     std::string filter_expression_;
     //! Parameters for CFT expression
     std::vector<std::string> expression_parameters_;
+
+    //! Preferred domain ID
+    bool use_preferred_domain_id_;
+    uint32_t preferred_domain_id_;
 };
 
 template<class TypeSupport>

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -88,7 +88,7 @@ class PubSubWriter
             static_cast<void>(should_be_ignored);
             if (writer_.onDiscovery_ != nullptr)
             {
-                writer_.discovery_result_ = writer_.onDiscovery_(info);
+                writer_.discovery_result_ = writer_.onDiscovery_(info, status);
             }
 
             if (status == eprosima::fastdds::rtps::ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT)
@@ -877,6 +877,12 @@ public:
         return *this;
     }
 
+    void set_on_discovery_function(
+            std::function<bool(const eprosima::fastdds::rtps::ParticipantBuiltinTopicData&,
+            eprosima::fastdds::rtps::ParticipantDiscoveryStatus)> f)
+    {
+        onDiscovery_ = f;
+    }
 
     /*** Function to change QoS ***/
     PubSubWriter& reliability(
@@ -2066,7 +2072,8 @@ protected:
     std::string participant_profile_ = "";
     std::string datawriter_profile_ = "";
 
-    std::function<bool(const eprosima::fastdds::dds::ParticipantBuiltinTopicData& info)> onDiscovery_;
+    std::function<bool(const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& info,
+            eprosima::fastdds::rtps::ParticipantDiscoveryStatus status)> onDiscovery_;
 
     //! A mutex for liveliness
     std::mutex liveliness_mutex_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1669,6 +1669,11 @@ public:
         return matched_;
     }
 
+    unsigned int get_participants_matched() const
+    {
+        return participant_matched_;
+    }
+
     unsigned int missed_deadlines() const
     {
         return listener_.missed_deadlines();

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -303,7 +303,8 @@ public:
         , times_liveliness_lost_(0)
         , times_incompatible_qos_(0)
         , last_incompatible_qos_(eprosima::fastdds::dds::INVALID_QOS_POLICY_ID)
-
+        , use_preferred_domain_id_(false)
+        , preferred_domain_id_(0)
 #if HAVE_SECURITY
         , authorized_(0)
         , unauthorized_(0)
@@ -392,7 +393,7 @@ public:
         if (participant_ == nullptr)
         {
             participant_ = DomainParticipantFactory::get_instance()->create_participant(
-                (uint32_t)GET_PID() % 230,
+                (use_preferred_domain_id_ ? preferred_domain_id_ : (uint32_t)GET_PID() % 230),
                 participant_qos_,
                 &participant_listener_,
                 eprosima::fastdds::dds::StatusMask::none());
@@ -867,6 +868,15 @@ public:
         status_mask_ = eprosima::fastdds::dds::StatusMask::all();
         return *this;
     }
+
+    PubSubWriter& set_domain_id(
+            const uint32_t& domain_id)
+    {
+        use_preferred_domain_id_ = true;
+        preferred_domain_id_ = domain_id;
+        return *this;
+    }
+
 
     /*** Function to change QoS ***/
     PubSubWriter& reliability(
@@ -2073,6 +2083,9 @@ protected:
     unsigned int times_incompatible_qos_;
     //! Latest conflicting PolicyId
     eprosima::fastdds::dds::QosPolicyId_t last_incompatible_qos_;
+    //! Preferred domain ID
+    bool use_preferred_domain_id_;
+    uint32_t preferred_domain_id_;
 
 #if HAVE_SECURITY
     std::mutex mutexAuthentication_;

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -891,7 +891,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldParticipantDiscovery)
     ASSERT_TRUE(writer.isInitialized());
 
     int count = 0;
-    reader.setOnDiscoveryFunction([&writer, &count](const ParticipantBuiltinTopicData& info,
+    reader.set_on_discovery_function([&writer, &count](const ParticipantBuiltinTopicData& info,
             ParticipantDiscoveryStatus status) -> bool
             {
                 if (info.guid == writer.participant_guid())
@@ -937,7 +937,7 @@ TEST_P(Discovery, PubSubAsReliableHelloworldUserData)
 
     ASSERT_TRUE(writer.isInitialized());
 
-    reader.setOnDiscoveryFunction([&writer](const ParticipantBuiltinTopicData& info,
+    reader.set_on_discovery_function([&writer](const ParticipantBuiltinTopicData& info,
             ParticipantDiscoveryStatus /*status*/) -> bool
             {
                 if (info.guid == writer.participant_guid())

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -2725,7 +2725,7 @@ TEST_P(Security, BuiltinAuthenticationAndCryptoPlugin_user_data)
     sub_property_policy.properties().emplace_back("rtps.endpoint.submessage_protection_kind", "ENCRYPT");
     sub_property_policy.properties().emplace_back("rtps.endpoint.payload_protection_kind", "ENCRYPT");
 
-    reader.setOnDiscoveryFunction([&writer](const ParticipantBuiltinTopicData& info,
+    reader.set_on_discovery_function([&writer](const ParticipantBuiltinTopicData& info,
             ParticipantDiscoveryStatus /*status*/) -> bool
             {
                 if (info.guid == writer.participant_guid())

--- a/test/blackbox/common/DDSBlackboxTestsDSAutoMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSAutoMode.cpp
@@ -1,0 +1,295 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/builtin/topic/ParticipantBuiltinTopicData.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/rtps/common/PortParameters.hpp>
+#include <fastdds/rtps/common/Types.hpp>
+#include <fastdds/rtps/RTPSDomain.hpp>
+
+#include "BlackboxTests.hpp"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+
+
+void set_ros_discovery_server_auto_env()
+{
+    /* Set environment variable */
+#ifdef _WIN32
+    _putenv_s("ROS_DISCOVERY_SERVER", "AUTO");
+#else
+    setenv("ROS_DISCOVERY_SERVER", "AUTO", 1);
+#endif // _WIN32
+
+}
+
+void stop_background_servers()
+{
+    // Stop server(s)
+    std::system("fastdds discovery stop all");
+}
+
+/**
+ * Refers to FASTDDS-DSAUTO-TEST:01 from the test plan.
+ *
+ * Launching a participant client with the environment variable ROS_DISCOVERY_SERVER
+ * set to AUTO correctly launches and discovers a Discovery Server in the expected
+ * domain.
+ *
+ */
+TEST(DSAutoMode, ros_discovery_server_auto_env_correctly_launches)
+{
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Configures as SUPER_CLIENT SHM and TCP
+    set_ros_discovery_server_auto_env();
+
+    std::atomic<bool> writer_background_ds_discovered(false);
+    std::atomic<bool> reader_background_ds_discovered(false);
+
+    writer.set_on_discovery_function(
+        [&writer_background_ds_discovered](
+            const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data,
+            eprosima::fastdds::rtps::ParticipantDiscoveryStatus)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                writer_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+    writer.init();
+
+    reader.set_on_discovery_function(
+        [&reader_background_ds_discovered](const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data,
+        eprosima::fastdds::rtps::ParticipantDiscoveryStatus)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                reader_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+    reader.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for endpoint discovery first
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Two participants are expected to have been discovered:
+    // Backgroud DS and the other reader/writer
+    ASSERT_GE(writer.get_participants_matched(), 2u);
+    ASSERT_GE(reader.get_participants_matched(), 2u);
+    ASSERT_TRUE(writer_background_ds_discovered.load());
+    ASSERT_TRUE(reader_background_ds_discovered.load());
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+    writer.send(data);
+    ASSERT_TRUE(data.empty());
+
+    reader.block_for_all();
+
+    // Stop server
+    stop_background_servers();
+}
+
+/**
+ * Refers to FASTDDS-DSAUTO-TEST:02 from the test plan.
+ *
+ * TCP and SHM are the transports used in ROS_DISCOVERY_SERVER=AUTO.
+ */
+TEST(DSAutoMode, ros_discovery_server_auto_env_correct_transports_are_used)
+{
+    PubSubWriter<HelloWorldPubSubType> writer_udp(TEST_TOPIC_NAME), writer_auto(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader_auto(TEST_TOPIC_NAME);
+
+    auto udpv4_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    writer_udp.disable_builtin_transport()
+            .add_user_transport_to_pparams(udpv4_transport)
+            .init();
+
+    ASSERT_TRUE(writer_udp.isInitialized());
+
+    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Configures as SUPER_CLIENT SHM and TCP
+    set_ros_discovery_server_auto_env();
+
+    std::atomic<bool> locators_match_ds_auto_transport(true);
+
+    reader_auto.set_on_discovery_function(
+        [&locators_match_ds_auto_transport](const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data,
+        eprosima::fastdds::rtps::ParticipantDiscoveryStatus)
+        {
+            for (auto locator : data.metatraffic_locators.unicast)
+            {
+                locators_match_ds_auto_transport.store( locators_match_ds_auto_transport &&
+                (locator.kind == LOCATOR_KIND_TCPv4 || locator.kind == LOCATOR_KIND_SHM));
+            }
+
+            if (!data.metatraffic_locators.multicast.empty())
+            {
+                locators_match_ds_auto_transport.store(false);
+            }
+
+            return true;
+        });
+    reader_auto.init();
+
+    ASSERT_TRUE(reader_auto.isInitialized());
+
+    // Discovery shall not happen
+    writer_udp.wait_discovery(std::chrono::seconds(1));
+    reader_auto.wait_discovery(std::chrono::seconds(1));
+
+    ASSERT_FALSE(writer_udp.is_matched());
+    ASSERT_FALSE(reader_auto.is_matched());
+
+    // Now launch another DS AUTO participant writer
+    writer_auto.init();
+
+    writer_auto.wait_discovery();
+    reader_auto.wait_discovery();
+
+    ASSERT_TRUE(locators_match_ds_auto_transport.load());
+
+    // Stop server
+    stop_background_servers();
+}
+
+/**
+ * Refers to FASTDDS-DSAUTO-TEST:03 from the test plan.
+ *
+ * Client participants are aware of the discovery
+ * information of the rest of participants in the same domain.
+ */
+TEST(DSAutoMode, ros_discovery_server_auto_env_discovery_info)
+{
+    unsigned int num_writers = 3;
+    std::vector<std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>> writers;
+    writers.reserve(num_writers);
+    PubSubReader<HelloWorldPubSubType> reader_auto(TEST_TOPIC_NAME + "_auto");
+
+    for (std::size_t i = 0; i < num_writers; ++i)
+    {
+        writers.emplace_back(std::make_shared<PubSubWriter<HelloWorldPubSubType>>(TEST_TOPIC_NAME + std::to_string(i)));
+
+        eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol_qos;
+
+        wire_protocol_qos.builtin.discovery_config.discoveryProtocol =
+                eprosima::fastdds::rtps::DiscoveryProtocol::CLIENT;
+
+        eprosima::fastdds::rtps::Locator_t locator;
+        locator.kind = LOCATOR_KIND_TCPv4;
+
+        eprosima::fastdds::rtps::PortParameters port_params;
+
+        auto ds_auto_port = port_params.getDiscoveryServerPort((uint32_t)GET_PID() % 230);
+
+        IPLocator::setPhysicalPort(locator, ds_auto_port);
+        IPLocator::setLogicalPort(locator, ds_auto_port);
+        IPLocator::setIPv4(locator, "127.0.0.1");
+
+        // Point to the well known DS port in the corresponding domain
+        wire_protocol_qos.builtin.discovery_config.m_DiscoveryServers.push_back(locator);
+
+        writers.back()->set_wire_protocol_qos(wire_protocol_qos)
+                .disable_builtin_transport()
+                .setup_large_data_tcp()
+                .init();
+
+        ASSERT_TRUE(writers.back()->isInitialized());
+    }
+
+    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Configures as SUPER_CLIENT SHM and TCP
+    set_ros_discovery_server_auto_env();
+
+    reader_auto.init();
+    ASSERT_TRUE(reader_auto.isInitialized());
+
+    // Discovery DS in Domain 0 + num_writers
+    reader_auto.wait_participant_discovery(num_writers + 1);
+
+    // This participant shall discover all the other participants
+    // Despite not sharing a common topic with them (SUPER_CLIENT)
+    ASSERT_EQ(reader_auto.get_participants_matched(), num_writers + 1u);
+
+    for (auto& writer : writers)
+    {
+        // Writers shall discover SERVER participant only
+        ASSERT_LE(writer->get_participants_matched(), 1u);
+    }
+
+    // Stop server
+    stop_background_servers();
+}
+
+/**
+ * Refers to FASTDDS-DSAUTO-TEST:04 from the test plan.
+ *
+ * Launching participant clients in different domains with
+ * ROS_DISCOVERY_SERVER set to AUTO correctly
+ * launch and discover the Discovery Server in its domain.
+ */
+TEST(DSAutoMode, ros_discovery_server_auto_env_multiple_clients_multiple_domains)
+{
+    unsigned int num_writer_reader_pairs = 5;
+
+    std::vector<std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>> writers;
+    std::vector<std::shared_ptr<PubSubReader<HelloWorldPubSubType>>> readers;
+
+    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Configures as SUPER_CLIENT SHM and TCP
+    set_ros_discovery_server_auto_env();
+
+    for (std::size_t i = 10; i < 10 + num_writer_reader_pairs; ++i)
+    {
+        writers.emplace_back(std::make_shared<PubSubWriter<HelloWorldPubSubType>>(TEST_TOPIC_NAME + "_domain_" +
+                std::to_string(i)));
+        readers.emplace_back(std::make_shared<PubSubReader<HelloWorldPubSubType>>(TEST_TOPIC_NAME + "_domain_" +
+                std::to_string(i)));
+
+        writers.back()->set_domain_id((uint32_t)i)
+                .init();
+        readers.back()->set_domain_id((uint32_t)i)
+                .init();
+    }
+
+    for (std::size_t i = 0; i < num_writer_reader_pairs; ++i)
+    {
+        writers[i]->wait_discovery();
+        readers[i]->wait_discovery();
+
+        auto data = default_helloworld_data_generator();
+
+        readers[i]->startReception(data);
+        writers[i]->send(data);
+        ASSERT_TRUE(data.empty());
+
+        readers[i]->block_for_all();
+    }
+
+    // Stop servers
+    stop_background_servers();
+}

--- a/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
@@ -214,7 +214,7 @@ static void shm_metatraffic_test(
                 check_shm_locators(info, unicast, multicast);
                 return true;
             };
-    reader.setOnDiscoveryFunction(discovery_checker);
+    reader.set_on_discovery_function(discovery_checker);
     reader.max_multicast_locators_number(2);
     reader.init();
     ASSERT_TRUE(reader.isInitialized());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR implements the test plan for the `Fast DDS Auto Discovery Server Mode` 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
