### PR TITLE
[22055] Fix unique network flows with TCP transports

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1737,7 +1737,15 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
             // Set port on unicast locators
             for (Locator_t& loc : attributes.unicastLocatorList)
             {
-                loc.port = port;
+                // Set logical port only TCP locators
+                if (LOCATOR_KIND_TCPv4 == loc.kind || LOCATOR_KIND_TCPv6 == loc.kind)
+                {
+                    IPLocator::setLogicalPort(loc, port);
+                }
+                else
+                {
+                    loc.port = port;
+                }
             }
 
             // Try creating receiver resources

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -701,6 +701,13 @@ public:
         return false;
     }
 
+    PubSubParticipant& initial_peers(
+            const eprosima::fastdds::rtps::LocatorList& initial_peers)
+    {
+        participant_qos_.wire_protocol().builtin.initialPeersList = initial_peers;
+        return *this;
+    }
+
     PubSubParticipant& pub_property_policy(
             const eprosima::fastdds::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -25,6 +25,7 @@
 
 #include "../api/dds-pim/TCPReqRepHelloWorldRequester.hpp"
 #include "../api/dds-pim/TCPReqRepHelloWorldReplier.hpp"
+#include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 #include "DatagramInjectionTransport.hpp"
@@ -1383,6 +1384,137 @@ TEST_P(TransportTCP, TCP_initial_peers_connection)
 
     p2.block_for_all();
     p3.block_for_all();
+}
+
+TEST_P(TransportTCP, tcp_unique_network_flows_init)
+{
+    // TCP Writer creation should fail as feature is not implemented for writers
+    {
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+        PropertyPolicy properties;
+        properties.properties().emplace_back("fastdds.unique_network_flows", "");
+
+        auto transport_desc = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+        transport_desc->add_listener_port(global_port);
+        writer.disable_builtin_transport().add_user_transport_to_pparams(transport_desc);
+
+        writer.entity_property_policy(properties).init();
+
+        EXPECT_FALSE(writer.isInitialized());
+    }
+
+    // Two readers on the same participant not requesting unique flows should give the same logical port and same physical port
+    {
+        PubSubParticipant<HelloWorldPubSubType> participant(0, 2, 0, 0);
+
+        participant.sub_topic_name(TEST_TOPIC_NAME);
+
+        test_transport_->add_listener_port(global_port);
+        participant.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
+
+        ASSERT_TRUE(participant.init_participant());
+        ASSERT_TRUE(participant.init_subscriber(0));
+        ASSERT_TRUE(participant.init_subscriber(1));
+
+        LocatorList_t locators;
+        LocatorList_t locators2;
+
+        participant.get_native_reader(0).get_listening_locators(locators);
+        participant.get_native_reader(1).get_listening_locators(locators2);
+
+        EXPECT_TRUE(locators == locators2);
+        ASSERT_EQ(locators.size(), 1);
+        ASSERT_EQ(locators2.size(), 1);
+        auto locator1 = locators.begin();
+        auto locator2 = locators2.begin();
+        EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));
+        EXPECT_EQ(IPLocator::getLogicalPort(*locator1), IPLocator::getLogicalPort(*locator2));
+    }
+
+    // Two TCP readers on the same participant requesting unique flows should give different logical ports but same physical port
+    {
+        PubSubParticipant<HelloWorldPubSubType> participant(0, 2, 0, 0);
+
+        PropertyPolicy properties;
+        properties.properties().emplace_back("fastdds.unique_network_flows", "");
+        participant.sub_topic_name(TEST_TOPIC_NAME).sub_property_policy(properties);
+
+        test_transport_->add_listener_port(global_port);
+        participant.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
+
+        ASSERT_TRUE(participant.init_participant());
+        ASSERT_TRUE(participant.init_subscriber(0));
+        ASSERT_TRUE(participant.init_subscriber(1));
+
+        LocatorList_t locators;
+        LocatorList_t locators2;
+
+        participant.get_native_reader(0).get_listening_locators(locators);
+        participant.get_native_reader(1).get_listening_locators(locators2);
+
+        EXPECT_FALSE(locators == locators2);
+        ASSERT_EQ(locators.size(), 1);
+        ASSERT_EQ(locators2.size(), 1);
+        auto locator1 = locators.begin();
+        auto locator2 = locators2.begin();
+        EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));
+        EXPECT_NE(IPLocator::getLogicalPort(*locator1), IPLocator::getLogicalPort(*locator2));
+    }
+}
+
+TEST_P(TransportTCP, tcp_unique_network_flows_communication)
+{
+    PubSubParticipant<HelloWorldPubSubType> readers(0, 2, 0, 2);
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+    PropertyPolicy properties;
+    properties.properties().emplace_back("fastdds.unique_network_flows", "");
+    readers.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
+
+    eprosima::fastdds::rtps::Locator_t initial_peer_locator;
+    if (use_ipv6)
+    {
+        initial_peer_locator.kind = LOCATOR_KIND_TCPv6;
+        eprosima::fastdds::rtps::IPLocator::setIPv6(initial_peer_locator, "::1");
+    }
+    else
+    {
+        initial_peer_locator.kind = LOCATOR_KIND_TCPv4;
+        eprosima::fastdds::rtps::IPLocator::setIPv4(initial_peer_locator, "127.0.0.1");
+    }
+    eprosima::fastdds::rtps::IPLocator::setPhysicalPort(initial_peer_locator, global_port);
+    eprosima::fastdds::rtps::LocatorList_t initial_peer_list;
+    initial_peer_list.push_back(initial_peer_locator);
+
+    readers.sub_topic_name(TEST_TOPIC_NAME)
+            .sub_property_policy(properties)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .initial_peers(initial_peer_list);
+
+    ASSERT_TRUE(readers.init_participant());
+    ASSERT_TRUE(readers.init_subscriber(0));
+    ASSERT_TRUE(readers.init_subscriber(1));
+
+    test_transport_->add_listener_port(global_port);
+    writer.disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport_)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .history_depth(100);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    readers.sub_wait_discovery();
+
+    // Send data
+    auto data = default_helloworld_data_generator();
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block until readers have acknowledged all samples.
+    EXPECT_TRUE(writer.waitForAllAcked(std::chrono::seconds(30)));
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -1394,9 +1394,8 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
         PropertyPolicy properties;
         properties.properties().emplace_back("fastdds.unique_network_flows", "");
 
-        auto transport_desc = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
-        transport_desc->add_listener_port(global_port);
-        writer.disable_builtin_transport().add_user_transport_to_pparams(transport_desc);
+        test_transport_->add_listener_port(global_port);
+        writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
 
         writer.entity_property_policy(properties).init();
 
@@ -1409,7 +1408,6 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
 
         participant.sub_topic_name(TEST_TOPIC_NAME);
 
-        test_transport_->add_listener_port(global_port);
         participant.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
 
         ASSERT_TRUE(participant.init_participant());
@@ -1423,8 +1421,9 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
         participant.get_native_reader(1).get_listening_locators(locators2);
 
         EXPECT_TRUE(locators == locators2);
-        ASSERT_EQ(locators.size(), 1);
-        ASSERT_EQ(locators2.size(), 1);
+        // LocatorList size depends on the number of interfaces. Different address but same port.
+        ASSERT_GT(locators.size(), 0);
+        ASSERT_GT(locators2.size(), 0);
         auto locator1 = locators.begin();
         auto locator2 = locators2.begin();
         EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));
@@ -1439,7 +1438,6 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
         properties.properties().emplace_back("fastdds.unique_network_flows", "");
         participant.sub_topic_name(TEST_TOPIC_NAME).sub_property_policy(properties);
 
-        test_transport_->add_listener_port(global_port);
         participant.disable_builtin_transport().add_user_transport_to_pparams(test_transport_);
 
         ASSERT_TRUE(participant.init_participant());
@@ -1453,8 +1451,9 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
         participant.get_native_reader(1).get_listening_locators(locators2);
 
         EXPECT_FALSE(locators == locators2);
-        ASSERT_EQ(locators.size(), 1);
-        ASSERT_EQ(locators2.size(), 1);
+        // LocatorList size depends on the number of interfaces. Different address but same port.
+        ASSERT_GT(locators.size(), 0);
+        ASSERT_GT(locators2.size(), 0);
         auto locator1 = locators.begin();
         auto locator2 = locators2.begin();
         EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes the behavior of Unique Network Flows with TCP transports. When activated, the logical port should be changed instead of modifying the physical port. This allows the communication of participants with TCP transports and the `fastdds.unique_network_flows` property activated, ensuring that the listening port specified is not modified.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x
<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
