### PR TITLE
[22427] Fast DDS Auto DS Mode - Feature

### DIFF
--- a/include/fastdds/rtps/attributes/BuiltinTransports.hpp
+++ b/include/fastdds/rtps/attributes/BuiltinTransports.hpp
@@ -104,14 +104,15 @@ inline bool operator ==(
  */
 enum class BuiltinTransports : uint16_t
 {
-    NONE = 0,      //< No transport will be instantiated
-    DEFAULT = 1,   //< Default value that will instantiate UDPv4 and SHM transports
+    NONE = 0,          //< No transport will be instantiated
+    DEFAULT = 1,       //< Default value that will instantiate UDPv4 and SHM transports
     DEFAULTv6 = 2,     //< Instantiate UDPv6 and SHM transports
     SHM = 3,           //< Instantiate SHM transport only
     UDPv4 = 4,         //< Instantiate UDPv4 transport only
     UDPv6 = 5,         //< Instantiate UDPv6 transport only
     LARGE_DATA = 6,    //< Instantiate SHM, UDPv4 and TCPv4 transports, but UDPv4 is only used for bootstrapping discovery
-    LARGE_DATAv6 = 7   //< Instantiate SHM, UDPv6 and TCPv6 transports, but UDPv6 is only used for bootstrapping discovery
+    LARGE_DATAv6 = 7,  //< Instantiate SHM, UDPv6 and TCPv6 transports, but UDPv6 is only used for bootstrapping discovery
+    DS_AUTO = 8        //< Instantiate SHM and TCPv4 transports, shall only be used along with ROS_DISCOVERY_SERVER=AUTO
 };
 
 inline std::ostream& operator <<(
@@ -143,6 +144,9 @@ inline std::ostream& operator <<(
             break;
         case BuiltinTransports::LARGE_DATAv6:
             output << "LARGE_DATAv6";
+            break;
+        case BuiltinTransports::DS_AUTO:
+            output << "DS_AUTO";
             break;
         default:
             output << "UNKNOWN";

--- a/resources/xsd/fastdds_profiles.xsd
+++ b/resources/xsd/fastdds_profiles.xsd
@@ -1963,6 +1963,7 @@
             <xs:enumeration value="UDPv6" />
             <xs:enumeration value="LARGE_DATA" />
             <xs:enumeration value="LARGE_DATAv6" />
+            <xs:enumeration value="DS_AUTO" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -301,6 +301,28 @@ static void setup_transports_large_datav6(
     }
 }
 
+static void setup_transports_ds_auto(
+        RTPSParticipantAttributes& att,
+        bool intraprocess_only,
+        const fastdds::rtps::BuiltinTransportsOptions& options)
+{
+    if (!intraprocess_only)
+    {
+        setup_large_data_shm_transport(att, options);
+
+        auto tcp_transport = create_tcpv4_transport(att, options);
+        att.userTransports.push_back(tcp_transport);
+
+        Locator_t tcp_loc;
+        tcp_loc.kind = LOCATOR_KIND_TCPv4;
+        IPLocator::setIPv4(tcp_loc, "0.0.0.0");
+        IPLocator::setPhysicalPort(tcp_loc, 0);
+        IPLocator::setLogicalPort(tcp_loc, 0);
+        att.builtin.metatrafficUnicastLocatorList.push_back(tcp_loc);
+        att.defaultUnicastLocatorList.push_back(tcp_loc);
+    }
+}
+
 void RTPSParticipantAttributes::setup_transports(
         fastdds::rtps::BuiltinTransports transports,
         const fastdds::rtps::BuiltinTransportsOptions& options)
@@ -356,6 +378,12 @@ void RTPSParticipantAttributes::setup_transports(
             // This parameter will allow allow the initialization of UDP transports with maxMessageSize > 65500 KB (s_maximumMessageSize)
             max_msg_size_no_frag = options.maxMessageSize;
             setup_transports_large_datav6(*this, intraprocess_only, options);
+            break;
+
+        case fastdds::rtps::BuiltinTransports::DS_AUTO:
+            // This parameter will allow allow the initialization of UDP transports with maxMessageSize > 65500 KB (s_maximumMessageSize)
+            max_msg_size_no_frag = options.maxMessageSize;
+            setup_transports_ds_auto(*this, intraprocess_only, options);
             break;
 
         default:

--- a/src/cpp/rtps/attributes/ServerAttributes.cpp
+++ b/src/cpp/rtps/attributes/ServerAttributes.cpp
@@ -64,9 +64,9 @@ bool ros_super_client_env()
 
 const std::string& ros_discovery_server_env()
 {
-    static std::string servers;
-    SystemInfo::get_env(DEFAULT_ROS2_MASTER_URI, servers);
-    return servers;
+    static std::string value;
+    SystemInfo::get_env(DEFAULT_ROS2_MASTER_URI, value);
+    return value;
 }
 
 bool load_environment_server_info(

--- a/src/cpp/rtps/attributes/ServerAttributes.hpp
+++ b/src/cpp/rtps/attributes/ServerAttributes.hpp
@@ -136,13 +136,15 @@ std::basic_ostream<charT>& operator <<(
 // Default server base guidPrefix
 const char* const DEFAULT_ROS2_SERVER_GUIDPREFIX = "44.53.00.5f.45.50.52.4f.53.49.4d.41";
 
-/* Environment variable to specify a semicolon-separated list of locators ([transport]ip:port) that define remote server
- * locators. The [transport] specification is optional. The default transport is UDPv4.
- * For the variable to take any effect, the following pre-condition must be met:
- *    - The discovery protocol must be either SIMPLE or SERVER.
- *       a. In the case of SIMPLE, the participant is created as a CLIENT instead.
- *       b. In the case of SERVER, the participant is created as a SERVER, using the DEFAULT_ROS2_MASTER_URI list to
- *          expand the list of remote servers.
+/* Environment variable that can either serve to:
+ * - Specify the Discovery Server auto mode by setting its value to AUTO.
+ * - Specify a semicolon-separated list of locators ([transport]ip:port) that define remote server
+ *   locators. The [transport] specification is optional. The default transport is UDPv4.
+ *   For the variable to take any effect, the following pre-condition must be met:
+ *      - The discovery protocol must be either SIMPLE or SERVER.
+ *         a. In the case of SIMPLE, the participant is created as a CLIENT instead.
+ *         b. In the case of SERVER, the participant is created as a SERVER, using the DEFAULT_ROS2_MASTER_URI list to
+ *            expand the list of remote servers.
  */
 const char* const DEFAULT_ROS2_MASTER_URI = "ROS_DISCOVERY_SERVER";
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -67,17 +67,19 @@ PDPServer::PDPServer(
     // Add remote servers from environment variable
     LocatorList_t env_servers;
     {
-        std::lock_guard<std::recursive_mutex> lock(*getMutex());
-
-        if (load_environment_server_info(env_servers))
+        if (ros_discovery_server_env() != "AUTO")
         {
-            for (auto server : env_servers)
+            std::lock_guard<std::recursive_mutex> lock(*getMutex());
+            if (load_environment_server_info(env_servers))
             {
+                for (auto server : env_servers)
                 {
-                    std::unique_lock<eprosima::shared_mutex> disc_lock(mp_builtin->getDiscoveryMutex());
-                    mp_builtin->m_DiscoveryServers.push_back(server);
+                    {
+                        std::unique_lock<eprosima::shared_mutex> disc_lock(mp_builtin->getDiscoveryMutex());
+                        mp_builtin->m_DiscoveryServers.push_back(server);
+                    }
+                    m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
                 }
-                m_discovery.discovery_config.m_DiscoveryServers.push_back(server);
             }
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -114,7 +114,8 @@ static void set_builtin_transports_from_env_var(
                     "UDPv4", BuiltinTransports::UDPv4,
                     "UDPv6", BuiltinTransports::UDPv6,
                     "LARGE_DATA", BuiltinTransports::LARGE_DATA,
-                    "LARGE_DATAv6", BuiltinTransports::LARGE_DATAv6))
+                    "LARGE_DATAv6", BuiltinTransports::LARGE_DATAv6,
+                    "DS_AUTO", BuiltinTransports::DS_AUTO))
             {
                 EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Wrong value '" << env_value << "' for environment variable '" <<
                         env_var_name << "'. Leaving as DEFAULT");
@@ -140,7 +141,8 @@ static void set_builtin_transports_from_env_var(
                         "UDPv4", BuiltinTransports::UDPv4,
                         "UDPv6", BuiltinTransports::UDPv6,
                         "LARGE_DATA", BuiltinTransports::LARGE_DATA,
-                        "LARGE_DATAv6", BuiltinTransports::LARGE_DATAv6))
+                        "LARGE_DATAv6", BuiltinTransports::LARGE_DATAv6,
+                        "DS_AUTO", BuiltinTransports::DS_AUTO))
                 {
                     EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Wrong value '" << env_value << "' for environment variable '" <<
                             env_var_name << "'. Leaving as DEFAULT");

--- a/src/cpp/utils/SystemCommandBuilder.hpp
+++ b/src/cpp/utils/SystemCommandBuilder.hpp
@@ -1,0 +1,79 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__SYSTEMCOMMANDBUILDER_HPP_
+#define UTILS__SYSTEMCOMMANDBUILDER_HPP_
+
+#include <cstdlib>
+#include <sstream>
+
+namespace eprosima {
+
+namespace fastdds {
+
+static constexpr const char* FAST_DDS_DEFAULT_CLI_SCRIPT_NAME = "fastdds";
+static constexpr const char* FAST_DDS_DEFAULT_CLI_DISCOVERY_VERB = "discovery";
+static constexpr const char* FAST_DDS_DEFAULT_CLI_AUTO_VERB = "auto";
+
+/**
+ * @brief Class to build and execute system commands.
+ */
+class SystemCommandBuilder
+{
+public:
+
+    SystemCommandBuilder() = default;
+
+    SystemCommandBuilder& executable(
+            const std::string& executable)
+    {
+        command_ << executable;
+        return *this;
+    }
+
+    SystemCommandBuilder& verb(
+            const std::string& verb)
+    {
+        command_ << " " << verb;
+        return *this;
+    }
+
+    SystemCommandBuilder& arg(
+            const std::string& arg)
+    {
+        command_ << " " << arg;
+        return *this;
+    }
+
+    SystemCommandBuilder& value(
+            const std::string& value)
+    {
+        command_ << " " << value;
+        return *this;
+    }
+
+    int build_and_call()
+    {
+        return std::system(command_.str().c_str());
+    }
+
+private:
+
+    std::stringstream command_;
+};
+
+} // namespace fastdds
+} // namespace eprosima
+
+#endif  // UTILS__SYSTEMCOMMANDBUILDER_HPP_

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -4687,6 +4687,7 @@ XMLP_ret XMLParser::getXMLBuiltinTransports(
                 <xs:enumeration value="UDPv6" />
                 <xs:enumeration value="LARGE_DATA" />
                 <xs:enumeration value="LARGE_DATAv6" />
+                <xs:enumeration value="DS_AUTO" />
             </xs:restriction>
         </xs:simpleType>
 
@@ -4848,7 +4849,8 @@ XMLP_ret XMLParser::getXMLBuiltinTransports(
             UDPv4, eprosima::fastdds::rtps::BuiltinTransports::UDPv4,
             UDPv6, eprosima::fastdds::rtps::BuiltinTransports::UDPv6,
             LARGE_DATA, eprosima::fastdds::rtps::BuiltinTransports::LARGE_DATA,
-            LARGE_DATAv6, eprosima::fastdds::rtps::BuiltinTransports::LARGE_DATAv6))
+            LARGE_DATAv6, eprosima::fastdds::rtps::BuiltinTransports::LARGE_DATAv6,
+            DS_AUTO, eprosima::fastdds::rtps::BuiltinTransports::DS_AUTO))
     {
         EPROSIMA_LOG_ERROR(XMLPARSER, "Node '" << KIND << "' bad content");
         ret = XMLP_ret::XML_ERROR;

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -199,6 +199,7 @@ const char* DEFAULT_C = "DEFAULT";
 const char* DEFAULTv6 = "DEFAULTv6";
 const char* LARGE_DATA = "LARGE_DATA";
 const char* LARGE_DATAv6 = "LARGE_DATAv6";
+const char* DS_AUTO = "DS_AUTO";
 const char* INIT_ACKNACK_DELAY = "initial_acknack_delay";
 const char* HEARTB_RESP_DELAY = "heartbeat_response_delay";
 const char* INIT_HEARTB_DELAY = "initial_heartbeat_delay";

--- a/src/cpp/xmlparser/XMLParserCommon.h
+++ b/src/cpp/xmlparser/XMLParserCommon.h
@@ -215,6 +215,7 @@ extern const char* DEFAULT_C;
 extern const char* DEFAULTv6;
 extern const char* LARGE_DATA;
 extern const char* LARGE_DATAv6;
+extern const char* DS_AUTO;
 extern const char* INIT_ACKNACK_DELAY;
 extern const char* HEARTB_RESP_DELAY;
 extern const char* INIT_HEARTB_DELAY;

--- a/test/blackbox/builtin_transports_profile.xml
+++ b/test/blackbox/builtin_transports_profile.xml
@@ -111,5 +111,13 @@
             </rtps>
         </participant>
 
+        <participant profile_name="participant_ds_auto">
+            <domainId>0</domainId>
+            <rtps>
+                <name>Participant.builtin_transports_ds_auto</name>
+                <builtinTransports>DS_AUTO</builtinTransports>
+            </rtps>
+        </participant>
+
     </profiles>
 </dds>

--- a/test/blackbox/common/BlackboxTestsTransportCustom.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportCustom.cpp
@@ -612,6 +612,17 @@ TEST(ChainingTransportTests, builtin_transports_env_large_data)
     BuiltinTransportsTest::test_env("LARGE_DATA");
 }
 
+TEST(ChainingTransportTests, builtin_transports_env_ds_auto)
+{
+    /* DS Auto transport shall always be used along with ROS_DISCOVERY_SERVER=AUTO */
+#ifdef _WIN32
+    _putenv_s("ROS_DISCOVERY_SERVER", "AUTO");
+#else
+    setenv("ROS_DISCOVERY_SERVER", "AUTO", 1);
+#endif // _WIN32
+    BuiltinTransportsTest::test_env("DS_AUTO");
+}
+
 TEST(ChainingTransportTests, builtin_transports_env_large_data_with_max_msg_size)
 {
     BuiltinTransportsTest::test_env("LARGE_DATA?max_msg_size=70KB&sockets_size=70KB");
@@ -673,6 +684,17 @@ TEST(ChainingTransportTests, builtin_transports_xml_udpv6)
 TEST(ChainingTransportTests, builtin_transports_xml_large_data)
 {
     BuiltinTransportsTest::test_xml("builtin_transports_profile.xml", "participant_largedata");
+}
+
+TEST(ChainingTransportTests, builtin_transports_xml_ds_auto)
+{
+    /* DS Auto transport shall always be used along with ROS_DISCOVERY_SERVER=AUTO */
+#ifdef _WIN32
+    _putenv_s("ROS_DISCOVERY_SERVER", "AUTO");
+#else
+    setenv("ROS_DISCOVERY_SERVER", "AUTO", 1);
+#endif // _WIN32
+    BuiltinTransportsTest::test_xml("builtin_transports_profile.xml", "participant_ds_auto");
 }
 
 TEST(ChainingTransportTests, builtin_transports_xml_large_data_with_max_msg_size)

--- a/test/blackbox/common/DDSBlackboxTestsDSAutoMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSAutoMode.cpp
@@ -39,7 +39,8 @@ void set_ros_discovery_server_auto_env()
 void stop_background_servers()
 {
     // Stop server(s)
-    std::system("fastdds discovery stop all");
+    int res = std::system("fastdds discovery stop all");
+    ASSERT_EQ(res, 0);
 }
 
 /**

--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -133,6 +133,7 @@ set(CLI_MANAGER_TESTS_EXEC CliDiscoveryManagerTests)
 
 set(CLI_MANAGER_TESTS_SOURCE
     CliDiscoveryManagerTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
     ${PROJECT_SOURCE_DIR}/tools/fds/CliDiscoveryManager.cpp
     )
 

--- a/test/unittest/xmlparser/XMLElementParserTests.cpp
+++ b/test/unittest/xmlparser/XMLElementParserTests.cpp
@@ -646,6 +646,7 @@ TEST_F(XMLParserTests, getXMLbuiltinTransports)
     bt_list.push_back("UDPv6");
     bt_list.push_back("LARGE_DATA");
     bt_list.push_back("LARGE_DATAv6");
+    bt_list.push_back("DS_AUTO");
 
     for (auto test_transport : bt_list)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR implements the `Fast DDS Auto Discovery Server Mode` feature

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
