### PR TITLE
[22469] Avoid calling setIPv4 in TCPTransportInterface

### DIFF
--- a/include/fastdds/utils/IPLocator.hpp
+++ b/include/fastdds/utils/IPLocator.hpp
@@ -252,6 +252,15 @@ public:
             const Locator_t& loc2,
             bool fullAddress = false);
 
+    /** Copies the whole address from one locator to another.
+     * @param loc1 Locator to copy from.
+     * @param loc2 Locator to copy to.
+     * @return True if the copy was successful.
+     */
+    FASTDDS_EXPORTED_API static bool copyAddress(
+            const Locator_t& loc1,
+            Locator_t& loc2);
+
     //! Checks if a both locators has the same IP address and physical port  (as in RTCP protocol).
     FASTDDS_EXPORTED_API static bool compareAddressAndPhysicalPort(
             const Locator_t& loc1,

--- a/include/fastdds/utils/IPLocator.hpp
+++ b/include/fastdds/utils/IPLocator.hpp
@@ -252,7 +252,8 @@ public:
             const Locator_t& loc2,
             bool fullAddress = false);
 
-    /** Copies the whole address from one locator to another.
+    /**
+     * Copies the whole address from one locator to another.
      * @param loc1 Locator to copy from.
      * @param loc2 Locator to copy to.
      * @return True if the copy was successful.

--- a/include/fastdds/utils/IPLocator.hpp
+++ b/include/fastdds/utils/IPLocator.hpp
@@ -258,7 +258,7 @@ public:
      * @param loc2 Locator to copy to.
      * @return True if the copy was successful.
      */
-    FASTDDS_EXPORTED_API static bool copyAddress(
+    FASTDDS_EXPORTED_API static bool copy_address(
             const Locator_t& loc1,
             Locator_t& loc2);
 

--- a/include/fastdds/utils/IPLocator.hpp
+++ b/include/fastdds/utils/IPLocator.hpp
@@ -97,12 +97,23 @@ public:
     FASTDDS_EXPORTED_API static std::string toIPv4string(
             const Locator_t& locator);
 
-    //! Copies locator's IPv4.
+    /**
+     * @brief Copies locator's IPv4 to a destination array.
+     * @param locator Locator from which to copy the IPv4.
+     * @param dest Destination array where the IPv4 will be copied.
+     * @return true if the copy was successful, false otherwise.
+     */
     FASTDDS_EXPORTED_API static bool copyIPv4(
             const Locator_t& locator,
             unsigned char* dest);
 
-    //! Copies locator's IPv4.
+    /**
+     * @brief Copies locator's IPv4 to a destination locator.
+     *        It only copies the IPv4 part (last 4 bytes), leaving other parts unchanged.
+     * @param locator Locator from which to copy the IPv4.
+     * @param dest Destination locator where the IPv4 will be copied.
+     * @return true if the copy was successful, false otherwise.
+     */
     FASTDDS_EXPORTED_API static bool copyIPv4(
             const Locator_t& locator,
             Locator_t& dest);

--- a/include/fastdds/utils/IPLocator.hpp
+++ b/include/fastdds/utils/IPLocator.hpp
@@ -102,6 +102,11 @@ public:
             const Locator_t& locator,
             unsigned char* dest);
 
+    //! Copies locator's IPv4.
+    FASTDDS_EXPORTED_API static bool copyIPv4(
+            const Locator_t& locator,
+            Locator_t& dest);
+
     // IPv6
     //! Sets locator's IPv6.
     FASTDDS_EXPORTED_API static bool setIPv6(

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -1357,7 +1357,8 @@ bool TCPTransportInterface::Receive(
         do
         {
             header_found = receive_header(channel, tcp_header, ec);
-        } while (!header_found && !ec && channel->connection_status());
+        }
+        while (!header_found && !ec && channel->connection_status());
 
         if (ec)
         {

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -325,7 +325,7 @@ ResponseCode TCPTransportInterface::bind_socket(
         Locator local_locator(channel->locator());
         for (auto& interface_it : local_interfaces)
         {
-            IPLocator::setIPv4(local_locator, interface_it.locator);
+            IPLocator::copyAddress(interface_it.locator, local_locator);
             const auto insert_ret_local = channel_resources_.insert(
                 decltype(channel_resources_)::value_type{local_locator, channel});
             if (!insert_ret_local.first->second->connection_established())
@@ -1041,7 +1041,7 @@ bool TCPTransportInterface::CreateInitialConnect(
         Locator local_locator(physical_locator);
         for (auto& interface_it : local_interfaces)
         {
-            IPLocator::setIPv4(local_locator, interface_it.locator);
+            IPLocator::copyAddress(interface_it.locator, local_locator);
             channel_resources_[local_locator] = channel;
         }
     }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -319,7 +319,7 @@ ResponseCode TCPTransportInterface::bind_socket(
 
     std::vector<fastdds::rtps::IPFinder::info_IP> local_interfaces;
     // Check if the locator is from an owned interface to link all local interfaces to the channel
-    // Note: Only appliable for TCPv4 until TCPv6 scope selection is implemented
+    // Note: Only applicable for TCPv4 until TCPv6 scope selection is implemented
     if (channel->locator().kind != LOCATOR_KIND_TCPv6)
     {
         is_own_interface(channel->locator(), local_interfaces);
@@ -328,7 +328,7 @@ ResponseCode TCPTransportInterface::bind_socket(
             Locator local_locator(channel->locator());
             for (auto& interface_it : local_interfaces)
             {
-                IPLocator::copyAddress(interface_it.locator, local_locator);
+                IPLocator::copy_address(interface_it.locator, local_locator);
                 const auto insert_ret_local = channel_resources_.insert(
                     decltype(channel_resources_)::value_type{local_locator, channel});
                 if (!insert_ret_local.first->second->connection_established())
@@ -1039,7 +1039,7 @@ bool TCPTransportInterface::CreateInitialConnect(
 
     std::vector<fastdds::rtps::IPFinder::info_IP> local_interfaces;
     // Check if the locator is from an owned interface to link all local interfaces to the channel
-    // Note: Only appliable for TCPv4 until TCPv6 scope selection is implemented
+    // Note: Only applicable for TCPv4 until TCPv6 scope selection is implemented
     if (physical_locator.kind != LOCATOR_KIND_TCPv6)
     {
         is_own_interface(physical_locator, local_interfaces);
@@ -1048,7 +1048,7 @@ bool TCPTransportInterface::CreateInitialConnect(
             Locator local_locator(physical_locator);
             for (auto& interface_it : local_interfaces)
             {
-                IPLocator::copyAddress(interface_it.locator, local_locator);
+                IPLocator::copy_address(interface_it.locator, local_locator);
                 channel_resources_[local_locator] = channel;
             }
         }

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -319,18 +319,22 @@ ResponseCode TCPTransportInterface::bind_socket(
 
     std::vector<fastdds::rtps::IPFinder::info_IP> local_interfaces;
     // Check if the locator is from an owned interface to link all local interfaces to the channel
-    is_own_interface(channel->locator(), local_interfaces);
-    if (!local_interfaces.empty())
+    // Note: Only appliable for TCPv4 until TCPv6 scope selection is implemented
+    if (channel->locator().kind != LOCATOR_KIND_TCPv6)
     {
-        Locator local_locator(channel->locator());
-        for (auto& interface_it : local_interfaces)
+        is_own_interface(channel->locator(), local_interfaces);
+        if (!local_interfaces.empty())
         {
-            IPLocator::copyAddress(interface_it.locator, local_locator);
-            const auto insert_ret_local = channel_resources_.insert(
-                decltype(channel_resources_)::value_type{local_locator, channel});
-            if (!insert_ret_local.first->second->connection_established())
+            Locator local_locator(channel->locator());
+            for (auto& interface_it : local_interfaces)
             {
-                insert_ret_local.first->second = channel;
+                IPLocator::copyAddress(interface_it.locator, local_locator);
+                const auto insert_ret_local = channel_resources_.insert(
+                    decltype(channel_resources_)::value_type{local_locator, channel});
+                if (!insert_ret_local.first->second->connection_established())
+                {
+                    insert_ret_local.first->second = channel;
+                }
             }
         }
     }
@@ -1035,14 +1039,18 @@ bool TCPTransportInterface::CreateInitialConnect(
 
     std::vector<fastdds::rtps::IPFinder::info_IP> local_interfaces;
     // Check if the locator is from an owned interface to link all local interfaces to the channel
-    is_own_interface(physical_locator, local_interfaces);
-    if (!local_interfaces.empty())
+    // Note: Only appliable for TCPv4 until TCPv6 scope selection is implemented
+    if (physical_locator.kind != LOCATOR_KIND_TCPv6)
     {
-        Locator local_locator(physical_locator);
-        for (auto& interface_it : local_interfaces)
+        is_own_interface(physical_locator, local_interfaces);
+        if (!local_interfaces.empty())
         {
-            IPLocator::copyAddress(interface_it.locator, local_locator);
-            channel_resources_[local_locator] = channel;
+            Locator local_locator(physical_locator);
+            for (auto& interface_it : local_interfaces)
+            {
+                IPLocator::copyAddress(interface_it.locator, local_locator);
+                channel_resources_[local_locator] = channel;
+            }
         }
     }
 

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -985,7 +985,7 @@ bool IPLocator::compareAddress(
     }
 }
 
-bool IPLocator::copyAddress(
+bool IPLocator::copy_address(
         const Locator_t& loc1,
         Locator_t& loc2)
 {
@@ -996,7 +996,7 @@ bool IPLocator::copyAddress(
 
     if (loc1.kind == LOCATOR_KIND_UDPv4 || loc1.kind == LOCATOR_KIND_TCPv4)
     {
-        memcpy(loc2.address, loc1.address, 16 * sizeof(char));
+        copyIPv4(loc1, loc2.address);
         return true;
     }
     else if (loc1.kind == LOCATOR_KIND_UDPv6 || loc1.kind == LOCATOR_KIND_TCPv6)

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -206,8 +206,7 @@ bool IPLocator::copyIPv4(
         const Locator_t& locator,
         Locator_t& dest)
 {
-    copyIPv4(locator, &(dest.address[12]));
-    return true;
+    return copyIPv4(locator, &(dest.address[12]));
 }
 
 // IPv6

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -202,6 +202,14 @@ bool IPLocator::copyIPv4(
     return true;
 }
 
+bool IPLocator::copyIPv4(
+        const Locator_t& locator,
+        Locator_t& dest)
+{
+    copyIPv4(locator, &(dest.address[12]));
+    return true;
+}
+
 // IPv6
 bool IPLocator::setIPv6(
         Locator_t& locator,
@@ -996,7 +1004,7 @@ bool IPLocator::copy_address(
 
     if (loc1.kind == LOCATOR_KIND_UDPv4 || loc1.kind == LOCATOR_KIND_TCPv4)
     {
-        copyIPv4(loc1, loc2.address);
+        copyIPv4(loc1, loc2);
         return true;
     }
     else if (loc1.kind == LOCATOR_KIND_UDPv6 || loc1.kind == LOCATOR_KIND_TCPv6)

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -985,6 +985,27 @@ bool IPLocator::compareAddress(
     }
 }
 
+bool IPLocator::copyAddress(
+        const Locator_t& loc1,
+        Locator_t& loc2)
+{
+    if (loc1.kind != loc2.kind)
+    {
+        return false;
+    }
+
+    if (loc1.kind == LOCATOR_KIND_UDPv4 || loc1.kind == LOCATOR_KIND_TCPv4)
+    {
+        memcpy(loc2.address, loc1.address, 16 * sizeof(char));
+        return true;
+    }
+    else if (loc1.kind == LOCATOR_KIND_UDPv6 || loc1.kind == LOCATOR_KIND_TCPv6)
+    {
+        return copyIPv6(loc1, loc2.address);
+    }
+    return false;
+}
+
 bool IPLocator::compareAddressAndPhysicalPort(
         const Locator_t& loc1,
         const Locator_t& loc2)

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2035,6 +2035,7 @@ TEST_F(TCPv4Tests, client_announced_local_port_uniqueness)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
+    EXPECT_GT(receiveTransportUnderTest.get_channel_resources().size(), 2u);
     std::set<std::shared_ptr<TCPChannelResource>> channels_created;
     for (const auto& channel_resource : receiveTransportUnderTest.get_channel_resources())
     {

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -368,7 +368,13 @@ TEST_F(TCPv6Tests, client_announced_local_port_uniqueness)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    ASSERT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2u);
+    EXPECT_GT(receiveTransportUnderTest.get_channel_resources().size(), 2u);
+    std::set<std::shared_ptr<TCPChannelResource>> channels_created;
+    for (const auto& channel_resource : receiveTransportUnderTest.get_channel_resources())
+    {
+        channels_created.insert(channel_resource.second);
+    }
+    ASSERT_EQ(channels_created.size(), 2u);
 }
 
 #ifndef _WIN32

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -368,13 +368,7 @@ TEST_F(TCPv6Tests, client_announced_local_port_uniqueness)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    EXPECT_GT(receiveTransportUnderTest.get_channel_resources().size(), 2u);
-    std::set<std::shared_ptr<TCPChannelResource>> channels_created;
-    for (const auto& channel_resource : receiveTransportUnderTest.get_channel_resources())
-    {
-        channels_created.insert(channel_resource.second);
-    }
-    ASSERT_EQ(channels_created.size(), 2u);
+    EXPECT_EQ(receiveTransportUnderTest.get_channel_resources().size(), 2u);
 }
 
 #ifndef _WIN32

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -768,6 +768,31 @@ TEST_F(IPLocatorTests, copyIPv6)
 }
 
 /*
+ * Check to copy an address
+ */
+TEST_F(IPLocatorTests, copyAddress)
+{
+    // Copy IPv4
+    Locator_t locator1(LOCATOR_KIND_UDPv4);
+    Locator_t locator2(LOCATOR_KIND_UDPv4);
+    IPLocator::setIPv4(locator1, ipv4_lo_address);
+    ASSERT_FALSE(IPLocator::compareAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::copyAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::compareAddress(locator1, locator2));
+
+    // Check cannot copy between different kinds
+    locator1.kind = LOCATOR_KIND_UDPv6;
+    ASSERT_FALSE(IPLocator::copyAddress(locator1, locator2));
+
+    // Copy IPv6
+    locator2.kind = LOCATOR_KIND_UDPv6;
+    IPLocator::setIPv6(locator1, ipv6_lo_address);
+    ASSERT_FALSE(IPLocator::compareAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::copyAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::compareAddress(locator1, locator2));
+}
+
+/*
  * Check to set ip of any kind
  */
 TEST_F(IPLocatorTests, ip)

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -770,31 +770,31 @@ TEST_F(IPLocatorTests, copyIPv6)
 /*
  * Check to copy an address
  */
-TEST_F(IPLocatorTests, copyAddress)
+TEST_F(IPLocatorTests, copy_address)
 {
     // Copy IPv4
     Locator_t locator1(LOCATOR_KIND_UDPv4);
     Locator_t locator2(LOCATOR_KIND_UDPv4);
     IPLocator::setIPv4(locator1, ipv4_lo_address);
     ASSERT_FALSE(IPLocator::compareAddress(locator1, locator2));
-    ASSERT_TRUE(IPLocator::copyAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::copy_address(locator1, locator2));
     ASSERT_TRUE(IPLocator::compareAddress(locator1, locator2));
 
     // Check cannot copy between different kinds
     locator1.kind = LOCATOR_KIND_UDPv6;
-    ASSERT_FALSE(IPLocator::copyAddress(locator1, locator2));
+    ASSERT_FALSE(IPLocator::copy_address(locator1, locator2));
 
     // Copy IPv6
     locator2.kind = LOCATOR_KIND_UDPv6;
     IPLocator::setIPv6(locator1, ipv6_lo_address);
     ASSERT_FALSE(IPLocator::compareAddress(locator1, locator2));
-    ASSERT_TRUE(IPLocator::copyAddress(locator1, locator2));
+    ASSERT_TRUE(IPLocator::copy_address(locator1, locator2));
     ASSERT_TRUE(IPLocator::compareAddress(locator1, locator2));
 
     // Check cannot copy between SHM locators
     locator1.kind = LOCATOR_KIND_SHM;
     Locator_t locator3(LOCATOR_KIND_SHM);
-    ASSERT_FALSE(IPLocator::copyAddress(locator1, locator3));
+    ASSERT_FALSE(IPLocator::copy_address(locator1, locator3));
     ASSERT_FALSE(IPLocator::compareAddress(locator1, locator3));
 }
 

--- a/test/unittest/utils/LocatorTests.cpp
+++ b/test/unittest/utils/LocatorTests.cpp
@@ -790,6 +790,12 @@ TEST_F(IPLocatorTests, copyAddress)
     ASSERT_FALSE(IPLocator::compareAddress(locator1, locator2));
     ASSERT_TRUE(IPLocator::copyAddress(locator1, locator2));
     ASSERT_TRUE(IPLocator::compareAddress(locator1, locator2));
+
+    // Check cannot copy between SHM locators
+    locator1.kind = LOCATOR_KIND_SHM;
+    Locator_t locator3(LOCATOR_KIND_SHM);
+    ASSERT_FALSE(IPLocator::copyAddress(locator1, locator3));
+    ASSERT_FALSE(IPLocator::compareAddress(locator1, locator3));
 }
 
 /*


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds a new method `copyAddress` which allows to copy the whole address of one locator to another. It uses this method to replace the `setIPv4` method of `TCPTransportInterace` introduced in https://github.com/eProsima/Fast-DDS/pull/5382 which caused undesired warnings. 

It also excludes `TCPv6` cases from this logic, leaving TCPv6 comms as before https://github.com/eProsima/Fast-DDS/pull/5382.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
