### PR TITLE
[22277] Split Windows nightly tests using name filter regex

### DIFF
--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -16,10 +16,13 @@ jobs:
         cmake_build_type:
           - 'Debug'
           - 'RelWithDebInfo'
+        test_filter:
+          - 'blackbox'
+          - 'unittest'
     uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@master
     with:
-      label: 'nightly-sec-${{ matrix.security }}-windows-ci-master'
+      label: nightly-sec-${{ matrix.security }}-${{ matrix.cmake_build_type }}-${{ matrix.test_filter }}-windows-ci-master
       cmake-config: ${{ matrix.cmake_build_type }}
       cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: "-LE xfail"
+      ctest-args: -LE xfail ${{ matrix.test_filter == 'blackbox' && '-R "BlackboxTests|example_tests"' || matrix.test_filter == 'unittest' && '-E "BlackboxTests|example_tests"' }}
       fastdds_branch: 'master'

--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -24,5 +24,5 @@ jobs:
       label: nightly-sec-${{ matrix.security }}-${{ matrix.cmake_build_type }}-${{ matrix.test_filter }}-windows-ci-master
       cmake-config: ${{ matrix.cmake_build_type }}
       cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: -LE xfail ${{ matrix.test_filter == 'blackbox' && '-R "BlackboxTests|example_tests"' || matrix.test_filter == 'unittest' && '-E "BlackboxTests|example_tests"' }}
+      ctest-args: -LE xfail ${{ matrix.test_filter == 'blackbox' && '-R "BlackboxTests|example_tests"' || matrix.test_filter == 'unittest' && '-E "BlackboxTests|example_tests" -j 4' }}
       fastdds_branch: 'master'

--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -20,7 +20,7 @@ jobs:
           - 'blackbox'
           - 'unittest'
         filter_expression:
-          - 'BlackboxTests|example_tests'
+          - 'BlackboxTests|example_tests|ParticipantTests|SecureDiscoverServer'
     uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@master
     with:
       label: nightly-sec-${{ matrix.security }}-${{ matrix.cmake_build_type }}-${{ matrix.test_filter }}-windows-ci-master

--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 22 * * *' # At 22:00 GMT
-    
+
 jobs:
   nightly-windows-ci-master:
+    name: nightly-windows-ci-master (SEC=${{ matrix.security }}, ${{ matrix.cmake_build_type }}, ${{ matrix.test_filter }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -7,16 +7,16 @@ on:
 
 jobs:
   nightly-windows-ci-master:
-    name: nightly-windows-ci-master (SEC=${{ matrix.security }}, ${{ matrix.cmake_build_type }}, ${{ matrix.test_filter }})
+    name: nightly-windows-ci-master (${{ matrix.cmake_build_type }}, SEC=${{ matrix.security }}, ${{ matrix.test_filter }})
     strategy:
       fail-fast: false
       matrix:
+        cmake_build_type:
+          - 'RelWithDebInfo'
+          - 'Debug'
         security:
           - 'ON'
           - 'OFF'
-        cmake_build_type:
-          - 'Debug'
-          - 'RelWithDebInfo'
         test_filter:
           - 'blackbox'
           - 'unittest'

--- a/.github/workflows/nightly-windows-master.yml
+++ b/.github/workflows/nightly-windows-master.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 22 * * *' # At 22:00 GMT
-
+    
 jobs:
   nightly-windows-ci-master:
     strategy:
@@ -19,10 +19,12 @@ jobs:
         test_filter:
           - 'blackbox'
           - 'unittest'
+        filter_expression:
+          - 'BlackboxTests|example_tests'
     uses: eProsima/Fast-DDS/.github/workflows/reusable-windows-ci.yml@master
     with:
       label: nightly-sec-${{ matrix.security }}-${{ matrix.cmake_build_type }}-${{ matrix.test_filter }}-windows-ci-master
       cmake-config: ${{ matrix.cmake_build_type }}
       cmake-args: "-DSECURITY=${{ matrix.security }}"
-      ctest-args: -LE xfail ${{ matrix.test_filter == 'blackbox' && '-R "BlackboxTests|example_tests"' || matrix.test_filter == 'unittest' && '-E "BlackboxTests|example_tests" -j 4' }}
+      ctest-args: -LE xfail ${{ matrix.test_filter == 'blackbox' && format('-R "{0}"', matrix.filter_expression) || format('-E "{0}" -j 4', matrix.filter_expression) }}
       fastdds_branch: 'master'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR splits Fast DDS tests, and runs some of them in parallel, to avoid exceeding the maximum allowed GitHub Workflow time.

Windows Nightly CI run:
https://github.com/eProsima/Fast-DDS/actions/runs/12687477053

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_ The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
