### PR TITLE
[21832] Regenerate types with Fast DDS Gen 4.0.3

### DIFF
--- a/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
+++ b/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ConfigurationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
+++ b/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool DeliveryMechanismsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
+++ b/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FlowControlPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
+++ b/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool CalculatorRequestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool CalculatorReplyTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/security/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/security/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
+++ b/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ShapeTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp
@@ -399,7 +399,11 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_hash.~EquivalenceHash();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::dds::xtypes;
+                        m_hash.~EquivalenceHash();
+                    };
                     new(&m_hash) EquivalenceHash();
 
                 }
@@ -2822,7 +2826,10 @@ public:
     eProsima_user_DllExport TypeIdentifier()
     {
         selected_member_ = 0x00000001;
-        member_destructor_ = [&]() {m_no_value.~Dummy();};
+        member_destructor_ = [&]()
+        {
+            m_no_value.~Dummy();
+        };
         new(&m_no_value) Dummy();
 
     }
@@ -3959,7 +3966,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_no_value.~Dummy();};
+                    member_destructor_ = [&]()
+                    {
+                        m_no_value.~Dummy();
+                    };
                     new(&m_no_value) Dummy();
 
                 }
@@ -3977,7 +3987,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_string_sdefn.~StringSTypeDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_string_sdefn.~StringSTypeDefn();
+                    };
                     new(&m_string_sdefn) StringSTypeDefn();
 
                 }
@@ -3995,7 +4008,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_string_ldefn.~StringLTypeDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_string_ldefn.~StringLTypeDefn();
+                    };
                     new(&m_string_ldefn) StringLTypeDefn();
 
                 }
@@ -4013,7 +4029,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_seq_sdefn.~PlainSequenceSElemDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_seq_sdefn.~PlainSequenceSElemDefn();
+                    };
                     new(&m_seq_sdefn) PlainSequenceSElemDefn();
 
                 }
@@ -4031,7 +4050,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_seq_ldefn.~PlainSequenceLElemDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_seq_ldefn.~PlainSequenceLElemDefn();
+                    };
                     new(&m_seq_ldefn) PlainSequenceLElemDefn();
 
                 }
@@ -4049,7 +4071,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_array_sdefn.~PlainArraySElemDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_array_sdefn.~PlainArraySElemDefn();
+                    };
                     new(&m_array_sdefn) PlainArraySElemDefn();
 
                 }
@@ -4067,7 +4092,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_array_ldefn.~PlainArrayLElemDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_array_ldefn.~PlainArrayLElemDefn();
+                    };
                     new(&m_array_ldefn) PlainArrayLElemDefn();
 
                 }
@@ -4085,7 +4113,10 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_map_sdefn.~PlainMapSTypeDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_map_sdefn.~PlainMapSTypeDefn();
+                    };
                     new(&m_map_sdefn) PlainMapSTypeDefn();
 
                 }
@@ -4103,7 +4134,10 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
-                    member_destructor_ = [&]() {m_map_ldefn.~PlainMapLTypeDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_map_ldefn.~PlainMapLTypeDefn();
+                    };
                     new(&m_map_ldefn) PlainMapLTypeDefn();
 
                 }
@@ -4121,7 +4155,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000a;
-                    member_destructor_ = [&]() {m_sc_component_id.~StronglyConnectedComponentId();};
+                    member_destructor_ = [&]()
+                    {
+                        m_sc_component_id.~StronglyConnectedComponentId();
+                    };
                     new(&m_sc_component_id) StronglyConnectedComponentId();
 
                 }
@@ -4139,7 +4176,11 @@ private:
                     }
 
                     selected_member_ = 0x0000000b;
-                    member_destructor_ = [&]() {m_equivalence_hash.~EquivalenceHash();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::dds::xtypes;
+                        m_equivalence_hash.~EquivalenceHash();
+                    };
                     new(&m_equivalence_hash) EquivalenceHash();
 
                 }
@@ -4157,7 +4198,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000c;
-                    member_destructor_ = [&]() {m_extended_defn.~ExtendedTypeDefn();};
+                    member_destructor_ = [&]()
+                    {
+                        m_extended_defn.~ExtendedTypeDefn();
+                    };
                     new(&m_extended_defn) ExtendedTypeDefn();
 
                 }
@@ -4303,7 +4347,10 @@ public:
     eProsima_user_DllExport AnnotationParameterValue()
     {
         selected_member_ = 0x00000013;
-        member_destructor_ = [&]() {m_extended_value.~ExtendedAnnotationParameterValue();};
+        member_destructor_ = [&]()
+        {
+            m_extended_value.~ExtendedAnnotationParameterValue();
+        };
         new(&m_extended_value) ExtendedAnnotationParameterValue();
 
     }
@@ -6094,7 +6141,10 @@ private:
                     }
 
                     selected_member_ = 0x00000011;
-                    member_destructor_ = [&]() {m_string8_value.~fixed_string();};
+                    member_destructor_ = [&]()
+                    {
+                        m_string8_value.~fixed_string();
+                    };
                     new(&m_string8_value) eprosima::fastcdr::fixed_string<ANNOTATION_STR_VALUE_MAX_LEN>();
 
                 }
@@ -6112,7 +6162,10 @@ private:
                     }
 
                     selected_member_ = 0x00000012;
-                    member_destructor_ = [&]() {m_string16_value.~basic_string();};
+                    member_destructor_ = [&]()
+                    {
+                        m_string16_value.~basic_string();
+                    };
                     new(&m_string16_value) std::wstring();
 
                 }
@@ -6130,7 +6183,10 @@ private:
                     }
 
                     selected_member_ = 0x00000013;
-                    member_destructor_ = [&]() {m_extended_value.~ExtendedAnnotationParameterValue();};
+                    member_destructor_ = [&]()
+                    {
+                        m_extended_value.~ExtendedAnnotationParameterValue();
+                    };
                     new(&m_extended_value) ExtendedAnnotationParameterValue();
 
                 }
@@ -20720,7 +20776,10 @@ public:
     eProsima_user_DllExport CompleteTypeObject()
     {
         selected_member_ = 0x0000000b;
-        member_destructor_ = [&]() {m_extended_type.~CompleteExtendedType();};
+        member_destructor_ = [&]()
+        {
+            m_extended_type.~CompleteExtendedType();
+        };
         new(&m_extended_type) CompleteExtendedType();
 
     }
@@ -21759,7 +21818,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_alias_type.~CompleteAliasType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_alias_type.~CompleteAliasType();
+                    };
                     new(&m_alias_type) CompleteAliasType();
 
                 }
@@ -21777,7 +21839,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_annotation_type.~CompleteAnnotationType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_annotation_type.~CompleteAnnotationType();
+                    };
                     new(&m_annotation_type) CompleteAnnotationType();
 
                 }
@@ -21795,7 +21860,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_struct_type.~CompleteStructType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_struct_type.~CompleteStructType();
+                    };
                     new(&m_struct_type) CompleteStructType();
 
                 }
@@ -21813,7 +21881,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_union_type.~CompleteUnionType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_union_type.~CompleteUnionType();
+                    };
                     new(&m_union_type) CompleteUnionType();
 
                 }
@@ -21831,7 +21902,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_bitset_type.~CompleteBitsetType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_bitset_type.~CompleteBitsetType();
+                    };
                     new(&m_bitset_type) CompleteBitsetType();
 
                 }
@@ -21849,7 +21923,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_sequence_type.~CompleteSequenceType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_sequence_type.~CompleteSequenceType();
+                    };
                     new(&m_sequence_type) CompleteSequenceType();
 
                 }
@@ -21867,7 +21944,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_array_type.~CompleteArrayType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_array_type.~CompleteArrayType();
+                    };
                     new(&m_array_type) CompleteArrayType();
 
                 }
@@ -21885,7 +21965,10 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_map_type.~CompleteMapType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_map_type.~CompleteMapType();
+                    };
                     new(&m_map_type) CompleteMapType();
 
                 }
@@ -21903,7 +21986,10 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
-                    member_destructor_ = [&]() {m_enumerated_type.~CompleteEnumeratedType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_enumerated_type.~CompleteEnumeratedType();
+                    };
                     new(&m_enumerated_type) CompleteEnumeratedType();
 
                 }
@@ -21921,7 +22007,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000a;
-                    member_destructor_ = [&]() {m_bitmask_type.~CompleteBitmaskType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_bitmask_type.~CompleteBitmaskType();
+                    };
                     new(&m_bitmask_type) CompleteBitmaskType();
 
                 }
@@ -21939,7 +22028,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000b;
-                    member_destructor_ = [&]() {m_extended_type.~CompleteExtendedType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_extended_type.~CompleteExtendedType();
+                    };
                     new(&m_extended_type) CompleteExtendedType();
 
                 }
@@ -22078,7 +22170,10 @@ public:
     eProsima_user_DllExport MinimalTypeObject()
     {
         selected_member_ = 0x0000000b;
-        member_destructor_ = [&]() {m_extended_type.~MinimalExtendedType();};
+        member_destructor_ = [&]()
+        {
+            m_extended_type.~MinimalExtendedType();
+        };
         new(&m_extended_type) MinimalExtendedType();
 
     }
@@ -23117,7 +23212,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_alias_type.~MinimalAliasType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_alias_type.~MinimalAliasType();
+                    };
                     new(&m_alias_type) MinimalAliasType();
 
                 }
@@ -23135,7 +23233,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_annotation_type.~MinimalAnnotationType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_annotation_type.~MinimalAnnotationType();
+                    };
                     new(&m_annotation_type) MinimalAnnotationType();
 
                 }
@@ -23153,7 +23254,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_struct_type.~MinimalStructType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_struct_type.~MinimalStructType();
+                    };
                     new(&m_struct_type) MinimalStructType();
 
                 }
@@ -23171,7 +23275,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_union_type.~MinimalUnionType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_union_type.~MinimalUnionType();
+                    };
                     new(&m_union_type) MinimalUnionType();
 
                 }
@@ -23189,7 +23296,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_bitset_type.~MinimalBitsetType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_bitset_type.~MinimalBitsetType();
+                    };
                     new(&m_bitset_type) MinimalBitsetType();
 
                 }
@@ -23207,7 +23317,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_sequence_type.~MinimalSequenceType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_sequence_type.~MinimalSequenceType();
+                    };
                     new(&m_sequence_type) MinimalSequenceType();
 
                 }
@@ -23225,7 +23338,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_array_type.~MinimalArrayType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_array_type.~MinimalArrayType();
+                    };
                     new(&m_array_type) MinimalArrayType();
 
                 }
@@ -23243,7 +23359,10 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_map_type.~MinimalMapType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_map_type.~MinimalMapType();
+                    };
                     new(&m_map_type) MinimalMapType();
 
                 }
@@ -23261,7 +23380,10 @@ private:
                     }
 
                     selected_member_ = 0x00000009;
-                    member_destructor_ = [&]() {m_enumerated_type.~MinimalEnumeratedType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_enumerated_type.~MinimalEnumeratedType();
+                    };
                     new(&m_enumerated_type) MinimalEnumeratedType();
 
                 }
@@ -23279,7 +23401,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000a;
-                    member_destructor_ = [&]() {m_bitmask_type.~MinimalBitmaskType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_bitmask_type.~MinimalBitmaskType();
+                    };
                     new(&m_bitmask_type) MinimalBitmaskType();
 
                 }
@@ -23297,7 +23422,10 @@ private:
                     }
 
                     selected_member_ = 0x0000000b;
-                    member_destructor_ = [&]() {m_extended_type.~MinimalExtendedType();};
+                    member_destructor_ = [&]()
+                    {
+                        m_extended_type.~MinimalExtendedType();
+                    };
                     new(&m_extended_type) MinimalExtendedType();
 
                 }
@@ -23666,7 +23794,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_complete.~CompleteTypeObject();};
+                    member_destructor_ = [&]()
+                    {
+                        m_complete.~CompleteTypeObject();
+                    };
                     new(&m_complete) CompleteTypeObject();
 
                 }
@@ -23684,7 +23815,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_minimal.~MinimalTypeObject();};
+                    member_destructor_ = [&]()
+                    {
+                        m_minimal.~MinimalTypeObject();
+                    };
                     new(&m_minimal) MinimalTypeObject();
 
                 }

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectCdrAux.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectCdrAux.hpp
@@ -433,25 +433,17 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::Dummy& data);
 
-
-
-
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::ExtendedAnnotationParameterValue& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::AppliedAnnotationParameter& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::AppliedAnnotation& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -477,11 +469,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteStructMember& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalStructMember& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -511,7 +501,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalStructType& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CommonUnionMember& data);
@@ -520,11 +509,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteUnionMember& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalUnionMember& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -562,11 +549,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteAnnotationParameter& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalAnnotationParameter& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -676,7 +661,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalMapType& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CommonEnumeratedLiteral& data);
@@ -685,11 +669,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteEnumeratedLiteral& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalEnumeratedLiteral& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -719,17 +701,13 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteBitflag& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalBitflag& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CommonBitmaskHeader& data);
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -747,11 +725,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteBitfield& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalBitfield& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -773,39 +749,29 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::CompleteExtendedType& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::MinimalExtendedType& data);
-
-
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::TypeIdentifierTypeObjectPair& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::TypeIdentifierPair& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::TypeIdentfierWithSize& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::TypeIdentifierWithDependencies& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::xtypes::TypeInformation& data);
-
 
 
 } // namespace fastcdr

--- a/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobjectPubSubTypes.hpp
@@ -48,65 +48,17 @@ namespace xtypes {
 
 
 typedef uint8_t EquivalenceKind;
-
-
-
 typedef uint8_t TypeKind;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 typedef uint8_t TypeIdentiferKind;
-
-
-
-
-
-
-
-
-
-
-
-
 typedef eprosima::fastcdr::fixed_string<MEMBER_NAME_MAX_LENGTH> MemberName;
-
 typedef eprosima::fastcdr::fixed_string<TYPE_NAME_MAX_LENGTH> QualifiedTypeName;
 typedef uint8_t PrimitiveTypeId;
 typedef std::array<uint8_t, 14> EquivalenceHash;
 typedef std::array<uint8_t, 4> NameHash;
 typedef uint32_t LBound;
 typedef std::vector<eprosima::fastdds::dds::xtypes::LBound> LBoundSeq;
-
 typedef uint8_t SBound;
 typedef std::vector<eprosima::fastdds::dds::xtypes::SBound> SBoundSeq;
-
-
-
 typedef eprosima::fastdds::dds::xtypes::MemberFlag CollectionElementFlag;
 typedef eprosima::fastdds::dds::xtypes::MemberFlag StructMemberFlag;
 typedef eprosima::fastdds::dds::xtypes::MemberFlag UnionMemberFlag;
@@ -116,8 +68,6 @@ typedef eprosima::fastdds::dds::xtypes::MemberFlag AnnotationParameterFlag;
 typedef eprosima::fastdds::dds::xtypes::MemberFlag AliasMemberFlag;
 typedef eprosima::fastdds::dds::xtypes::MemberFlag BitflagFlag;
 typedef eprosima::fastdds::dds::xtypes::MemberFlag BitsetMemberFlag;
-
-
 typedef eprosima::fastdds::dds::xtypes::TypeFlag StructTypeFlag;
 typedef eprosima::fastdds::dds::xtypes::TypeFlag UnionTypeFlag;
 typedef eprosima::fastdds::dds::xtypes::TypeFlag CollectionTypeFlag;
@@ -126,8 +76,6 @@ typedef eprosima::fastdds::dds::xtypes::TypeFlag AliasTypeFlag;
 typedef eprosima::fastdds::dds::xtypes::TypeFlag EnumTypeFlag;
 typedef eprosima::fastdds::dds::xtypes::TypeFlag BitmaskTypeFlag;
 typedef eprosima::fastdds::dds::xtypes::TypeFlag BitsetTypeFlag;
-
-
 
 #ifndef SWIG
 namespace detail {
@@ -1225,11 +1173,8 @@ private:
     }
 
 };
-
 typedef std::vector<eprosima::fastdds::dds::xtypes::TypeIdentifier> TypeIdentifierSeq;
 typedef uint32_t MemberId;
-
-
 
 /*!
  * @brief This class represents the TopicDataType of the type ExtendedAnnotationParameterValue defined by the user in the IDL file.
@@ -1311,7 +1256,6 @@ private:
     unsigned char* key_buffer_;
 
 };
-
 
 /*!
  * @brief This class represents the TopicDataType of the type AppliedAnnotationParameter defined by the user in the IDL file.
@@ -7882,7 +7826,6 @@ private:
 
 };
 
-
 /*!
  * @brief This class represents the TopicDataType of the type MinimalExtendedType defined by the user in the IDL file.
  * @ingroup dds_xtypes_typeobject
@@ -7963,8 +7906,6 @@ private:
     unsigned char* key_buffer_;
 
 };
-
-
 typedef std::vector<eprosima::fastdds::dds::xtypes::TypeObject> TypeObjectSeq;
 typedef eprosima::fastdds::dds::xtypes::TypeObjectSeq StronglyConnectedComponent;
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp
@@ -640,7 +640,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_result.~TypeLookup_getTypes_Out();};
+                    member_destructor_ = [&]()
+                    {
+                        m_result.~TypeLookup_getTypes_Out();
+                    };
                     new(&m_result) TypeLookup_getTypes_Out();
 
                 }
@@ -1279,7 +1282,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_result.~TypeLookup_getTypeDependencies_Out();};
+                    member_destructor_ = [&]()
+                    {
+                        m_result.~TypeLookup_getTypeDependencies_Out();
+                    };
                     new(&m_result) TypeLookup_getTypeDependencies_Out();
 
                 }
@@ -1638,7 +1644,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_getTypes.~TypeLookup_getTypes_In();};
+                    member_destructor_ = [&]()
+                    {
+                        m_getTypes.~TypeLookup_getTypes_In();
+                    };
                     new(&m_getTypes) TypeLookup_getTypes_In();
 
                 }
@@ -1656,7 +1665,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_getTypeDependencies.~TypeLookup_getTypeDependencies_In();};
+                    member_destructor_ = [&]()
+                    {
+                        m_getTypeDependencies.~TypeLookup_getTypeDependencies_In();
+                    };
                     new(&m_getTypeDependencies) TypeLookup_getTypeDependencies_In();
 
                 }
@@ -2196,7 +2208,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_getType.~TypeLookup_getTypes_Result();};
+                    member_destructor_ = [&]()
+                    {
+                        m_getType.~TypeLookup_getTypes_Result();
+                    };
                     new(&m_getType) TypeLookup_getTypes_Result();
 
                 }
@@ -2214,7 +2229,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_getTypeDependencies.~TypeLookup_getTypeDependencies_Result();};
+                    member_destructor_ = [&]()
+                    {
+                        m_getTypeDependencies.~TypeLookup_getTypeDependencies_Result();
+                    };
                     new(&m_getTypeDependencies) TypeLookup_getTypeDependencies_Result();
 
                 }

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesCdrAux.hpp
@@ -180,7 +180,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::builtin::TypeLookup_getTypes_Out& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::builtin::TypeLookup_getTypeDependencies_In& data);
@@ -189,12 +188,9 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::builtin::TypeLookup_getTypeDependencies_Out& data);
 
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::dds::builtin::TypeLookup_Request& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
@@ -82,6 +82,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -264,6 +265,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -401,7 +403,6 @@ namespace builtin {
             "TypeObject type representation support disabled in generated code");
     }
 
-
     TypeLookup_getTypeDependencies_InPubSubType::TypeLookup_getTypeDependencies_InPubSubType()
     {
         set_name("eprosima::fastdds::dds::builtin::TypeLookup_getTypeDependencies_In");
@@ -447,6 +448,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -629,6 +631,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -766,8 +769,6 @@ namespace builtin {
             "TypeObject type representation support disabled in generated code");
     }
 
-
-
     TypeLookup_RequestPubSubType::TypeLookup_RequestPubSubType()
     {
         set_name("eprosima::fastdds::dds::builtin::TypeLookup_Request");
@@ -813,6 +814,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -950,7 +952,6 @@ namespace builtin {
             "TypeObject type representation support disabled in generated code");
     }
 
-
     TypeLookup_ReplyPubSubType::TypeLookup_ReplyPubSubType()
     {
         set_name("eprosima::fastdds::dds::builtin::TypeLookup_Reply");
@@ -996,6 +997,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.hpp
@@ -212,7 +212,6 @@ namespace builtin
 
     };
 
-
     /*!
      * @brief This class represents the TopicDataType of the type TypeLookup_getTypeDependencies_In defined by the user in the IDL file.
      * @ingroup TypeLookupTypes
@@ -375,8 +374,6 @@ namespace builtin
 
     };
 
-
-
     /*!
      * @brief This class represents the TopicDataType of the type TypeLookup_Request defined by the user in the IDL file.
      * @ingroup TypeLookupTypes
@@ -457,7 +454,6 @@ namespace builtin
         unsigned char* key_buffer_;
 
     };
-
 
     /*!
      * @brief This class represents the TopicDataType of the type TypeLookup_Reply defined by the user in the IDL file.

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
@@ -81,6 +81,7 @@ bool EntityId_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -263,6 +264,7 @@ bool GUID_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -445,6 +447,7 @@ bool SequenceNumber_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -627,6 +630,7 @@ bool SampleIdentityPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -810,6 +814,7 @@ namespace rpc {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -992,6 +997,7 @@ namespace rpc {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.hpp
@@ -590,7 +590,6 @@ namespace rpc
     typedef uint8_t UnknownOperation;
     typedef uint8_t UnknownException;
     typedef uint8_t UnusedMember;
-
     typedef eprosima::fastcdr::fixed_string<255> InstanceName;
 
     /*!

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectCdrAux.ipp
@@ -153,28 +153,6 @@ eProsima_user_DllExport void deserialize(
             });
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -1818,10 +1796,6 @@ eProsima_user_DllExport void deserialize(
             });
 }
 
-
-
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -2474,7 +2448,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -2572,7 +2545,6 @@ void serialize_key(
                         }
 
 }
-
 
 
 template<>
@@ -3222,7 +3194,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -3325,7 +3296,6 @@ void serialize_key(
                         serialize_key(scdr, data.detail());
 
 }
-
 
 
 template<>
@@ -4033,7 +4003,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -4254,7 +4223,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -4357,7 +4325,6 @@ void serialize_key(
                         serialize_key(scdr, data.detail());
 
 }
-
 
 
 template<>
@@ -5305,7 +5272,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -5416,7 +5382,6 @@ void serialize_key(
                         scdr << data.default_value();
 
 }
-
 
 
 template<>
@@ -8168,7 +8133,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -8369,7 +8333,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -8472,7 +8435,6 @@ void serialize_key(
                         serialize_key(scdr, data.detail());
 
 }
-
 
 
 template<>
@@ -9177,7 +9139,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -9282,7 +9243,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -9367,8 +9327,6 @@ void serialize_key(
                         scdr << data.bit_bound();
 
 }
-
-
 
 
 template<>
@@ -9803,7 +9761,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -9903,7 +9860,6 @@ void serialize_key(
                         scdr << data.name_hash();
 
 }
-
 
 
 template<>
@@ -11202,8 +11158,6 @@ eProsima_user_DllExport void deserialize(
             });
 }
 
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -11298,7 +11252,6 @@ void serialize_key(
                         scdr << data.type_object();
 
 }
-
 
 
 template<>
@@ -11397,7 +11350,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -11492,7 +11444,6 @@ void serialize_key(
                         scdr << data.typeobject_serialized_size();
 
 }
-
 
 
 template<>
@@ -11607,7 +11558,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -11710,7 +11660,6 @@ void serialize_key(
                         serialize_key(scdr, data.complete());
 
 }
-
 
 
 

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
@@ -84,6 +84,7 @@ bool StringSTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -266,6 +267,7 @@ bool StringLTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -448,6 +450,7 @@ bool PlainCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -630,6 +633,7 @@ bool PlainSequenceSElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -812,6 +816,7 @@ bool PlainSequenceLElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -994,6 +999,7 @@ bool PlainArraySElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1176,6 +1182,7 @@ bool PlainArrayLElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1358,6 +1365,7 @@ bool PlainMapSTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1540,6 +1548,7 @@ bool PlainMapLTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1722,6 +1731,7 @@ bool StronglyConnectedComponentIdPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1904,6 +1914,7 @@ bool ExtendedTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2086,6 +2097,7 @@ bool DummyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2223,11 +2235,6 @@ void DummyPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
-
-
-
-
 ExtendedAnnotationParameterValuePubSubType::ExtendedAnnotationParameterValuePubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::ExtendedAnnotationParameterValue");
@@ -2273,6 +2280,7 @@ bool ExtendedAnnotationParameterValuePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2410,7 +2418,6 @@ void ExtendedAnnotationParameterValuePubSubType::register_type_object_representa
         "TypeObject type representation support disabled in generated code");
 }
 
-
 AppliedAnnotationParameterPubSubType::AppliedAnnotationParameterPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::AppliedAnnotationParameter");
@@ -2456,6 +2463,7 @@ bool AppliedAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2593,7 +2601,6 @@ void AppliedAnnotationParameterPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 AppliedAnnotationPubSubType::AppliedAnnotationPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::AppliedAnnotation");
@@ -2639,6 +2646,7 @@ bool AppliedAnnotationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2776,7 +2784,6 @@ void AppliedAnnotationPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 AppliedVerbatimAnnotationPubSubType::AppliedVerbatimAnnotationPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::AppliedVerbatimAnnotation");
@@ -2822,6 +2829,7 @@ bool AppliedVerbatimAnnotationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3004,6 +3012,7 @@ bool AppliedBuiltinMemberAnnotationsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3186,6 +3195,7 @@ bool CommonStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3368,6 +3378,7 @@ bool CompleteMemberDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3550,6 +3561,7 @@ bool MinimalMemberDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3732,6 +3744,7 @@ bool CompleteStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3869,7 +3882,6 @@ void CompleteStructMemberPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalStructMemberPubSubType::MinimalStructMemberPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalStructMember");
@@ -3915,6 +3927,7 @@ bool MinimalStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4052,7 +4065,6 @@ void MinimalStructMemberPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 AppliedBuiltinTypeAnnotationsPubSubType::AppliedBuiltinTypeAnnotationsPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::AppliedBuiltinTypeAnnotations");
@@ -4098,6 +4110,7 @@ bool AppliedBuiltinTypeAnnotationsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4280,6 +4293,7 @@ bool MinimalTypeDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4462,6 +4476,7 @@ bool CompleteTypeDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4644,6 +4659,7 @@ bool CompleteStructHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4826,6 +4842,7 @@ bool MinimalStructHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5008,6 +5025,7 @@ bool CompleteStructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5190,6 +5208,7 @@ bool MinimalStructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5327,7 +5346,6 @@ void MinimalStructTypePubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CommonUnionMemberPubSubType::CommonUnionMemberPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CommonUnionMember");
@@ -5373,6 +5391,7 @@ bool CommonUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5555,6 +5574,7 @@ bool CompleteUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5692,7 +5712,6 @@ void CompleteUnionMemberPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalUnionMemberPubSubType::MinimalUnionMemberPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalUnionMember");
@@ -5738,6 +5757,7 @@ bool MinimalUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5875,7 +5895,6 @@ void MinimalUnionMemberPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CommonDiscriminatorMemberPubSubType::CommonDiscriminatorMemberPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CommonDiscriminatorMember");
@@ -5921,6 +5940,7 @@ bool CommonDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6103,6 +6123,7 @@ bool CompleteDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6285,6 +6306,7 @@ bool MinimalDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6467,6 +6489,7 @@ bool CompleteUnionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6649,6 +6672,7 @@ bool MinimalUnionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6831,6 +6855,7 @@ bool CompleteUnionTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7013,6 +7038,7 @@ bool MinimalUnionTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7195,6 +7221,7 @@ bool CommonAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7377,6 +7404,7 @@ bool CompleteAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7514,7 +7542,6 @@ void CompleteAnnotationParameterPubSubType::register_type_object_representation(
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalAnnotationParameterPubSubType::MinimalAnnotationParameterPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalAnnotationParameter");
@@ -7560,6 +7587,7 @@ bool MinimalAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7697,7 +7725,6 @@ void MinimalAnnotationParameterPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CompleteAnnotationHeaderPubSubType::CompleteAnnotationHeaderPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CompleteAnnotationHeader");
@@ -7743,6 +7770,7 @@ bool CompleteAnnotationHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7925,6 +7953,7 @@ bool MinimalAnnotationHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8107,6 +8136,7 @@ bool CompleteAnnotationTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8289,6 +8319,7 @@ bool MinimalAnnotationTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8471,6 +8502,7 @@ bool CommonAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8653,6 +8685,7 @@ bool CompleteAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8835,6 +8868,7 @@ bool MinimalAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9017,6 +9051,7 @@ bool CompleteAliasHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9199,6 +9234,7 @@ bool MinimalAliasHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9381,6 +9417,7 @@ bool CompleteAliasTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9563,6 +9600,7 @@ bool MinimalAliasTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9745,6 +9783,7 @@ bool CompleteElementDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9927,6 +9966,7 @@ bool CommonCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10109,6 +10149,7 @@ bool CompleteCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10291,6 +10332,7 @@ bool MinimalCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10473,6 +10515,7 @@ bool CommonCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10655,6 +10698,7 @@ bool CompleteCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10837,6 +10881,7 @@ bool MinimalCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11019,6 +11064,7 @@ bool CompleteSequenceTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11201,6 +11247,7 @@ bool MinimalSequenceTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11383,6 +11430,7 @@ bool CommonArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11565,6 +11613,7 @@ bool CompleteArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11747,6 +11796,7 @@ bool MinimalArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11929,6 +11979,7 @@ bool CompleteArrayTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12111,6 +12162,7 @@ bool MinimalArrayTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12293,6 +12345,7 @@ bool CompleteMapTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12475,6 +12528,7 @@ bool MinimalMapTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12612,7 +12666,6 @@ void MinimalMapTypePubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CommonEnumeratedLiteralPubSubType::CommonEnumeratedLiteralPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CommonEnumeratedLiteral");
@@ -12658,6 +12711,7 @@ bool CommonEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12840,6 +12894,7 @@ bool CompleteEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12977,7 +13032,6 @@ void CompleteEnumeratedLiteralPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalEnumeratedLiteralPubSubType::MinimalEnumeratedLiteralPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalEnumeratedLiteral");
@@ -13023,6 +13077,7 @@ bool MinimalEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13160,7 +13215,6 @@ void MinimalEnumeratedLiteralPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CommonEnumeratedHeaderPubSubType::CommonEnumeratedHeaderPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CommonEnumeratedHeader");
@@ -13206,6 +13260,7 @@ bool CommonEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13388,6 +13443,7 @@ bool CompleteEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13570,6 +13626,7 @@ bool MinimalEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13752,6 +13809,7 @@ bool CompleteEnumeratedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13934,6 +13992,7 @@ bool MinimalEnumeratedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14116,6 +14175,7 @@ bool CommonBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14298,6 +14358,7 @@ bool CompleteBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14435,7 +14496,6 @@ void CompleteBitflagPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalBitflagPubSubType::MinimalBitflagPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalBitflag");
@@ -14481,6 +14541,7 @@ bool MinimalBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14618,7 +14679,6 @@ void MinimalBitflagPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CommonBitmaskHeaderPubSubType::CommonBitmaskHeaderPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CommonBitmaskHeader");
@@ -14664,6 +14724,7 @@ bool CommonBitmaskHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14801,8 +14862,6 @@ void CommonBitmaskHeaderPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
-
 CompleteBitmaskTypePubSubType::CompleteBitmaskTypePubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CompleteBitmaskType");
@@ -14848,6 +14907,7 @@ bool CompleteBitmaskTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15030,6 +15090,7 @@ bool MinimalBitmaskTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15212,6 +15273,7 @@ bool CommonBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15394,6 +15456,7 @@ bool CompleteBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15531,7 +15594,6 @@ void CompleteBitfieldPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalBitfieldPubSubType::MinimalBitfieldPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalBitfield");
@@ -15577,6 +15639,7 @@ bool MinimalBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15714,7 +15777,6 @@ void MinimalBitfieldPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 CompleteBitsetHeaderPubSubType::CompleteBitsetHeaderPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::CompleteBitsetHeader");
@@ -15760,6 +15822,7 @@ bool CompleteBitsetHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15942,6 +16005,7 @@ bool MinimalBitsetHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16124,6 +16188,7 @@ bool CompleteBitsetTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16306,6 +16371,7 @@ bool MinimalBitsetTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16488,6 +16554,7 @@ bool CompleteExtendedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16625,7 +16692,6 @@ void CompleteExtendedTypePubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 MinimalExtendedTypePubSubType::MinimalExtendedTypePubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::MinimalExtendedType");
@@ -16671,6 +16737,7 @@ bool MinimalExtendedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16808,10 +16875,6 @@ void MinimalExtendedTypePubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
-
-
-
 TypeIdentifierTypeObjectPairPubSubType::TypeIdentifierTypeObjectPairPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::TypeIdentifierTypeObjectPair");
@@ -16857,6 +16920,7 @@ bool TypeIdentifierTypeObjectPairPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16994,7 +17058,6 @@ void TypeIdentifierTypeObjectPairPubSubType::register_type_object_representation
         "TypeObject type representation support disabled in generated code");
 }
 
-
 TypeIdentifierPairPubSubType::TypeIdentifierPairPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::TypeIdentifierPair");
@@ -17040,6 +17103,7 @@ bool TypeIdentifierPairPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17177,7 +17241,6 @@ void TypeIdentifierPairPubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 TypeIdentfierWithSizePubSubType::TypeIdentfierWithSizePubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::TypeIdentfierWithSize");
@@ -17223,6 +17286,7 @@ bool TypeIdentfierWithSizePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17360,7 +17424,6 @@ void TypeIdentfierWithSizePubSubType::register_type_object_representation()
         "TypeObject type representation support disabled in generated code");
 }
 
-
 TypeIdentifierWithDependenciesPubSubType::TypeIdentifierWithDependenciesPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::TypeIdentifierWithDependencies");
@@ -17406,6 +17469,7 @@ bool TypeIdentifierWithDependenciesPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17543,7 +17607,6 @@ void TypeIdentifierWithDependenciesPubSubType::register_type_object_representati
         "TypeObject type representation support disabled in generated code");
 }
 
-
 TypeInformationPubSubType::TypeInformationPubSubType()
 {
     set_name("eprosima::fastdds::dds::xtypes::TypeInformation");
@@ -17589,6 +17652,7 @@ bool TypeInformationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17725,7 +17789,6 @@ void TypeInformationPubSubType::register_type_object_representation()
     EPROSIMA_LOG_WARNING(XTYPES_TYPE_REPRESENTATION,
         "TypeObject type representation support disabled in generated code");
 }
-
 
 
 } // namespace xtypes

--- a/src/cpp/statistics/types/monitorservice_types.hpp
+++ b/src/cpp/statistics/types/monitorservice_types.hpp
@@ -2114,7 +2114,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_entity_proxy.~vector();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_proxy.~vector();
+                    };
                     new(&m_entity_proxy) std::vector<uint8_t>();
 
                 }
@@ -2132,7 +2135,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_connection_list.~vector();};
+                    member_destructor_ = [&]()
+                    {
+                        m_connection_list.~vector();
+                    };
                     new(&m_connection_list) std::vector<Connection>();
 
                 }
@@ -2150,7 +2156,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_incompatible_qos_status.~IncompatibleQoSStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_incompatible_qos_status.~IncompatibleQoSStatus_s();
+                    };
                     new(&m_incompatible_qos_status) IncompatibleQoSStatus_s();
 
                 }
@@ -2168,7 +2177,11 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_inconsistent_topic_status.~InconsistentTopicStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_inconsistent_topic_status.~InconsistentTopicStatus_s();
+                    };
                     new(&m_inconsistent_topic_status) InconsistentTopicStatus_s();
 
                 }
@@ -2186,7 +2199,11 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_liveliness_lost_status.~LivelinessLostStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_liveliness_lost_status.~LivelinessLostStatus_s();
+                    };
                     new(&m_liveliness_lost_status) LivelinessLostStatus_s();
 
                 }
@@ -2204,7 +2221,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_liveliness_changed_status.~LivelinessChangedStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_liveliness_changed_status.~LivelinessChangedStatus_s();
+                    };
                     new(&m_liveliness_changed_status) LivelinessChangedStatus_s();
 
                 }
@@ -2222,7 +2242,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_deadline_missed_status.~DeadlineMissedStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_deadline_missed_status.~DeadlineMissedStatus_s();
+                    };
                     new(&m_deadline_missed_status) DeadlineMissedStatus_s();
 
                 }
@@ -2240,7 +2263,11 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_sample_lost_status.~SampleLostStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_sample_lost_status.~SampleLostStatus_s();
+                    };
                     new(&m_sample_lost_status) SampleLostStatus_s();
 
                 }

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.hpp
@@ -85,7 +85,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::BaseStatus_s& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::IncompatibleQoSStatus_s& data);
@@ -97,11 +96,6 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
-
-
-
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
+++ b/src/cpp/statistics/types/monitorservice_typesCdrAux.ipp
@@ -338,7 +338,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -645,10 +644,6 @@ void serialize_key(
                         scdr << data.last_instance_handle();
 
 }
-
-
-
-
 
 
 template<>

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -79,6 +79,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -260,6 +261,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -441,6 +443,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -577,7 +580,6 @@ namespace eprosima {
                 register_BaseStatus_s_type_identifier(type_identifiers_);
             }
 
-
             IncompatibleQoSStatus_sPubSubType::IncompatibleQoSStatus_sPubSubType()
             {
                 set_name("eprosima::fastdds::statistics::IncompatibleQoSStatus_s");
@@ -623,6 +625,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -804,6 +807,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -985,6 +989,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1121,12 +1126,8 @@ namespace eprosima {
                 register_DeadlineMissedStatus_s_type_identifier(type_identifiers_);
             }
 
-
-
-
             namespace StatusKind {
             } // namespace StatusKind
-
 
             MonitorServiceStatusDataPubSubType::MonitorServiceStatusDataPubSubType()
             {
@@ -1173,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.hpp
@@ -537,17 +537,7 @@ namespace eprosima
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;
-
-
-
-
-
-
-
-
-
             } // namespace StatusKind
-
 
             /*!
              * @brief This class represents the TopicDataType of the type MonitorServiceStatusData defined by the user in the IDL file.

--- a/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
+++ b/src/cpp/statistics/types/monitorservice_typesTypeObjectSupport.hpp
@@ -208,15 +208,6 @@ eProsima_user_DllExport void register_StatusKind_type_identifier(
 
 
 
-
-
-
-
-
-
-
-
-
 } // namespace StatusKind
 
 /**

--- a/src/cpp/statistics/types/types.hpp
+++ b/src/cpp/statistics/types/types.hpp
@@ -3774,7 +3774,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_writer_reader_data.~WriterReaderData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_writer_reader_data.~WriterReaderData();
+                    };
                     new(&m_writer_reader_data) WriterReaderData();
 
                 }
@@ -3792,7 +3795,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_locator2locator_data.~Locator2LocatorData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_locator2locator_data.~Locator2LocatorData();
+                    };
                     new(&m_locator2locator_data) Locator2LocatorData();
 
                 }
@@ -3810,7 +3816,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_entity_data.~EntityData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_data.~EntityData();
+                    };
                     new(&m_entity_data) EntityData();
 
                 }
@@ -3828,7 +3837,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_entity2locator_traffic.~Entity2LocatorTraffic();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity2locator_traffic.~Entity2LocatorTraffic();
+                    };
                     new(&m_entity2locator_traffic) Entity2LocatorTraffic();
 
                 }
@@ -3846,7 +3858,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_entity_count.~EntityCount();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_count.~EntityCount();
+                    };
                     new(&m_entity_count) EntityCount();
 
                 }
@@ -3864,7 +3879,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_discovery_time.~DiscoveryTime();};
+                    member_destructor_ = [&]()
+                    {
+                        m_discovery_time.~DiscoveryTime();
+                    };
                     new(&m_discovery_time) DiscoveryTime();
 
                 }
@@ -3882,7 +3900,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_sample_identity_count.~SampleIdentityCount();};
+                    member_destructor_ = [&]()
+                    {
+                        m_sample_identity_count.~SampleIdentityCount();
+                    };
                     new(&m_sample_identity_count) SampleIdentityCount();
 
                 }
@@ -3900,7 +3921,10 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_physical_data.~PhysicalData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_physical_data.~PhysicalData();
+                    };
                     new(&m_physical_data) PhysicalData();
 
                 }

--- a/src/cpp/statistics/types/typesCdrAux.hpp
+++ b/src/cpp/statistics/types/typesCdrAux.hpp
@@ -131,8 +131,6 @@ eProsima_user_DllExport void serialize_key(
         const eprosima::fastdds::statistics::PhysicalData& data);
 
 
-
-
 } // namespace fastcdr
 } // namespace eprosima
 

--- a/src/cpp/statistics/types/typesCdrAux.ipp
+++ b/src/cpp/statistics/types/typesCdrAux.ipp
@@ -1542,7 +1542,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/src/cpp/statistics/types/typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/typesPubSubTypes.cxx
@@ -80,6 +80,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -261,6 +262,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -442,6 +444,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -623,6 +626,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -804,6 +808,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -985,6 +990,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1168,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1530,6 +1538,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1711,6 +1720,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1892,6 +1902,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2073,6 +2084,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2254,6 +2266,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2435,6 +2448,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2573,7 +2587,6 @@ namespace eprosima {
 
             namespace EventKind {
             } // namespace EventKind
-
 
         } // namespace statistics
 

--- a/src/cpp/statistics/types/typesPubSubTypes.hpp
+++ b/src/cpp/statistics/types/typesPubSubTypes.hpp
@@ -1183,7 +1183,6 @@ namespace eprosima
             namespace EventKind
             {
             } // namespace EventKind
-
         } // namespace statistics
     } // namespace fastdds
 } // namespace eprosima

--- a/test/blackbox/types/Data1mbPubSubTypes.cxx
+++ b/test/blackbox/types/Data1mbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Data1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/Data64kbPubSubTypes.cxx
+++ b/test/blackbox/types/Data64kbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Data64kbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/FixedSizedPubSubTypes.cxx
+++ b/test/blackbox/types/FixedSizedPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FixedSizedPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/HelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool KeyedData1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool KeyedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/StringTestPubSubTypes.cxx
+++ b/test/blackbox/types/StringTestPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StringTestPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/TestRegression3361PubSubTypes.cxx
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TestRegression3361PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool UnboundedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/core/core_types.hpp
+++ b/test/blackbox/types/core/core_types.hpp
@@ -4103,7 +4103,10 @@ public:
     eProsima_user_DllExport Submessage()
     {
         selected_member_ = 0x00000005;
-        member_destructor_ = [&]() {m_unknown_submsg.~SubmessageHeader();};
+        member_destructor_ = [&]()
+        {
+            m_unknown_submsg.~SubmessageHeader();
+        };
         new(&m_unknown_submsg) SubmessageHeader();
 
     }
@@ -4662,7 +4665,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_heartbeat_submsg.~HeartBeatSubmessage();};
+                    member_destructor_ = [&]()
+                    {
+                        m_heartbeat_submsg.~HeartBeatSubmessage();
+                    };
                     new(&m_heartbeat_submsg) HeartBeatSubmessage();
 
                 }
@@ -4680,7 +4686,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_info_ts_submsg.~InfoTimestampSubmessage();};
+                    member_destructor_ = [&]()
+                    {
+                        m_info_ts_submsg.~InfoTimestampSubmessage();
+                    };
                     new(&m_info_ts_submsg) InfoTimestampSubmessage();
 
                 }
@@ -4698,7 +4707,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_info_src_submsg.~InfoSourceSubmessage();};
+                    member_destructor_ = [&]()
+                    {
+                        m_info_src_submsg.~InfoSourceSubmessage();
+                    };
                     new(&m_info_src_submsg) InfoSourceSubmessage();
 
                 }
@@ -4716,7 +4728,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_info_dst_submsg.~InfoDestinationSubmessage();};
+                    member_destructor_ = [&]()
+                    {
+                        m_info_dst_submsg.~InfoDestinationSubmessage();
+                    };
                     new(&m_info_dst_submsg) InfoDestinationSubmessage();
 
                 }
@@ -4734,7 +4749,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_unknown_submsg.~SubmessageHeader();};
+                    member_destructor_ = [&]()
+                    {
+                        m_unknown_submsg.~SubmessageHeader();
+                    };
                     new(&m_unknown_submsg) SubmessageHeader();
 
                 }

--- a/test/blackbox/types/core/core_typesCdrAux.hpp
+++ b/test/blackbox/types/core/core_typesCdrAux.hpp
@@ -133,7 +133,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::detail::Time_t& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::detail::SequenceNumberSet& data);
@@ -145,8 +144,6 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::detail::Duration_t& data);
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -168,7 +165,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::SubmessageHeader& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::AckNackSubmessage& data);
@@ -188,7 +184,6 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::rtps::core::InfoTimestampSubmessage& data);
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/test/blackbox/types/core/core_typesCdrAux.ipp
+++ b/test/blackbox/types/core/core_typesCdrAux.ipp
@@ -770,7 +770,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -1083,8 +1082,6 @@ void serialize_key(
                         scdr << data.fraction();
 
 }
-
-
 
 
 template<>
@@ -1577,7 +1574,6 @@ void serialize_key(
                         scdr << data.submessageLength();
 
 }
-
 
 
 template<>

--- a/test/blackbox/types/core/core_typesPubSubTypes.cxx
+++ b/test/blackbox/types/core/core_typesPubSubTypes.cxx
@@ -81,6 +81,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -262,6 +263,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -443,6 +445,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -624,6 +627,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -805,6 +809,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -986,6 +991,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1167,6 +1173,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1348,6 +1355,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1484,7 +1492,6 @@ namespace eprosima {
                         register_Time_t_type_identifier(type_identifiers_);
                     }
 
-
                     SequenceNumberSetPubSubType::SequenceNumberSetPubSubType()
                     {
                         set_name("eprosima::fastdds::rtps::core::detail::SequenceNumberSet");
@@ -1530,6 +1537,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1711,6 +1719,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1892,6 +1901,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2028,8 +2038,6 @@ namespace eprosima {
                         register_Duration_t_type_identifier(type_identifiers_);
                     }
 
-
-
                     StatusInfo_tPubSubType::StatusInfo_tPubSubType()
                     {
                         set_name("eprosima::fastdds::rtps::core::detail::StatusInfo_t");
@@ -2075,6 +2083,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2256,6 +2265,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2437,6 +2447,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2620,6 +2631,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -2801,6 +2813,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -2985,6 +2998,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3166,6 +3180,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3347,6 +3362,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3528,6 +3544,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3709,6 +3726,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3845,7 +3863,6 @@ namespace eprosima {
                     register_InfoTimestampSubmessage_type_identifier(type_identifiers_);
                 }
 
-
                 RTPSMessagePubSubType::RTPSMessagePubSubType()
                 {
                     set_name("eprosima::fastdds::rtps::core::RTPSMessage");
@@ -3891,6 +3908,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {

--- a/test/blackbox/types/core/core_typesPubSubTypes.hpp
+++ b/test/blackbox/types/core/core_typesPubSubTypes.hpp
@@ -1756,7 +1756,6 @@ namespace eprosima
 
                 };
 
-
                 /*!
                  * @brief This class represents the TopicDataType of the type RTPSMessage defined by the user in the IDL file.
                  * @ingroup core_types

--- a/test/blackbox/types/statistics/monitorservice_types.hpp
+++ b/test/blackbox/types/statistics/monitorservice_types.hpp
@@ -2114,7 +2114,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_entity_proxy.~vector();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_proxy.~vector();
+                    };
                     new(&m_entity_proxy) std::vector<uint8_t>();
 
                 }
@@ -2132,7 +2135,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_connection_list.~vector();};
+                    member_destructor_ = [&]()
+                    {
+                        m_connection_list.~vector();
+                    };
                     new(&m_connection_list) std::vector<Connection>();
 
                 }
@@ -2150,7 +2156,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_incompatible_qos_status.~IncompatibleQoSStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_incompatible_qos_status.~IncompatibleQoSStatus_s();
+                    };
                     new(&m_incompatible_qos_status) IncompatibleQoSStatus_s();
 
                 }
@@ -2168,7 +2177,11 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_inconsistent_topic_status.~InconsistentTopicStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_inconsistent_topic_status.~InconsistentTopicStatus_s();
+                    };
                     new(&m_inconsistent_topic_status) InconsistentTopicStatus_s();
 
                 }
@@ -2186,7 +2199,11 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_liveliness_lost_status.~LivelinessLostStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_liveliness_lost_status.~LivelinessLostStatus_s();
+                    };
                     new(&m_liveliness_lost_status) LivelinessLostStatus_s();
 
                 }
@@ -2204,7 +2221,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_liveliness_changed_status.~LivelinessChangedStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_liveliness_changed_status.~LivelinessChangedStatus_s();
+                    };
                     new(&m_liveliness_changed_status) LivelinessChangedStatus_s();
 
                 }
@@ -2222,7 +2242,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_deadline_missed_status.~DeadlineMissedStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        m_deadline_missed_status.~DeadlineMissedStatus_s();
+                    };
                     new(&m_deadline_missed_status) DeadlineMissedStatus_s();
 
                 }
@@ -2240,7 +2263,11 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_sample_lost_status.~SampleLostStatus_s();};
+                    member_destructor_ = [&]()
+                    {
+                        using namespace eprosima::fastdds::statistics;
+                        m_sample_lost_status.~SampleLostStatus_s();
+                    };
                     new(&m_sample_lost_status) SampleLostStatus_s();
 
                 }

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.hpp
@@ -85,7 +85,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::BaseStatus_s& data);
 
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::IncompatibleQoSStatus_s& data);
@@ -97,11 +96,6 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const eprosima::fastdds::statistics::DeadlineMissedStatus_s& data);
-
-
-
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,

--- a/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
+++ b/test/blackbox/types/statistics/monitorservice_typesCdrAux.ipp
@@ -338,7 +338,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
@@ -645,10 +644,6 @@ void serialize_key(
                         scdr << data.last_instance_handle();
 
 }
-
-
-
-
 
 
 template<>

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -79,6 +79,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -260,6 +261,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -441,6 +443,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -577,7 +580,6 @@ namespace eprosima {
                 register_BaseStatus_s_type_identifier(type_identifiers_);
             }
 
-
             IncompatibleQoSStatus_sPubSubType::IncompatibleQoSStatus_sPubSubType()
             {
                 set_name("eprosima::fastdds::statistics::IncompatibleQoSStatus_s");
@@ -623,6 +625,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -804,6 +807,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -985,6 +989,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1121,12 +1126,8 @@ namespace eprosima {
                 register_DeadlineMissedStatus_s_type_identifier(type_identifiers_);
             }
 
-
-
-
             namespace StatusKind {
             } // namespace StatusKind
-
 
             MonitorServiceStatusDataPubSubType::MonitorServiceStatusDataPubSubType()
             {
@@ -1173,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.hpp
@@ -537,17 +537,7 @@ namespace eprosima
             namespace StatusKind
             {
                 typedef uint32_t StatusKind;
-
-
-
-
-
-
-
-
-
             } // namespace StatusKind
-
 
             /*!
              * @brief This class represents the TopicDataType of the type MonitorServiceStatusData defined by the user in the IDL file.

--- a/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
+++ b/test/blackbox/types/statistics/monitorservice_typesTypeObjectSupport.hpp
@@ -208,15 +208,6 @@ eProsima_user_DllExport void register_StatusKind_type_identifier(
 
 
 
-
-
-
-
-
-
-
-
-
 } // namespace StatusKind
 
 /**

--- a/test/blackbox/types/statistics/types.hpp
+++ b/test/blackbox/types/statistics/types.hpp
@@ -3774,7 +3774,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_writer_reader_data.~WriterReaderData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_writer_reader_data.~WriterReaderData();
+                    };
                     new(&m_writer_reader_data) WriterReaderData();
 
                 }
@@ -3792,7 +3795,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_locator2locator_data.~Locator2LocatorData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_locator2locator_data.~Locator2LocatorData();
+                    };
                     new(&m_locator2locator_data) Locator2LocatorData();
 
                 }
@@ -3810,7 +3816,10 @@ private:
                     }
 
                     selected_member_ = 0x00000003;
-                    member_destructor_ = [&]() {m_entity_data.~EntityData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_data.~EntityData();
+                    };
                     new(&m_entity_data) EntityData();
 
                 }
@@ -3828,7 +3837,10 @@ private:
                     }
 
                     selected_member_ = 0x00000004;
-                    member_destructor_ = [&]() {m_entity2locator_traffic.~Entity2LocatorTraffic();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity2locator_traffic.~Entity2LocatorTraffic();
+                    };
                     new(&m_entity2locator_traffic) Entity2LocatorTraffic();
 
                 }
@@ -3846,7 +3858,10 @@ private:
                     }
 
                     selected_member_ = 0x00000005;
-                    member_destructor_ = [&]() {m_entity_count.~EntityCount();};
+                    member_destructor_ = [&]()
+                    {
+                        m_entity_count.~EntityCount();
+                    };
                     new(&m_entity_count) EntityCount();
 
                 }
@@ -3864,7 +3879,10 @@ private:
                     }
 
                     selected_member_ = 0x00000006;
-                    member_destructor_ = [&]() {m_discovery_time.~DiscoveryTime();};
+                    member_destructor_ = [&]()
+                    {
+                        m_discovery_time.~DiscoveryTime();
+                    };
                     new(&m_discovery_time) DiscoveryTime();
 
                 }
@@ -3882,7 +3900,10 @@ private:
                     }
 
                     selected_member_ = 0x00000007;
-                    member_destructor_ = [&]() {m_sample_identity_count.~SampleIdentityCount();};
+                    member_destructor_ = [&]()
+                    {
+                        m_sample_identity_count.~SampleIdentityCount();
+                    };
                     new(&m_sample_identity_count) SampleIdentityCount();
 
                 }
@@ -3900,7 +3921,10 @@ private:
                     }
 
                     selected_member_ = 0x00000008;
-                    member_destructor_ = [&]() {m_physical_data.~PhysicalData();};
+                    member_destructor_ = [&]()
+                    {
+                        m_physical_data.~PhysicalData();
+                    };
                     new(&m_physical_data) PhysicalData();
 
                 }

--- a/test/blackbox/types/statistics/typesCdrAux.hpp
+++ b/test/blackbox/types/statistics/typesCdrAux.hpp
@@ -131,8 +131,6 @@ eProsima_user_DllExport void serialize_key(
         const eprosima::fastdds::statistics::PhysicalData& data);
 
 
-
-
 } // namespace fastcdr
 } // namespace eprosima
 

--- a/test/blackbox/types/statistics/typesCdrAux.ipp
+++ b/test/blackbox/types/statistics/typesCdrAux.ipp
@@ -1542,7 +1542,6 @@ void serialize_key(
 }
 
 
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/test/blackbox/types/statistics/typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/typesPubSubTypes.cxx
@@ -80,6 +80,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -261,6 +262,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -442,6 +444,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -623,6 +626,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -804,6 +808,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -985,6 +990,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1168,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1530,6 +1538,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1711,6 +1720,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1892,6 +1902,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2073,6 +2084,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2254,6 +2266,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2435,6 +2448,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2573,7 +2587,6 @@ namespace eprosima {
 
             namespace EventKind {
             } // namespace EventKind
-
 
         } // namespace statistics
 

--- a/test/blackbox/types/statistics/typesPubSubTypes.hpp
+++ b/test/blackbox/types/statistics/typesPubSubTypes.hpp
@@ -1183,7 +1183,6 @@ namespace eprosima
             namespace EventKind
             {
             } // namespace EventKind
-
         } // namespace statistics
     } // namespace fastdds
 } // namespace eprosima

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType1PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType1PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type1PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType2PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType2PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type2PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType3PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType3PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type3PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeBigPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeBigPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type4PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool Type5PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool Type6PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool Type7PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -800,6 +804,7 @@ bool Type8PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -981,6 +986,7 @@ bool Type9PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1162,6 +1168,7 @@ bool Type10PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1343,6 +1350,7 @@ bool Type11PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1524,6 +1532,7 @@ bool Type12PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1705,6 +1714,7 @@ bool Type13PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1886,6 +1896,7 @@ bool Type14PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2067,6 +2078,7 @@ bool Type15PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2248,6 +2260,7 @@ bool Type16PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2429,6 +2442,7 @@ bool Type17PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2610,6 +2624,7 @@ bool Type18PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2791,6 +2806,7 @@ bool Type19PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2972,6 +2988,7 @@ bool Type20PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3153,6 +3170,7 @@ bool Type21PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3334,6 +3352,7 @@ bool Type22PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3515,6 +3534,7 @@ bool Type23PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3696,6 +3716,7 @@ bool Type24PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3877,6 +3898,7 @@ bool Type25PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4058,6 +4080,7 @@ bool Type26PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4239,6 +4262,7 @@ bool Type27PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4420,6 +4444,7 @@ bool Type28PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4601,6 +4626,7 @@ bool Type29PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4782,6 +4808,7 @@ bool Type30PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4963,6 +4990,7 @@ bool Type31PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5144,6 +5172,7 @@ bool Type32PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5325,6 +5354,7 @@ bool Type33PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5506,6 +5536,7 @@ bool Type34PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5687,6 +5718,7 @@ bool Type35PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5868,6 +5900,7 @@ bool Type36PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6049,6 +6082,7 @@ bool Type37PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6230,6 +6264,7 @@ bool Type38PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6411,6 +6446,7 @@ bool Type39PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6592,6 +6628,7 @@ bool Type40PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6773,6 +6810,7 @@ bool Type41PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6954,6 +6992,7 @@ bool Type42PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7135,6 +7174,7 @@ bool Type43PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7316,6 +7356,7 @@ bool Type44PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7497,6 +7538,7 @@ bool Type45PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7678,6 +7720,7 @@ bool Type46PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7859,6 +7902,7 @@ bool Type47PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8040,6 +8084,7 @@ bool Type48PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8221,6 +8266,7 @@ bool Type49PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8402,6 +8448,7 @@ bool Type50PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8583,6 +8630,7 @@ bool Type51PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8764,6 +8812,7 @@ bool Type52PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8945,6 +8994,7 @@ bool Type53PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9126,6 +9176,7 @@ bool Type54PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9307,6 +9358,7 @@ bool Type55PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9488,6 +9540,7 @@ bool Type56PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9669,6 +9722,7 @@ bool Type57PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9850,6 +9904,7 @@ bool Type58PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10031,6 +10086,7 @@ bool Type59PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10212,6 +10268,7 @@ bool Type60PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10393,6 +10450,7 @@ bool Type61PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10574,6 +10632,7 @@ bool Type62PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10755,6 +10814,7 @@ bool Type63PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10936,6 +10996,7 @@ bool Type64PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11117,6 +11178,7 @@ bool Type65PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11298,6 +11360,7 @@ bool Type66PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11479,6 +11542,7 @@ bool Type67PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11660,6 +11724,7 @@ bool Type68PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11841,6 +11906,7 @@ bool Type69PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12022,6 +12088,7 @@ bool Type70PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12203,6 +12270,7 @@ bool Type71PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12384,6 +12452,7 @@ bool Type72PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12565,6 +12634,7 @@ bool Type73PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12746,6 +12816,7 @@ bool Type74PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12927,6 +12998,7 @@ bool Type75PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13108,6 +13180,7 @@ bool Type76PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13289,6 +13362,7 @@ bool Type77PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13470,6 +13544,7 @@ bool Type78PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13651,6 +13726,7 @@ bool Type79PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13832,6 +13908,7 @@ bool Type80PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14013,6 +14090,7 @@ bool Type81PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14194,6 +14272,7 @@ bool Type82PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14375,6 +14454,7 @@ bool Type83PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14556,6 +14636,7 @@ bool Type84PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14737,6 +14818,7 @@ bool Type85PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14918,6 +15000,7 @@ bool Type86PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15099,6 +15182,7 @@ bool Type87PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15280,6 +15364,7 @@ bool Type88PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15461,6 +15546,7 @@ bool Type89PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15642,6 +15728,7 @@ bool Type90PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15823,6 +15910,7 @@ bool Type91PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16004,6 +16092,7 @@ bool Type92PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16185,6 +16274,7 @@ bool Type93PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16366,6 +16456,7 @@ bool Type94PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16547,6 +16638,7 @@ bool Type95PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16728,6 +16820,7 @@ bool Type96PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16909,6 +17002,7 @@ bool Type97PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17090,6 +17184,7 @@ bool Type98PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17271,6 +17366,7 @@ bool Type99PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17452,6 +17548,7 @@ bool Type100PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17633,6 +17730,7 @@ bool TypeBigPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeDepPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeDepPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TypeDepPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeNoTypeObjectPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeNoTypeObjectPubSubTypes.cxx
@@ -74,6 +74,7 @@ bool TypeNoTypeObjectPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool AllocTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.hpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.hpp
@@ -43,8 +43,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const StructType& data);
 
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const ContentFilterTestType& data);

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.ipp
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypeCdrAux.ipp
@@ -253,8 +253,6 @@ void serialize_key(
 }
 
 
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -212,8 +213,6 @@ void StructTypePubSubType::register_type_object_representation()
     register_StructType_type_identifier(type_identifiers_);
 }
 
-
-
 ContentFilterTestTypePubSubType::ContentFilterTestTypePubSubType()
 {
     set_name("ContentFilterTestType");
@@ -259,6 +258,7 @@ bool ContentFilterTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.hpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.hpp
@@ -119,8 +119,6 @@ private:
 
 };
 
-
-
 /*!
  * @brief This class represents the TopicDataType of the type ContentFilterTestType defined by the user in the IDL file.
  * @ingroup ContentFilterTestType

--- a/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool AliasStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool NestedArrayElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ComplexArrayElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool ArrayStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool BitmaskStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool BitsetStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool EnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FinalStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool MutableStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool AppendableStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool ExtensibilityStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ImportantStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool KeyStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ValueStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool MapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool PrimitivesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool NestedSequenceElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ComplexSequenceElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool SequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool GrandparentStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ParentStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool NestedStructElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool StructStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_struct.hpp
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_struct.hpp
@@ -377,7 +377,10 @@ private:
                     }
 
                     selected_member_ = 0x00000001;
-                    member_destructor_ = [&]() {m_first.~basic_string();};
+                    member_destructor_ = [&]()
+                    {
+                        m_first.~basic_string();
+                    };
                     new(&m_first) std::string();
 
                 }
@@ -430,7 +433,10 @@ public:
     eProsima_user_DllExport ComplexUnion()
     {
         selected_member_ = 0x00000002;
-        member_destructor_ = [&]() {m_fourth.~BasicUnion();};
+        member_destructor_ = [&]()
+        {
+            m_fourth.~BasicUnion();
+        };
         new(&m_fourth) BasicUnion();
 
     }
@@ -757,7 +763,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_fourth.~BasicUnion();};
+                    member_destructor_ = [&]()
+                    {
+                        m_fourth.~BasicUnion();
+                    };
                     new(&m_fourth) BasicUnion();
 
                 }

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool UnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveType.hpp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveType.hpp
@@ -1052,7 +1052,10 @@ private:
                     }
 
                     selected_member_ = 0x00000010;
-                    member_destructor_ = [&]() {m_first.~PrimitivesStruct();};
+                    member_destructor_ = [&]()
+                    {
+                        m_first.~PrimitivesStruct();
+                    };
                     new(&m_first) PrimitivesStruct();
 
                 }
@@ -1105,7 +1108,10 @@ public:
     eProsima_user_DllExport ComplexUnion()
     {
         selected_member_ = 0x00000002;
-        member_destructor_ = [&]() {m_fourth.~InnerUnion();};
+        member_destructor_ = [&]()
+        {
+            m_fourth.~InnerUnion();
+        };
         new(&m_fourth) InnerUnion();
 
     }
@@ -1432,7 +1438,10 @@ private:
                     }
 
                     selected_member_ = 0x00000002;
-                    member_destructor_ = [&]() {m_fourth.~InnerUnion();};
+                    member_destructor_ = [&]()
+                    {
+                        m_fourth.~InnerUnion();
+                    };
                     new(&m_fourth) InnerUnion();
 
                 }

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.hpp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.hpp
@@ -49,15 +49,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const PrimitivesStruct& data);
 
-
-
-
-
-
-
-
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AllStruct& data);

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypeCdrAux.ipp
@@ -253,12 +253,6 @@ void serialize_key(
 }
 
 
-
-
-
-
-
-
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool PrimitivesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -212,15 +213,6 @@ void PrimitivesStructPubSubType::register_type_object_representation()
     register_PrimitivesStruct_type_identifier(type_identifiers_);
 }
 
-
-
-
-
-
-
-
-
-
 AllStructPubSubType::AllStructPubSubType()
 {
     set_name("AllStruct");
@@ -266,6 +258,7 @@ bool AllStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -447,6 +440,7 @@ bool ComprehensiveTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.hpp
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.hpp
@@ -118,15 +118,10 @@ private:
     unsigned char* key_buffer_;
 
 };
-
-
 typedef PrimitivesStruct MyAliasedStruct;
 typedef MyEnum MyAliasedEnum;
 typedef eprosima::fastcdr::fixed_string<100> MyAliasedBoundedString;
 typedef MyAliasedEnum MyRecursiveAlias;
-
-
-
 
 /*!
  * @brief This class represents the TopicDataType of the type AllStruct defined by the user in the IDL file.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This updates the types in 3.1.x with https://github.com/eProsima/Fast-DDS-Gen/pull/424 in preparation of release 3.1.1

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
