### PR TITLE
[22497] Regenerate types with Fast DDS Gen 4.0.3

### DIFF
--- a/examples/cpp/benchmark/types/Benchmark.hpp
+++ b/examples/cpp/benchmark/types/Benchmark.hpp
@@ -22,7 +22,7 @@
 #ifndef FAST_DDS_GENERATED__BENCHMARK_HPP
 #define FAST_DDS_GENERATED__BENCHMARK_HPP
 
-#include  <cstdint>
+#include <cstdint>
 #include <utility>
 
 #if defined(_WIN32)
@@ -78,7 +78,7 @@ public:
     eProsima_user_DllExport BenchMark(
             const BenchMark& x)
     {
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
     }
 
@@ -100,7 +100,7 @@ public:
             const BenchMark& x)
     {
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
         return *this;
     }
@@ -164,6 +164,8 @@ public:
     {
         return m_index;
     }
+
+
 
 private:
 

--- a/examples/cpp/benchmark/types/Benchmark_big.hpp
+++ b/examples/cpp/benchmark/types/Benchmark_big.hpp
@@ -22,7 +22,7 @@
 #ifndef FAST_DDS_GENERATED__BENCHMARK_BIG_HPP
 #define FAST_DDS_GENERATED__BENCHMARK_BIG_HPP
 
-#include  <array>
+#include <array>
 #include <cstdint>
 #include <utility>
 
@@ -79,9 +79,9 @@ public:
     eProsima_user_DllExport BenchMarkBig(
             const BenchMarkBig& x)
     {
-        m_data = x.m_data;
+                    m_data = x.m_data;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
     }
 
@@ -104,9 +104,9 @@ public:
             const BenchMarkBig& x)
     {
 
-        m_data = x.m_data;
+                    m_data = x.m_data;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
         return *this;
     }
@@ -132,7 +132,7 @@ public:
             const BenchMarkBig& x) const
     {
         return (m_data == x.m_data &&
-               m_index == x.m_index);
+           m_index == x.m_index);
     }
 
     /*!
@@ -183,6 +183,7 @@ public:
         return m_data;
     }
 
+
     /*!
      * @brief This function sets a value in member index
      * @param _index New value for member index
@@ -210,6 +211,8 @@ public:
     {
         return m_index;
     }
+
+
 
 private:
 

--- a/examples/cpp/benchmark/types/Benchmark_medium.hpp
+++ b/examples/cpp/benchmark/types/Benchmark_medium.hpp
@@ -22,7 +22,7 @@
 #ifndef FAST_DDS_GENERATED__BENCHMARK_MEDIUM_HPP
 #define FAST_DDS_GENERATED__BENCHMARK_MEDIUM_HPP
 
-#include  <array>
+#include <array>
 #include <cstdint>
 #include <utility>
 
@@ -79,9 +79,9 @@ public:
     eProsima_user_DllExport BenchMarkMedium(
             const BenchMarkMedium& x)
     {
-        m_data = x.m_data;
+                    m_data = x.m_data;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
     }
 
@@ -104,9 +104,9 @@ public:
             const BenchMarkMedium& x)
     {
 
-        m_data = x.m_data;
+                    m_data = x.m_data;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
         return *this;
     }
@@ -132,7 +132,7 @@ public:
             const BenchMarkMedium& x) const
     {
         return (m_data == x.m_data &&
-               m_index == x.m_index);
+           m_index == x.m_index);
     }
 
     /*!
@@ -183,6 +183,7 @@ public:
         return m_data;
     }
 
+
     /*!
      * @brief This function sets a value in member index
      * @param _index New value for member index
@@ -210,6 +211,8 @@ public:
     {
         return m_index;
     }
+
+
 
 private:
 

--- a/examples/cpp/benchmark/types/Benchmark_small.hpp
+++ b/examples/cpp/benchmark/types/Benchmark_small.hpp
@@ -22,7 +22,7 @@
 #ifndef FAST_DDS_GENERATED__BENCHMARK_SMALL_HPP
 #define FAST_DDS_GENERATED__BENCHMARK_SMALL_HPP
 
-#include  <array>
+#include <array>
 #include <cstdint>
 #include <utility>
 
@@ -79,9 +79,9 @@ public:
     eProsima_user_DllExport BenchMarkSmall(
             const BenchMarkSmall& x)
     {
-        m_array = x.m_array;
+                    m_array = x.m_array;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
     }
 
@@ -104,9 +104,9 @@ public:
             const BenchMarkSmall& x)
     {
 
-        m_array = x.m_array;
+                    m_array = x.m_array;
 
-        m_index = x.m_index;
+                    m_index = x.m_index;
 
         return *this;
     }
@@ -132,7 +132,7 @@ public:
             const BenchMarkSmall& x) const
     {
         return (m_array == x.m_array &&
-               m_index == x.m_index);
+           m_index == x.m_index);
     }
 
     /*!
@@ -183,6 +183,7 @@ public:
         return m_array;
     }
 
+
     /*!
      * @brief This function sets a value in member index
      * @param _index New value for member index
@@ -210,6 +211,8 @@ public:
     {
         return m_index;
     }
+
+
 
 private:
 

--- a/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
+++ b/examples/cpp/configuration/ConfigurationPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ConfigurationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/content_filter/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/custom_payload_pool/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
+++ b/examples/cpp/delivery_mechanisms/DeliveryMechanismsPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool DeliveryMechanismsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/discovery_server/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
+++ b/examples/cpp/flow_control/FlowControlPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FlowControlPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/hello_world/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
+++ b/examples/cpp/request_reply/types/CalculatorPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool CalculatorRequestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool CalculatorReplyTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/security/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/security/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
+++ b/examples/cpp/static_edp_discovery/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
+++ b/examples/cpp/topic_instances/ShapeTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ShapeTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.cxx
@@ -82,6 +82,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -264,6 +265,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -446,6 +448,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -628,6 +631,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -810,6 +814,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -992,6 +997,7 @@ namespace builtin {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {

--- a/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
+++ b/src/cpp/fastdds/builtin/type_lookup_service/detail/rpc_typesPubSubTypes.cxx
@@ -81,6 +81,7 @@ bool EntityId_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -263,6 +264,7 @@ bool GUID_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -445,6 +447,7 @@ bool SequenceNumber_tPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -627,6 +630,7 @@ bool SampleIdentityPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -810,6 +814,7 @@ namespace rpc {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {
@@ -992,6 +997,7 @@ namespace rpc {
             ser.serialize_encapsulation();
             // Serialize the object.
             ser << *p_type;
+            ser.set_dds_cdr_options({0,0});
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
         {

--- a/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
+++ b/src/cpp/fastdds/xtypes/type_representation/dds_xtypes_typeobjectPubSubTypes.cxx
@@ -84,6 +84,7 @@ bool StringSTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -266,6 +267,7 @@ bool StringLTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -448,6 +450,7 @@ bool PlainCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -630,6 +633,7 @@ bool PlainSequenceSElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -812,6 +816,7 @@ bool PlainSequenceLElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -994,6 +999,7 @@ bool PlainArraySElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1176,6 +1182,7 @@ bool PlainArrayLElemDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1358,6 +1365,7 @@ bool PlainMapSTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1540,6 +1548,7 @@ bool PlainMapLTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1722,6 +1731,7 @@ bool StronglyConnectedComponentIdPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1904,6 +1914,7 @@ bool ExtendedTypeDefnPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2086,6 +2097,7 @@ bool DummyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2268,6 +2280,7 @@ bool ExtendedAnnotationParameterValuePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2450,6 +2463,7 @@ bool AppliedAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2632,6 +2646,7 @@ bool AppliedAnnotationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2814,6 +2829,7 @@ bool AppliedVerbatimAnnotationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2996,6 +3012,7 @@ bool AppliedBuiltinMemberAnnotationsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3178,6 +3195,7 @@ bool CommonStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3360,6 +3378,7 @@ bool CompleteMemberDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3542,6 +3561,7 @@ bool MinimalMemberDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3724,6 +3744,7 @@ bool CompleteStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3906,6 +3927,7 @@ bool MinimalStructMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4088,6 +4110,7 @@ bool AppliedBuiltinTypeAnnotationsPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4270,6 +4293,7 @@ bool MinimalTypeDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4452,6 +4476,7 @@ bool CompleteTypeDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4634,6 +4659,7 @@ bool CompleteStructHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4816,6 +4842,7 @@ bool MinimalStructHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4998,6 +5025,7 @@ bool CompleteStructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5180,6 +5208,7 @@ bool MinimalStructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5362,6 +5391,7 @@ bool CommonUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5544,6 +5574,7 @@ bool CompleteUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5726,6 +5757,7 @@ bool MinimalUnionMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5908,6 +5940,7 @@ bool CommonDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6090,6 +6123,7 @@ bool CompleteDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6272,6 +6306,7 @@ bool MinimalDiscriminatorMemberPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6454,6 +6489,7 @@ bool CompleteUnionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6636,6 +6672,7 @@ bool MinimalUnionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6818,6 +6855,7 @@ bool CompleteUnionTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7000,6 +7038,7 @@ bool MinimalUnionTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7182,6 +7221,7 @@ bool CommonAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7364,6 +7404,7 @@ bool CompleteAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7546,6 +7587,7 @@ bool MinimalAnnotationParameterPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7728,6 +7770,7 @@ bool CompleteAnnotationHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7910,6 +7953,7 @@ bool MinimalAnnotationHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8092,6 +8136,7 @@ bool CompleteAnnotationTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8274,6 +8319,7 @@ bool MinimalAnnotationTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8456,6 +8502,7 @@ bool CommonAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8638,6 +8685,7 @@ bool CompleteAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8820,6 +8868,7 @@ bool MinimalAliasBodyPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9002,6 +9051,7 @@ bool CompleteAliasHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9184,6 +9234,7 @@ bool MinimalAliasHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9366,6 +9417,7 @@ bool CompleteAliasTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9548,6 +9600,7 @@ bool MinimalAliasTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9730,6 +9783,7 @@ bool CompleteElementDetailPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9912,6 +9966,7 @@ bool CommonCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10094,6 +10149,7 @@ bool CompleteCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10276,6 +10332,7 @@ bool MinimalCollectionElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10458,6 +10515,7 @@ bool CommonCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10640,6 +10698,7 @@ bool CompleteCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10822,6 +10881,7 @@ bool MinimalCollectionHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11004,6 +11064,7 @@ bool CompleteSequenceTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11186,6 +11247,7 @@ bool MinimalSequenceTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11368,6 +11430,7 @@ bool CommonArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11550,6 +11613,7 @@ bool CompleteArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11732,6 +11796,7 @@ bool MinimalArrayHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11914,6 +11979,7 @@ bool CompleteArrayTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12096,6 +12162,7 @@ bool MinimalArrayTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12278,6 +12345,7 @@ bool CompleteMapTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12460,6 +12528,7 @@ bool MinimalMapTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12642,6 +12711,7 @@ bool CommonEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12824,6 +12894,7 @@ bool CompleteEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13006,6 +13077,7 @@ bool MinimalEnumeratedLiteralPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13188,6 +13260,7 @@ bool CommonEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13370,6 +13443,7 @@ bool CompleteEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13552,6 +13626,7 @@ bool MinimalEnumeratedHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13734,6 +13809,7 @@ bool CompleteEnumeratedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13916,6 +13992,7 @@ bool MinimalEnumeratedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14098,6 +14175,7 @@ bool CommonBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14280,6 +14358,7 @@ bool CompleteBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14462,6 +14541,7 @@ bool MinimalBitflagPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14644,6 +14724,7 @@ bool CommonBitmaskHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14826,6 +14907,7 @@ bool CompleteBitmaskTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15008,6 +15090,7 @@ bool MinimalBitmaskTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15190,6 +15273,7 @@ bool CommonBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15372,6 +15456,7 @@ bool CompleteBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15554,6 +15639,7 @@ bool MinimalBitfieldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15736,6 +15822,7 @@ bool CompleteBitsetHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15918,6 +16005,7 @@ bool MinimalBitsetHeaderPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16100,6 +16188,7 @@ bool CompleteBitsetTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16282,6 +16371,7 @@ bool MinimalBitsetTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16464,6 +16554,7 @@ bool CompleteExtendedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16646,6 +16737,7 @@ bool MinimalExtendedTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16828,6 +16920,7 @@ bool TypeIdentifierTypeObjectPairPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17010,6 +17103,7 @@ bool TypeIdentifierPairPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17192,6 +17286,7 @@ bool TypeIdentfierWithSizePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17374,6 +17469,7 @@ bool TypeIdentifierWithDependenciesPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17556,6 +17652,7 @@ bool TypeInformationPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/monitorservice_typesPubSubTypes.cxx
@@ -79,6 +79,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -260,6 +261,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -441,6 +443,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -622,6 +625,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -803,6 +807,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -984,6 +989,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1165,6 +1171,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/src/cpp/statistics/types/typesPubSubTypes.cxx
+++ b/src/cpp/statistics/types/typesPubSubTypes.cxx
@@ -80,6 +80,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -261,6 +262,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -442,6 +444,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -623,6 +626,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -804,6 +808,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -985,6 +990,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1168,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1530,6 +1538,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1711,6 +1720,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1892,6 +1902,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2073,6 +2084,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2254,6 +2266,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2435,6 +2448,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/blackbox/types/Data1mbPubSubTypes.cxx
+++ b/test/blackbox/types/Data1mbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Data1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/Data64kbPubSubTypes.cxx
+++ b/test/blackbox/types/Data64kbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Data64kbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/FixedSizedPubSubTypes.cxx
+++ b/test/blackbox/types/FixedSizedPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FixedSizedPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/HelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/HelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool HelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedData1mbPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool KeyedData1mbPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/KeyedHelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool KeyedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/StringTestPubSubTypes.cxx
+++ b/test/blackbox/types/StringTestPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StringTestPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/TestRegression3361PubSubTypes.cxx
+++ b/test/blackbox/types/TestRegression3361PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TestRegression3361PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
+++ b/test/blackbox/types/UnboundedHelloWorldPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool UnboundedHelloWorldPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/blackbox/types/core/core_typesPubSubTypes.cxx
+++ b/test/blackbox/types/core/core_typesPubSubTypes.cxx
@@ -81,6 +81,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -262,6 +263,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -443,6 +445,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -624,6 +627,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -805,6 +809,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -986,6 +991,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1167,6 +1173,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1348,6 +1355,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1529,6 +1537,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1710,6 +1719,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -1891,6 +1901,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2072,6 +2083,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2253,6 +2265,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2434,6 +2447,7 @@ namespace eprosima {
                             ser.serialize_encapsulation();
                             // Serialize the object.
                             ser << *p_type;
+                            ser.set_dds_cdr_options({0,0});
                         }
                         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                         {
@@ -2617,6 +2631,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -2798,6 +2813,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -2982,6 +2998,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3163,6 +3180,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3344,6 +3362,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3525,6 +3544,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3706,6 +3726,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -3887,6 +3908,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {

--- a/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/monitorservice_typesPubSubTypes.cxx
@@ -79,6 +79,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -260,6 +261,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -441,6 +443,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -622,6 +625,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -803,6 +807,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -984,6 +989,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1165,6 +1171,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/blackbox/types/statistics/typesPubSubTypes.cxx
+++ b/test/blackbox/types/statistics/typesPubSubTypes.cxx
@@ -80,6 +80,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -261,6 +262,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -442,6 +444,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -623,6 +626,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -804,6 +808,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -985,6 +990,7 @@ namespace eprosima {
                         ser.serialize_encapsulation();
                         // Serialize the object.
                         ser << *p_type;
+                        ser.set_dds_cdr_options({0,0});
                     }
                     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                     {
@@ -1168,6 +1174,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1349,6 +1356,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1530,6 +1538,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1711,6 +1720,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -1892,6 +1902,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2073,6 +2084,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2254,6 +2266,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {
@@ -2435,6 +2448,7 @@ namespace eprosima {
                     ser.serialize_encapsulation();
                     // Serialize the object.
                     ser << *p_type;
+                    ser.set_dds_cdr_options({0,0});
                 }
                 catch (eprosima::fastcdr::exception::Exception& /*exception*/)
                 {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType1PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType1PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type1PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType2PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType2PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type2PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType3PubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsType3PubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type3PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeBigPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeBigPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool Type4PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool Type5PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool Type6PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool Type7PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -800,6 +804,7 @@ bool Type8PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -981,6 +986,7 @@ bool Type9PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1162,6 +1168,7 @@ bool Type10PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1343,6 +1350,7 @@ bool Type11PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1524,6 +1532,7 @@ bool Type12PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1705,6 +1714,7 @@ bool Type13PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1886,6 +1896,7 @@ bool Type14PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2067,6 +2078,7 @@ bool Type15PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2248,6 +2260,7 @@ bool Type16PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2429,6 +2442,7 @@ bool Type17PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2610,6 +2624,7 @@ bool Type18PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2791,6 +2806,7 @@ bool Type19PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -2972,6 +2988,7 @@ bool Type20PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3153,6 +3170,7 @@ bool Type21PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3334,6 +3352,7 @@ bool Type22PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3515,6 +3534,7 @@ bool Type23PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3696,6 +3716,7 @@ bool Type24PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -3877,6 +3898,7 @@ bool Type25PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4058,6 +4080,7 @@ bool Type26PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4239,6 +4262,7 @@ bool Type27PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4420,6 +4444,7 @@ bool Type28PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4601,6 +4626,7 @@ bool Type29PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4782,6 +4808,7 @@ bool Type30PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -4963,6 +4990,7 @@ bool Type31PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5144,6 +5172,7 @@ bool Type32PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5325,6 +5354,7 @@ bool Type33PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5506,6 +5536,7 @@ bool Type34PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5687,6 +5718,7 @@ bool Type35PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -5868,6 +5900,7 @@ bool Type36PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6049,6 +6082,7 @@ bool Type37PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6230,6 +6264,7 @@ bool Type38PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6411,6 +6446,7 @@ bool Type39PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6592,6 +6628,7 @@ bool Type40PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6773,6 +6810,7 @@ bool Type41PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -6954,6 +6992,7 @@ bool Type42PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7135,6 +7174,7 @@ bool Type43PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7316,6 +7356,7 @@ bool Type44PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7497,6 +7538,7 @@ bool Type45PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7678,6 +7720,7 @@ bool Type46PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -7859,6 +7902,7 @@ bool Type47PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8040,6 +8084,7 @@ bool Type48PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8221,6 +8266,7 @@ bool Type49PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8402,6 +8448,7 @@ bool Type50PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8583,6 +8630,7 @@ bool Type51PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8764,6 +8812,7 @@ bool Type52PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -8945,6 +8994,7 @@ bool Type53PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9126,6 +9176,7 @@ bool Type54PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9307,6 +9358,7 @@ bool Type55PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9488,6 +9540,7 @@ bool Type56PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9669,6 +9722,7 @@ bool Type57PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -9850,6 +9904,7 @@ bool Type58PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10031,6 +10086,7 @@ bool Type59PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10212,6 +10268,7 @@ bool Type60PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10393,6 +10450,7 @@ bool Type61PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10574,6 +10632,7 @@ bool Type62PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10755,6 +10814,7 @@ bool Type63PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -10936,6 +10996,7 @@ bool Type64PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11117,6 +11178,7 @@ bool Type65PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11298,6 +11360,7 @@ bool Type66PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11479,6 +11542,7 @@ bool Type67PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11660,6 +11724,7 @@ bool Type68PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -11841,6 +11906,7 @@ bool Type69PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12022,6 +12088,7 @@ bool Type70PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12203,6 +12270,7 @@ bool Type71PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12384,6 +12452,7 @@ bool Type72PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12565,6 +12634,7 @@ bool Type73PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12746,6 +12816,7 @@ bool Type74PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -12927,6 +12998,7 @@ bool Type75PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13108,6 +13180,7 @@ bool Type76PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13289,6 +13362,7 @@ bool Type77PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13470,6 +13544,7 @@ bool Type78PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13651,6 +13726,7 @@ bool Type79PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -13832,6 +13908,7 @@ bool Type80PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14013,6 +14090,7 @@ bool Type81PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14194,6 +14272,7 @@ bool Type82PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14375,6 +14454,7 @@ bool Type83PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14556,6 +14636,7 @@ bool Type84PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14737,6 +14818,7 @@ bool Type85PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -14918,6 +15000,7 @@ bool Type86PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15099,6 +15182,7 @@ bool Type87PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15280,6 +15364,7 @@ bool Type88PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15461,6 +15546,7 @@ bool Type89PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15642,6 +15728,7 @@ bool Type90PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -15823,6 +15910,7 @@ bool Type91PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16004,6 +16092,7 @@ bool Type92PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16185,6 +16274,7 @@ bool Type93PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16366,6 +16456,7 @@ bool Type94PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16547,6 +16638,7 @@ bool Type95PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16728,6 +16820,7 @@ bool Type96PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -16909,6 +17002,7 @@ bool Type97PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17090,6 +17184,7 @@ bool Type98PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17271,6 +17366,7 @@ bool Type99PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17452,6 +17548,7 @@ bool Type100PubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -17633,6 +17730,7 @@ bool TypeBigPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeDepPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeDepPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TypeDepPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeNoTypeObjectPubSubTypes.cxx
+++ b/test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeNoTypeObjectPubSubTypes.cxx
@@ -74,6 +74,7 @@ bool TypeNoTypeObjectPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
+++ b/test/profiling/allocations/AllocTestTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool AllocTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
+++ b/test/unittest/dds/topic/DDSSQLFilter/data_types/ContentFilterTestTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StructTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ContentFilterTestTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/alias_struct/gen/alias_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool AliasStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/array_struct/gen/array_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool NestedArrayElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ComplexArrayElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool ArrayStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitmask_struct/gen/bitmask_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool BitmaskStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/bitset_struct/gen/bitset_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool BitsetStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/enum_struct/gen/enum_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool EnumStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/extensibility_struct/gen/extensibility_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool FinalStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool MutableStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool AppendableStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool ExtensibilityStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/key_struct/gen/key_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ImportantStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool KeyStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/map_struct/gen/map_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool ValueStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool MapStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/primitives_struct/gen/primitives_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool PrimitivesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/sequence_struct/gen/sequence_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool NestedSequenceElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ComplexSequenceElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool SequenceStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/string_struct/gen/string_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool StringStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/struct_struct/gen/struct_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool GrandparentStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool ParentStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool NestedStructElementPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -619,6 +622,7 @@ bool StructStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/idl/types/union_struct/gen/union_structPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool UnionStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {

--- a/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
+++ b/test/unittest/dds/xtypes/serializers/json/types/comprehensive_type/gen/ComprehensiveTypePubSubTypes.cxx
@@ -76,6 +76,7 @@ bool PrimitivesStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -257,6 +258,7 @@ bool AllStructPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -438,6 +440,7 @@ bool ComprehensiveTypePubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This updates the types with https://github.com/eProsima/Fast-DDS-Gen/pull/424

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
