### PR TITLE
[22210] Handle socket buffer size setting when system's maximum exceeded

### DIFF
--- a/src/cpp/rtps/transport/asio_helpers.hpp
+++ b/src/cpp/rtps/transport/asio_helpers.hpp
@@ -53,18 +53,47 @@ struct asio_helpers
         final_buffer_value = initial_buffer_value;
         while (final_buffer_value >= minimum_buffer_value)
         {
-            socket.set_option(BufferOptionType(static_cast<int32_t>(final_buffer_value)), ec);
+            int32_t value_to_set = static_cast<int32_t>(final_buffer_value);
+            socket.set_option(BufferOptionType(value_to_set), ec);
             if (!ec)
             {
+                BufferOptionType option;
+                socket.get_option(option, ec);
+                if (!ec)
+                {
+                    if (option.value() == value_to_set)
+                    {
+                        // Option actually set to the desired value
+                        return true;
+                    }
+                    // Try again with the value actually set
+                    final_buffer_value = option.value();
+                    continue;
+                }
+                // Could not determine the actual value, but the option was set successfully.
+                // Assume the option was set to the desired value.
                 return true;
             }
 
             final_buffer_value /= 2;
         }
 
+        // Perform a final attempt to set the minimum value
         final_buffer_value = minimum_buffer_value;
-        socket.set_option(BufferOptionType(final_buffer_value), ec);
-        return !ec;
+        int32_t value_to_set = static_cast<int32_t>(final_buffer_value);
+        socket.set_option(BufferOptionType(value_to_set), ec);
+        if (!ec)
+        {
+            // Last attempt was successful. Get the actual value set.
+            BufferOptionType option;
+            socket.get_option(option, ec);
+            if (!ec)
+            {
+                final_buffer_value = option.value();
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/cpp/rtps/transport/asio_helpers.hpp
+++ b/src/cpp/rtps/transport/asio_helpers.hpp
@@ -51,7 +51,7 @@ struct asio_helpers
         asio::error_code ec;
 
         final_buffer_value = initial_buffer_value;
-        while (final_buffer_value >= minimum_buffer_value)
+        while (final_buffer_value > minimum_buffer_value)
         {
             int32_t value_to_set = static_cast<int32_t>(final_buffer_value);
             socket.set_option(BufferOptionType(value_to_set), ec);

--- a/test/unittest/transport/AsioHelpersTests.cpp
+++ b/test/unittest/transport/AsioHelpersTests.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <limits>
+#include <memory>
+#include <thread>
+
+#include <asio.hpp>
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>
+#include <fastdds/utils/IPFinder.hpp>
+#include <fastdds/utils/IPLocator.hpp>
+
+#include <utils/Semaphore.hpp>
+
+#include <MockReceiverResource.h>
+#include <rtps/transport/asio_helpers.hpp>
+#include <rtps/transport/UDPv4Transport.h>
+
+using namespace eprosima::fastdds::rtps;
+
+
+// Regression tests for redmine issue #22210
+// Test that the buffer size is set actually to the value stored as the final value
+TEST(AsioHelpersTests, try_setting_buffer_size)
+{
+    for (uint32_t initial_buffer_value = std::numeric_limits<uint32_t>::max(); initial_buffer_value > 0;
+            initial_buffer_value /= 2)
+    {
+        asio::io_service io_service;
+        eProsimaUDPSocket socket = createUDPSocket(io_service);
+        getSocketPtr(socket)->open(asio::ip::udp::v4());
+
+        uint32_t minimum_buffer_value = 0;
+        uint32_t final_buffer_value = 0;
+        ASSERT_TRUE(asio_helpers::try_setting_buffer_size<asio::socket_base::send_buffer_size>(
+                socket, initial_buffer_value, minimum_buffer_value, final_buffer_value));
+
+        asio::socket_base::send_buffer_size option;
+        asio::error_code ec;
+        socket.get_option(option, ec);
+        if (!ec)
+        {
+            ASSERT_EQ(option.value(), final_buffer_value);
+        }
+    }
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -97,6 +97,39 @@ set(UDPV4TESTS_SOURCE
     ${TCPTransportInterface_SOURCE}
     )
 
+set(ASIOHELPERSTESTS_SOURCE
+    AsioHelpersTests.cpp
+    mock/MockReceiverResource.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/PropertyPolicy.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/attributes/ThreadSettings.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/GuidPrefix_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/LocatorWithMask.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/SerializedPayload.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/CDRMessage.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkBuffer.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterfaceWithFilter.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/PortBasedTransportDescriptor.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPChannelResource.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPTransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/UDPv4Transport.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/Host.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPFinder.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/IPLocator.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/md5.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/utils/SystemInfo.cpp
+    ${TCPTransportInterface_SOURCE}
+    )
+
+
 set(UDPV6TESTS_SOURCE
     UDPv6Tests.cpp
     mock/MockReceiverResource.cpp
@@ -514,3 +547,38 @@ target_link_libraries(${PORTBASED_TRANSPORTDESCRIPTOR_TESTS_TARGET}
     ${MOCKS})
 
 gtest_discover_tests(${PORTBASED_TRANSPORTDESCRIPTOR_TESTS_TARGET})
+
+#####################################
+# AsioHelpers tests
+#####################################
+add_executable(AsioHelpersTests ${ASIOHELPERSTESTS_SOURCE})
+target_compile_definitions(AsioHelpersTests PRIVATE
+    BOOST_ASIO_STANDALONE
+    ASIO_STANDALONE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(AsioHelpersTests PRIVATE
+    ${Asio_INCLUDE_DIR}
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/MessageReceiver
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReceiverResource
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    $<$<BOOL:${ANDROID}>:${ANDROID_IFADDRS_INCLUDE_DIR}>
+    )
+target_link_libraries(AsioHelpersTests
+    fastcdr
+    fastdds::log
+    GTest::gtest
+    ${MOCKS}
+    $<$<BOOL:${TLS_FOUND}>:OpenSSL::SSL$<SEMICOLON>OpenSSL::Crypto>)
+if(QNX)
+    target_link_libraries(AsioHelpersTests socket)
+endif()
+if(MSVC OR MSVC_IDE)
+    target_link_libraries(AsioHelpersTests ${PRIVACY} iphlpapi Shlwapi )
+endif()
+if (APPLE)
+    target_link_libraries(AsioHelpersTests ${PRIVACY} "-framework CoreFoundation" "-framework IOKit")
+endif()
+gtest_discover_tests(AsioHelpersTests)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x 2.6.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _NA_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _NA_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _NA_: New feature has been added to the `versions.md` file (if applicable).
- _NA_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
