### PR TITLE
Log any errors before cancel_init()

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -398,7 +398,7 @@ bool SecurityManager::init(
         {
             // Unexpected code path. Let's log any errors
             logError(SECURITY, "Error while configuring security plugin.")
-            if (strlen(exception.what()))
+            if (0 != strlen(exception.what()))
             {
                 logError(SECURITY, exception.what())
             }

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -398,7 +398,10 @@ bool SecurityManager::init(
         {
             // Unexpected code path. Let's log any errors
             logError(SECURITY, "Error while configuring security plugin.")
-            if (strlen(exception.what())) logError(SECURITY, exception.what())
+            if (strlen(exception.what()))
+            {
+                logError(SECURITY, exception.what())
+            }
 
             cancel_init();
             return false;

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -117,9 +117,9 @@ bool SecurityManager::init(
         ParticipantSecurityAttributes& attributes,
         const PropertyPolicy& participant_properties)
 {
+    SecurityException exception;
     try
     {
-        SecurityException exception;
         domain_id_ = participant_->get_domain_id();
         auto part_attributes = participant_->get_attributes();
         const PropertyPolicy log_properties = PropertyPolicyHelper::get_properties_with_prefix(
@@ -396,6 +396,10 @@ bool SecurityManager::init(
     {
         if (!e)
         {
+            // Unexpected code path. Let's log any errors
+            logError(SECURITY, "Error while configuring security plugin.")
+            if (strlen(exception.what())) logError(SECURITY, exception.what())
+
             cancel_init();
             return false;
         }


### PR DESCRIPTION
This PR improves the debugging process by adding a proper logging right before running `SecurityManager::cancel_init()` in [this catch block](https://github.com/eProsima/Fast-DDS/blob/2.6.9/src/cpp/rtps/security/SecurityManager.cpp#L386-L393)



## Description

More details in this ticket https://github.com/eProsima/Fast-DDS/issues/5531

@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x


<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->

Fixes #(issue) 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _NA_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _NA_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _NA_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _NA_ New feature has been added to the `versions.md` file (if applicable).
- _NA_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- _NA_ Check CI results: failing tests are unrelated with the changes.
