### PR TITLE
[22537] Fix EDP reliability timings

### DIFF
--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -56,9 +56,9 @@ namespace rtps {
 
 // Default configuration values for EDP entities.
 static const dds::Duration_t edp_heartbeat_period{1, 0}; // 1 second
-static const dds::Duration_t edp_nack_response_delay{0, 100 * 1000 }; // 100 milliseconds
-static const dds::Duration_t edp_nack_supression_duration{0, 10 * 1000}; // 10 milliseconds
-static const dds::Duration_t edp_heartbeat_response_delay{0, 10 * 1000}; // 10 milliseconds
+static const dds::Duration_t edp_nack_response_delay{0, 100 * 1000 * 1000 }; // 100 milliseconds
+static const dds::Duration_t edp_nack_supression_duration{0, 10 * 1000 * 1000}; // 10 milliseconds
+static const dds::Duration_t edp_heartbeat_response_delay{0, 10 * 1000 * 1000}; // 10 milliseconds
 
 static const int32_t edp_reader_initial_reserved_caches = 1;
 static const int32_t edp_writer_initial_reserved_caches = 20;

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -762,7 +762,7 @@ TEST(DDSStatistics, correct_deletion_upon_delete_contained_entities)
                 {
                     writer->init();
                     ASSERT_TRUE(writer->isInitialized());
-                    writer->wait_discovery();
+                    writer->wait_discovery(std::chrono::seconds(3));
                     writer->send(*data, 10);
                     writer->destroy();
                 }));

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -762,8 +762,8 @@ TEST(DDSStatistics, correct_deletion_upon_delete_contained_entities)
                 {
                     writer->init();
                     ASSERT_TRUE(writer->isInitialized());
-                    writer->wait_discovery(std::chrono::seconds(3));
-                    writer->send(*data, 10);
+                    writer->wait_discovery();
+                    writer->send(*data, 200);
                     writer->destroy();
                 }));
 


### PR DESCRIPTION
## Description

happened to find this miscalculation during https://github.com/ros2/rmw_fastrtps/issues/789.
i believe that comments are the correct values, so that default Duration_t adjusted accordingly in milliseconds.

@mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
