### PR TITLE
[21861] Enable Datasharing segments clean from CLI 

### DIFF
--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -31,6 +31,7 @@ if(Python3_Interpreter_FOUND)
         test_fastdds_discovery_run
         test_ros_discovery
         test_fastdds_shm
+        test_fastdds_shm_force
         test_fastdds_xml_validate
     )
 

--- a/test/system/tools/fastdds/tests.py
+++ b/test/system/tools/fastdds/tests.py
@@ -125,6 +125,22 @@ def test_fastdds_shm(install_path):
         print('test_fastdds_shm FAILED')
         sys.exit(ret)
 
+def test_fastdds_shm_force(install_path):
+    """Test that shm command runs."""
+    args = ' shm clean -f'
+    ret = subprocess.call(cmd(
+        install_path=install_path, args=args), shell=True)
+    if 0 != ret:
+        print('test_fastdds_shm FAILED')
+        sys.exit(ret)
+
+    args = ' shm clean --force'
+    ret = subprocess.call(cmd(
+        install_path=install_path, args=args), shell=True)
+    if 0 != ret:
+        print('test_fastdds_shm FAILED')
+        sys.exit(ret)
+
 
 def test_fastdds_discovery(install_path, setup_script_path):
     """Test that discovery command runs."""
@@ -156,7 +172,7 @@ def test_fastdds_discovery_run(install_path, setup_script_path):
     except subprocess.TimeoutExpired:
         print(f'Timeout {test_timeout} expired. Test successful')
         try:
-            # Need to kill all child processes to properly end the test 
+            # Need to kill all child processes to properly end the test
             parent = psutil.Process(process.pid)
             for child in parent.children(recursive=True):
                 child.terminate()
@@ -256,6 +272,7 @@ if __name__ == '__main__':
         'test_ros_discovery':
         lambda: test_ros_discovery(ros_disc_tool_path, setup_script_path),
         'test_fastdds_shm': lambda: test_fastdds_shm(fastdds_tool_path),
+        'test_fastdds_shm_force': lambda: test_fastdds_shm_force(fastdds_tool_path),
         'test_fastdds_xml_validate':
         lambda: test_fastdds_xml_validate(fastdds_tool_path)
     }

--- a/tools/fastdds/shm/clean.py
+++ b/tools/fastdds/shm/clean.py
@@ -36,13 +36,16 @@ elif os.name == 'nt':
 class Clean:
     """This command searches and deletes zombie SHM ports / segments."""
 
-    def run(self):
+    def run(self, force: bool):
         """Execute the clean."""
         self.__ports_in_use = 0
         self.__segments_in_use = 0
 
         zombie_segments = self.__clean_zombie_segments()
         zombie_ports = self.__clean_zombie_ports()
+        if force:
+            zombie_datasharing_segments = self.__clean_zombie_datasharing_segments()
+            print(f'Datasharing segment: {zombie_datasharing_segments}')
 
         print('shm.clean:')
         print(self.__ports_in_use, 'ports in use')
@@ -51,6 +54,8 @@ class Clean:
         print(int(len(zombie_ports) / 3), 'zombie ports cleaned')
         # each segment has 2 files
         print(int(len(zombie_segments) / 2), 'zombie segments cleaned')
+        if force:
+            print(int(len(zombie_datasharing_segments)), 'datasharing segments cleaned')
 
     def __shm_dir(self):
         """
@@ -165,6 +170,28 @@ class Clean:
             return ''.join(['sem.', port_file_name, '_mutex'])
         else:
             return ''.join([port_file_name, '_mutex'])
+
+    def __clean_zombie_datasharing_segments(self):
+        """
+        Find & delete datasharing segments in the default SHM dir.
+
+        returns list(str):
+            the deleted file names
+
+        """
+        segment_lock_re = re.compile('fast_datasharing_([0-9a-f\.]){35}_([\d\.]{7})')
+        segments_locks = [
+            file_name for file_name in self.__list_dir() if segment_lock_re.match(
+                file_name)]
+        zombie_files = []
+
+        # Check is_file_locked for each lock file
+        for file in segments_locks:
+            file_name = self.__shm_dir() / file
+            self.__remove_file(file_name)
+            zombie_files.append(file)
+
+        return [file_name for file_name in zombie_files]
 
     def __remove_file(self, file):
         """

--- a/tools/fastdds/shm/clean.py
+++ b/tools/fastdds/shm/clean.py
@@ -45,7 +45,7 @@ class Clean:
         zombie_ports = self.__clean_zombie_ports()
         if force:
             zombie_datasharing_segments = self.__clean_zombie_datasharing_segments()
-            print(f'Datasharing segment: {zombie_datasharing_segments}')
+            print(f'Datasharing segments: {zombie_datasharing_segments}')
 
         print('shm.clean:')
         print(self.__ports_in_use, 'ports in use')

--- a/tools/fastdds/shm/parser.py
+++ b/tools/fastdds/shm/parser.py
@@ -63,12 +63,13 @@ class Parser:
         )
 
         parser.add_argument('command', nargs='?', help='shm-command to run')
+        parser.add_argument('-f', '--force', action='store_true', help='Force the clean of data sharing segments')
 
         args = parser.parse_args(argv)
 
         if args.command is not None:
             if args.command == 'clean':
-                Clean().run()
+                Clean().run(args.force)
             else:
                 print('shm-command ' + args.shm_command + ' is not valid')
         else:

--- a/versions.md
+++ b/versions.md
@@ -11,6 +11,7 @@ Forthcoming
 * Windows ci example testing infrastructure and `hello world` example.
 * New property to configure the preferred key agreement algorithm.
 * Refactor benchmark example.
+* Extended CLI ``shm`` command with ``-f`` param to clean Data Sharing segments.
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR enables to clean Datasharing files from the CLI. It adds a new argument (-f/--force) that will clean all datasharing segments found in the SHM directory. It does NOT check if these files are in use. It is user responsibility to ensure that the CLI is not called with the new argument at runtime, which would cause errors if new endpoints are initialized.
Issue related: https://github.com/eProsima/Fast-DDS/issues/5308

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation.
    - https://github.com/eProsima/Fast-DDS-docs/pull/1012
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
