### PR TITLE
[22545] Add test for security initialization error

### DIFF
--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -397,10 +397,10 @@ bool SecurityManager::init(
         if (!e)
         {
             // Unexpected code path. Let's log any errors
-            logError(SECURITY, "Error while configuring security plugin.")
+            EPROSIMA_LOG_ERROR(SECURITY, "Error while configuring security plugin.");
             if (0 != strlen(exception.what()))
             {
-                logError(SECURITY, exception.what())
+                EPROSIMA_LOG_ERROR(SECURITY, exception.what());
             }
 
             cancel_init();

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -233,6 +233,9 @@ TEST_F(SecurityTest, initialization_logging_error)
     security_activated_ = manager_.init(security_attributes_, participant_properties_);
 
     // Check that the error message was logged.
+    // First flush the log to make sure the message is there.
+    eprosima::fastdds::dds::Log::Flush();
+
     auto log_entries = mockConsumer->ConsumedEntries();
     ASSERT_GE(log_entries.size(), 1);
     bool found = false;

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -226,7 +226,7 @@ TEST_F(SecurityTest, initialization_logging_error)
             register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
             WillOnce(Return(nullptr));
 
-    eprosima::fastdds::dds::MockConsumer* mockConsumer= new eprosima::fastdds::dds::MockConsumer();
+    eprosima::fastdds::dds::MockConsumer* mockConsumer = new eprosima::fastdds::dds::MockConsumer();
     eprosima::fastdds::dds::Log::RegisterConsumer(std::unique_ptr<eprosima::fastdds::dds::LogConsumer>(mockConsumer));
     eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Error);
 
@@ -234,11 +234,11 @@ TEST_F(SecurityTest, initialization_logging_error)
 
     // Check that the error message was logged.
     auto log_entries = mockConsumer->ConsumedEntries();
-    ASSERT_GE(log_entries.size(),1);
+    ASSERT_GE(log_entries.size(), 1);
     bool found = false;
-    for(auto entry : log_entries)
+    for (auto entry : log_entries)
     {
-        if(entry.message.find("Error while configuring security plugin.") != std::string::npos)
+        if (entry.message.find("Error while configuring security plugin.") != std::string::npos)
         {
             found = true;
             break;

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -14,6 +14,8 @@
 
 #include "SecurityTests.hpp"
 
+#include "../../logging/mock/MockConsumer.h"
+
 const char* const MockIdentity::class_id_ = "MockIdentityHandle";
 const char* const MockHandshake::class_id_ = "MockHandshakeHandle";
 const char* const SharedSecret::class_id_ = "SharedSecretHandle";
@@ -206,5 +208,42 @@ TEST_F(SecurityTest, initialization_ok)
 
     initialization_ok();
 
+}
+
+/* Regression test for Redmine 22545.
+ *
+ * Triggering a throw false in SecurityManager::init() should be logged properly as
+ * the error: "Error while configuring security plugin.".
+ */
+TEST_F(SecurityTest, initialization_logging_error)
+{
+    DefaultValue<const GUID_t&>::Set(guid);
+    DefaultValue<const ParticipantSecurityAttributes&>::Set(security_attributes_);
+
+    EXPECT_CALL(*auth_plugin_, validate_local_identity(_, _, _, _, _, _)).Times(1).
+            WillOnce(DoAll(SetArgPointee<0>(&local_identity_handle_), Return(ValidationResult_t::VALIDATION_OK)));
+    EXPECT_CALL(crypto_plugin_->cryptokeyfactory_,
+            register_local_participant(Ref(local_identity_handle_), _, _, _, _)).Times(1).
+            WillOnce(Return(nullptr));
+
+    eprosima::fastdds::dds::MockConsumer* mockConsumer= new eprosima::fastdds::dds::MockConsumer();
+    eprosima::fastdds::dds::Log::RegisterConsumer(std::unique_ptr<eprosima::fastdds::dds::LogConsumer>(mockConsumer));
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Error);
+
+    security_activated_ = manager_.init(security_attributes_, participant_properties_);
+
+    // Check that the error message was logged.
+    auto log_entries = mockConsumer->ConsumedEntries();
+    ASSERT_GE(log_entries.size(),1);
+    bool found = false;
+    for(auto entry : log_entries)
+    {
+        if(entry.message.find("Error while configuring security plugin.") != std::string::npos)
+        {
+            found = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(found);
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR is a follow up of [#5530](https://github.com/eProsima/Fast-DDS/pull/5530/files) updating the macro log and adding regression tests.

After merging, manual backport the commits to the corresponding already created backport branches:
* [#5544 Log any errors before cancel_init() (backport #5530)](https://github.com/eProsima/Fast-DDS/pull/5544) has been created for branch `3.1.x`
* [#5545 Log any errors before cancel_init() (backport #5530)](https://github.com/eProsima/Fast-DDS/pull/5545) has been created for branch `3.0.x`
* [#5546 Log any errors before cancel_init() (backport #5530)](https://github.com/eProsima/Fast-DDS/pull/5546) has been created for branch `2.14.x`
* [#5547 Log any errors before cancel_init() (backport #5530)](https://github.com/eProsima/Fast-DDS/pull/5547) has been created for branch `2.10.x`

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _NA_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _NA_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _NA_ New feature has been added to the `versions.md` file (if applicable).
- _NA_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _NA_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
