### PR TITLE
[22519] Decouple transport receivers creation using unique network flows

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -1731,11 +1732,16 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
         attributes.unicastLocatorList.clear();
         attributes.external_unicast_locators.clear();
 
+        // Register created resources to distinguish the case where a receiver was created in this same function call
+        // (and can be reused for other locators of the same kind in this reader), and that in which it was already
+        // created before for other reader in this same participant.
+        std::map<int32_t, int16_t> created_resources;
+
         // Create unique flows for unicast locators
         LocatorList_t input_locator_list = m_att.defaultUnicastLocatorList;
         for (Locator_t& loc : input_locator_list)
         {
-            uint16_t port = initial_unique_port;
+            uint16_t port = created_resources.count(loc.kind) ? created_resources[loc.kind] : initial_unique_port;
             while (port < final_unique_port)
             {
                 // Set logical port only TCP locators
@@ -1751,15 +1757,18 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
                     loc.port = port;
                 }
 
-                // Try creating receiver  for this locator
+                // Try creating receiver for this locator
                 LocatorList_t aux_locator_list;
                 aux_locator_list.push_back(loc);
-                // if (createReceiverResources(aux_locator_list, false, true, false))
-                // {
-                //     break;
-                // }
-                createReceiverResources(aux_locator_list, false, true, false);
-                if (!aux_locator_list.empty())
+                if (createReceiverResources(aux_locator_list, false, true, false))
+                {
+                    created_resources[loc.kind] = port;
+                }
+
+                // Locator will be present in the list if receiver was created, or was already created
+                // Continue if receiver not created for this reader (might exist but created for other reader in this same participant)
+                if (!aux_locator_list.empty() &&
+                        created_resources.count(loc.kind) && (created_resources[loc.kind] == port))
                 {
                     break;
                 }
@@ -1893,7 +1902,7 @@ bool RTPSParticipantImpl::createReceiverResources(
     bool ret_val = input_list.empty();
 
 #if HAVE_SECURITY
-    // An auxilary buffer is needed in the ReceiverResource to to decrypt the message,
+    // An auxilary buffer is needed in the ReceiverResource to decrypt the message,
     // that imposes a limit in the received messages size even if the transport allows (uint32_t) messages size.
     uint32_t max_receiver_buffer_size =
             is_secure() ? std::numeric_limits<uint16_t>::max() : (std::numeric_limits<uint32_t>::max)();

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1741,6 +1741,9 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
                 // Set logical port only TCP locators
                 if (LOCATOR_KIND_TCPv4 == loc.kind || LOCATOR_KIND_TCPv6 == loc.kind)
                 {
+                    // Due to current implementation limitations only one physical port (actual socket receiver)
+                    // is allowed when using TCP tranport. All we can do for now is to create a unique "logical" flow.
+                    // TODO: create a unique dedicated TCP communication channel once this limitation is removed.
                     IPLocator::setLogicalPort(loc, port);
                 }
                 else

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1728,14 +1728,15 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
     if (unique_flows)
     {
         attributes.multicastLocatorList.clear();
-        attributes.unicastLocatorList = m_att.defaultUnicastLocatorList;
+        attributes.unicastLocatorList.clear();
         attributes.external_unicast_locators.clear();
 
-        uint16_t port = initial_unique_port;
-        while (port < final_unique_port)
+        // Create unique flows for unicast locators
+        LocatorList_t input_locator_list = m_att.defaultUnicastLocatorList;
+        for (Locator_t& loc : input_locator_list)
         {
-            // Set port on unicast locators
-            for (Locator_t& loc : attributes.unicastLocatorList)
+            uint16_t port = initial_unique_port;
+            while (port < final_unique_port)
             {
                 // Set logical port only TCP locators
                 if (LOCATOR_KIND_TCPv4 == loc.kind || LOCATOR_KIND_TCPv6 == loc.kind)
@@ -1746,24 +1747,34 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
                 {
                     loc.port = port;
                 }
+
+                // Try creating receiver  for this locator
+                LocatorList_t aux_locator_list;
+                aux_locator_list.push_back(loc);
+                if (createReceiverResources(aux_locator_list, false, true, false))
+                {
+                    break;
+                }
+
+                // Try with next port
+                ++port;
             }
 
-            // Try creating receiver resources
-            LocatorList_t aux_locator_list = attributes.unicastLocatorList;
-            if (createReceiverResources(aux_locator_list, false, true, false))
+            // Fail when unique ports are exhausted
+            if (port >= final_unique_port)
             {
-                break;
+                EPROSIMA_LOG_WARNING(RTPS_PARTICIPANT, "Unique flows requested but exhausted. Port range: "
+                        << initial_unique_port << "-" << final_unique_port << ". Discarding locator: " << loc);
             }
-
-            // Try with next port
-            ++port;
+            else
+            {
+                attributes.unicastLocatorList.push_back(loc);
+            }
         }
 
-        // Fail when unique ports are exhausted
-        if (port >= final_unique_port)
+        if (attributes.unicastLocatorList.empty())
         {
-            EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Unique flows requested but exhausted. Port range: "
-                    << initial_unique_port << "-" << final_unique_port);
+            EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "No unicast locators to create unique flows");
             return false;
         }
     }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1743,7 +1743,7 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
                 {
                     // Due to current implementation limitations only one physical port (actual socket receiver)
                     // is allowed when using TCP tranport. All we can do for now is to create a unique "logical" flow.
-                    // TODO: create a unique dedicated TCP communication channel once this limitation is removed.
+                    // TODO(juanlofer): create a unique dedicated TCP communication channel once this limitation is removed.
                     IPLocator::setLogicalPort(loc, port);
                 }
                 else
@@ -1754,7 +1754,12 @@ bool RTPSParticipantImpl::createAndAssociateReceiverswithEndpoint(
                 // Try creating receiver  for this locator
                 LocatorList_t aux_locator_list;
                 aux_locator_list.push_back(loc);
-                if (createReceiverResources(aux_locator_list, false, true, false))
+                // if (createReceiverResources(aux_locator_list, false, true, false))
+                // {
+                //     break;
+                // }
+                createReceiverResources(aux_locator_list, false, true, false);
+                if (!aux_locator_list.empty())
                 {
                     break;
                 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -1031,6 +1031,7 @@ public:
      * @param ApplyMutation - True if we want to create a Resource with a "similar" locator if the one we provide is unavailable
      * @param RegisterReceiver - True if we want the receiver to be registered. Useful for receivers created after participant is enabled.
      * @param log_when_creation_fails - True if a log warning shall be issued for each locator when a receiver resource cannot be created.
+     * @return True if a receiver resource was created for at least a locator in the list, false otherwise.
      */
     bool createReceiverResources(
             LocatorList_t& Locator_list,

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <fastdds/rtps/common/Locator.hpp>
+#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp>
 #include <fastdds/utils/IPFinder.hpp>
 
 #include "BlackboxTests.hpp"
@@ -168,6 +169,106 @@ TEST_P(NetworkConfig, sub_unique_network_flows)
         participant.get_native_reader(1).get_listening_locators(locators2);
 
         EXPECT_TRUE(locators == locators2);
+    }
+}
+
+// Regression test for redmine issue #22519 to check that readers using unique network flows cannot share locators
+// with other readers. The mentioned issue referred to the case where TCP + builtin transports are present.
+// In that concrete scenario, the problem was that while the TCP (and UDP) transports rightly were able
+// to create a receiver in the dedicated "unique flow" port, shared memory failed for that same port as the other
+// process (or participant) is already listening on it. However this was not being handled properly, so once matched,
+// the publisher attempts to send data to the wrongfully announced shared memory locator.
+// Note that the underlying problem is that, when creating unique network flows, all transports are requested to
+// create a receiver for a specific port all together. This is, the creation of unique flow receivers is only
+// considered to fail when it fails for all transports, instead of decoupling them and keep trying for alternative
+// ports when the creation of a specific transport receiver fails.
+// In this test a similar scenario is presented, but using instead UDP and shared memory transports. In the first
+// participant, only shared memory is used (which should create a SHM receiver in the first "unique" port attempted).
+// In the second participant both UDP and shared memory are used (which should create a UDP receiver in the first
+// "unique" port attempted, and a shared memory receiver in the second "unique" port attempted, as the first one is
+// already being used by the first participant). As a result, the listening shared memory locators of each data
+// reader should be different. Finally, a third data reader is created in the second participant, and it is verified
+// that its listening locators are different from those of the other reader created in the same participant, as well as
+// from the (SHM) one of the reader created in the first participant.
+TEST_P(NetworkConfig, sub_unique_network_flows_multiple_locators)
+{
+    // Enable unique network flows feature
+    PropertyPolicy properties;
+    properties.properties().emplace_back("fastdds.unique_network_flows", "");
+
+    // First participant
+    PubSubParticipant<HelloWorldPubSubType> participant(0, 1, 0, 0);
+
+    participant.sub_topic_name(TEST_TOPIC_NAME).sub_property_policy(properties);
+
+    std::shared_ptr<SharedMemTransportDescriptor> shm_descriptor = std::make_shared<SharedMemTransportDescriptor>();
+    // Use only SHM transport in the first participant
+    participant.disable_builtin_transport().add_user_transport_to_pparams(shm_descriptor);
+
+    ASSERT_TRUE(participant.init_participant());
+    ASSERT_TRUE(participant.init_subscriber(0));
+
+    LocatorList_t locators;
+
+    participant.get_native_reader(0).get_listening_locators(locators);
+    ASSERT_EQ(locators.size(), 1u);
+    ASSERT_EQ((*locators.begin()).kind, LOCATOR_KIND_SHM);
+
+    // Second participant
+    PubSubParticipant<HelloWorldPubSubType> participant2(0, 2, 0, 0);
+
+    participant2.sub_topic_name(TEST_TOPIC_NAME).sub_property_policy(properties);
+
+    // Use both UDP and SHM in the second participant
+    if (!use_udpv4)
+    {
+        participant2.disable_builtin_transport().add_user_transport_to_pparams(descriptor_).
+                add_user_transport_to_pparams(shm_descriptor);
+    }
+
+    ASSERT_TRUE(participant2.init_participant());
+    ASSERT_TRUE(participant2.init_subscriber(0));
+
+    LocatorList_t locators2_1;
+
+    participant2.get_native_reader(0).get_listening_locators(locators2_1);
+    ASSERT_TRUE(locators2_1.size() >= 2u); // There should be at least two locators, one for SHM and N(#interfaces) for UDP
+
+    // Check SHM locator is different from the one in the first participant
+    for (const Locator_t& loc : locators2_1)
+    {
+        if (LOCATOR_KIND_SHM == loc.kind)
+        {
+            // Ports should be different (expected second and first values of the unique network flows port range)
+            ASSERT_FALSE(loc == *locators.begin());
+        }
+    }
+
+    // Now create a second reader in the second participant
+    ASSERT_TRUE(participant2.init_subscriber(1));
+
+    LocatorList_t locators2_2;
+
+    participant2.get_native_reader(1).get_listening_locators(locators2_2);
+    ASSERT_TRUE(locators2_2.size() >= 2u); // There should be at least two locators, one for SHM and N(#interfaces) for UDP
+
+    // Check SHM locator is different from the one in the first participant
+    for (const Locator_t& loc : locators2_2)
+    {
+        if (LOCATOR_KIND_SHM == loc.kind)
+        {
+            // Ports should be different (expected third and first values of the unique network flows port range)
+            ASSERT_FALSE(loc == *locators.begin());
+        }
+    }
+
+    // Now check no locators are shared between the two readers in the second participant
+    for (const Locator_t& loc_1 : locators2_1)
+    {
+        for (const Locator_t& loc_2 : locators2_2)
+        {
+            ASSERT_FALSE(loc_1 == loc_2);
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This is a follow-up of https://github.com/eProsima/Fast-DDS/pull/5461, attempting to solve https://github.com/ros2/ros2/issues/1617.

In that concrete scenario (where builtin + TCP transports are used in clients), the problem is that while the TCP (and UDP) transports are rightly able to create a receiver in the dedicated "unique flow" port, shared memory fails for that same port as the other process is already listening on it. However this was not being handled properly, so once matched, the publisher attempts to send data to the wrongfully announced shared memory locator.

Note that the underlying problem is that, when creating unique network flows, all transports are requested to create a receiver for a specific port all together. This is, the creation of unique flow receivers is only considered to fail when it fails for all transports, instead of decoupling them and keep trying for alternative ports when the creation of a specific transport receiver fails. The present PR fixes this behavior.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
