### PR TITLE
[22657] Fix log category name macro collision in `MacOS` 

### DIFF
--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -363,7 +363,7 @@ ReturnCode_t DomainParticipantFactory::get_participant_qos_from_xml(
 {
     if (profile_name.empty())
     {
-        EPROSIMA_LOG_ERROR(DOMAIN, "Provided profile name must be non-empty");
+        EPROSIMA_LOG_ERROR(DDS_DOMAIN, "Provided profile name must be non-empty");
         return RETCODE_BAD_PARAMETER;
     }
 
@@ -430,7 +430,7 @@ ReturnCode_t DomainParticipantFactory::get_participant_extended_qos_from_xml(
 {
     if (profile_name.empty())
     {
-        EPROSIMA_LOG_ERROR(DOMAIN, "Provided profile name must be non-empty");
+        EPROSIMA_LOG_ERROR(DDS_DOMAIN, "Provided profile name must be non-empty");
         return RETCODE_BAD_PARAMETER;
     }
 
@@ -511,7 +511,7 @@ ReturnCode_t DomainParticipantFactory::load_XML_profiles_file(
 {
     if (XMLP_ret::XML_ERROR == XMLProfileManager::loadXMLFile(xml_profile_file))
     {
-        EPROSIMA_LOG_ERROR(DOMAIN, "Problem loading XML file '" << xml_profile_file << "'");
+        EPROSIMA_LOG_ERROR(DDS_DOMAIN, "Problem loading XML file '" << xml_profile_file << "'");
         return RETCODE_ERROR;
     }
     return RETCODE_OK;
@@ -523,7 +523,7 @@ ReturnCode_t DomainParticipantFactory::load_XML_profiles_string(
 {
     if (XMLP_ret::XML_ERROR == XMLProfileManager::loadXMLString(data, length))
     {
-        EPROSIMA_LOG_ERROR(DOMAIN, "Problem loading XML string");
+        EPROSIMA_LOG_ERROR(DDS_DOMAIN, "Problem loading XML string");
         return RETCODE_ERROR;
     }
     return RETCODE_OK;
@@ -535,7 +535,7 @@ ReturnCode_t DomainParticipantFactory::check_xml_static_discovery(
     xmlparser::XMLEndpointParser parser;
     if (XMLP_ret::XML_OK != parser.loadXMLFile(xml_file))
     {
-        EPROSIMA_LOG_ERROR(DOMAIN, "Error parsing xml file");
+        EPROSIMA_LOG_ERROR(DDS_DOMAIN, "Error parsing xml file");
         return RETCODE_ERROR;
     }
     return RETCODE_OK;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -510,7 +510,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     // Check the specified discovery protocol: if other than simple it has priority over ros environment variable
     if (att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SIMPLE)
     {
-        EPROSIMA_LOG_INFO(DOMAIN, "Detected non simple discovery protocol attributes."
+        EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Detected non simple discovery protocol attributes."
                 << " Ignoring auto default client-server setup.");
         return nullptr;
     }
@@ -566,7 +566,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
             client_att.userTransports.push_back(std::move(descriptor));
         }
 
-        EPROSIMA_LOG_INFO(DOMAIN, "Detected auto client-server environment variable."
+        EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Detected auto client-server environment variable."
                 << "Trying to create client with the default server setup: "
                 << client_att.builtin.discovery_config.m_DiscoveryServers);
 
@@ -647,13 +647,13 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     if (nullptr != part)
     {
         // Client successfully created
-        EPROSIMA_LOG_INFO(DOMAIN, "Auto default server-client setup. Default client created.");
+        EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Auto default server-client setup. Default client created.");
         part->mp_impl->client_override(true);
         return part;
     }
 
     // Unable to create auto server-client default participants
-    EPROSIMA_LOG_ERROR(DOMAIN, "Auto default server-client setup. Unable to create the client.");
+    EPROSIMA_LOG_ERROR(RTPS_DOMAIN, "Auto default server-client setup. Unable to create the client.");
     return nullptr;
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -1088,6 +1088,7 @@ TEST(DDSBasic, participant_factory_output_log_error_no_macro_collision)
     auto dpf = DomainParticipantFactory::get_shared_instance();
     DomainParticipantQos qos;
     dpf->get_participant_qos_from_xml("", qos, "");
+    Log::Flush();
     ASSERT_GE(n_logs.load(), 1u);
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -1054,7 +1054,6 @@ TEST(DDSBasic, reliable_volatile_writer_secure_builtin_no_potential_deadlock)
 
 TEST(DDSBasic, participant_factory_output_log_error_no_macro_collision)
 {
-#ifdef __APPLE__
     using Log = eprosima::fastdds::dds::Log;
     using LogConsumer = eprosima::fastdds::dds::LogConsumer;
 
@@ -1090,7 +1089,6 @@ TEST(DDSBasic, participant_factory_output_log_error_no_macro_collision)
     DomainParticipantQos qos;
     dpf->get_participant_qos_from_xml("", qos, "");
     ASSERT_GE(n_logs.load(), 1u);
-#endif //__APPLE__
 }
 
 } // namespace dds


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

During MacOs testing in other PR, it was detected that the `DOMAIN` category used in some logs `EPROSIMA_LOG_...(DOMAIN)` collides with a `#define DOMAIN` in `math.h` in the DeveoperTools under `MacOs`.
This PR solves the issue by adding a prefix depending on the domain.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
