### PR TITLE
refs 22648 Acknowledge change if removed in KeepAll mode

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterHistory.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterHistory.cpp
@@ -160,6 +160,8 @@ bool DataWriterHistory::prepare_change(
         if (history_qos_.kind == KEEP_ALL_HISTORY_QOS)
         {
             ret = this->mp_writer->try_remove_change(max_blocking_time, lock);
+            // If change was removed (ret == 1) in KeepAllHistory, it must have been acked
+            is_acked = ret;
         }
         else if (history_qos_.kind == KEEP_LAST_HISTORY_QOS)
         {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1521,6 +1521,8 @@ void StatefulWriter::check_acked_status()
 
         if (min_low_mark >= get_seq_num_min())
         {
+            // get_seq_num_min() returns SequenceNumber_t::unknown() when the history is empty.
+            // Thus, it is set to 2 to indicate that all samples have been removed.
             may_remove_change_ = (get_seq_num_min() == SequenceNumber_t::unknown()) ? 2 : 1;
         }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1521,7 +1521,7 @@ void StatefulWriter::check_acked_status()
 
         if (min_low_mark >= get_seq_num_min())
         {
-            may_remove_change_ = 1;
+            may_remove_change_ = (get_seq_num_min() == SequenceNumber_t::unknown()) ? 2 : 1;
         }
 
         min_readers_low_mark_ = min_low_mark;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -894,10 +894,10 @@ public:
 
     PubSubWriter& reliability(
             const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind,
-            const int max_blocking_time)
+            eprosima::fastdds::dds::Duration_t max_blocking_time)
     {
         datawriter_qos_.reliability().kind = kind;
-        datawriter_qos_.reliability().max_blocking_time.seconds = max_blocking_time;
+        datawriter_qos_.reliability().max_blocking_time = max_blocking_time;
 
         return *this;
     }

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -892,6 +892,16 @@ public:
         return *this;
     }
 
+    PubSubWriter& reliability(
+            const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind,
+            const int max_blocking_time)
+    {
+        datawriter_qos_.reliability().kind = kind;
+        datawriter_qos_.reliability().max_blocking_time.seconds = max_blocking_time;
+
+        return *this;
+    }
+
     PubSubWriter& mem_policy(
             const eprosima::fastdds::rtps::MemoryManagementPolicy mem_policy)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -898,7 +898,6 @@ public:
     {
         datawriter_qos_.reliability().kind = kind;
         datawriter_qos_.reliability().max_blocking_time = max_blocking_time;
-
         return *this;
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -15,6 +15,10 @@
 #include <set>
 #include <thread>
 #include <vector>
+#include <iostream>
+#include <chrono>
+#include <iomanip>
+#include <ctime>
 
 #include <fastdds/dds/core/condition/GuardCondition.hpp>
 #include <fastdds/dds/core/condition/StatusCondition.hpp>
@@ -3443,18 +3447,70 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
  */
 TEST(DDSStatus, reliable_keep_all_unack_sample_removed_call)
 {
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport->drop_data_messages_filter_ = [](eprosima::fastdds::rtps::CDRMessage_t& msg) -> bool
+    {
+        static std::vector<std::pair<eprosima::fastdds::rtps::SequenceNumber_t, std::chrono::steady_clock::time_point>> delayed_messages;
+
+        uint32_t old_pos = msg.pos;
+
+        // Parse writer ID and sequence number
+        msg.pos += 2; // flags
+        msg.pos += 2; // inline QoS
+        msg.pos += 4; // reader ID
+        auto writerID = eprosima::fastdds::helpers::cdr_parse_entity_id((char*)&msg.buffer[msg.pos]);
+        msg.pos += 4;
+        eprosima::fastdds::rtps::SequenceNumber_t sn;
+        sn.high = (int32_t)eprosima::fastdds::helpers::cdr_parse_u32((char*)&msg.buffer[msg.pos]);
+        msg.pos += 4;
+        sn.low = eprosima::fastdds::helpers::cdr_parse_u32((char*)&msg.buffer[msg.pos]);
+
+        // Restore buffer position
+        msg.pos = old_pos;
+
+        // Delay logic for user endpoints only
+        if ((writerID.value[3] & 0xC0) == 0) // only user endpoints
+        {
+            auto now = std::chrono::steady_clock::now();
+            auto it = std::find_if(delayed_messages.begin(), delayed_messages.end(),
+                [&sn](const auto& pair) {
+                    return pair.first == sn;
+                });
+
+            if (it == delayed_messages.end())
+            {
+                // If the sequence number is encountered for the first time, start the delay
+                delayed_messages.emplace_back(sn, now + std::chrono::milliseconds(750)); // Add delay
+                return true; // Start dropping this message
+            }
+            else if (now < it->second)
+            {
+                // If the delay period has not elapsed, keep dropping the message
+                return true;
+            }
+            else
+            {
+                // Once the delay has elapsed, allow the message to proceed
+                delayed_messages.erase(it);
+            }
+        }
+        return false; // Allow message to proceed
+    };
+    
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
 
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .durability_kind(eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS)
+    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, 200)
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
-            .history_depth(1)
+            .resource_limits_max_instances(1)
+            .resource_limits_max_samples(1)
+            .resource_limits_max_samples_per_instance(1)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
             .init();
     ASSERT_TRUE(writer.isInitialized());
 
     reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
-            .durability_kind(eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS)
             .init();
     ASSERT_TRUE(reader.isInitialized());
 
@@ -3462,24 +3518,11 @@ TEST(DDSStatus, reliable_keep_all_unack_sample_removed_call)
     writer.wait_discovery();
     reader.wait_discovery();
 
-    auto data = default_helloworld_data_generator();
-
-    bool firstOneSent = false;
+    auto data = default_helloworld_data_generator(2);
 
     for (auto sample : data)
     {
-        reader.stopReception();
         writer.send_sample(sample);
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        if (firstOneSent)
-        {
-            reader.startReception(data);
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        }
-        else
-        {
-            firstOneSent = true;
-        }
     }
 
     EXPECT_EQ(writer.times_unack_sample_removed(), 0u);

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3437,11 +3437,10 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
 }
 
 /*¡
-* Regression Test for 22648: on_unacknowledged_sample_removed callback is called when best effort writer with keep all
-* history is used, when the history was full but before max_blocking_time a sample was acknowledged, as is_acked was
-* checked before the waiting time, and is not re-checked. This should not happen.
-*/
-
+ * Regression Test for 22648: on_unacknowledged_sample_removed callback is called when best effort writer with keep all
+ * history is used, when the history was full but before max_blocking_time a sample was acknowledged, as is_acked was
+ * checked before the waiting time, and is not re-checked. This should not happen.
+ */
 TEST(DDSStatus, reliable_keep_all_unack_sample_removed_call)
 {
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3502,7 +3502,7 @@ TEST(DDSStatus, reliable_keep_all_unack_sample_removed_call)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
 
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, 200)
+    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, eprosima::fastdds::dds::Duration_t (200, 0))
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_instances(1)
             .resource_limits_max_samples(1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

on_unacknowledged_sample_removed callback is called when best effort writer with keep all history is used, when the history was full but before max_blocking_time a sample was acknowledged, as is_acked was checked before the waiting time, and is not re-checked. This should not happen, as keep all should never drop an unacknowledged sample.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
