### PR TITLE
Feature/mingw compile

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,23 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,26 @@ endif()
 ###############################################################################
 # Tools default setup
 ###############################################################################
-option(COMPILE_TOOLS "Build tools" ON)
+if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} -dumpmachine
+        OUTPUT_VARIABLE COMPILER_MACHINE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(COMPILER_MACHINE MATCHES "mingw")
+        message(STATUS "Using MinGW compiler.")
+        option(COMPILE_TOOLS "Build tools" OFF)
+        add_definitions(-DMINGW_COMPILER=1)
+        set(CMAKE_CXX_FLAGS
+            "${CMAKE_CXX_FLAGS} -Wno-attributes -Wno-stringop-overread -Wno-builtin-macro-redefined -Wno-cast-function-type -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wno-missing-field-initializers")
+        target_link_libraries(fastdds PUBLIC ws2_32 mswsock)
+    else()
+        message(STATUS "Using a GNU compiler on Windows but not MinGW.")
+    endif()
+else()
+    message(STATUS "Not using a GNU compiler on Windows.")
+    option(COMPILE_TOOLS "Build tools" ON)
+endif()
 
 if(EPROSIMA_BUILD)
     set(COMPILE_TOOLS ON)

--- a/include/fastdds/fastdds_dll.hpp
+++ b/include/fastdds/fastdds_dll.hpp
@@ -44,11 +44,19 @@
 
 #if defined(_WIN32)
 #if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTDDS_DYN_LINK)
-#if defined(fastdds_EXPORTS)
-#define FASTDDS_EXPORTED_API __declspec( dllexport )
+#if defined(MINGW_COMPILER)
+    #if defined(fastdds_EXPORTS)
+    #define FASTDDS_EXPORTED_API __declspec( dllexport )
+    #else
+    #define FASTDDS_EXPORTED_API __attribute__((visibility("default")))
+    #endif // FASTDDS_SOURCE
 #else
-#define FASTDDS_EXPORTED_API __declspec( dllimport )
-#endif // FASTDDS_SOURCE
+    #if defined(fastdds_EXPORTS)
+    #define FASTDDS_EXPORTED_API __declspec( dllexport )
+    #else
+    #define FASTDDS_EXPORTED_API __declspec( dllimport )
+    #endif // FASTDDS_SOURCE
+#endif // if defined(MINGW_COMPILER)
 #else
 #define FASTDDS_EXPORTED_API
 #endif // if defined(EPROSIMA_ALL_DYN_LINK) || defined(FASTDDS_DYN_LINK)

--- a/include/fastdds/utils/TimedMutex.hpp
+++ b/include/fastdds/utils/TimedMutex.hpp
@@ -26,6 +26,8 @@
 
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
 #include <mutex>
+#elif defined(MINGW_COMPILER)
+#include <mutex>
 #else
 #include <thread>
 extern int clock_gettime(
@@ -45,6 +47,9 @@ namespace fastdds {
 #if defined(_WIN32)
 
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 193632528
+using TimedMutex = std::timed_mutex;
+using RecursiveTimedMutex = std::recursive_timed_mutex;
+#elif defined(MINGW_COMPILER)
 using TimedMutex = std::timed_mutex;
 using RecursiveTimedMutex = std::recursive_timed_mutex;
 #else

--- a/src/cpp/fastdds/xtypes/serializers/json/dynamic_data_json.cpp
+++ b/src/cpp/fastdds/xtypes/serializers/json/dynamic_data_json.cpp
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include <bitset>
-#include <codecvt>
+#ifndef MINGW_COMPILER
+    #include <codecvt>
+#endif  // ifndef MINGW_COMPILER
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -744,9 +746,20 @@ ReturnCode_t json_serialize_basic_member(
             if (RETCODE_OK == ret)
             {
                 // Insert UTF-8 converted value
+#if defined(MINGW_COMPILER)
+                std::wstring aux_wstring_value({value});
+                std::string utf8_value;
+                int size_needed = std::wcstombs(nullptr, aux_wstring_value.data(), 0);
+                if (size_needed > 0) {
+                    utf8_value.resize(size_needed);
+                    std::wcstombs(&utf8_value[0], aux_wstring_value.data(), size_needed);
+                }
+#else
                 std::wstring aux_wstring_value({value});
                 std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
                 std::string utf8_value = converter.to_bytes(aux_wstring_value);
+
+#endif  // defined(MINGW_COMPILER)              
                 json_insert(member_name, utf8_value, output);
             }
             else
@@ -776,8 +789,17 @@ ReturnCode_t json_serialize_basic_member(
             if (RETCODE_OK == ret)
             {
                 // Insert UTF-8 converted value
+#ifdef MINGW_COMPILER
+                std::string utf8_value;
+                int size_needed = std::wcstombs(nullptr, value.data(), 0);
+                if (size_needed > 0) {
+                    utf8_value.resize(size_needed);
+                    std::wcstombs(&utf8_value[0], value.data(), size_needed);
+                }
+#else
                 std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
                 std::string utf8_value = converter.to_bytes(value);
+#endif  // defined(MINGW_COMPILER)
                 json_insert(member_name, utf8_value, output);
             }
             else

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -155,9 +155,17 @@ fastdds::dds::ReturnCode_t SystemInfo::get_username(
 bool SystemInfo::file_exists(
         const std::string& filename)
 {
+#ifdef _WIN32
+    // modify for mingw
+    DWORD fileAttributes = GetFileAttributesA(filename.c_str());
+    if (fileAttributes == INVALID_FILE_ATTRIBUTES) {
+        return false;
+    }
+    return !(fileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+#else
     struct stat s;
-    // Check existence and that it is a regular file (and not a folder)
     return (stat(filename.c_str(), &s) == 0 && s.st_mode & S_IFREG);
+#endif
 }
 
 bool SystemInfo::wait_for_file_closure(

--- a/src/cpp/utils/TimedConditionVariable.cpp
+++ b/src/cpp/utils/TimedConditionVariable.cpp
@@ -50,9 +50,15 @@
     return 0;
    }
  */
-#define exp7           10000000i64     //1E+7     //C-file part
-#define exp9         1000000000i64     //1E+9
-#define w2ux 116444736000000000i64     //1.jan1601 to 1.jan1970
+#ifdef MINGW_COMPILER
+    #define exp7           10000000LL     //1E+7     //C-file part
+    #define exp9         1000000000LL     //1E+9
+    #define w2ux 116444736000000000LL     //1.jan1601 to 1.jan1970
+#else
+    #define exp7           10000000i64     //1E+7     //C-file part
+    #define exp9         1000000000i64     //1E+9
+    #define w2ux 116444736000000000i64     //1.jan1601 to 1.jan1970
+#endif
 void unix_time(
         struct timespec* spec)
 {

--- a/src/cpp/utils/shared_memory/RobustSharedLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustSharedLock.hpp
@@ -17,6 +17,8 @@
 
 #ifdef  _MSC_VER
 #include <io.h>
+#elif defined(MINGW_COMPILER)
+#include <io.h>
 #else
 #include <sys/file.h>
 #endif // ifdef  _MSC_VER
@@ -205,6 +207,118 @@ private:
 
             // Lock exclusive
             ret = _sopen_s(&fd, file_path.c_str(), _O_WRONLY, _SH_DENYWR, _S_IREAD | _S_IWRITE);
+            if (ret != 0)
+            {
+                lock_status = LockStatus::LOCKED;
+            }
+            else
+            {
+                _close(fd);
+            }
+        }
+        else
+        {
+            lock_status = LockStatus::OPEN_FAILED;
+        }
+
+        if (lock_status == LockStatus::NOT_LOCKED && remove_if_unlocked)
+        {
+            if (0 != std::remove(file_path.c_str()))
+            {
+                EPROSIMA_LOG_WARNING(RTPS_TRANSPORT_SHM, "Failed to remove " << file_path);
+            }
+        }
+
+        return lock_status;
+    }
+
+#elif defined(MINGW_COMPILER)
+    int open_and_lock_file(
+            const std::string& file_path,
+            bool* was_lock_created,
+            bool* was_lock_released)
+    {
+        int test_exist;
+
+        // Try open exclusive
+        auto ret = _sopen_s(&test_exist, file_path.c_str(), _O_WRONLY, 0x0010, _S_IREAD | _S_IWRITE);
+
+        if (ret == 0)
+        {
+            *was_lock_created = false;
+
+            if (was_lock_released)
+            {
+                *was_lock_released = true;
+            }
+
+            _close(test_exist);
+        }
+        else
+        {
+            // Try open shared
+            ret = _sopen_s(&test_exist, file_path.c_str(), _O_RDONLY, 0x0010, _S_IREAD | _S_IWRITE);
+
+            if (ret == 0)
+            {
+                if (was_lock_released)
+                {
+                    *was_lock_released = false;
+                }
+
+                *was_lock_created = false;
+
+                return test_exist;
+            }
+            else
+            {
+                if (was_lock_released)
+                {
+                    *was_lock_released = true;
+                }
+
+                *was_lock_created = true;
+            }
+        }
+
+        int fd;
+        // Open or create shared
+        ret = _sopen_s(&fd, file_path.c_str(), O_CREAT | _O_RDONLY, 0x0010, _S_IREAD | _S_IWRITE);
+
+        if (ret != 0)
+        {
+            char errmsg[1024];
+            strerror_s(errmsg, sizeof(errmsg), errno);
+            throw std::runtime_error("failed to open/create " + file_path + " " + std::string(errmsg));
+        }
+
+        return fd;
+    }
+
+    void unlock_and_close()
+    {
+        _close(fd_);
+
+        test_lock(SharedDir::get_lock_path(name_), true);
+    }
+
+    static LockStatus test_lock(
+            const std::string& file_path,
+            bool remove_if_unlocked = false)
+    {
+        LockStatus lock_status;
+
+        int fd;
+        auto ret = _sopen_s(&fd, file_path.c_str(), _O_RDONLY, 0x0010, _S_IREAD | _S_IWRITE);
+
+        if (ret == 0)
+        {
+            lock_status = LockStatus::NOT_LOCKED;
+
+            _close(fd);
+
+            // Lock exclusive
+            ret = _sopen_s(&fd, file_path.c_str(), _O_WRONLY, 0x0010, _S_IREAD | _S_IWRITE);
             if (ret != 0)
             {
                 lock_status = LockStatus::LOCKED;

--- a/thirdparty/filewatch/FileWatch.hpp
+++ b/thirdparty/filewatch/FileWatch.hpp
@@ -30,7 +30,9 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#define stat _stat
+#ifndef MINGW_COMPILER
+    #define stat _stat  // do not use stat in windows
+#endif  // ifndef MINGW_COMPILER
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -404,7 +406,7 @@ namespace filewatch {
                                 std::ratio_multiply<std::hecto, typename std::chrono::nanoseconds::period>>(
                                     reinterpret_cast<ULARGE_INTEGER*>(&att.ftLastWriteTime)->QuadPart - base_.first.QuadPart);
 
-                    if (bytes_returned == 0 || (current_time == last_write_time_) && current_size == last_size_ ) {
+                    if (bytes_returned == 0 || ((current_time == last_write_time_) && current_size == last_size_ )) {
                         break;
                     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->
Support compilation using MinGW. Version: MSYS2-MinGW-V14.2, x86_64-w64-mingw32.
<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
1. The ‘COMPILE_TOOLS’ compilation option is turned off when compiling with MinGW because there are still some issues that have not been resolved here, but it does not affect the use of the main body of fastdds.
2. The import and export settings in thefastdds_dll.hpp file were changed to adapt to the symbol import and export rules of mingw. Tests found that these changes were effective.
3. The macro definition 'MINGW_COMPILER' has been added in cmakelists.txt to control some code to move towards new branches, which are used to resolve library dependency differences between compilers.
4. Some compile-time warnings that do not affect use have been canceled. 'ws2_32' and 'mswsock' libraries have been manually linked. The above changes are written in cmakelists.txt and will only take effect when the compiler is MinGW.
5. Almost all changes only take effect when the compiler is MinGW. Before compiling Fast-DDS with MinGW, it was best to use MinGW to compile its dependent libraries, such as fastcdr, tinyxml2 and foonathan_memory.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #5575

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
