### PR TITLE
[22658] Reliable volatile change dropped when all history acked 

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1521,6 +1521,8 @@ void StatefulWriter::check_acked_status()
 
         if (min_low_mark >= get_seq_num_min())
         {
+            // get_seq_num_min() returns SequenceNumber_t::unknown() when the history is empty.
+            // Thus, it is set to 2 to indicate that all samples have been removed.
             may_remove_change_ = (get_seq_num_min() == SequenceNumber_t::unknown()) ? 2 : 1;
         }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1521,7 +1521,7 @@ void StatefulWriter::check_acked_status()
 
         if (min_low_mark >= get_seq_num_min())
         {
-            may_remove_change_ = 1;
+            may_remove_change_ = (get_seq_num_min() == SequenceNumber_t::unknown()) ? 2 : 1;
         }
 
         min_readers_low_mark_ = min_low_mark;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -893,7 +893,8 @@ public:
     }
 
     PubSubWriter& reliability(
-            const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind, int max_blocking_time)
+            const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind,
+            int max_blocking_time)
     {
         datawriter_qos_.reliability().kind = kind;
         datawriter_qos_.reliability().max_blocking_time.seconds = max_blocking_time;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -894,10 +894,10 @@ public:
 
     PubSubWriter& reliability(
             const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind,
-            int max_blocking_time)
+            eprosima::fastdds::dds::Duration_t max_blocking_time)
     {
         datawriter_qos_.reliability().kind = kind;
-        datawriter_qos_.reliability().max_blocking_time.seconds = max_blocking_time;
+        datawriter_qos_.reliability().max_blocking_time = max_blocking_time;
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -892,6 +892,14 @@ public:
         return *this;
     }
 
+    PubSubWriter& reliability(
+            const eprosima::fastdds::dds::ReliabilityQosPolicyKind kind, int max_blocking_time)
+    {
+        datawriter_qos_.reliability().kind = kind;
+        datawriter_qos_.reliability().max_blocking_time.seconds = max_blocking_time;
+        return *this;
+    }
+
     PubSubWriter& mem_policy(
             const eprosima::fastdds::rtps::MemoryManagementPolicy mem_policy)
     {

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3437,7 +3437,7 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
 }
 
 /*!
- * Regression Test for 22658: when he entire history is acked in volatile, given that the entries are deleted from the
+ * Regression Test for 22658: when the entire history is acked in volatile, given that the entries are deleted from the
  * history, check_acked_status satisfies min_low_mark >= get_seq_num_min() because seq_num_min is unknown. This makes
  * try_remove to fail, because it tries to remove changes but there were none. This causes prepare_change to not
  * perform the changes, since the history was full and could not delete any changes.
@@ -3448,7 +3448,7 @@ TEST(DDSStatus, entire_history_acked_volatile_unknown_pointer)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
 
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, 200)
+    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, eprosima::fastdds::dds::Duration_t (200, 0))
             .durability_kind(eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS)
             .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
             .resource_limits_max_instances(1)
@@ -3469,6 +3469,9 @@ TEST(DDSStatus, entire_history_acked_volatile_unknown_pointer)
     auto data = default_helloworld_data_generator(2);
     for (auto sample : data)
     {
+        // A value of true means that the sample was sent successfully.
+        // This aligns with the expected behaviour of having the history
+        // acknowledged and emptied before the next message.
         EXPECT_TRUE(writer.send_sample(sample));
     }
 }

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3439,7 +3439,7 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
 /*!
  * Regression Test for 22658: when he entire history is acked in volatile, given that the entries are deleted from the
  * history, check_acked_status satisfies min_low_mark >= get_seq_num_min() because seq_num_min is unknown. This makes
- * try_remove to fail, because it tries to remove changes but there were none. This causes prepare_change to not 
+ * try_remove to fail, because it tries to remove changes but there were none. This causes prepare_change to not
  * perform the changes, since the history was full and could not delete any changes.
  */
 
@@ -3467,7 +3467,6 @@ TEST(DDSStatus, entire_history_acked_volatile_unknown_pointer)
     reader.wait_discovery();
 
     auto data = default_helloworld_data_generator(2);
-    
     for (auto sample : data)
     {
         EXPECT_TRUE(writer.send_sample(sample));

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3437,6 +3437,44 @@ TEST(DDSStatus, keyed_reliable_positive_acks_disabled_on_unack_sample_removed)
 }
 
 /*!
+ * Regression Test for 22658: when he entire history is acked in volatile, given that the entries are deleted from the
+ * history, check_acked_status satisfies min_low_mark >= get_seq_num_min() because seq_num_min is unknown. This makes
+ * try_remove to fail, because it tries to remove changes but there were none. This causes prepare_change to not 
+ * perform the changes, since the history was full and could not delete any changes.
+ */
+
+TEST(DDSStatus, entire_history_acked_volatile_unknown_pointer)
+{
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, 200)
+            .durability_kind(eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS)
+            .history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .resource_limits_max_instances(1)
+            .resource_limits_max_samples(1)
+            .resource_limits_max_samples_per_instance(1)
+            .init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS)
+            .init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_helloworld_data_generator(2);
+    
+    for (auto sample : data)
+    {
+        EXPECT_TRUE(writer.send_sample(sample));
+    }
+}
+
+/*!
  * Test that checks with a writer of each type that having the same listener attached, the notified writer in the
  * callback is the corresponding writer that has removed a sample unacknowledged.
  */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

When the entire history is acked in volatile, given that the entries are deleted from the history, check_acked_status satisfies min_low_mark >= get_seq_num_min() because seq_num_min is unknown. This makes try_remove to fail, because it tries to remove changes but there were none. This causes prepare_change to not perform the changes, since the history was full and could not delete any changes.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
