### PR TITLE
[22721] Increase 'max_blocking_time' in Easy Mode

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -645,8 +645,8 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
         else
         {
             // There is already a profile with the given name. Do not overwrite it
-            EPROSIMA_LOG_WARNING(RTPS_DOMAIN, "A XML profile for 'service' was found. When using ROS2_EASY_MODE, please ensure"
-                    " the max_blocking_time is configured with a higher value than default.");
+            EPROSIMA_LOG_WARNING(RTPS_DOMAIN, "An XML profile for 'service' was found. When using ROS2_EASY_MODE, please ensure"
+                    " the max_blocking_time is configured with a value higher than the default.");
         }
 
         SystemCommandBuilder sys_command;

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -58,6 +58,23 @@ namespace eprosima {
 namespace fastdds {
 namespace rtps {
 
+const char* EASY_MODE_SERVICE_PROFILE =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+        "<dds xmlns=\"http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles\">\n"
+        "    <profiles>\n"
+        "        <data_writer profile_name=\"service\">\n"
+        "            <qos>\n"
+        "                <reliability>\n"
+        "                    <max_blocking_time>\n"
+        "                        <sec>1</sec>\n"
+        "                        <nanosec>0</nanosec>\n"
+        "                    </max_blocking_time>\n"
+        "                </reliability>\n"
+        "            </qos>\n"
+        "        </data_writer>\n"
+        "    </profiles>\n"
+        "</dds>\n";
+
 template<typename _Descriptor>
 bool has_user_transport(
         const RTPSParticipantAttributes& att)
@@ -615,6 +632,22 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
 
         // Point to the well known DS port in the corresponding domain
         client_att.builtin.discovery_config.m_DiscoveryServers.push_back(locator_udp);
+
+        // Load the 'service' profile for ROS2_EASY_MODE services if there is no existing profile yet
+        xmlparser::PublisherAttributes attr;
+        auto ret_if = xmlparser::XMLProfileManager::fillPublisherAttributes("service", attr, false);
+        if (ret_if == xmlparser::XMLP_ret::XML_ERROR)
+        {
+            // An XML_ERROR is returned if there is no existing profile for the given name
+            xmlparser::XMLProfileManager::loadXMLString(EASY_MODE_SERVICE_PROFILE, strlen(EASY_MODE_SERVICE_PROFILE));
+            EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Loaded service profile for ROS2_EASY_MODE servers");
+        }
+        else
+        {
+            // There is already a profile with the given name. Do not overwrite it
+            EPROSIMA_LOG_WARNING(RTPS_DOMAIN, "A XML profile for 'service' was found. When using ROS2_EASY_MODE, please ensure"
+                    " the max_blocking_time is configured with a higher value than default.");
+        }
 
         SystemCommandBuilder sys_command;
         int res = sys_command.executable(FAST_DDS_DEFAULT_CLI_SCRIPT_NAME)

--- a/test/blackbox/common/BlackboxTestsTransportCustom.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportCustom.cpp
@@ -613,7 +613,7 @@ TEST(ChainingTransportTests, builtin_transports_env_large_data)
 }
 
 /**
- * DS Auto transport shall always be used along with ROS_DISCOVERY_SERVER=AUTO.
+ * P2P transport shall always be used along with ROS2_EASY_MODE.
  * This is due to the working principle of the mode. If it is not specified,
  * the background discovery server will not be launched and the test will never
  * finish since both clients will keep waiting for it.

--- a/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
@@ -58,7 +58,7 @@ TEST(DSEasyMode, easy_discovery_mode_env_correctly_launches)
     PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
 
-    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Setting ROS2_EASY_MODE
     // Configures as SUPER_CLIENT SHM and TCP
     set_easy_discovery_mode_env();
 
@@ -136,8 +136,7 @@ TEST(DSEasyMode, easy_discovery_mode_env_correct_transports_are_used)
 
     ASSERT_TRUE(writer_udp.isInitialized());
 
-    // Setting ROS_DISCOVERY_SERVER to AUTO
-    // Configures as SUPER_CLIENT SHM and TCP
+    // Setting ROS2_EASY_MODE configures as SUPER_CLIENT SHM and TCP
     set_easy_discovery_mode_env();
 
     std::atomic<bool> locators_match_p2p_transport(true);
@@ -226,7 +225,7 @@ TEST(DSEasyMode, easy_discovery_mode_env_discovery_info)
         ASSERT_TRUE(writers.back()->isInitialized());
     }
 
-    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Setting ROS2_EASY_MODE
     // Configures as SUPER_CLIENT SHM and TCP
     set_easy_discovery_mode_env();
 
@@ -266,7 +265,7 @@ TEST(DSEasyMode, easy_discovery_mode_env_multiple_clients_multiple_domains)
     std::vector<std::shared_ptr<PubSubWriter<HelloWorldPubSubType>>> writers;
     std::vector<std::shared_ptr<PubSubReader<HelloWorldPubSubType>>> readers;
 
-    // Setting ROS_DISCOVERY_SERVER to AUTO
+    // Setting ROS2_EASY_MODE
     // Configures as SUPER_CLIENT SHM and TCP
     set_easy_discovery_mode_env();
 

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -16,6 +16,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_profile.xml
     ${CMAKE_CURRENT_BINARY_DIR}/test_xml_profile.xml
     COPYONLY)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_service_easy_mode.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/test_xml_service_easy_mode.xml
+    COPYONLY)
+
 set(PARTICIPANTTESTS_SOURCE
         ParticipantTests.cpp
     )

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -83,9 +83,11 @@
 
 void stop_background_servers()
 {
+#ifndef _WIN32 // The feature is not supported on Windows yet
     // Stop server(s)
     int res = std::system("fastdds discovery stop");
     ASSERT_EQ(res, 0);
+#endif // _WIN32
 }
 
 namespace eprosima {
@@ -1528,7 +1530,7 @@ TEST(ParticipantTests, EasyModeParticipantLoadsServiceDataWriterQos)
         DataWriterQos dw_qos;
         EXPECT_EQ(easy_mode_publisher->get_datawriter_qos_from_profile("service", dw_qos), RETCODE_OK);
         EXPECT_EQ(dw_qos.reliability().max_blocking_time.seconds, 1);         // Easy Mode value
-        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0);         // Easy Mode value
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0u);        // Easy Mode value
         EXPECT_EQ(dw_qos.durability().kind, TRANSIENT_LOCAL_DURABILITY_QOS);  // Default value
 
         EXPECT_EQ(RETCODE_OK, participant->delete_publisher(easy_mode_publisher));
@@ -1554,9 +1556,9 @@ TEST(ParticipantTests, EasyModeParticipantDoNotOverwriteCustomDataWriterQos)
                 RETCODE_OK);
         DataWriterQos dw_qos;
         easy_mode_publisher->get_datawriter_qos_from_profile("service", dw_qos);
-        EXPECT_EQ(dw_qos.reliability().max_blocking_time.seconds, 5);  // XML value
-        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0);  // XML value
-        EXPECT_EQ(dw_qos.durability().kind, VOLATILE_DURABILITY_QOS);  // XML value
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.seconds, 5);   // XML value
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0u);  // XML value
+        EXPECT_EQ(dw_qos.durability().kind, VOLATILE_DURABILITY_QOS);   // XML value
 
         EXPECT_EQ(RETCODE_OK, participant->delete_publisher(easy_mode_publisher));
         EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -81,6 +81,12 @@
 #define GET_PID getpid
 #endif // if defined(_WIN32)
 
+void stop_background_servers()
+{
+    // Stop server(s)
+    int res = std::system("fastdds discovery stop");
+    ASSERT_EQ(res, 0);
+}
 
 namespace eprosima {
 namespace fastdds {
@@ -1077,6 +1083,17 @@ void set_environment_variable(
 #endif // _WIN32
 }
 
+void set_easy_mode_environment_variable(
+        const std::string ip = "127.0.0.1"
+        )
+{
+#ifdef _WIN32
+    ASSERT_EQ(0, _putenv_s(rtps::EASY_MODE_URI, ip.c_str()));
+#else
+    ASSERT_EQ(0, setenv(rtps::EASY_MODE_URI, ip.c_str(), 1));
+#endif // _WIN32
+}
+
 void set_environment_file(
         const std::string& filename)
 {
@@ -1481,6 +1498,91 @@ TEST(ParticipantTests, ServerParticipantRemoteServerListConfiguration)
     DomainParticipantQos result_qos = participant->get_qos();
     EXPECT_EQ(RETCODE_OK, participant->set_qos(result_qos));
     EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+}
+
+TEST(ParticipantTests, EasyModeParticipantLoadsServiceDataWriterQos)
+{
+    // Use get_publisher_qos_from_profile to check if the profile is correctly loaded.
+    // But we cannot check the actual value of the max_blocking_time from qos because it belongs to the PublisherAttributes
+    {
+        // Default participant
+        DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
+            (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+        ASSERT_NE(nullptr, participant);
+        Publisher* default_publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+        ASSERT_NE(default_publisher, nullptr);
+        PublisherQos profile_qos;
+        EXPECT_EQ(default_publisher->get_participant()->get_publisher_qos_from_profile("service", profile_qos),
+                RETCODE_BAD_PARAMETER);
+
+        EXPECT_EQ(RETCODE_OK, participant->delete_publisher(default_publisher));
+        EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+    }
+
+    {
+        // Easy mode participant
+        set_easy_mode_environment_variable();
+        DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
+            (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+        ASSERT_NE(nullptr, participant);
+        Publisher* easy_mode_publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+        ASSERT_NE(easy_mode_publisher, nullptr);
+        PublisherQos profile_qos;
+        EXPECT_EQ(easy_mode_publisher->get_participant()->get_publisher_qos_from_profile("service", profile_qos),
+                RETCODE_OK);
+        TypeSupport type(new TopicDataTypeMock());
+        type.register_type(participant, "footype");
+        Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);
+        ASSERT_NE(nullptr, topic);
+        DataWriter* data_writer = easy_mode_publisher->create_datawriter_with_profile(topic, "service");
+        ASSERT_NE(nullptr, data_writer);
+        DataWriterQos dw_qos;
+        EXPECT_EQ(data_writer->get_qos(dw_qos), RETCODE_OK);
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.seconds, 1);
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0);
+        EXPECT_EQ(dw_qos.durability().kind, TRANSIENT_LOCAL_DURABILITY_QOS);  // Default value
+
+        EXPECT_EQ(RETCODE_OK, easy_mode_publisher->delete_datawriter(data_writer));
+        EXPECT_EQ(RETCODE_OK, participant->delete_topic(topic));
+        EXPECT_EQ(RETCODE_OK, participant->delete_publisher(easy_mode_publisher));
+        EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+        stop_background_servers();
+    }
+}
+
+TEST(ParticipantTests, EasyModeParticipantDoNotOverwriteCustomDataWriterQos)
+{
+    {
+        // Easy mode participant with existing profile
+        // set XML profile as environment variable: "export FASTDDS_DEFAULT_PROFILES_FILE=test_xml_service_easy_mode.xml"
+        eprosima::testing::set_environment_variable("FASTDDS_DEFAULT_PROFILES_FILE", "test_xml_service_easy_mode.xml");
+        set_easy_mode_environment_variable();
+        DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
+            (uint32_t)GET_PID() % 230, PARTICIPANT_QOS_DEFAULT);
+        ASSERT_NE(nullptr, participant);
+        Publisher* easy_mode_publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+        ASSERT_NE(easy_mode_publisher, nullptr);
+        PublisherQos profile_qos;
+        EXPECT_EQ(easy_mode_publisher->get_participant()->get_publisher_qos_from_profile("service", profile_qos),
+                RETCODE_OK);
+        TypeSupport type(new TopicDataTypeMock());
+        type.register_type(participant, "footype");
+        Topic* topic = participant->create_topic("footopic", "footype", TOPIC_QOS_DEFAULT);
+        ASSERT_NE(nullptr, topic);
+        DataWriter* data_writer = easy_mode_publisher->create_datawriter_with_profile(topic, "service");
+        ASSERT_NE(nullptr, data_writer);
+        DataWriterQos dw_qos;
+        EXPECT_EQ(data_writer->get_qos(dw_qos), RETCODE_OK);
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.seconds, 5);
+        EXPECT_EQ(dw_qos.reliability().max_blocking_time.nanosec, 0);
+        EXPECT_EQ(dw_qos.durability().kind, VOLATILE_DURABILITY_QOS);  // XML value
+
+        EXPECT_EQ(RETCODE_OK, easy_mode_publisher->delete_datawriter(data_writer));
+        EXPECT_EQ(RETCODE_OK, participant->delete_topic(topic));
+        EXPECT_EQ(RETCODE_OK, participant->delete_publisher(easy_mode_publisher));
+        EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+        stop_background_servers();
+    }
 }
 
 /**

--- a/test/unittest/dds/profiles/test_xml_service_easy_mode.xml
+++ b/test/unittest/dds/profiles/test_xml_service_easy_mode.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+        <data_writer profile_name="service">
+            <qos>
+                <reliability>
+                    <max_blocking_time>
+                        <sec>5</sec>
+                        <nanosec>0</nanosec>
+                    </max_blocking_time>
+                </reliability>
+                <durability>
+                    <kind>VOLATILE</kind>
+                </durability>
+            </qos>
+        </data_writer>
+    </profiles>
+</dds>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Adding a Discovery Server as central discovery point might introduce small delays in discovery in resource limited CPUs. When using services in ROS2, this might cause some of the server's responses to fail due to timeout. However, the `max_blocking_time` can be automatically increased for services in Easy Mode.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - https://github.com/eProsima/Fast-DDS-docs/pull/1024
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
