### PR TITLE
[22722] Support interfaces for RPC generated code

### DIFF
--- a/include/fastdds/dds/rpc/exceptions.hpp
+++ b/include/fastdds/dds/rpc/exceptions.hpp
@@ -1,0 +1,27 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file exceptions.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC__EXCEPTIONS_HPP
+#define FASTDDS_DDS_RPC__EXCEPTIONS_HPP
+
+#include <fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp>
+
+#endif  // FASTDDS_DDS_RPC__EXCEPTIONS_HPP

--- a/include/fastdds/dds/rpc/exceptions.hpp
+++ b/include/fastdds/dds/rpc/exceptions.hpp
@@ -21,6 +21,7 @@
 
 #include <fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcInputFeedCancelledException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp>
 

--- a/include/fastdds/dds/rpc/exceptions.hpp
+++ b/include/fastdds/dds/rpc/exceptions.hpp
@@ -21,7 +21,7 @@
 
 #include <fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcException.hpp>
-#include <fastdds/dds/rpc/exceptions/RpcInputFeedCancelledException.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcOperationError.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp>
 

--- a/include/fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp
@@ -1,0 +1,71 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcBrokenPipeException.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCBROKENPIPEEXCEPTION_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCBROKENPIPEEXCEPTION_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the communication with the remote endpoint breaks.
+ */
+class FASTDDS_EXPORTED_API RpcBrokenPipeException : public RpcException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RpcBrokenPipeException(
+            bool local_is_server)
+        : RpcException(local_is_server ? "Communication lost with the client" : "Communication lost with the server")
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcBrokenPipeException(
+            const RpcBrokenPipeException& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcBrokenPipeException& operator =(
+            const RpcBrokenPipeException& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcBrokenPipeException() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCBROKENPIPEEXCEPTION_HPP

--- a/include/fastdds/dds/rpc/exceptions/RpcException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcException.hpp
@@ -32,7 +32,7 @@ namespace rpc {
 /**
  * Base class for all exceptions thrown by the RPC API.
  */
-class FASTDDS_EXPORTED_API RpcException : public std::logic_error
+class FASTDDS_EXPORTED_API RpcException
 {
 
 public:
@@ -44,7 +44,7 @@ public:
      */
     explicit RpcException(
             const std::string& message)
-        : std::logic_error(message)
+        : logic_error_(message)
     {
     }
 
@@ -55,7 +55,7 @@ public:
      */
     explicit RpcException(
             const char* message)
-        : std::logic_error(message)
+        : logic_error_(message)
     {
     }
 
@@ -75,6 +75,18 @@ public:
      * Destructor.
      */
     virtual ~RpcException() noexcept = default;
+
+    /**
+     * Returns the explanatory string.
+     */
+    const char* what() const noexcept
+    {
+        return logic_error_.what();
+    }
+
+private:
+
+    std::logic_error logic_error_;
 
 };
 

--- a/include/fastdds/dds/rpc/exceptions/RpcException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcException.hpp
@@ -1,0 +1,86 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcException.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCEXCEPTION_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCEXCEPTION_HPP
+
+#include <stdexcept>
+#include <string>
+
+#include <fastdds/fastdds_dll.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Base class for all exceptions thrown by the RPC API.
+ */
+class FASTDDS_EXPORTED_API RpcException : public std::logic_error
+{
+
+public:
+
+    /**
+     * Constructor.
+     *
+     * @param message The exception message.
+     */
+    explicit RpcException(
+            const std::string& message)
+        : std::logic_error(message)
+    {
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message The exception message.
+     */
+    explicit RpcException(
+            const char* message)
+        : std::logic_error(message)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcException(
+            const RpcException& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcException& operator =(
+            const RpcException& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcException() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCEXCEPTION_HPP

--- a/include/fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @file RpcInputFeedCancelledException.hpp
+ * @file RpcFeedCancelledException.hpp
  */
 
 #ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCINPUTFEEDCANCELLEDEXCEPTION_HPP
@@ -33,7 +33,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the client cancels an input feed.
  */
-class FASTDDS_EXPORTED_API RpcInputFeedCancelledException : public RpcException
+class FASTDDS_EXPORTED_API RpcFeedCancelledException : public RpcException
 {
 
 public:
@@ -41,7 +41,7 @@ public:
     /**
      * Constructor.
      */
-    RpcInputFeedCancelledException(
+    RpcFeedCancelledException(
             RpcStatusCode reason)
         : RpcException("Input feed cancelled with reason '" + std::to_string(reason) + "'")
     {
@@ -50,19 +50,19 @@ public:
     /**
      * Copy constructor.
      */
-    RpcInputFeedCancelledException(
-            const RpcInputFeedCancelledException& other) noexcept = default;
+    RpcFeedCancelledException(
+            const RpcFeedCancelledException& other) noexcept = default;
 
     /**
      * Copy assignment.
      */
-    RpcInputFeedCancelledException& operator =(
-            const RpcInputFeedCancelledException& other) noexcept = default;
+    RpcFeedCancelledException& operator =(
+            const RpcFeedCancelledException& other) noexcept = default;
 
     /**
      * Destructor.
      */
-    virtual ~RpcInputFeedCancelledException() noexcept = default;
+    virtual ~RpcFeedCancelledException() noexcept = default;
 
 };
 

--- a/include/fastdds/dds/rpc/exceptions/RpcInputFeedCancelledException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcInputFeedCancelledException.hpp
@@ -1,0 +1,74 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcInputFeedCancelledException.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCINPUTFEEDCANCELLEDEXCEPTION_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCINPUTFEEDCANCELLEDEXCEPTION_HPP
+
+#include <string>
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the client cancels an input feed.
+ */
+class FASTDDS_EXPORTED_API RpcInputFeedCancelledException : public RpcException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RpcInputFeedCancelledException(
+            RpcStatusCode reason)
+        : RpcException("Input feed cancelled with reason '" + std::to_string(reason) + "'")
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcInputFeedCancelledException(
+            const RpcInputFeedCancelledException& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcInputFeedCancelledException& operator =(
+            const RpcInputFeedCancelledException& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcInputFeedCancelledException() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCINPUTFEEDCANCELLEDEXCEPTION_HPP

--- a/include/fastdds/dds/rpc/exceptions/RpcOperationError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcOperationError.hpp
@@ -1,0 +1,82 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcOperationError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCOPERATIONERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCOPERATIONERROR_HPP
+
+#include <string>
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Base class for exceptions thrown by the RPC API when the server communicates an error.
+ */
+class FASTDDS_EXPORTED_API RpcOperationError : public RpcException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RpcOperationError(
+            const std::string& message)
+        : RpcException(message)
+    {
+    }
+
+    /**
+     * Constructor.
+     */
+    RpcOperationError(
+            const char* message)
+        : RpcException(message)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcOperationError(
+            const RpcOperationError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcOperationError& operator =(
+            const RpcOperationError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcOperationError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCOPERATIONERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp
@@ -1,0 +1,70 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcTimeoutException.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCTIMEOUTEXCEPTION_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCTIMEOUTEXCEPTION_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when an operation times out.
+ */
+class FASTDDS_EXPORTED_API RpcTimeoutException : public RpcException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RpcTimeoutException()
+        : RpcException("The RPC operation timed out")
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcTimeoutException(
+            const RpcTimeoutException& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcTimeoutException& operator =(
+            const RpcTimeoutException& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcTimeoutException() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCTIMEOUTEXCEPTION_HPP

--- a/include/fastdds/dds/rpc/interfaces.hpp
+++ b/include/fastdds/dds/rpc/interfaces.hpp
@@ -1,0 +1,29 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file interfaces.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC__INTERFACES_HPP
+#define FASTDDS_DDS_RPC__INTERFACES_HPP
+
+#include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcServerReader.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcServerWriter.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
+
+#endif  // FASTDDS_DDS_RPC__INTERFACES_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
@@ -1,0 +1,92 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcClientReader.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTREADER_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTREADER_HPP
+
+#include <fastdds/dds/core/Time_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * An interface for a client-side RPC reader.
+ *
+ * Would be used to read replies from a server on an operation with a `@feed` annotated return type.
+ */
+template <typename T>
+class RpcClientReader
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcClientReader() = default;
+
+    /**
+     * Blocking read operation.
+     *
+     * Will block until a reply is available or the replies feed has finished.
+     *
+     * @param value The value to read the reply into.
+     *
+     * @return True if a reply was read, false if the feed has finished.
+     *
+     * @throw RpcOperationError if the server communicates an error.
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     */
+    virtual bool read(
+            T& value) = 0;
+
+    /**
+     * Blocking read operation with timeout.
+     *
+     * Will block until a reply is available, the replies feed has finished, or the timeout expires.
+     *
+     * @param value The value to read the reply into.
+     *
+     * @return True if a reply was read, false if the feed has finished.
+     *
+     * @throw RpcOperationError if the server communicates an error.
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     * @throw RpcTimeoutException if the timeout expires.
+     */
+    virtual bool read(
+            T& value,
+            const eprosima::fastdds::dds::Duration_t& timeout) = 0;
+
+    /**
+     * Cancel the replies feed.
+     *
+     * Will tell the server to stop sending replies, and block until the server acknowledges the cancellation.
+     * The replies feed would then be finished locally, so all pending read operations will return false.
+     *
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     */
+    virtual void cancel() = 0;
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTREADER_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
@@ -48,7 +48,7 @@ public:
      *
      * @param value The value to read the reply into.
      *
-     * @return True if a reply was read, false if the feed has finished.
+     * @return True if a reply was read, false if the feed has finished or has been cancelled.
      *
      * @throw RpcOperationError if the server communicates an error.
      * @throw RpcBrokenPipeException if the communication with the server breaks.
@@ -63,7 +63,7 @@ public:
      *
      * @param value The value to read the reply into.
      *
-     * @return True if a reply was read, false if the feed has finished.
+     * @return True if a reply was read, false if the feed has finished or has been cancelled.
      *
      * @throw RpcOperationError if the server communicates an error.
      * @throw RpcBrokenPipeException if the communication with the server breaks.

--- a/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientReader.hpp
@@ -62,6 +62,7 @@ public:
      * Will block until a reply is available, the replies feed has finished, or the timeout expires.
      *
      * @param value The value to read the reply into.
+     * @param timeout The maximum time to wait for a reply.
      *
      * @return True if a reply was read, false if the feed has finished or has been cancelled.
      *

--- a/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
@@ -1,0 +1,93 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcClientWriter.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTWRITER_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTWRITER_HPP
+
+#include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * An interface for a client-side RPC writer.
+ *
+ * Would be used to write inputs from a client on an operation with `@feed` annotated inputs.
+ */
+template <typename T>
+class RpcClientWriter
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcClientWriter() noexcept = default;
+
+    /**
+     * Copy write operation.
+     *
+     * Will add a value to the input feed, that would be eventually sent to the server.
+     * May block depending on the configured queue sizes in both the client and the server.
+     *
+     * @param value The value to write to the input feed.
+     *
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     */
+    virtual void write(
+            const T& value) = 0;
+
+    /**
+     * Move write operation.
+     *
+     * Will add a value to the input feed, that would be eventually sent to the server.
+     * May block depending on the configured queue sizes in both the client and the server.
+     *
+     * @param value The value to write to the input feed.
+     *
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     */
+    virtual void write(
+            T&& value) = 0;
+
+    /**
+     * Marks the end of the input feed.
+     *
+     * Will indicate to the server that no more inputs will be sent.
+     * May block depending on the configured queue sizes in both the client and the server.
+     *
+     * @param reason The status code to indicate the reason for finishing the feed.
+     *
+     * @throw RpcBrokenPipeException if the communication with the server breaks.
+     * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     */
+    virtual void finish(
+            RpcStatusCode reason = RPC_STATUS_CODE_OK) = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCCLIENTWRITER_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
@@ -51,6 +51,7 @@ public:
      *
      * @throw RpcBrokenPipeException if the communication with the server breaks.
      * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     * @throw RpcOperationError if the server communicates an error.
      */
     virtual void write(
             const T& value) = 0;
@@ -65,6 +66,7 @@ public:
      *
      * @throw RpcBrokenPipeException if the communication with the server breaks.
      * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     * @throw RpcOperationError if the server communicates an error.
      */
     virtual void write(
             T&& value) = 0;

--- a/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcClientWriter.hpp
@@ -73,6 +73,9 @@ public:
      * Marks the end of the input feed.
      *
      * Will indicate to the server that no more inputs will be sent.
+     * Specifying a reason different from `RPC_STATUS_CODE_OK` will indicate that the feed was finished due to an
+     * error, and that the client will not be expecting a reply.
+     *
      * May block depending on the configured queue sizes in both the client and the server.
      *
      * @param reason The status code to indicate the reason for finishing the feed.

--- a/include/fastdds/dds/rpc/interfaces/RpcFuture.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcFuture.hpp
@@ -1,0 +1,37 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcFuture.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCFUTURE_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCFUTURE_HPP
+
+#include <future>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+template <typename T>
+using RpcFuture = std::future<T>;
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCFUTURE_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
@@ -1,0 +1,81 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcServerReader.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCSERVERREADER_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCSERVERREADER_HPP
+
+#include <fastdds/dds/core/Time_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * An interface for a server-side RPC reader.
+ *
+ * Would be used to read inputs from a client on an operation with `@feed` annotated inputs.
+ */
+template <typename T>
+class RpcServerReader
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcServerReader() noexcept = default;
+
+    /**
+     * Blocking read operation.
+     *
+     * Will block until an input is available or the input feed has finished.
+     *
+     * @param value The value to read the input into.
+     *
+     * @return True if a value was read, false if the feed has finished.
+     *
+     * @throw RpcBrokenPipeException if the communication with the client breaks.
+     */
+    virtual bool read(
+            T& value) = 0;
+
+    /**
+     * Blocking read operation with timeout.
+     *
+     * Will block until an input is available, the input feed has finished, or the timeout expires.
+     *
+     * @param value The value to read the input into.
+     *
+     * @return True if a value was read, false if the feed has finished.
+     *
+     * @throw RpcTimeoutException if the timeout expires.
+     * @throw RpcBrokenPipeException if the communication with the client breaks.
+     */
+    virtual bool read(
+            T& value,
+            const eprosima::fastdds::dds::Duration_t& timeout) = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCSERVERREADER_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
@@ -51,7 +51,7 @@ public:
      * @return True if a value was read, false if the feed has finished.
      *
      * @throw RpcBrokenPipeException if the communication with the client breaks.
-     * @throw RpcInputFeedCancelledException if the client cancels the input feed.
+     * @throw RpcFeedCancelledException if the client cancels the input feed.
      */
     virtual bool read(
             T& value) = 0;
@@ -67,7 +67,7 @@ public:
      *
      * @throw RpcTimeoutException if the timeout expires.
      * @throw RpcBrokenPipeException if the communication with the client breaks.
-     * @throw RpcInputFeedCancelledException if the client cancels the input feed.
+     * @throw RpcFeedCancelledException if the client cancels the input feed.
      */
     virtual bool read(
             T& value,

--- a/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
@@ -62,6 +62,7 @@ public:
      * Will block until an input is available, the input feed has finished, or the timeout expires.
      *
      * @param value The value to read the input into.
+     * @param timeout The maximum time to wait for an input.
      *
      * @return True if a value was read, false if the feed has finished.
      *

--- a/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerReader.hpp
@@ -51,6 +51,7 @@ public:
      * @return True if a value was read, false if the feed has finished.
      *
      * @throw RpcBrokenPipeException if the communication with the client breaks.
+     * @throw RpcInputFeedCancelledException if the client cancels the input feed.
      */
     virtual bool read(
             T& value) = 0;
@@ -66,6 +67,7 @@ public:
      *
      * @throw RpcTimeoutException if the timeout expires.
      * @throw RpcBrokenPipeException if the communication with the client breaks.
+     * @throw RpcInputFeedCancelledException if the client cancels the input feed.
      */
     virtual bool read(
             T& value,

--- a/include/fastdds/dds/rpc/interfaces/RpcServerWriter.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerWriter.hpp
@@ -49,6 +49,7 @@ public:
      *
      * @throw RpcBrokenPipeException if the communication with the client breaks.
      * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     * @throw RpcFeedCancelledException if the client cancels the output feed.
      */
     virtual void write(
             const T& value) = 0;
@@ -63,6 +64,7 @@ public:
      *
      * @throw RpcBrokenPipeException if the communication with the client breaks.
      * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     * @throw RpcFeedCancelledException if the client cancels the output feed.
      */
     virtual void write(
             T&& value) = 0;

--- a/include/fastdds/dds/rpc/interfaces/RpcServerWriter.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerWriter.hpp
@@ -1,0 +1,77 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcServerWriter.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCSERVERWRITER_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCSERVERWRITER_HPP
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * An interface for a server-side RPC writer.
+ *
+ * Would be used to write replies from a server on an operation with a `@feed` annotated return type.
+ */
+template <typename T>
+class RpcServerWriter
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcServerWriter() noexcept = default;
+
+    /**
+     * Copy write operation.
+     *
+     * Will add a value to the replies feed, that would be eventually sent to the client.
+     * May block depending on the configured queue sizes in both the client and the server.
+     *
+     * @param value The value to write to the replies feed.
+     *
+     * @throw RpcBrokenPipeException if the communication with the client breaks.
+     * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     */
+    virtual void write(
+            const T& value) = 0;
+
+    /**
+     * Move write operation.
+     *
+     * Will add a value to the replies feed, that would be eventually sent to the client.
+     * May block depending on the configured queue sizes in both the client and the server.
+     *
+     * @param value The value to write to the replies feed.
+     *
+     * @throw RpcBrokenPipeException if the communication with the client breaks.
+     * @throw RpcTimeoutException if the operation needs to block for a time longer than the configured timeout.
+     */
+    virtual void write(
+            T&& value) = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCSERVERWRITER_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcStatusCode.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcStatusCode.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcStatusCode.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCSTATUSCODE_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCSTATUSCODE_HPP
+
+#include <cstdint>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Status codes for RPC operations.
+ */
+using RpcStatusCode = uint32_t;
+
+/**
+ * Status code for successful operations.
+ */
+constexpr RpcStatusCode RPC_STATUS_OK = 0;
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCSTATUSCODE_HPP


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds the generic interfaces that the code generated by Fast DDS Gen for RPC interfaces will use.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 3.0.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
