### PR TITLE
Fix for DDS Examples: Configurability

### DIFF
--- a/examples/cpp/dds/Configurability/ConfigurabilityPublisher.cpp
+++ b/examples/cpp/dds/Configurability/ConfigurabilityPublisher.cpp
@@ -345,7 +345,7 @@ int main()
         return 1;
     }
 
-    int no_keys = 1;
+    int no_keys = (int)user_configuration.no_keys;
     sample my_sample;
 
     std::string c;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

In the example: In `examples/cpp/ddds/Configurability/ConfigurabilityPublisher.cpp`, I found that the variable  `no_keys` has not been assigned a valid value and defaults to only 1, which will cause the following loop to only process once. According to the example code, multiple loops need to be executed based on the input  `user_configuration.no_keys`.

![image](https://github.com/user-attachments/assets/053c481a-257e-45a5-91f9-b567a488f725)

After modification, subscribers can receive additional data:

pub:
![img_v3_02ja_2241eb25-81ed-4955-b325-9f477e2bfb5g](https://github.com/user-attachments/assets/77a0e4bf-df24-4b73-ae83-9403f326d6f0)
sub:
![knfyZHO8Os](https://github.com/user-attachments/assets/50511555-fc52-411f-a84b-fd8a2e714f1c)



<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->


@Mergifyio backport 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [_N/A_] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ _N/A_] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [_N/A_ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [_N/A_ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [_N/A_ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [_N/A_ ] New feature has been added to the `versions.md` file (if applicable).
- [ _N/A_] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ _N/A_] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
