### PR TITLE
[22710] Filter interested readers on PDP writer (backport #5604)

### DIFF
--- a/include/fastdds/rtps/writer/StatelessWriter.h
+++ b/include/fastdds/rtps/writer/StatelessWriter.h
@@ -76,6 +76,12 @@ protected:
             WriterHistory* hist,
             WriterListener* listen = nullptr);
 
+    mutable LocatorList_t fixed_locators_;
+
+    virtual bool send_to_fixed_locators(
+            CDRMessage_t* message,
+            std::chrono::steady_clock::time_point& max_blocking_time_point) const;
+
 public:
 
     virtual ~StatelessWriter();
@@ -159,10 +165,11 @@ public:
         //FOR NOW THERE IS NOTHING TO UPDATE.
     }
 
+    //! Deprecated in favor of PDP simple writer
     bool set_fixed_locators(
             const LocatorList_t& locator_list);
 
-    //!Reset the unsent changes.
+    //! Deprecated in favor of PDP simple writer
     void unsent_changes_reset();
 
     /**
@@ -272,7 +279,6 @@ private:
 
 
     bool is_inline_qos_expected_ = false;
-    LocatorList_t fixed_locators_;
     ResourceLimitedVector<std::unique_ptr<ReaderLocator>> matched_remote_readers_;
 
     std::condition_variable_any unsent_changes_cond_;

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -195,6 +195,7 @@ set(${PROJECT_NAME}_source_files
     rtps/builtin/discovery/participant/PDP.cpp
     rtps/builtin/discovery/participant/ServerAttributes.cpp
     rtps/builtin/discovery/participant/PDPSimple.cpp
+    rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
     rtps/builtin/discovery/participant/PDPListener.cpp
     rtps/builtin/discovery/endpoint/EDP.cpp
     rtps/builtin/discovery/endpoint/EDPSimple.cpp

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -285,7 +285,7 @@ void PDPSimple::announceParticipantState(
 
         if (!(dispose || new_change))
         {
-            endpoints->writer.writer_->unsent_changes_reset();
+            endpoints->writer.writer_->send_periodic_announcement();
         }
     }
 }
@@ -399,7 +399,7 @@ bool PDPSimple::create_dcps_participant_endpoints()
     if (mp_RTPSParticipant->createWriter(&rtps_writer, watt, writer.payload_pool_, writer.history_.get(),
             nullptr, writer_entity_id, true))
     {
-        writer.writer_ = dynamic_cast<StatelessWriter*>(rtps_writer);
+        writer.writer_ = dynamic_cast<PDPStatelessWriter*>(rtps_writer);
         assert(nullptr != writer.writer_);
 
 #if HAVE_SECURITY
@@ -451,7 +451,7 @@ bool PDPSimple::create_dcps_participant_endpoints()
                 EPROSIMA_LOG_WARNING(RTPS_PDP, "Ignoring initial peers locator " << loc << " : not allowed.");
             }
         }
-        writer.writer_->set_fixed_locators(fixed_locators);
+        writer.writer_->set_initial_peers(fixed_locators);
     }
     else
     {
@@ -720,11 +720,6 @@ void PDPSimple::match_pdp_remote_endpoints(
 #endif // HAVE_SECURITY
         {
             writer->matched_reader_add(*temp_reader_data);
-        }
-
-        if (!writer_only && (BEST_EFFORT_RELIABILITY_QOS == reliability_kind))
-        {
-            endpoints->writer.writer_->unsent_changes_reset();
         }
     }
 }

--- a/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
@@ -1,0 +1,179 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PDPStatelessWriter.cpp
+ */
+
+#include <rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <set>
+#include <vector>
+
+#include <fastrtps/rtps/history/WriterHistory.h>
+#include <rtps/participant/RTPSParticipantImpl.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+PDPStatelessWriter::PDPStatelessWriter(
+        RTPSParticipantImpl* participant,
+        const GUID_t& guid,
+        const WriterAttributes& attributes,
+        fastdds::rtps::FlowController* flow_controller,
+        WriterHistory* history,
+        WriterListener* listener)
+    : StatelessWriter(participant, guid, attributes, flow_controller, history, listener)
+    , interested_readers_(participant->getRTPSParticipantAttributes().allocation.participants)
+{
+}
+
+bool PDPStatelessWriter::matched_reader_add(
+        const ReaderProxyData& data)
+{
+    bool ret = StatelessWriter::matched_reader_add(data);
+    if (ret)
+    {
+        // Mark new reader as interested
+        add_interested_reader(data.guid());
+        // Send announcement to new reader
+        reschedule_all_samples();
+    }
+    return ret;
+}
+
+bool PDPStatelessWriter::matched_reader_remove(
+        const GUID_t& reader_guid)
+{
+    bool ret = StatelessWriter::matched_reader_remove(reader_guid);
+    if (ret)
+    {
+        // Mark reader as not interested
+        remove_interested_reader(reader_guid);
+    }
+    return ret;
+}
+
+void PDPStatelessWriter::unsent_change_added_to_history(
+        CacheChange_t* change,
+        const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
+{
+    mark_all_readers_interested();
+    StatelessWriter::unsent_change_added_to_history(change, max_blocking_time);
+}
+
+void PDPStatelessWriter::set_initial_peers(
+        const fastdds::rtps::LocatorList& locator_list)
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+
+    initial_peers_.push_back(locator_list);
+    mp_RTPSParticipant->createSenderResources(initial_peers_);
+}
+
+void PDPStatelessWriter::send_periodic_announcement()
+{
+    mark_all_readers_interested();
+    reschedule_all_samples();
+}
+
+bool PDPStatelessWriter::send_to_fixed_locators(
+        CDRMessage_t* message,
+        std::chrono::steady_clock::time_point& max_blocking_time_point) const
+{
+    bool ret = true;
+
+    if (should_reach_all_destinations_)
+    {
+        ret = initial_peers_.empty() ||
+                mp_RTPSParticipant->sendSync(message, m_guid,
+                        Locators(initial_peers_.begin()), Locators(initial_peers_.end()),
+                        max_blocking_time_point);
+
+        if (ret)
+        {
+            fixed_locators_.clear();
+            should_reach_all_destinations_ = false;
+        }
+    }
+    else
+    {
+        interested_readers_.clear();
+    }
+
+    return ret;
+}
+
+bool PDPStatelessWriter::is_relevant(
+        const CacheChange_t& /* change */,
+        const GUID_t& reader_guid) const
+{
+    return interested_readers_.end() !=
+           std::find(interested_readers_.begin(), interested_readers_.end(), reader_guid);
+}
+
+void PDPStatelessWriter::mark_all_readers_interested()
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    should_reach_all_destinations_ = true;
+    interested_readers_.clear();
+    fixed_locators_.clear();
+    fixed_locators_.push_back(initial_peers_);
+    reader_data_filter(nullptr);
+}
+
+void PDPStatelessWriter::add_interested_reader(
+        const GUID_t& reader_guid)
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    if (!should_reach_all_destinations_)
+    {
+        auto it = std::find(interested_readers_.begin(), interested_readers_.end(), reader_guid);
+        if (it == interested_readers_.end())
+        {
+            interested_readers_.emplace_back(reader_guid);
+            reader_data_filter(this);
+        }
+    }
+}
+
+void PDPStatelessWriter::remove_interested_reader(
+        const GUID_t& reader_guid)
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    interested_readers_.remove(reader_guid);
+}
+
+void PDPStatelessWriter::reschedule_all_samples()
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    size_t n_samples = mp_history->getHistorySize();
+    if (0 < n_samples)
+    {
+        assert(1 == n_samples);
+        auto it = mp_history->changesBegin();
+        CacheChange_t* change = *it;
+        flow_controller_->add_new_sample(this, change, std::chrono::steady_clock::now() + std::chrono::hours(24));
+    }
+}
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima

--- a/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp
@@ -1,0 +1,151 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file PDPStatelessWriter.hpp
+ */
+
+#ifndef FASTDDS_RTPS_BUILTIN_DISCOVERY_PARTICIPANT_SIMPLE__PDPSTATELESSWRITER_HPP
+#define FASTDDS_RTPS_BUILTIN_DISCOVERY_PARTICIPANT_SIMPLE__PDPSTATELESSWRITER_HPP
+
+#include <chrono>
+
+// #include <fastdds/rtps/common/LocatorList.hpp>
+#include <fastdds/rtps/interfaces/IReaderDataFilter.hpp>
+#include <fastrtps/utils/collections/ResourceLimitedVector.hpp>
+
+#include <fastdds/rtps/writer/StatelessWriter.h>
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+/**
+ * Class PDPStatelessWriter, specialization of StatelessWriter with specific behavior for PDP.
+ */
+class PDPStatelessWriter : public StatelessWriter, private fastdds::rtps::IReaderDataFilter
+{
+
+public:
+
+    PDPStatelessWriter(
+            RTPSParticipantImpl* participant,
+            const GUID_t& guid,
+            const WriterAttributes& attributes,
+            fastdds::rtps::FlowController* flow_controller,
+            WriterHistory* history,
+            WriterListener* listener);
+
+    virtual ~PDPStatelessWriter() = default;
+
+    //vvvvvvvvvvvvvvvvvvvvv [RTPSWriter API] vvvvvvvvvvvvvvvvvvvvv
+
+    bool matched_reader_add(
+            const ReaderProxyData& data) final;
+
+    bool matched_reader_remove(
+            const GUID_t& reader_guid) final;
+
+    void unsent_change_added_to_history(
+            CacheChange_t* change,
+            const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time) final;
+
+    //^^^^^^^^^^^^^^^^^^^^^^ [RTPSWriter API] ^^^^^^^^^^^^^^^^^^^^^^^
+
+    /**
+     * @brief Set the locators to which the writer should send periodic announcements.
+     *
+     * This method is used to configure the initial peers list on the PDP writer.
+     *
+     * @param locator_list List of locators to which the writer should send periodic announcements.
+     *
+     * @return true if the locators were set successfully.
+     */
+    void set_initial_peers(
+            const fastdds::rtps::LocatorList& locator_list);
+
+    /**
+     * Reset the unsent changes.
+     */
+    void send_periodic_announcement();
+
+protected:
+
+    bool send_to_fixed_locators(
+            CDRMessage_t* message,
+            std::chrono::steady_clock::time_point& max_blocking_time_point) const override;
+
+private:
+
+    /**
+     * This method checks whether a CacheChange_t is relevant for the specified reader
+     * This callback should return always the same result given the same arguments
+     * @param change The CacheChange_t to be evaluated
+     * @param reader_guid remote reader GUID_t
+     * @return true if relevant, false otherwise.
+     */
+    bool is_relevant(
+            const CacheChange_t& change,
+            const GUID_t& reader_guid) const final;
+
+    /**
+     * @brief Mark all readers as interested.
+     *
+     * This method sets the flag indicating that all readers are interested in the data sent by this writer.
+     * It is used to ensure that all readers are considered when sending data.
+     * The flag will be reset when all the samples from this writer have been sent.
+     */
+    void mark_all_readers_interested();
+
+    /**
+     * @brief Mark an interested reader.
+     *
+     * Add the guid of a reader to the list of interested readers.
+     *
+     * @param reader_guid The GUID of the reader to mark as interested.
+     */
+    void add_interested_reader(
+            const GUID_t& reader_guid);
+
+    /**
+     * @brief Unmark an interested reader.
+     *
+     * Remove the guid of a reader from the list of interested readers.
+     *
+     * @param reader_guid The GUID of the reader to mark as interested.
+     */
+    void remove_interested_reader(
+            const GUID_t& reader_guid);
+
+    /**
+     * @brief Add all samples from this writer to the flow controller.
+     */
+    void reschedule_all_samples();
+
+    //! Configured initial peers
+    fastdds::rtps::LocatorList initial_peers_{};
+    
+    //! The set of readers interested
+    mutable ResourceLimitedVector<GUID_t> interested_readers_;
+    //! Whether we have set that all destinations are interested
+    mutable bool should_reach_all_destinations_ = false;
+
+};
+
+} // namespace rtps
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // FASTDDS_RTPS_BUILTIN_DISCOVERY_PARTICIPANT_SIMPLE__PDPSTATELESSWRITER_HPP
+

--- a/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp
@@ -135,7 +135,7 @@ private:
 
     //! Configured initial peers
     fastdds::rtps::LocatorList initial_peers_{};
-    
+
     //! The set of readers interested
     mutable ResourceLimitedVector<GUID_t> interested_readers_;
     //! Whether we have set that all destinations are interested

--- a/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpoints.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/SimplePDPEndpoints.hpp
@@ -23,11 +23,11 @@
 
 #include <fastdds/rtps/builtin/data/BuiltinEndpoints.hpp>
 #include <fastdds/rtps/reader/StatelessReader.h>
-#include <fastdds/rtps/writer/StatelessWriter.h>
 
 #include <rtps/builtin/BuiltinReader.hpp>
 #include <rtps/builtin/BuiltinWriter.hpp>
 #include <rtps/builtin/discovery/participant/PDPEndpoints.hpp>
+#include <rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp>
 #include <rtps/history/ITopicPayloadPool.h>
 
 namespace eprosima {
@@ -86,7 +86,7 @@ struct SimplePDPEndpoints : public PDPEndpoints
     BuiltinReader<fastrtps::rtps::StatelessReader> reader;
 
     //! Builtin Simple PDP writer
-    BuiltinWriter<fastrtps::rtps::StatelessWriter> writer;
+    BuiltinWriter<fastrtps::rtps::PDPStatelessWriter> writer;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -32,6 +32,7 @@
 #include <fastdds/rtps/builtin/discovery/endpoint/EDP.h>
 #include <fastdds/rtps/builtin/discovery/participant/PDP.h>
 #include <fastdds/rtps/builtin/discovery/participant/PDPSimple.h>
+#include <rtps/builtin/discovery/participant/simple/PDPStatelessWriter.hpp>
 #include <fastdds/rtps/builtin/liveliness/WLP.h>
 #include <fastdds/rtps/common/EntityId_t.hpp>
 #include <fastdds/rtps/history/WriterHistory.h>
@@ -1405,7 +1406,7 @@ bool RTPSParticipantImpl::createWriter(
         return false;
     }
 
-    auto callback = [hist, listen, &payload_pool, this]
+    auto callback = [hist, listen, entityId, &payload_pool, this]
                 (const GUID_t& guid, WriterAttributes& param, fastdds::rtps::FlowController* flow_controller,
                     IPersistenceService* persistence, bool is_reliable) -> RTPSWriter*
             {
@@ -1424,7 +1425,12 @@ bool RTPSParticipantImpl::createWriter(
                 }
                 else
                 {
-                    if (persistence != nullptr)
+                    if (entityId == c_EntityId_SPDPWriter)
+                    {
+                        return new PDPStatelessWriter(this, guid, param, flow_controller,
+                                        hist, listen);
+                    }
+                    else if (persistence != nullptr)
                     {
                         return new StatelessPersistentWriter(this, guid, param, payload_pool, flow_controller,
                                        hist, listen, persistence);

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -147,7 +147,8 @@ static void set_builtin_transports_from_env_var(
                         "LARGE_DATA", BuiltinTransports::LARGE_DATA,
                         "LARGE_DATAv6", BuiltinTransports::LARGE_DATAv6))
                 {
-                    EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Wrong value '" << env_value << "' for environment variable '" <<
+                    EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT,
+                            "Wrong value '" << env_value << "' for environment variable '" <<
                             env_var_name << "'. Leaving as DEFAULT");
                 }
                 // Max_msg_size parser
@@ -486,7 +487,8 @@ RTPSParticipantImpl::RTPSParticipantImpl(
                     {
                         EPROSIMA_LOG_INFO(RTPS_PARTICIPANT,
                                 "Participant " << m_att.getName() << " with GUID " << m_guid <<
-                                " tries to create a TCP client for discovery server without providing a proper listening port." <<
+                                " tries to create a TCP client for discovery server without providing a proper listening port."
+                                               <<
                                 " No TCP participants will be able to connect to this participant, but it will be able make connections.");
                     }
                     for (fastdds::rtps::RemoteServerAttributes& it : m_att.builtin.discovery_config.m_DiscoveryServers)
@@ -1428,7 +1430,7 @@ bool RTPSParticipantImpl::createWriter(
                     if (entityId == c_EntityId_SPDPWriter)
                     {
                         return new PDPStatelessWriter(this, guid, param, flow_controller,
-                                        hist, listen);
+                                       hist, listen);
                     }
                     else if (persistence != nullptr)
                     {
@@ -3027,7 +3029,8 @@ void RTPSParticipantImpl::environment_file_has_changed()
     }
     else
     {
-        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK, "Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP " <<
+        EPROSIMA_LOG_WARNING(RTPS_QOS_CHECK,
+                "Trying to add Discovery Servers to a participant which is not a SERVER, BACKUP " <<
                 "or an overriden CLIENT (SIMPLE participant transformed into CLIENT with the environment variable)");
     }
 }

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -565,6 +565,17 @@ bool StatelessWriter::matched_reader_add(
                                                         << " as remote reader");
     }
 
+    // Create sender resources for the case when we send to a single reader
+    locator_selector_.locator_selector.reset(false);
+    locator_selector_.locator_selector.enable(data.guid());
+    mp_RTPSParticipant->network_factory().select_locators(locator_selector_.locator_selector);
+    RTPSParticipantImpl* part = mp_RTPSParticipant;
+    locator_selector_.locator_selector.for_each([part](const Locator_t& loc)
+            {
+                part->createSenderResources(loc);
+            });
+
+    // Create sender resources for the case when we send to all readers
     update_reader_info(true);
 
     if (nullptr != mp_listener)
@@ -590,20 +601,7 @@ bool StatelessWriter::matched_reader_add(
 bool StatelessWriter::set_fixed_locators(
         const LocatorList_t& locator_list)
 {
-#if HAVE_SECURITY
-    if (getAttributes().security_attributes().is_submessage_protected ||
-            getAttributes().security_attributes().is_payload_protected)
-    {
-        EPROSIMA_LOG_ERROR(RTPS_WRITER, "A secure besteffort writer cannot add a lonely locator");
-        return false;
-    }
-#endif // if HAVE_SECURITY
-
-    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-
-    fixed_locators_.push_back(locator_list);
-    mp_RTPSParticipant->createSenderResources(fixed_locators_);
-
+    (void)locator_list;
     return true;
 }
 
@@ -700,12 +698,6 @@ bool StatelessWriter::matched_reader_is_matched(
 
 void StatelessWriter::unsent_changes_reset()
 {
-    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
-    std::for_each(mp_history->changesBegin(), mp_history->changesEnd(), [&](CacheChange_t* change)
-            {
-                flow_controller_->add_new_sample(this, change,
-                std::chrono::steady_clock::now() + std::chrono::hours(24));
-            });
 }
 
 bool StatelessWriter::send_nts(
@@ -718,6 +710,13 @@ bool StatelessWriter::send_nts(
         return false;
     }
 
+    return send_to_fixed_locators(message, max_blocking_time_point);
+}
+
+bool StatelessWriter::send_to_fixed_locators(
+        CDRMessage_t* message,
+        std::chrono::steady_clock::time_point& max_blocking_time_point) const
+{
     return fixed_locators_.empty() ||
            mp_RTPSParticipant->sendSync(message, m_guid,
                    Locators(fixed_locators_.begin()), Locators(fixed_locators_.end()),

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -671,6 +671,13 @@ public:
         return *this;
     }
 
+    PubSubParticipant& wire_protocol_builtin(
+            const eprosima::fastrtps::rtps::BuiltinAttributes& wire_protocol_builtin)
+    {
+        participant_qos_.wire_protocol().builtin = wire_protocol_builtin;
+        return *this;
+    }
+
     bool update_wire_protocol(
             const eprosima::fastdds::dds::WireProtocolConfigQos& wire_protocol)
     {

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -39,6 +39,7 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 #include "PubSubWriterReader.hpp"
+#include "PubSubParticipant.hpp"
 
 using namespace eprosima::fastrtps;
 using namespace eprosima::fastrtps::rtps;
@@ -1326,9 +1327,8 @@ TEST_P(Discovery, AsymmeticIgnoreParticipantFlags)
     // This will hold the multicast port. Since the test is not always run in the same domain, we'll need to set
     // its value when the first multicast datagram is sent.
     std::atomic<uint32_t> multicast_port{ 0 };
-    // Only two multicast datagrams are allowed: the initial DATA(p) and the DATA(p) sent in response of the discovery
-    // of p1.
-    constexpr uint32_t allowed_messages_on_port = 2;
+    // Only one multicast datagram is allowed: the initial DATA(p)
+    constexpr uint32_t allowed_messages_on_port = 1;
 
     auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
 
@@ -1362,6 +1362,115 @@ TEST_P(Discovery, AsymmeticIgnoreParticipantFlags)
 
     // Check expectation on the number of multicast datagrams sent by p2
     EXPECT_EQ(messages_on_port, allowed_messages_on_port);
+}
+
+//! Regression test for redmine issue 22506
+TEST_P(Discovery, single_unicast_pdp_response)
+{
+    // Leverage intraprocess so transport is only used for participant discovery
+    if (INTRAPROCESS != GetParam())
+    {
+        GTEST_SKIP() << "Only makes sense on INTRAPROCESS";
+        return;
+    }
+
+    using namespace eprosima::fastdds::rtps;
+
+    // All participants would restrict communication to UDP localhost.
+    // The main participant should send a single initial announcement, and have a big announcement period.
+    // This is to ensure that we only check the datagrams sent in response to the participant discovery,
+    // and not the ones sent in the periodic announcements.
+    // The main participant will use the test transport to count the number of unicast messages sent.
+
+    // This will hold the multicast port. Since the test is not always run in the same domain, we'll need to set
+    // its value when the first multicast datagram is sent.
+    std::atomic<uint32_t> multicast_port{ 0 };
+    // Declare a test transport that will count the number of unicast messages sent
+    std::atomic<size_t> num_unicast_sends{ 0 };
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport->interfaceWhiteList.push_back("127.0.0.1");
+    test_transport->locator_filter_ = [&num_unicast_sends, &multicast_port](
+        const Locator& destination)
+            {
+                if (IPLocator::isMulticast(destination))
+                {
+                    uint32_t port = 0;
+                    multicast_port.compare_exchange_strong(port, destination.port);
+                }
+                else
+                {
+                    num_unicast_sends.fetch_add(1u, std::memory_order_seq_cst);
+                }
+
+                // Do not discard any message
+                return false;
+            };
+
+    // Create the main participant
+    auto main_participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+    eprosima::fastdds::dds::WireProtocolConfigQos main_wire_protocol;
+    main_wire_protocol.builtin.avoid_builtin_multicast = true;
+    main_wire_protocol.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    main_wire_protocol.builtin.discovery_config.leaseDuration_announcementperiod = { 3600, 0 };
+    main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
+    main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000 };
+
+    // The main participant will use the test transport and a specific announcments configuration
+    main_participant->disable_builtin_transport().add_user_transport_to_pparams(test_transport)
+            .wire_protocol(main_wire_protocol);
+
+    // Start the main participant
+    ASSERT_TRUE(main_participant->init_participant());
+
+    // Wait for the initial announcements to be sent
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // This would have set the multicast port
+    EXPECT_NE(multicast_port, 0u);
+
+    // The rest of the participants only send announcements to the main participant
+    // Calculate the metatraffic unicast port of the main participant
+    uint32_t port = multicast_port + main_wire_protocol.port.offsetd1 - main_wire_protocol.port.offsetd0;
+
+    // The rest of the participants only send announcements to the main participant
+    auto udp_localhost_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    udp_localhost_transport->interfaceWhiteList.push_back("127.0.0.1");
+    Locator peer_locator;
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "127.0.0.1", port, peer_locator);
+    eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol;
+    wire_protocol.builtin.avoid_builtin_multicast = true;
+    wire_protocol.builtin.initialPeersList.push_back(peer_locator);
+
+    std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> participants;
+    for (size_t i = 0; i < 5; ++i)
+    {
+        auto participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+        // All participants use the same transport
+        participant->disable_builtin_transport().add_user_transport_to_pparams(udp_localhost_transport)
+                .wire_protocol(wire_protocol);
+        participants.push_back(participant);
+    }
+
+    // Start the rest of the participants
+    for (auto& participant : participants)
+    {
+        ASSERT_TRUE(participant->init_participant());
+        participant->wait_discovery();
+    }
+
+    // Destroy main participant
+    main_participant.reset();
+    for (auto& participant : participants)
+    {
+        participant->wait_discovery(std::chrono::seconds::zero(), 0, true);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Check that only two unicast messages per participant were sent
+    EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst),
+            participants.size() + participants.size());
+
+    // Clean up
+    participants.clear();
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1417,7 +1417,7 @@ TEST_P(Discovery, single_unicast_pdp_response)
 
     // The main participant will use the test transport and a specific announcments configuration
     main_participant->disable_builtin_transport().add_user_transport_to_pparams(test_transport)
-            .wire_protocol(main_wire_protocol);
+            .wire_protocol_builtin(main_wire_protocol.builtin);
 
     // Start the main participant
     ASSERT_TRUE(main_participant->init_participant());
@@ -1446,7 +1446,7 @@ TEST_P(Discovery, single_unicast_pdp_response)
         auto participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
         // All participants use the same transport
         participant->disable_builtin_transport().add_user_transport_to_pparams(udp_localhost_transport)
-                .wire_protocol(wire_protocol);
+                .wire_protocol_builtin(wire_protocol.builtin);
         participants.push_back(participant);
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -428,7 +428,7 @@ TEST_P(DDSStatus, IncompatibleQosGetters)
             .deactivate_status_listener(eprosima::fastdds::dds::StatusMask::requested_incompatible_qos()).init();
     ASSERT_TRUE(compatible_reader.isInitialized());
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(std::chrono::seconds(3));
 
     EXPECT_FALSE(writer.is_matched());
     EXPECT_FALSE(incompatible_reliability_reader.is_matched());

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -119,6 +119,7 @@ public:
     void setup()
     {
         DomainParticipantQos pqos;
+        pqos.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod = { 0, 250000000 };
         pqos.name() = "Monitor_Service_Participant";
         auto participant = DomainParticipantFactory::get_instance()->
                         create_participant((uint32_t)GET_PID() % 230, pqos);

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -127,6 +127,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -200,6 +200,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp
@@ -402,6 +403,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/ServerAttributes.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DSClientEvent.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/builtin/discovery/participant/timedevent/DServerEvent.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Manual backport ABI compatible from: #5604  

This fixes a high CPU and network usage situation with PDP simple discovery when a new participant is created in a network where there is a high number of existing participants.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.10x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _NA_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _NA_ New feature has been added to the `versions.md` file (if applicable).
- _NA_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
