### PR TITLE
[22849] Refactor builtin endpoints creation

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -560,12 +560,14 @@ bool TypeLookupManager::create_endpoints()
 
     WriterAttributes watt = PDP::static_create_builtin_writer_attributes(participant_);
     rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
+    watt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
     watt.endpoint.topicKind = fastdds::rtps::NO_KEY;
     watt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
     watt.mode = fastdds::rtps::ASYNCHRONOUS_WRITER;
 
     ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(participant_);
     rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
+    ratt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
     ratt.expects_inline_qos = true;
     ratt.endpoint.topicKind = fastdds::rtps::NO_KEY;
     ratt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -37,6 +37,7 @@
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
+#include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/participant/RTPSParticipantImpl.hpp>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/RTPSDomainImpl.hpp>
@@ -557,15 +558,9 @@ bool TypeLookupManager::create_endpoints()
     hatt.maximumReservedCaches = 1000;
     hatt.payloadMaxSize = TypeLookupManager::typelookup_data_max_size;
 
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = builtin_protocols_->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = builtin_protocols_->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = builtin_protocols_->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
-    watt.matched_readers_allocation = pattr.allocation.participants;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(participant_);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
     watt.endpoint.topicKind = fastdds::rtps::NO_KEY;
-    watt.endpoint.reliabilityKind = fastdds::rtps::RELIABLE;
     watt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
     watt.mode = fastdds::rtps::ASYNCHRONOUS_WRITER;
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -564,16 +564,10 @@ bool TypeLookupManager::create_endpoints()
     watt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
     watt.mode = fastdds::rtps::ASYNCHRONOUS_WRITER;
 
-    ReaderAttributes ratt;
-    ratt.endpoint.unicastLocatorList = builtin_protocols_->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = builtin_protocols_->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = builtin_protocols_->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
-    ratt.matched_writers_allocation = pattr.allocation.participants;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(participant_);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
     ratt.expects_inline_qos = true;
     ratt.endpoint.topicKind = fastdds::rtps::NO_KEY;
-    ratt.endpoint.reliabilityKind = fastdds::rtps::RELIABLE;
     ratt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
 
     // Built-in request writer

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1620,7 +1620,7 @@ void set_builtin_endpoint_locators(
         const ParticipantProxyData* part_data,
         const BuiltinAttributes& builtin_attr,
         const BuiltinProtocols* builtin_protocol)
-{    
+{
     if (nullptr == part_data)
     {
         // Local participant data has not yet been created.
@@ -1648,7 +1648,8 @@ void set_builtin_endpoint_locators(
     endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
 }
 
-ReaderAttributes PDP::static_create_builtin_reader_attributes(const RTPSParticipantImpl* RTPSParticipant)
+ReaderAttributes PDP::static_create_builtin_reader_attributes(
+        const RTPSParticipantImpl* RTPSParticipant)
 {
     ReaderAttributes attributes;
 
@@ -1673,13 +1674,15 @@ ReaderAttributes PDP::static_create_builtin_reader_attributes(const RTPSParticip
 ReaderAttributes PDP::create_builtin_reader_attributes()
 {
     ReaderAttributes attributes = static_create_builtin_reader_attributes(getRTPSParticipant());
-    
-    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(), this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
+
+    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(),
+            this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
 
     return attributes;
 }
 
-WriterAttributes PDP::static_create_builtin_writer_attributes(const RTPSParticipantImpl* RTPSParticipant)
+WriterAttributes PDP::static_create_builtin_writer_attributes(
+        const RTPSParticipantImpl* RTPSParticipant)
 {
     WriterAttributes attributes;
 
@@ -1692,7 +1695,7 @@ WriterAttributes PDP::static_create_builtin_writer_attributes(const RTPSParticip
     attributes.endpoint.topicKind = WITH_KEY;
 
     attributes.endpoint.endpointKind = WRITER;
-    
+
     // We assume that if we have at least one flow controller defined, we use async flow controller
     if (!pattr.flow_controllers.empty())
     {
@@ -1710,7 +1713,8 @@ WriterAttributes PDP::create_builtin_writer_attributes()
 {
     WriterAttributes attributes = static_create_builtin_writer_attributes(getRTPSParticipant());
 
-    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(), this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
+    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(),
+            this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
 
     return attributes;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1660,8 +1660,12 @@ ReaderAttributes PDP::static_create_builtin_reader_attributes(const RTPSParticip
     attributes.endpoint.durabilityKind = TRANSIENT_LOCAL;
     attributes.endpoint.topicKind = WITH_KEY;
 
+    attributes.endpoint.endpointKind = READER;
+
     // Built-in readers never expect inline qos
     attributes.expects_inline_qos = false;
+
+    attributes.times.heartbeat_response_delay = pdp_heartbeat_response_delay;
 
     return attributes;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1614,20 +1614,19 @@ static void set_builtin_matched_allocation(
     }
 }
 
-static void set_builtin_endpoint_locators(
+void set_builtin_endpoint_locators(
         EndpointAttributes& endpoint,
-        const PDP* pdp,
-        const BuiltinProtocols* builtin)
-{
-    const RTPSParticipantAttributes& pattr = pdp->getRTPSParticipant()->get_attributes();
-
-    auto part_data = pdp->getLocalParticipantProxyData();
+        const RTPSParticipantAttributes& pattr,
+        const ParticipantProxyData* part_data,
+        const BuiltinAttributes& builtin_attr,
+        const BuiltinProtocols* builtin_protocol)
+{    
     if (nullptr == part_data)
     {
         // Local participant data has not yet been created.
         // This means we are creating the PDP endpoints, so we copy the locators from mp_builtin
-        endpoint.multicastLocatorList = builtin->m_metatrafficMulticastLocatorList;
-        endpoint.unicastLocatorList = builtin->m_metatrafficUnicastLocatorList;
+        endpoint.multicastLocatorList = builtin_protocol->m_metatrafficMulticastLocatorList;
+        endpoint.unicastLocatorList = builtin_protocol->m_metatrafficUnicastLocatorList;
     }
     else
     {
@@ -1645,17 +1644,16 @@ static void set_builtin_endpoint_locators(
     }
 
     // External locators are always taken from the same place
-    endpoint.external_unicast_locators = pdp->builtin_attributes().metatraffic_external_unicast_locators;
+    endpoint.external_unicast_locators = builtin_attr.metatraffic_external_unicast_locators;
     endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
 }
 
-ReaderAttributes PDP::create_builtin_reader_attributes() const
+ReaderAttributes PDP::static_create_builtin_reader_attributes(const RTPSParticipantImpl* RTPSParticipant)
 {
     ReaderAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_attributes();
+    const RTPSParticipantAttributes& pattr = RTPSParticipant->get_attributes();
     set_builtin_matched_allocation(attributes.matched_writers_allocation, pattr);
-    set_builtin_endpoint_locators(attributes.endpoint, this, mp_builtin);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
     attributes.endpoint.reliabilityKind = RELIABLE;
@@ -1668,18 +1666,47 @@ ReaderAttributes PDP::create_builtin_reader_attributes() const
     return attributes;
 }
 
-WriterAttributes PDP::create_builtin_writer_attributes() const
+ReaderAttributes PDP::create_builtin_reader_attributes()
+{
+    ReaderAttributes attributes = static_create_builtin_reader_attributes(getRTPSParticipant());
+    
+    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(), this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
+
+    return attributes;
+}
+
+WriterAttributes PDP::static_create_builtin_writer_attributes(const RTPSParticipantImpl* RTPSParticipant)
 {
     WriterAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_attributes();
+    const RTPSParticipantAttributes& pattr = RTPSParticipant->get_attributes();
     set_builtin_matched_allocation(attributes.matched_readers_allocation, pattr);
-    set_builtin_endpoint_locators(attributes.endpoint, this, mp_builtin);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
     attributes.endpoint.reliabilityKind = RELIABLE;
     attributes.endpoint.durabilityKind = TRANSIENT_LOCAL;
     attributes.endpoint.topicKind = WITH_KEY;
+
+    attributes.endpoint.endpointKind = WRITER;
+    
+    // We assume that if we have at least one flow controller defined, we use async flow controller
+    if (!pattr.flow_controllers.empty())
+    {
+        attributes.mode = ASYNCHRONOUS_WRITER;
+    }
+
+    attributes.times.heartbeat_period = pdp_heartbeat_period;
+    attributes.times.nack_response_delay = pdp_nack_response_delay;
+    attributes.times.nack_supression_duration = pdp_nack_supression_duration;
+
+    return attributes;
+}
+
+WriterAttributes PDP::create_builtin_writer_attributes()
+{
+    WriterAttributes attributes = static_create_builtin_writer_attributes(getRTPSParticipant());
+
+    set_builtin_endpoint_locators(attributes.endpoint, getRTPSParticipant()->get_attributes(), this->getLocalParticipantProxyData(), this->builtin_attributes(), mp_builtin);
 
     return attributes;
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -450,14 +450,16 @@ public:
      * It is a static method to allow TypeLookupManager to create builtin readers
      * @return ReaderAttributes
      */
-    static ReaderAttributes static_create_builtin_reader_attributes(const RTPSParticipantImpl* RTPSParticipant);
+    static ReaderAttributes static_create_builtin_reader_attributes(
+            const RTPSParticipantImpl* RTPSParticipant);
 
     /**
      * Create the attributes common to any builtin writer
      * It is a static method to allow TypeLookupManager to create builtin writers
      * @return WriterAttributes
      */
-    static WriterAttributes static_create_builtin_writer_attributes(const RTPSParticipantImpl* RTPSParticipant);
+    static WriterAttributes static_create_builtin_writer_attributes(
+            const RTPSParticipantImpl* RTPSParticipant);
 
 #if HAVE_SECURITY
     void add_builtin_security_attributes(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -441,9 +441,23 @@ public:
         return temp_writer_proxies_;
     }
 
-    ReaderAttributes create_builtin_reader_attributes() const;
+    ReaderAttributes create_builtin_reader_attributes();
 
-    WriterAttributes create_builtin_writer_attributes() const;
+    WriterAttributes create_builtin_writer_attributes();
+
+    /**
+     * Create the attributes common to any builtin reader
+     * It is a static method to allow TypeLookupManager to create builtin readers
+     * @return ReaderAttributes
+     */
+    static ReaderAttributes static_create_builtin_reader_attributes(const RTPSParticipantImpl* RTPSParticipant);
+
+    /**
+     * Create the attributes common to any builtin writer
+     * It is a static method to allow TypeLookupManager to create builtin writers
+     * @return WriterAttributes
+     */
+    static WriterAttributes static_create_builtin_writer_attributes(const RTPSParticipantImpl* RTPSParticipant);
 
 #if HAVE_SECURITY
     void add_builtin_security_attributes(
@@ -678,6 +692,13 @@ private:
             RTPSParticipantListener* listener);
 
 };
+
+void set_builtin_endpoint_locators(
+        EndpointAttributes& endpoint,
+        const RTPSParticipantAttributes& pattr,
+        const ParticipantProxyData* part_data,
+        const BuiltinAttributes& builtin_attr,
+        const BuiltinProtocols* builtin_protocol);
 
 
 // configuration values for PDP reliable entities.

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -310,8 +310,6 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
 
     EPROSIMA_LOG_INFO(RTPS_PDP, "Beginning PDPClient Endpoints creation");
 
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
-
     /***********************************
     * PDP READER
     ***********************************/
@@ -322,17 +320,8 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
     hatt.memoryPolicy = mp_builtin->m_att.readerHistoryMemoryPolicy;
     endpoints.reader.history_.reset(new ReaderHistory(hatt));
 
-    ReaderAttributes ratt;
-    ratt.expects_inline_qos = false;
-    ratt.endpoint.endpointKind = READER;
-    ratt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.times.heartbeat_response_delay = pdp_heartbeat_response_delay;
+    ReaderAttributes ratt = create_builtin_reader_attributes();
+
 #if HAVE_SECURITY
     if (is_discovery_protected)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -377,18 +377,7 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
     hatt.memoryPolicy = mp_builtin->m_att.writerHistoryMemoryPolicy;
     endpoints.writer.history_.reset(new WriterHistory(hatt));
 
-    WriterAttributes watt;
-    watt.endpoint.endpointKind = WRITER;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    watt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.times.heartbeat_period = pdp_heartbeat_period;
-    watt.times.nack_response_delay = pdp_nack_response_delay;
-    watt.times.nack_supression_duration = pdp_nack_supression_duration;
+    WriterAttributes watt = create_builtin_writer_attributes();
 
 #if HAVE_SECURITY
     if (is_discovery_protected)
@@ -398,13 +387,6 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
                 PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
     }
 #endif // HAVE_SECURITY
-
-    // We assume that if we have at least one flow controller defined, we use async flow controller
-    if (!pattr.flow_controllers.empty())
-    {
-        watt.mode = ASYNCHRONOUS_WRITER;
-        watt.flow_controller_name = fastdds::rtps::async_flow_controller_name;
-    }
 
     RTPSWriter* wout = nullptr;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -336,7 +336,6 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
         bool secure)
 {
     static_cast<void>(secure);
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
 
     /***********************************
     * PDP READER
@@ -349,18 +348,10 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
     endpoints.reader.history_.reset(new ReaderHistory(hatt));
 
     // PDP Reader Attributes
-    ReaderAttributes ratt;
-    ratt.expects_inline_qos = false;
-    ratt.endpoint.endpointKind = READER;
-    ratt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.topicKind = WITH_KEY;
+    ReaderAttributes ratt = create_builtin_reader_attributes();
     // Change depending on backup mode
     ratt.endpoint.durabilityKind = durability_;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.times.heartbeat_response_delay = pdp_heartbeat_response_delay;
+
 #if HAVE_SECURITY
     if (secure)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -422,8 +422,8 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
     endpoints.writer.history_.reset(new WriterHistory(hatt));
 
     // PDP Writer Attributes
-    WriterAttributes watt;
-    watt.endpoint.endpointKind = WRITER;
+    WriterAttributes watt = create_builtin_writer_attributes();
+
     // VOLATILE durability to highlight that on steady state the history is empty (except for announcement DATAs)
     // this setting is incompatible with CLIENTs TRANSIENT_LOCAL PDP readers but not validation is done on builitin
     // endpoints
@@ -435,16 +435,8 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
             get_writer_persistence_file_name()));
 #endif // HAVE_SQLITE3
 
-    watt.endpoint.reliabilityKind = RELIABLE;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    watt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.times.heartbeat_period = pdp_heartbeat_period;
-    watt.times.nack_response_delay = pdp_nack_response_delay;
-    watt.times.nack_supression_duration = pdp_nack_supression_duration;
-    watt.mode = ASYNCHRONOUS_WRITER;
+    watt.mode = ASYNCHRONOUS_WRITER; //
+
     // Enable separate sending so the filter can be called for each change and reader proxy
     watt.separate_sending = true;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -392,12 +392,6 @@ bool PDPSimple::create_dcps_participant_endpoints()
         mp_RTPSParticipant->createSenderResources(entry);
     }
 
-    // We assume that if we have at least one flow controller defined, we use async flow controller
-    if (!pattr.flow_controllers.empty())
-    {
-        watt.mode = ASYNCHRONOUS_WRITER;
-        watt.flow_controller_name = fastdds::rtps::async_flow_controller_name;
-    }
 
     RTPSWriter* rtps_writer = nullptr;
     if (mp_RTPSParticipant->createWriter(&rtps_writer, watt, writer.history_.get(),

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -248,16 +248,10 @@ bool WLP::createEndpoints()
     mp_builtinWriterHistory = new WriterHistory(hatt, payload_pool_);
 
     // Built-in writer
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     watt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
-    watt.matched_readers_allocation = participants_allocation;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
+
     RTPSWriter* wout;
     if (mp_participant->createWriter(
                 &wout,
@@ -292,18 +286,11 @@ bool WLP::createEndpoints()
 
     // Built-in reader
 
-    ReaderAttributes ratt;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.expects_inline_qos = true;
-    ratt.endpoint.unicastLocatorList =  mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     ratt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
-    ratt.matched_writers_allocation = participants_allocation;
-    ratt.endpoint.topicKind = WITH_KEY;
+    ratt.expects_inline_qos = true;
+
     RTPSReader* rout;
     if (mp_participant->createReader(
                 &rout,
@@ -346,17 +333,10 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(writer_pool_cfg, false);
     mp_builtinWriterSecureHistory = new WriterHistory(hatt, secure_payload_pool_);
 
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.matched_readers_allocation = participants_allocation;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     //	Wparam.topic.topicName = "DCPSParticipantMessageSecure";
     //	Wparam.topic.topicDataType = "RTPSParticipantMessageData";
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
 
     const security::ParticipantSecurityAttributes& part_attrs = mp_participant->security_attributes();
     security::PluginParticipantSecurityAttributes plugin_attrs(part_attrs.plugin_participant_attributes);
@@ -398,19 +378,12 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(reader_pool_cfg, true);
 
     mp_builtinReaderSecureHistory = new ReaderHistory(hatt);
-    ReaderAttributes ratt;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     ratt.expects_inline_qos = true;
-    ratt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.matched_writers_allocation = participants_allocation;
     //Rparam.topic.topicName = "DCPSParticipantMessageSecure";
     //Rparam.topic.topicDataType = "RTPSParticipantMessageData";
-    ratt.endpoint.topicKind = WITH_KEY;
+
     sec_attrs = &ratt.endpoint.security_attributes();
     sec_attrs->is_submessage_protected = part_attrs.is_liveliness_protected;
     if (part_attrs.is_liveliness_protected)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Refactor of the creation of the PDP and EDP builtin endpoints in order to have a common method to create builtin endpoints.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
