### PR TITLE
[22849] Builtin flow controller

### DIFF
--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -391,6 +391,9 @@ public:
     //! Set to true to avoid multicast traffic on builtin endpoints
     bool avoid_builtin_multicast = true;
 
+    //! Flow controller name to use for the builtin writers
+    std::string flow_controller_name = "";
+
     BuiltinAttributes() = default;
 
     virtual ~BuiltinAttributes() = default;
@@ -410,6 +413,7 @@ public:
                (this->writerHistoryMemoryPolicy == b.writerHistoryMemoryPolicy) &&
                (this->writerPayloadSize == b.writerPayloadSize) &&
                (this->mutation_tries == b.mutation_tries) &&
+               (this->flow_controller_name == b.flow_controller_name) &&
                (this->avoid_builtin_multicast == b.avoid_builtin_multicast);
     }
 

--- a/resources/xsd/fastdds_profiles.xsd
+++ b/resources/xsd/fastdds_profiles.xsd
@@ -722,7 +722,8 @@
         ├ writerHistoryMemoryPolicy             [0~1],
         ├ readerPayloadSize                     [uint32],
         ├ writerPayloadSize                     [uint32],
-        └ mutation_tries                        [uint32]-->
+        ├ mutation_tries                        [uint32],
+        └ flow_controller_name                  [string] -->
     <xs:complexType name="builtinAttributesType">
         <xs:all>
             <xs:element name="discovery_config" type="discoverySettingsType" minOccurs="0" maxOccurs="1"/>
@@ -737,6 +738,7 @@
             <xs:element name="readerPayloadSize" type="uint32" minOccurs="0" maxOccurs="1"/>
             <xs:element name="writerPayloadSize" type="uint32" minOccurs="0" maxOccurs="1"/>
             <xs:element name="mutation_tries" type="uint32" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="flow_controller_name" type="string" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -550,23 +550,19 @@ bool TypeLookupManager::create_endpoints()
 {
     bool ret = true;
 
-    const RTPSParticipantAttributes& pattr = participant_->get_attributes();
-
     // Built-in history attributes.
     HistoryAttributes hatt;
     hatt.initialReservedCaches = 20;
     hatt.maximumReservedCaches = 1000;
     hatt.payloadMaxSize = TypeLookupManager::typelookup_data_max_size;
 
-    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(participant_);
-    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
+    WriterAttributes watt = participant_->pdp()->create_builtin_writer_attributes();
     watt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
     watt.endpoint.topicKind = fastdds::rtps::NO_KEY;
     watt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
     watt.mode = fastdds::rtps::ASYNCHRONOUS_WRITER;
 
-    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(participant_);
-    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
+    ReaderAttributes ratt = participant_->pdp()->create_builtin_reader_attributes();
     ratt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
     ratt.expects_inline_qos = true;
     ratt.endpoint.topicKind = fastdds::rtps::NO_KEY;

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -37,6 +37,7 @@
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
 #include <rtps/builtin/data/ReaderProxyData.hpp>
 #include <rtps/builtin/data/WriterProxyData.hpp>
+#include <rtps/builtin/discovery/participant/PDP.h>
 #include <rtps/participant/RTPSParticipantImpl.hpp>
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/RTPSDomainImpl.hpp>
@@ -557,28 +558,18 @@ bool TypeLookupManager::create_endpoints()
     hatt.maximumReservedCaches = 1000;
     hatt.payloadMaxSize = TypeLookupManager::typelookup_data_max_size;
 
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = builtin_protocols_->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = builtin_protocols_->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = builtin_protocols_->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(participant_);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
     watt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
-    watt.matched_readers_allocation = pattr.allocation.participants;
     watt.endpoint.topicKind = fastdds::rtps::NO_KEY;
-    watt.endpoint.reliabilityKind = fastdds::rtps::RELIABLE;
     watt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
     watt.mode = fastdds::rtps::ASYNCHRONOUS_WRITER;
 
-    ReaderAttributes ratt;
-    ratt.endpoint.unicastLocatorList = builtin_protocols_->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = builtin_protocols_->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = builtin_protocols_->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(participant_);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, builtin_protocols_->m_att, builtin_protocols_);
     ratt.endpoint.remoteLocatorList = builtin_protocols_->m_initialPeersList;
-    ratt.matched_writers_allocation = pattr.allocation.participants;
     ratt.expects_inline_qos = true;
     ratt.endpoint.topicKind = fastdds::rtps::NO_KEY;
-    ratt.endpoint.reliabilityKind = fastdds::rtps::RELIABLE;
     ratt.endpoint.durabilityKind = fastdds::rtps::VOLATILE;
 
     // Built-in request writer

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -2504,6 +2504,7 @@ bool DomainParticipantImpl::can_qos_be_updated(
                 from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
                 !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
                 !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
+                !(to.wire_protocol().builtin.flow_controller_name == from.wire_protocol().builtin.flow_controller_name) ||
                 !(to.wire_protocol().builtin.avoid_builtin_multicast ==
                 from.wire_protocol().builtin.avoid_builtin_multicast) ||
                 !(to.wire_protocol().builtin.discovery_config.discoveryProtocol ==

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -2449,7 +2449,7 @@ ReturnCode_t DomainParticipantImpl::check_qos(
             return RETCODE_INCONSISTENT_POLICY;
         }
     }
-    
+
     // Check participant's wire protocol (builtin flow controller) configuration
     if (RETCODE_OK == ret_val)
     {
@@ -2462,10 +2462,11 @@ ReturnCode_t DomainParticipantImpl::check_qos(
 
             // Check if any flow controller matches the builtin flow controller name
             bool found = std::any_of(flow_controllers.begin(), flow_controllers.end(),
-                                    [&builtin_flow_controller_name](const std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>& fc)
-                                    {
-                                        return fc && fc->name == builtin_flow_controller_name;
-                                    });
+                            [&builtin_flow_controller_name](const std::shared_ptr<fastdds::rtps::
+                                    FlowControllerDescriptor>& fc)
+                            {
+                                return fc && fc->name == builtin_flow_controller_name;
+                            });
 
             if (!found)
             {
@@ -2531,7 +2532,8 @@ bool DomainParticipantImpl::can_qos_be_updated(
                 from.wire_protocol().builtin.writerHistoryMemoryPolicy) ||
                 !(to.wire_protocol().builtin.writerPayloadSize == from.wire_protocol().builtin.writerPayloadSize) ||
                 !(to.wire_protocol().builtin.mutation_tries == from.wire_protocol().builtin.mutation_tries) ||
-                !(to.wire_protocol().builtin.flow_controller_name == from.wire_protocol().builtin.flow_controller_name) ||
+                !(to.wire_protocol().builtin.flow_controller_name ==
+                from.wire_protocol().builtin.flow_controller_name) ||
                 !(to.wire_protocol().builtin.avoid_builtin_multicast ==
                 from.wire_protocol().builtin.avoid_builtin_multicast) ||
                 !(to.wire_protocol().builtin.discovery_config.discoveryProtocol ==

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -49,6 +49,7 @@
 #include <rtps/builtin/discovery/participant/PDPEndpoints.hpp>
 #include <rtps/builtin/discovery/participant/PDPListener.h>
 #include <rtps/builtin/liveliness/WLP.hpp>
+#include <rtps/flowcontrol/FlowControllerFactory.hpp>
 #include <rtps/history/TopicPayloadPoolRegistry.hpp>
 #include <rtps/network/utils/external_locators.hpp>
 #include <rtps/participant/RTPSParticipantImpl.hpp>
@@ -1679,6 +1680,7 @@ WriterAttributes PDP::static_create_builtin_writer_attributes(
     if (!pattr.flow_controllers.empty())
     {
         attributes.mode = ASYNCHRONOUS_WRITER;
+        attributes.flow_controller_name = (pattr.builtin.flow_controller_name != "") ? pattr.builtin.flow_controller_name : fastdds::rtps::async_flow_controller_name;
     }
 
     attributes.times.heartbeat_period = pdp_heartbeat_period;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1680,7 +1680,8 @@ WriterAttributes PDP::static_create_builtin_writer_attributes(
     if (!pattr.flow_controllers.empty())
     {
         attributes.mode = ASYNCHRONOUS_WRITER;
-        attributes.flow_controller_name = (pattr.builtin.flow_controller_name != "") ? pattr.builtin.flow_controller_name : fastdds::rtps::async_flow_controller_name;
+        attributes.flow_controller_name = (pattr.builtin.flow_controller_name !=
+                "") ? pattr.builtin.flow_controller_name : fastdds::rtps::async_flow_controller_name;
     }
 
     attributes.times.heartbeat_period = pdp_heartbeat_period;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -445,22 +445,6 @@ public:
 
     WriterAttributes create_builtin_writer_attributes();
 
-    /**
-     * Create the attributes common to any builtin reader
-     * It is a static method to allow TypeLookupManager to create builtin readers
-     * @return ReaderAttributes
-     */
-    static ReaderAttributes static_create_builtin_reader_attributes(
-            const RTPSParticipantImpl* RTPSParticipant);
-
-    /**
-     * Create the attributes common to any builtin writer
-     * It is a static method to allow TypeLookupManager to create builtin writers
-     * @return WriterAttributes
-     */
-    static WriterAttributes static_create_builtin_writer_attributes(
-            const RTPSParticipantImpl* RTPSParticipant);
-
 #if HAVE_SECURITY
     void add_builtin_security_attributes(
             ReaderAttributes& ratt,
@@ -694,14 +678,6 @@ private:
             RTPSParticipantListener* listener);
 
 };
-
-void set_builtin_endpoint_locators(
-        EndpointAttributes& endpoint,
-        const RTPSParticipantAttributes& pattr,
-        const ParticipantProxyData* part_data,
-        const BuiltinAttributes& builtin_attr,
-        const BuiltinProtocols* builtin_protocol);
-
 
 // configuration values for PDP reliable entities.
 extern const dds::Duration_t pdp_heartbeat_period;

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.h
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.h
@@ -441,9 +441,25 @@ public:
         return temp_writer_proxies_;
     }
 
-    ReaderAttributes create_builtin_reader_attributes() const;
+    ReaderAttributes create_builtin_reader_attributes();
 
-    WriterAttributes create_builtin_writer_attributes() const;
+    WriterAttributes create_builtin_writer_attributes();
+
+    /**
+     * Create the attributes common to any builtin reader
+     * It is a static method to allow TypeLookupManager to create builtin readers
+     * @return ReaderAttributes
+     */
+    static ReaderAttributes static_create_builtin_reader_attributes(
+            const RTPSParticipantImpl* RTPSParticipant);
+
+    /**
+     * Create the attributes common to any builtin writer
+     * It is a static method to allow TypeLookupManager to create builtin writers
+     * @return WriterAttributes
+     */
+    static WriterAttributes static_create_builtin_writer_attributes(
+            const RTPSParticipantImpl* RTPSParticipant);
 
 #if HAVE_SECURITY
     void add_builtin_security_attributes(
@@ -678,6 +694,13 @@ private:
             RTPSParticipantListener* listener);
 
 };
+
+void set_builtin_endpoint_locators(
+        EndpointAttributes& endpoint,
+        const RTPSParticipantAttributes& pattr,
+        const ParticipantProxyData* part_data,
+        const BuiltinAttributes& builtin_attr,
+        const BuiltinProtocols* builtin_protocol);
 
 
 // configuration values for PDP reliable entities.

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -310,8 +310,6 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
 
     EPROSIMA_LOG_INFO(RTPS_PDP, "Beginning PDPClient Endpoints creation");
 
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
-
     /***********************************
     * PDP READER
     ***********************************/
@@ -322,17 +320,8 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
     hatt.memoryPolicy = mp_builtin->m_att.readerHistoryMemoryPolicy;
     endpoints.reader.history_.reset(new ReaderHistory(hatt));
 
-    ReaderAttributes ratt;
-    ratt.expects_inline_qos = false;
-    ratt.endpoint.endpointKind = READER;
-    ratt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.times.heartbeat_response_delay = pdp_heartbeat_response_delay;
+    ReaderAttributes ratt = create_builtin_reader_attributes();
+
 #if HAVE_SECURITY
     if (is_discovery_protected)
     {
@@ -377,18 +366,7 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
     hatt.memoryPolicy = mp_builtin->m_att.writerHistoryMemoryPolicy;
     endpoints.writer.history_.reset(new WriterHistory(hatt));
 
-    WriterAttributes watt;
-    watt.endpoint.endpointKind = WRITER;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    watt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.times.heartbeat_period = pdp_heartbeat_period;
-    watt.times.nack_response_delay = pdp_nack_response_delay;
-    watt.times.nack_supression_duration = pdp_nack_supression_duration;
+    WriterAttributes watt = create_builtin_writer_attributes();
 
 #if HAVE_SECURITY
     if (is_discovery_protected)
@@ -398,13 +376,6 @@ bool PDPClient::create_ds_pdp_reliable_endpoints(
                 PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED;
     }
 #endif // HAVE_SECURITY
-
-    // We assume that if we have at least one flow controller defined, we use async flow controller
-    if (!pattr.flow_controllers.empty())
-    {
-        watt.mode = ASYNCHRONOUS_WRITER;
-        watt.flow_controller_name = fastdds::rtps::async_flow_controller_name;
-    }
 
     RTPSWriter* wout = nullptr;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -336,7 +336,6 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
         bool secure)
 {
     static_cast<void>(secure);
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
 
     /***********************************
     * PDP READER
@@ -349,18 +348,10 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
     endpoints.reader.history_.reset(new ReaderHistory(hatt));
 
     // PDP Reader Attributes
-    ReaderAttributes ratt;
-    ratt.expects_inline_qos = false;
-    ratt.endpoint.endpointKind = READER;
-    ratt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.endpoint.topicKind = WITH_KEY;
+    ReaderAttributes ratt = create_builtin_reader_attributes();
     // Change depending on backup mode
     ratt.endpoint.durabilityKind = durability_;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.times.heartbeat_response_delay = pdp_heartbeat_response_delay;
+
 #if HAVE_SECURITY
     if (secure)
     {
@@ -422,8 +413,8 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
     endpoints.writer.history_.reset(new WriterHistory(hatt));
 
     // PDP Writer Attributes
-    WriterAttributes watt;
-    watt.endpoint.endpointKind = WRITER;
+    WriterAttributes watt = create_builtin_writer_attributes();
+
     // VOLATILE durability to highlight that on steady state the history is empty (except for announcement DATAs)
     // this setting is incompatible with CLIENTs TRANSIENT_LOCAL PDP readers but not validation is done on builitin
     // endpoints
@@ -435,16 +426,8 @@ bool PDPServer::create_ds_pdp_reliable_endpoints(
             get_writer_persistence_file_name()));
 #endif // HAVE_SQLITE3
 
-    watt.endpoint.reliabilityKind = RELIABLE;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.multicastLocatorList = mp_builtin->m_metatrafficMulticastLocatorList;
-    watt.endpoint.unicastLocatorList = mp_builtin->m_metatrafficUnicastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtin->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.times.heartbeat_period = pdp_heartbeat_period;
-    watt.times.nack_response_delay = pdp_nack_response_delay;
-    watt.times.nack_supression_duration = pdp_nack_supression_duration;
-    watt.mode = ASYNCHRONOUS_WRITER;
+    watt.mode = ASYNCHRONOUS_WRITER; //
+
     // Enable separate sending so the filter can be called for each change and reader proxy
     watt.separate_sending = true;
 #if HAVE_SECURITY

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -395,12 +395,6 @@ bool PDPSimple::create_dcps_participant_endpoints()
         mp_RTPSParticipant->createSenderResources(entry);
     }
 
-    // We assume that if we have at least one flow controller defined, we use async flow controller
-    if (!pattr.flow_controllers.empty())
-    {
-        watt.mode = ASYNCHRONOUS_WRITER;
-        watt.flow_controller_name = fastdds::rtps::async_flow_controller_name;
-    }
 
     RTPSWriter* rtps_writer = nullptr;
     if (mp_RTPSParticipant->createWriter(&rtps_writer, watt, writer.history_.get(),

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -248,8 +248,7 @@ bool WLP::createEndpoints()
     mp_builtinWriterHistory = new WriterHistory(hatt, payload_pool_);
 
     // Built-in writer
-    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
-    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
+    WriterAttributes watt = mp_participant->pdp()->create_builtin_writer_attributes();
     watt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
 
     RTPSWriter* wout;
@@ -286,8 +285,7 @@ bool WLP::createEndpoints()
 
     // Built-in reader
 
-    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
-    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
+    ReaderAttributes ratt = mp_participant->pdp()->create_builtin_reader_attributes();
     ratt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
     ratt.expects_inline_qos = true;
 
@@ -333,8 +331,7 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(writer_pool_cfg, false);
     mp_builtinWriterSecureHistory = new WriterHistory(hatt, secure_payload_pool_);
 
-    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
-    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
+    WriterAttributes watt = mp_participant->pdp()->create_builtin_writer_attributes();
     //	Wparam.topic.topicName = "DCPSParticipantMessageSecure";
     //	Wparam.topic.topicDataType = "RTPSParticipantMessageData";
 
@@ -378,8 +375,7 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(reader_pool_cfg, true);
 
     mp_builtinReaderSecureHistory = new ReaderHistory(hatt);
-    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
-    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
+    ReaderAttributes ratt = mp_participant->pdp()->create_builtin_reader_attributes();
     ratt.expects_inline_qos = true;
     //Rparam.topic.topicName = "DCPSParticipantMessageSecure";
     //Rparam.topic.topicDataType = "RTPSParticipantMessageData";

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -248,16 +248,10 @@ bool WLP::createEndpoints()
     mp_builtinWriterHistory = new WriterHistory(hatt, payload_pool_);
 
     // Built-in writer
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     watt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
-    watt.matched_readers_allocation = participants_allocation;
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
+
     RTPSWriter* wout;
     if (mp_participant->createWriter(
                 &wout,
@@ -292,18 +286,11 @@ bool WLP::createEndpoints()
 
     // Built-in reader
 
-    ReaderAttributes ratt;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
-    ratt.expects_inline_qos = true;
-    ratt.endpoint.unicastLocatorList =  mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     ratt.endpoint.remoteLocatorList = mp_builtinProtocols->m_initialPeersList;
-    ratt.matched_writers_allocation = participants_allocation;
-    ratt.endpoint.topicKind = WITH_KEY;
+    ratt.expects_inline_qos = true;
+
     RTPSReader* rout;
     if (mp_participant->createReader(
                 &rout,
@@ -346,17 +333,10 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(writer_pool_cfg, false);
     mp_builtinWriterSecureHistory = new WriterHistory(hatt, secure_payload_pool_);
 
-    WriterAttributes watt;
-    watt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    watt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    watt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    watt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    watt.matched_readers_allocation = participants_allocation;
+    WriterAttributes watt = PDP::static_create_builtin_writer_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(watt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     //	Wparam.topic.topicName = "DCPSParticipantMessageSecure";
     //	Wparam.topic.topicDataType = "RTPSParticipantMessageData";
-    watt.endpoint.topicKind = WITH_KEY;
-    watt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    watt.endpoint.reliabilityKind = RELIABLE;
 
     const security::ParticipantSecurityAttributes& part_attrs = mp_participant->security_attributes();
     security::PluginParticipantSecurityAttributes plugin_attrs(part_attrs.plugin_participant_attributes);
@@ -398,19 +378,12 @@ bool WLP::createSecureEndpoints()
     secure_payload_pool_->reserve_history(reader_pool_cfg, true);
 
     mp_builtinReaderSecureHistory = new ReaderHistory(hatt);
-    ReaderAttributes ratt;
-    ratt.endpoint.topicKind = WITH_KEY;
-    ratt.endpoint.durabilityKind = TRANSIENT_LOCAL;
-    ratt.endpoint.reliabilityKind = RELIABLE;
+    ReaderAttributes ratt = PDP::static_create_builtin_reader_attributes(mp_participant);
+    rtps::set_builtin_endpoint_locators(ratt.endpoint, pattr, nullptr, mp_builtinProtocols->m_att, mp_builtinProtocols);
     ratt.expects_inline_qos = true;
-    ratt.endpoint.unicastLocatorList = mp_builtinProtocols->m_metatrafficUnicastLocatorList;
-    ratt.endpoint.multicastLocatorList = mp_builtinProtocols->m_metatrafficMulticastLocatorList;
-    ratt.endpoint.external_unicast_locators = mp_builtinProtocols->m_att.metatraffic_external_unicast_locators;
-    ratt.endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
-    ratt.matched_writers_allocation = participants_allocation;
     //Rparam.topic.topicName = "DCPSParticipantMessageSecure";
     //Rparam.topic.topicDataType = "RTPSParticipantMessageData";
-    ratt.endpoint.topicKind = WITH_KEY;
+
     sec_attrs = &ratt.endpoint.security_attributes();
     sec_attrs->is_submessage_protected = part_attrs.is_liveliness_protected;
     if (part_attrs.is_liveliness_protected)

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -1127,7 +1127,6 @@ private:
             const std::chrono::time_point<std::chrono::steady_clock>& max_blocking_time)
     {
         bool ret_value = false;
-        assert(!change->writer_info.is_linked.load());
         // Sync delivery failed. Try to store for asynchronous delivery.
 #if HAVE_STRICT_REALTIME
         std::unique_lock<fastdds::TimedMutex> lock(async_mode.changes_interested_mutex, std::defer_lock);

--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -593,6 +593,7 @@ XMLP_ret XMLParser::getXMLBuiltinAttributes(
             <xs:element name="readerHistoryMemoryPolicy" type="historyMemoryPolicyType" minOccurs="0"/>
             <xs:element name="writerHistoryMemoryPolicy" type="historyMemoryPolicyType" minOccurs="0"/>
             <xs:element name="mutation_tries" type="uint32Type" minOccurs="0"/>
+            <xs:element name="flow_controller_name" type="stringType" minOccurs="0"/>
         </xs:all>
        </xs:complexType>
      */
@@ -705,6 +706,14 @@ XMLP_ret XMLParser::getXMLBuiltinAttributes(
         {
             // avoid_builtin_multicast - boolType
             if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &builtin.avoid_builtin_multicast, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, FLOW_CONTROLLER_NAME) == 0)
+        {
+            // flow_controller_name - stringType
+            if (XMLP_ret::XML_OK != getXMLString(p_aux0, &builtin.flow_controller_name, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -701,6 +701,14 @@ public:
         return false;
     }
 
+    PubSubParticipant& flow_controller(
+            const std::shared_ptr<eprosima::fastdds::rtps::FlowControllerDescriptor>& flow_controller)
+    {
+        participant_qos_.flow_controllers().clear();
+        participant_qos_.flow_controllers().push_back(flow_controller);
+        return *this;
+    }
+
     PubSubParticipant& initial_peers(
             const eprosima::fastdds::rtps::LocatorList& initial_peers)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1005,7 +1005,7 @@ public:
         new_flow_controller->period_ms = static_cast<uint64_t>(periodInMs);
         participant_qos_.flow_controllers().push_back(new_flow_controller);
         participant_qos_.wire_protocol().builtin.flow_controller_name = new_flow_controller->name;
-        
+
         return *this;
     }
 

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -993,6 +993,22 @@ public:
         return *this;
     }
 
+    PubSubWriter& add_builtin_flow_controller(
+            eprosima::fastdds::rtps::FlowControllerSchedulerPolicy scheduler_policy,
+            uint32_t bytesPerPeriod,
+            uint32_t periodInMs)
+    {
+        auto new_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
+        new_flow_controller->name = "MyFlowController";
+        new_flow_controller->scheduler = scheduler_policy;
+        new_flow_controller->max_bytes_per_period = bytesPerPeriod;
+        new_flow_controller->period_ms = static_cast<uint64_t>(periodInMs);
+        participant_qos_.flow_controllers().push_back(new_flow_controller);
+        participant_qos_.wire_protocol().builtin.flow_controller_name = new_flow_controller->name;
+        
+        return *this;
+    }
+
     PubSubWriter& asynchronously(
             const eprosima::fastdds::dds::PublishModeQosPolicyKind kind)
     {

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -999,7 +999,7 @@ public:
             uint32_t periodInMs)
     {
         auto new_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
-        new_flow_controller->name = "MyFlowController";
+        new_flow_controller->name = "MyBuiltinFlowController";
         new_flow_controller->scheduler = scheduler_policy;
         new_flow_controller->max_bytes_per_period = bytesPerPeriod;
         new_flow_controller->period_ms = static_cast<uint64_t>(periodInMs);

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1526,7 +1526,6 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller)
     main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
     main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
     main_wire_protocol.builtin.flow_controller_name = "TestFlowController";
-    // main_wire_protocol.builtin.flow_controller_name = "FastDDSFlowControllerDefault";
 
     // Flowcontroller to limit the bandwidth
     auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
@@ -1650,7 +1649,6 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller_limited)
     main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
     main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
     main_wire_protocol.builtin.flow_controller_name = "TestFlowController";
-    // main_wire_protocol.builtin.flow_controller_name = "FastDDSFlowControllerDefault";
 
     // Flowcontroller to limit the bandwidth
     auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1298,7 +1298,7 @@ TEST_P(Discovery, EndpointCreationMultithreaded)
     endpoint_thr.join();
 }
 
-// Regression test for redmine issue 16253
+//! Regression test for redmine issue 16253
 TEST_P(Discovery, AsymmeticIgnoreParticipantFlags)
 {
     if (INTRAPROCESS != GetParam())
@@ -1416,7 +1416,7 @@ TEST_P(Discovery, single_unicast_pdp_response)
     main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
     main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000 };
 
-    // The main participant will use the test transport and a specific announcments configuration
+    // The main participant will use the test transport and a specific announcements configuration
     main_participant->disable_builtin_transport().add_user_transport_to_pparams(test_transport)
             .wire_protocol(main_wire_protocol);
 
@@ -1469,6 +1469,257 @@ TEST_P(Discovery, single_unicast_pdp_response)
     // Check that only two unicast messages per participant were sent
     EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst),
             participants.size() + participants.size());
+
+    // Clean up
+    participants.clear();
+}
+
+//! Regression test for redmine issue 22506
+//! Test using a user's flowcontroller limiting the bandwidth and 5 remote participants waiting for the PDP sample.
+TEST_P(Discovery, single_unicast_pdp_response_flowcontroller)
+{
+    // Leverage intraprocess so transport is only used for participant discovery
+    if (INTRAPROCESS != GetParam())
+    {
+        GTEST_SKIP() << "Only makes sense on INTRAPROCESS";
+        return;
+    }
+
+    using namespace eprosima::fastdds::dds;
+
+    // All participants would restrict communication to UDP localhost.
+    // The main participant should send a single initial announcement, and have a big announcement period.
+    // This is to ensure that we only check the datagrams sent in response to the participant discovery,
+    // and not the ones sent in the periodic announcements.
+    // The main participant will use the test transport to count the number of unicast messages sent.
+
+    // This will hold the multicast port. Since the test is not always run in the same domain, we'll need to set
+    // its value when the first multicast datagram is sent.
+    std::atomic<uint32_t> multicast_port{ 0 };
+    // Declare a test transport that will count the number of unicast messages sent
+    std::atomic<size_t> num_unicast_sends{ 0 };
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport->interfaceWhiteList.push_back("127.0.0.1");
+    test_transport->locator_filter_ = [&num_unicast_sends, &multicast_port](
+        const eprosima::fastdds::rtps::Locator& destination)
+            {
+                if (IPLocator::isMulticast(destination))
+                {
+                    uint32_t port = 0;
+                    multicast_port.compare_exchange_strong(port, destination.port);
+                }
+                else
+                {
+                    num_unicast_sends.fetch_add(1u, std::memory_order_seq_cst);
+                }
+
+                // Do not discard any message
+                return false;
+            };
+
+    // Create the main participant
+    auto main_participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+    WireProtocolConfigQos main_wire_protocol;
+    main_wire_protocol.builtin.avoid_builtin_multicast = true;
+    main_wire_protocol.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    main_wire_protocol.builtin.discovery_config.leaseDuration_announcementperiod = { 3600, 0 };
+    main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
+    main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
+    main_wire_protocol.builtin.flow_controller_name = "TestFlowController";
+    // main_wire_protocol.builtin.flow_controller_name = "FastDDSFlowControllerDefault";
+
+    // Flowcontroller to limit the bandwidth
+    auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
+    test_flow_controller->name = "TestFlowController";
+    test_flow_controller->max_bytes_per_period = 3120; //3120 OK
+    test_flow_controller->period_ms = static_cast<uint64_t>(100);
+
+    // The main participant will use the test transport, specific announcements configuration and a flowcontroller
+    main_participant->disable_builtin_transport().add_user_transport_to_pparams(test_transport)
+            .wire_protocol(main_wire_protocol)
+            .flow_controller(test_flow_controller);
+
+    // Start the main participant
+    ASSERT_TRUE(main_participant->init_participant());
+
+    // Wait for the initial announcements to be sent
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // This would have set the multicast port
+    EXPECT_NE(multicast_port, 0u);
+
+    // The rest of the participants only send announcements to the main participant
+    // Calculate the metatraffic unicast port of the main participant
+    uint32_t port = multicast_port + main_wire_protocol.port.offsetd1 - main_wire_protocol.port.offsetd0;
+
+    // The rest of the participants only send announcements to the main participant
+    auto udp_localhost_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    udp_localhost_transport->interfaceWhiteList.push_back("127.0.0.1");
+    Locator peer_locator;
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "127.0.0.1", port, peer_locator);
+    WireProtocolConfigQos wire_protocol;
+    wire_protocol.builtin.avoid_builtin_multicast = true;
+    wire_protocol.builtin.initialPeersList.push_back(peer_locator);
+    wire_protocol.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    wire_protocol.builtin.discovery_config.leaseDuration_announcementperiod = { 3600, 0 };
+    wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
+    wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
+
+    std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> participants;
+    for (size_t i = 0; i < 5; ++i)
+    {
+        auto participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+        // All participants use the same transport
+        participant->disable_builtin_transport().add_user_transport_to_pparams(udp_localhost_transport)
+                .wire_protocol(wire_protocol);
+        participants.push_back(participant);
+    }
+
+    // Start the rest of the participants
+    for (auto& participant : participants)
+    {
+        ASSERT_TRUE(participant->init_participant());
+        participant->wait_discovery(std::chrono::seconds(1), 1, true);
+    }
+
+    // Destroy main participant
+    main_participant.reset();
+    for (auto& participant : participants)
+    {
+        participant->wait_discovery(std::chrono::seconds(1), 0, true);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Check that only two unicast messages per participant were sent
+    EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst),
+            participants.size() + participants.size());
+
+    // Clean up
+    participants.clear();
+}
+
+//! Regression test for redmine issue 22506
+//! Same test as single_unicast_pdp_response_flowcontroller but the main participant's builtin controller is so limited
+//! that it will not be able to send all the initial announcements.
+TEST_P(Discovery, single_unicast_pdp_response_flowcontroller_limited)
+{
+    // Leverage intraprocess so transport is only used for participant discovery
+    if (INTRAPROCESS != GetParam())
+    {
+        GTEST_SKIP() << "Only makes sense on INTRAPROCESS";
+        return;
+    }
+
+    using namespace eprosima::fastdds::dds;
+
+    // All participants would restrict communication to UDP localhost.
+    // The main participant should send a single initial announcement, and have a big announcement period.
+    // This is to ensure that we only check the datagrams sent in response to the participant discovery,
+    // and not the ones sent in the periodic announcements.
+    // The main participant will use the test transport to count the number of unicast messages sent.
+
+    // This will hold the multicast port. Since the test is not always run in the same domain, we'll need to set
+    // its value when the first multicast datagram is sent.
+    std::atomic<uint32_t> multicast_port{ 0 };
+    // Declare a test transport that will count the number of unicast messages sent
+    std::atomic<size_t> num_unicast_sends{ 0 };
+    auto test_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport->interfaceWhiteList.push_back("127.0.0.1");
+    test_transport->locator_filter_ = [&num_unicast_sends, &multicast_port](
+        const eprosima::fastdds::rtps::Locator& destination)
+            {
+                if (IPLocator::isMulticast(destination))
+                {
+                    uint32_t port = 0;
+                    multicast_port.compare_exchange_strong(port, destination.port);
+                }
+                else
+                {
+                    num_unicast_sends.fetch_add(1u, std::memory_order_seq_cst);
+                }
+
+                // Do not discard any message
+                return false;
+            };
+
+    // Create the main participant
+    auto main_participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+    WireProtocolConfigQos main_wire_protocol;
+    main_wire_protocol.builtin.avoid_builtin_multicast = true;
+    main_wire_protocol.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    main_wire_protocol.builtin.discovery_config.leaseDuration_announcementperiod = { 3600, 0 };
+    main_wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
+    main_wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
+    main_wire_protocol.builtin.flow_controller_name = "TestFlowController";
+    // main_wire_protocol.builtin.flow_controller_name = "FastDDSFlowControllerDefault";
+
+    // Flowcontroller to limit the bandwidth
+    auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
+    test_flow_controller->name = "TestFlowController";
+    test_flow_controller->max_bytes_per_period = 3120; //3120 OK
+    test_flow_controller->period_ms = static_cast<uint64_t>(100000);
+
+    // The main participant will use the test transport, specific announcements configuration and a flowcontroller
+    main_participant->disable_builtin_transport().add_user_transport_to_pparams(test_transport)
+            .wire_protocol(main_wire_protocol)
+            .flow_controller(test_flow_controller);
+
+    // Start the main participant
+    ASSERT_TRUE(main_participant->init_participant());
+
+    // Wait for the initial announcements to be sent
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    // This would have set the multicast port
+    EXPECT_NE(multicast_port, 0u);
+
+    // The rest of the participants only send announcements to the main participant
+    // Calculate the metatraffic unicast port of the main participant
+    uint32_t port = multicast_port + main_wire_protocol.port.offsetd1 - main_wire_protocol.port.offsetd0;
+
+    // The rest of the participants only send announcements to the main participant
+    auto udp_localhost_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    udp_localhost_transport->interfaceWhiteList.push_back("127.0.0.1");
+    Locator peer_locator;
+    IPLocator::createLocator(LOCATOR_KIND_UDPv4, "127.0.0.1", port, peer_locator);
+    WireProtocolConfigQos wire_protocol;
+    wire_protocol.builtin.avoid_builtin_multicast = true;
+    wire_protocol.builtin.initialPeersList.push_back(peer_locator);
+    wire_protocol.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    wire_protocol.builtin.discovery_config.leaseDuration_announcementperiod = { 3600, 0 };
+    wire_protocol.builtin.discovery_config.initial_announcements.count = 1;
+    wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
+
+    std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> participants;
+    for (size_t i = 0; i < 5; ++i)
+    {
+        auto participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+        // All participants use the same transport
+        participant->disable_builtin_transport().add_user_transport_to_pparams(udp_localhost_transport)
+                .wire_protocol(wire_protocol);
+        participants.push_back(participant);
+    }
+
+    // Start the rest of the participants
+    for (auto& participant : participants)
+    {
+        ASSERT_TRUE(participant->init_participant());
+        participant->wait_discovery(std::chrono::seconds(1), 1, true);
+    }
+
+    // The builtin flowcontroller of the main participant will not be able to send all the initial announcements as the max byter per period has already
+    // been reached. In fact no more messages will be sent from the builtin writers of the main participant.
+    EXPECT_LT(num_unicast_sends.load(std::memory_order::memory_order_seq_cst), participants.size());
+    auto num_unicast_sends_limit = num_unicast_sends.load(std::memory_order::memory_order_seq_cst);
+
+    // Destroy main participant
+    main_participant.reset();
+    for (auto& participant : participants)
+    {
+        participant->wait_discovery(std::chrono::seconds(1), 0, true);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // No more messages have been sent sin the limit was reached
+    EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst),num_unicast_sends_limit);
 
     // Clean up
     participants.clear();

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -1530,7 +1530,7 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller)
     // Flowcontroller to limit the bandwidth
     auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
     test_flow_controller->name = "TestFlowController";
-    test_flow_controller->max_bytes_per_period = 3120; //3120 OK
+    test_flow_controller->max_bytes_per_period = 3700;
     test_flow_controller->period_ms = static_cast<uint64_t>(100);
 
     // The main participant will use the test transport, specific announcements configuration and a flowcontroller
@@ -1653,7 +1653,7 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller_limited)
     // Flowcontroller to limit the bandwidth
     auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
     test_flow_controller->name = "TestFlowController";
-    test_flow_controller->max_bytes_per_period = 3120; //3120 OK
+    test_flow_controller->max_bytes_per_period = 3700;
     test_flow_controller->period_ms = static_cast<uint64_t>(100000);
 
     // The main participant will use the test transport, specific announcements configuration and a flowcontroller
@@ -1687,7 +1687,7 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller_limited)
     wire_protocol.builtin.discovery_config.initial_announcements.period = { 0, 100000000u };
 
     std::vector<std::shared_ptr<PubSubParticipant<HelloWorldPubSubType>>> participants;
-    for (size_t i = 0; i < 5; ++i)
+    for (size_t i = 0; i < 10; ++i)
     {
         auto participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
         // All participants use the same transport
@@ -1717,7 +1717,7 @@ TEST_P(Discovery, single_unicast_pdp_response_flowcontroller_limited)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     // No more messages have been sent sin the limit was reached
-    EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst),num_unicast_sends_limit);
+    EXPECT_EQ(num_unicast_sends.load(std::memory_order::memory_order_seq_cst), num_unicast_sends_limit);
 
     // Clean up
     participants.clear();

--- a/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
@@ -25,6 +25,9 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+#define SIZE_PDP 625
+#define SIZE_EDP 1675
+
 class PubSubFlowControllers : public testing::TestWithParam<eprosima::fastdds::rtps::FlowControllerSchedulerPolicy>
 {
 public:
@@ -281,6 +284,121 @@ TEST_P(PubSubFlowControllers, AsyncPubSubAsReliableData64kbWithParticipantFlowCo
     reader.destroy();
     writer.destroy();
     std::remove(db_file_name.c_str());
+}
+
+// This test checks that the PDP and EDP discovery are successful when proper parameters
+//  for builtin flow controller are set
+TEST_P(PubSubFlowControllers, BuiltinFlowControllerPubSub)
+{
+    PubSubReader<Data64kbPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data64kbPubSubType> writer(TEST_TOPIC_NAME);
+
+    reader.history_depth(3).
+            reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS).init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    uint32_t bytesPerPeriod = SIZE_PDP + SIZE_EDP;
+    uint32_t periodInMs = 50000;
+    writer.add_builtin_flow_controller(scheduler_policy_, bytesPerPeriod, periodInMs);
+
+    writer.history_depth(3).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Because its volatile the durability
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_data64kb_data_generator(3);
+
+    reader.startReception(data);
+
+    // Send data
+    writer.send(data);
+    // In this test all data should be sent.
+    ASSERT_TRUE(data.empty());
+    // Block reader until reception finished or timeout.
+    reader.block_for_all();
+}
+
+// This test checks that the PDP discovery process is not successful when the builtin 
+//  flow controller is set with not enough size to send the PDP
+TEST_P(PubSubFlowControllers, BuiltinFlowControllerFailDiscovery)
+{
+    PubSubReader<Data64kbPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data64kbPubSubType> writer(TEST_TOPIC_NAME);
+
+    reader.init();
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    uint32_t bytesPerPeriod = SIZE_PDP - 20; // Not enough size to send Data P
+    uint32_t periodInMs = 50000;
+    writer.add_builtin_flow_controller(scheduler_policy_, bytesPerPeriod, periodInMs);
+
+    writer.init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Reader discovery should fail
+    ASSERT_FALSE(reader.wait_participant_discovery(1,std::chrono::seconds(1)));
+}
+
+// This test checks that the WLP service is not able to send non stop liveliness messages when the builtin
+//  flow controller is set with not enough size to send all the liveliness messages
+TEST_P(PubSubFlowControllers, BuiltinFlowControllerWLPLimited)
+{
+    eprosima::fastdds::LibrarySettings att;
+    att.intraprocess_delivery = eprosima::fastdds::INTRAPROCESS_OFF;
+    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->set_library_settings(att);
+
+    unsigned int lease_duration_ms = 501;
+    unsigned int announcement_period_ms = 200;
+    
+    PubSubReader<Data64kbPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<Data64kbPubSubType> writer(TEST_TOPIC_NAME);
+
+    reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
+            .liveliness_lease_duration(lease_duration_ms * 1e-3).init();
+            // .liveliness_announcement_period(announcement_period_ms * 1e-3)
+
+    ASSERT_TRUE(reader.isInitialized());
+
+    uint32_t bytesPerPeriod = SIZE_PDP + SIZE_EDP + 5000;
+    uint32_t periodInMs = 50000;
+    writer.add_builtin_flow_controller(scheduler_policy_, bytesPerPeriod, periodInMs);
+
+    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .liveliness_kind(eprosima::fastdds::dds::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS)
+            .liveliness_lease_duration(lease_duration_ms * 1e-3)
+            .liveliness_announcement_period(announcement_period_ms * 1e-3).init();
+
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+    
+    // Once asserted that the writer is matched, it should eventually be declared as not alive because the
+    // flow controller will not allow the wlp writer to send more liveliness messages
+    
+    std::atomic<bool> stop(false);
+    auto assert_liveliness_func = [&writer, &reader, lease_duration_ms, &stop]()
+    {
+        while (!stop)
+        {
+            writer.assert_liveliness();
+            std::this_thread::sleep_for(std::chrono::milliseconds(lease_duration_ms / 10));
+        }
+    };
+    std::thread liveliness_thread(assert_liveliness_func);
+
+    reader.wait_liveliness_lost(1);
+    stop.store(true);
+    liveliness_thread.join();
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
@@ -21,6 +21,7 @@
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 #include "PubSubWriterReader.hpp"
+#include "PubSubParticipant.hpp"
 
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
@@ -399,6 +400,22 @@ TEST_P(PubSubFlowControllers, BuiltinFlowControllerWLPLimited)
     reader.wait_liveliness_lost(1);
     stop.store(true);
     liveliness_thread.join();
+}
+
+TEST_P(PubSubFlowControllers, BuiltinFlowControllerNotRegistered)
+{
+    using namespace eprosima::fastdds::dds;
+
+    // Create the main participant
+    auto main_participant = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+    WireProtocolConfigQos main_wire_protocol;
+    main_wire_protocol.builtin.flow_controller_name = "NotRegisteredTestFlowController";
+
+    // The main participant will use the test transport, specific announcements configuration and a flowcontroller
+    main_participant->wire_protocol(main_wire_protocol);
+
+    // Start the main participant
+    ASSERT_FALSE(main_participant->init_participant());
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
@@ -324,7 +324,7 @@ TEST_P(PubSubFlowControllers, BuiltinFlowControllerPubSub)
     reader.block_for_all();
 }
 
-// This test checks that the PDP discovery process is not successful when the builtin 
+// This test checks that the PDP discovery process is not successful when the builtin
 //  flow controller is set with not enough size to send the PDP
 TEST_P(PubSubFlowControllers, BuiltinFlowControllerFailDiscovery)
 {
@@ -344,7 +344,7 @@ TEST_P(PubSubFlowControllers, BuiltinFlowControllerFailDiscovery)
     ASSERT_TRUE(writer.isInitialized());
 
     // Reader discovery should fail
-    ASSERT_FALSE(reader.wait_participant_discovery(1,std::chrono::seconds(1)));
+    ASSERT_FALSE(reader.wait_participant_discovery(1, std::chrono::seconds(1)));
 }
 
 // This test checks that the WLP service is not able to send non stop liveliness messages when the builtin
@@ -357,14 +357,13 @@ TEST_P(PubSubFlowControllers, BuiltinFlowControllerWLPLimited)
 
     unsigned int lease_duration_ms = 501;
     unsigned int announcement_period_ms = 200;
-    
+
     PubSubReader<Data64kbPubSubType> reader(TEST_TOPIC_NAME);
     PubSubWriter<Data64kbPubSubType> writer(TEST_TOPIC_NAME);
 
     reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
             .liveliness_kind(eprosima::fastdds::dds::AUTOMATIC_LIVELINESS_QOS)
             .liveliness_lease_duration(lease_duration_ms * 1e-3).init();
-            // .liveliness_announcement_period(announcement_period_ms * 1e-3)
 
     ASSERT_TRUE(reader.isInitialized());
 
@@ -382,19 +381,18 @@ TEST_P(PubSubFlowControllers, BuiltinFlowControllerWLPLimited)
     // Wait for discovery.
     writer.wait_discovery();
     reader.wait_discovery();
-    
+
     // Once asserted that the writer is matched, it should eventually be declared as not alive because the
     // flow controller will not allow the wlp writer to send more liveliness messages
-    
     std::atomic<bool> stop(false);
-    auto assert_liveliness_func = [&writer, &reader, lease_duration_ms, &stop]()
-    {
-        while (!stop)
-        {
-            writer.assert_liveliness();
-            std::this_thread::sleep_for(std::chrono::milliseconds(lease_duration_ms / 10));
-        }
-    };
+    auto assert_liveliness_func = [&writer, lease_duration_ms, &stop]()
+            {
+                while (!stop)
+                {
+                    writer.assert_liveliness();
+                    std::this_thread::sleep_for(std::chrono::milliseconds(lease_duration_ms / 10));
+                }
+            };
     std::thread liveliness_thread(assert_liveliness_func);
 
     reader.wait_liveliness_lost(1);

--- a/test/dds/xtypes/BaseCases/Case11.json
+++ b/test/dds/xtypes/BaseCases/Case11.json
@@ -1,0 +1,27 @@
+{
+    "test_cases": [
+        {
+            "TestCase": "Case_11",
+            "participants": [
+                {
+                    "kind": "publisher",
+                    "samples": "10",
+                    "timeout": "10",
+                    "expected_matches": "1",
+                    "known_types": [
+                        "Type1"
+                    ],
+                    "builtin_flow_controller_bytes": "3000"
+                },
+                {
+                    "kind": "subscriber",
+                    "samples": "10",
+                    "timeout": "10",
+                    "expected_matches": "1",
+                    "known_types": [],
+                    "builtin_flow_controller_bytes": "3000"
+                }
+            ]
+        }
+    ]
+}

--- a/test/dds/xtypes/BaseCases/Case12.json
+++ b/test/dds/xtypes/BaseCases/Case12.json
@@ -1,0 +1,27 @@
+{
+    "test_cases": [
+        {
+            "TestCase": "Case_11",
+            "participants": [
+                {
+                    "kind": "publisher",
+                    "samples": "10",
+                    "timeout": "10",
+                    "expected_matches": "1",
+                    "known_types": [
+                        "Type1"
+                    ],
+                    "builtin_flow_controller_bytes": "10000"
+                },
+                {
+                    "kind": "subscriber",
+                    "samples": "10",
+                    "timeout": "10",
+                    "expected_matches": "1",
+                    "known_types": [],
+                    "builtin_flow_controller_bytes": "10000"
+                }
+            ]
+        }
+    ]
+}

--- a/test/dds/xtypes/TypeLookupServicePublisher.h
+++ b/test/dds/xtypes/TypeLookupServicePublisher.h
@@ -79,7 +79,8 @@ public:
 
     bool init(
             uint32_t domain_id,
-            std::vector<std::string> known_types);
+            std::vector<std::string> known_types,
+            uint32_t builtin_flow_controller_bytes);
 
     bool wait_discovery(
             uint32_t expected_matches,

--- a/test/dds/xtypes/TypeLookupServiceSubscriber.cpp
+++ b/test/dds/xtypes/TypeLookupServiceSubscriber.cpp
@@ -488,7 +488,8 @@ void TypeLookupServiceSubscriber::on_participant_discovery(
     static_cast<void>(should_be_ignored);
     if (status == ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT)
     {
-        std::cout << "Participant " << participant->guid() << " discovered participant " << info.guid << ": " << ++participant_matched_ << std::endl;
+        std::cout << "Participant " << participant->guid() << " discovered participant " << info.guid << ": " <<
+            ++participant_matched_ << std::endl;
     }
     else if (status == ParticipantDiscoveryStatus::CHANGED_QOS_PARTICIPANT)
     {
@@ -498,7 +499,8 @@ void TypeLookupServiceSubscriber::on_participant_discovery(
     else if (status == ParticipantDiscoveryStatus::REMOVED_PARTICIPANT ||
             status == ParticipantDiscoveryStatus::DROPPED_PARTICIPANT)
     {
-        std::cout << "Participant " << participant->guid() << " undiscovered participant " << info.guid << ": " << --participant_matched_ << std::endl;
+        std::cout << "Participant " << participant->guid() << " undiscovered participant " << info.guid << ": " <<
+            --participant_matched_ << std::endl;
     }
     cv_.notify_all();
 }

--- a/test/dds/xtypes/TypeLookupServiceSubscriber.cpp
+++ b/test/dds/xtypes/TypeLookupServiceSubscriber.cpp
@@ -47,7 +47,8 @@ TypeLookupServiceSubscriber::~TypeLookupServiceSubscriber()
 
 bool TypeLookupServiceSubscriber::init(
         uint32_t domain_id,
-        std::vector<std::string> known_types)
+        std::vector<std::string> known_types,
+        uint32_t builtin_flow_controller_bytes)
 {
     domain_id_ = domain_id;
     create_type_creator_functions();
@@ -60,8 +61,18 @@ bool TypeLookupServiceSubscriber::init(
             << StatusMask::data_available()
             << StatusMask::liveliness_changed();
 
+    auto qos = PARTICIPANT_QOS_DEFAULT;
+    if (builtin_flow_controller_bytes > 0)
+    {
+        auto new_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
+        new_flow_controller->name = "MyFlowController";
+        new_flow_controller->max_bytes_per_period = builtin_flow_controller_bytes;
+        new_flow_controller->period_ms = static_cast<uint64_t>(100000);
+        qos.flow_controllers().push_back(new_flow_controller);
+        qos.wire_protocol().builtin.flow_controller_name = new_flow_controller->name;
+    }
     participant_ = DomainParticipantFactory::get_instance()
-                    ->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT, this, mask);
+                    ->create_participant(domain_id, qos, this, mask);
     if (participant_ == nullptr)
     {
         std::cout << "ERROR TypeLookupServiceSubscriber: create_participant" << std::endl;
@@ -314,6 +325,26 @@ bool TypeLookupServiceSubscriber::wait_discovery(
     return true;
 }
 
+bool TypeLookupServiceSubscriber::wait_participant_discovery(
+        uint32_t expected_matches,
+        uint32_t timeout)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool result = cv_.wait_for(lock, std::chrono::seconds(timeout),
+                    [&]()
+                    {
+                        return participant_matched_ == static_cast<int32_t>(expected_matches);
+                    });
+
+    if (!result)
+    {
+        std::cout << "ERROR TypeLookupServiceSubscriber participoant discovery Timeout with matched = " <<
+            participant_matched_ << std::endl;
+        return false;
+    }
+    return true;
+}
+
 bool TypeLookupServiceSubscriber::run(
         uint32_t samples,
         uint32_t timeout)
@@ -446,4 +477,28 @@ void TypeLookupServiceSubscriber::on_data_writer_discovery(
             }
         }
     }
+}
+
+void TypeLookupServiceSubscriber::on_participant_discovery(
+        DomainParticipant* participant,
+        eprosima::fastdds::rtps::ParticipantDiscoveryStatus status,
+        const ParticipantBuiltinTopicData& info,
+        bool& should_be_ignored)
+{
+    static_cast<void>(should_be_ignored);
+    if (status == ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " discovered participant " << info.guid << ": " << ++participant_matched_ << std::endl;
+    }
+    else if (status == ParticipantDiscoveryStatus::CHANGED_QOS_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " detected changes on participant " << info.guid
+                  << std::endl;
+    }
+    else if (status == ParticipantDiscoveryStatus::REMOVED_PARTICIPANT ||
+            status == ParticipantDiscoveryStatus::DROPPED_PARTICIPANT)
+    {
+        std::cout << "Participant " << participant->guid() << " undiscovered participant " << info.guid << ": " << --participant_matched_ << std::endl;
+    }
+    cv_.notify_all();
 }

--- a/test/dds/xtypes/TypeLookupServiceSubscriber.h
+++ b/test/dds/xtypes/TypeLookupServiceSubscriber.h
@@ -80,9 +80,14 @@ public:
 
     bool init(
             uint32_t domain_id,
-            std::vector<std::string> known_types);
+            std::vector<std::string> known_types,
+            uint32_t builtin_flow_controller_bytes);
 
     bool wait_discovery(
+            uint32_t expected_matches,
+            uint32_t timeout);
+
+    bool wait_participant_discovery(
             uint32_t expected_matches,
             uint32_t timeout);
 
@@ -101,6 +106,12 @@ public:
             eprosima::fastdds::dds::DomainParticipant* /*participant*/,
             eprosima::fastdds::rtps::WriterDiscoveryStatus reason,
             const eprosima::fastdds::dds::PublicationBuiltinTopicData& info,
+            bool& should_be_ignored) override;
+
+    void on_participant_discovery(
+            DomainParticipant* participant,
+            eprosima::fastdds::rtps::ParticipantDiscoveryStatus status,
+            const ParticipantBuiltinTopicData& info,
             bool& should_be_ignored) override;
 
 private:
@@ -133,6 +144,7 @@ private:
     std::mutex mutex_;
     std::condition_variable cv_;
     int32_t matched_ {0};
+    int32_t participant_matched_ {0};
     uint32_t expected_matches_ {0};
     std::map<eprosima::fastdds::rtps::GUID_t, uint32_t> received_samples_;
 

--- a/test/dds/xtypes/TypeLookupService_main.cpp
+++ b/test/dds/xtypes/TypeLookupService_main.cpp
@@ -33,6 +33,7 @@ struct CommandLineArgs
     int expected_matches;
     std::vector<std::string> known_types;
     uint32_t seed {10800};
+    uint32_t builtin_flow_controller_bytes {0};
 };
 
 CommandLineArgs parse_args(
@@ -87,6 +88,10 @@ CommandLineArgs parse_args(
         {
             args.seed = strtol(value.c_str(), nullptr, 10);
         }
+        else if (key == "builtin_flow_controller_bytes")
+        {
+            args.builtin_flow_controller_bytes = strtol(value.c_str(), nullptr, 10);
+        }
     }
 
     return args;
@@ -110,16 +115,38 @@ int main(
         switch (args.kind){
             case 1: {
                 eprosima::fastdds::dds::TypeLookupServicePublisher pub;
-                return (pub.init(args.seed % 230, args.known_types) &&
-                       pub.wait_discovery(args.expected_matches, args.timeout) &&
-                       pub.run(args.samples, args.timeout) &&
-                       pub.wait_discovery(0, args.timeout)) ? 0 : -1;
+                // This case checks that the TypeLookUpService is controller by builtin flow controller, so it will
+                // not be able to send the type object because the builtin flow controller is too small, thus there will
+                // be no data writer to discover.
+                if (args.builtin_flow_controller_bytes <= 3000)
+                {
+                    return (pub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
+                        !pub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
+                }
+                else
+                {
+                    return (pub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
+                        pub.wait_discovery(args.expected_matches, args.timeout) &&
+                        pub.run(args.samples, args.timeout) &&
+                        pub.wait_discovery(0, args.timeout)) ? 0 : -1;
+                }
             }
             case 2: {
                 eprosima::fastdds::dds::TypeLookupServiceSubscriber sub;
-                return (sub.init(args.seed % 230, args.known_types) &&
-                       sub.wait_discovery(args.expected_matches, args.timeout) &&
-                       sub.run(args.samples, args.timeout)) ? 0 : -1;
+                if (args.builtin_flow_controller_bytes <= 3000)
+                {
+                    return (sub.init(args.seed % 230, args.known_types, 0) &&
+                        sub.wait_participant_discovery(args.expected_matches, args.timeout) &&
+                        // Once asserted that the participant is discovered, we assert that no type is discovered thus
+                        // not creating a data reader to match with the data writer.
+                        !sub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
+                }
+                else
+                {
+                    return (sub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
+                        sub.wait_discovery(args.expected_matches, args.timeout) &&
+                        sub.run(args.samples, args.timeout)) ? 0 : -1;
+                }
             }
             default:
                 std::cout << "Invalid participant type. Use 'publisher' or 'subscriber'." << std::endl;

--- a/test/dds/xtypes/TypeLookupService_main.cpp
+++ b/test/dds/xtypes/TypeLookupService_main.cpp
@@ -118,34 +118,34 @@ int main(
                 // This case checks that the TypeLookUpService is controller by builtin flow controller, so it will
                 // not be able to send the type object because the builtin flow controller is too small, thus there will
                 // be no data writer to discover.
-                if (args.builtin_flow_controller_bytes <= 3000)
+                if (args.builtin_flow_controller_bytes > 0 && args.builtin_flow_controller_bytes <= 3000)
                 {
                     return (pub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
-                        !pub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
+                           !pub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
                 }
                 else
                 {
                     return (pub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
-                        pub.wait_discovery(args.expected_matches, args.timeout) &&
-                        pub.run(args.samples, args.timeout) &&
-                        pub.wait_discovery(0, args.timeout)) ? 0 : -1;
+                           pub.wait_discovery(args.expected_matches, args.timeout) &&
+                           pub.run(args.samples, args.timeout) &&
+                           pub.wait_discovery(0, args.timeout)) ? 0 : -1;
                 }
             }
             case 2: {
                 eprosima::fastdds::dds::TypeLookupServiceSubscriber sub;
-                if (args.builtin_flow_controller_bytes <= 3000)
+                if (args.builtin_flow_controller_bytes > 0 && args.builtin_flow_controller_bytes <= 3000)
                 {
                     return (sub.init(args.seed % 230, args.known_types, 0) &&
-                        sub.wait_participant_discovery(args.expected_matches, args.timeout) &&
-                        // Once asserted that the participant is discovered, we assert that no type is discovered thus
-                        // not creating a data reader to match with the data writer.
-                        !sub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
+                           sub.wait_participant_discovery(args.expected_matches, args.timeout) &&
+                           // Once asserted that the participant is discovered, we assert that no type is discovered thus
+                           // not creating a data reader to match with the data writer.
+                           !sub.wait_discovery(args.expected_matches, args.timeout)) ? 0 : -1;
                 }
                 else
                 {
                     return (sub.init(args.seed % 230, args.known_types, args.builtin_flow_controller_bytes) &&
-                        sub.wait_discovery(args.expected_matches, args.timeout) &&
-                        sub.run(args.samples, args.timeout)) ? 0 : -1;
+                           sub.wait_discovery(args.expected_matches, args.timeout) &&
+                           sub.run(args.samples, args.timeout)) ? 0 : -1;
                 }
             }
             default:

--- a/test/dds/xtypes/test_build.py
+++ b/test/dds/xtypes/test_build.py
@@ -88,6 +88,7 @@ def define_args(participant):
     args.extend([f"timeout={participant.get('timeout', 10)}"])
     args.extend([f"expected_matches={participant.get('expected_matches', 1)}"])
     args.extend([f"seed={str(os.getpid())}"])
+    args.extend([f"builtin_flow_controller_bytes={participant.get('builtin_flow_controller_bytes', 0)}"])
 
     # Check if 'known_types' key exists and is a list
     if 'known_types' in participant and isinstance(participant['known_types'], list):

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -377,6 +377,9 @@ public:
     //! Mutation tries if the port is being used.
     uint32_t mutation_tries = 100u;
 
+    //! Flow controller name to use for the builtin writers
+    std::string flow_controller_name = "";
+
     //! Set to true to avoid multicast traffic on builtin endpoints
     bool avoid_builtin_multicast = true;
 
@@ -399,6 +402,7 @@ public:
                (this->writerHistoryMemoryPolicy == b.writerHistoryMemoryPolicy) &&
                (this->writerPayloadSize == b.writerPayloadSize) &&
                (this->mutation_tries == b.mutation_tries) &&
+               (this->flow_controller_name == b.flow_controller_name) &&
                (this->avoid_builtin_multicast == b.avoid_builtin_multicast);
     }
 

--- a/versions.md
+++ b/versions.md
@@ -21,6 +21,7 @@ Forthcoming
 * Added RPC over DDS internal API:
   * New classes: `Service`, `Requester`, `Replier`, `ServiceTypeSupport`
   * Added methods in DomainParticipant public API
+* Added builtin flow controller for builtin writers (PDP, EDP, WLP and Type Look Up Service).
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR introduces the feature of setting a flow controller for the builtin rtps data writers of PDP and EDP.

This PR is on top of the refactor done in #5679 

The feature has been documented in this [PR](https://github.com/eProsima/Fast-DDS-docs/pull/1042)

Todo:
- [x] Tests for WLP
- [x] Test for TypeLookup
- [x] Tests for general discovery
- [ ] Test participant destruction Data P [ud]
- [x] Test low bytes per second
- [x] Test flow controller name not included in flow controllers list
- [ ] PR documenting new feature

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#1042
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
