### PR TITLE
Review `FASTDDS_TODO_BEFORE` for release 3.2.0

### DIFF
--- a/include/fastdds/rtps/common/Types.hpp
+++ b/include/fastdds/rtps/common/Types.hpp
@@ -158,10 +158,6 @@ const ProtocolVersion_t c_ProtocolVersion_2_3{2, 3};
 
 const ProtocolVersion_t c_ProtocolVersion;
 
-//!@brief Structure VendorId_t, specifying the vendor Id of the implementation.
-// FASTDDS_TODO_BEFORE(3, 0, "Remove eprosima::fastdds::rtps::VendorId_t usings");
-using VendorId_t = eprosima::fastdds::rtps::VendorId_t;
-
 } // namespace rtps
 } // namespace fastdds
 } // namespace eprosima

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -93,7 +93,7 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                              * Changing this here implies a behaviour change in the
                              * RTPS layer, so it is postponed until the next major release.
                              */
-                            // FASTDDS_TODO_BEFORE(3, 0, "Fill related sample identity instead");
+                            FASTDDS_TODO_BEFORE(4, 0, "Fill related sample identity instead");
                             change.write_params.sample_identity(p.sample_id);
                         }
                         break;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -243,7 +243,7 @@ struct ReadTakeCommand
          * More importantly, the related sample identity should be taken from the related sample identity
          * in write_params.
          */
-        // FASTDDS_TODO_BEFORE(3, 0, "Fill both sample_identity and related_sample_identity with write_params");
+        FASTDDS_TODO_BEFORE(4, 0, "Fill both sample_identity and related_sample_identity with write_params");
         info.sample_identity.writer_guid(item->writerGUID);
         info.sample_identity.sequence_number(item->sequenceNumber);
         info.related_sample_identity = item->write_params.sample_identity();

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -867,7 +867,7 @@ bool MessageReceiver::proc_Submsg_Data(
         uint32_t next_pos = msg->pos + payload_size;
         if (msg->length >= next_pos && payload_size > 0)
         {
-            FASTDDS_TODO_BEFORE(3, 2, "Pass keyFlag in serializedPayload, and always pass input data upwards");
+            FASTDDS_TODO_BEFORE(3, 3, "Pass keyFlag in serializedPayload, and always pass input data upwards");
             if (dataFlag)
             {
                 ch.serializedPayload.data = &msg->buffer[msg->pos];


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
