### PR TITLE
[22872] Configure ROS 2 Easy Mode via C++ and XML

### DIFF
--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2664,6 +2664,7 @@ public:
     FASTDDS_EXPORTED_API WireProtocolConfigQos()
         : QosPolicy(false)
         , participant_id(-1)
+        , easy_mode_("")
     {
     }
 
@@ -2683,6 +2684,7 @@ public:
                (this->default_multicast_locator_list == b.default_multicast_locator_list) &&
                (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
                (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
+               (this->easy_mode_ == b.easy_mode()) &&
                QosPolicy::operator ==(b);
     }
 
@@ -2725,6 +2727,27 @@ public:
      * Whether locators that don't match with the announced locators should be kept.
      */
     bool ignore_non_matching_locators = false;
+
+    /**
+     * Setter for ROS 2 Easy Mode IP
+     */
+    void easy_mode(std::string ip)
+    {
+        easy_mode_ = ip;
+    }
+
+    /**
+     * Getter for ROS 2 Easy Mode IP
+     */
+    const std::string& easy_mode() const
+    {
+        return easy_mode_;
+    }
+
+private:
+
+    //! ROS 2 Easy Mode IP
+    std::string easy_mode_;
 };
 
 //! Qos Policy to configure the transport layer

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2729,7 +2729,10 @@ public:
     bool ignore_non_matching_locators = false;
 
     /**
-     * Setter for ROS 2 Easy Mode IP
+     * @brief Setter for ROS 2 Easy Mode IP
+     *
+     * @param ip IP address to set
+     * @note The IP address must be an IPv4 address. If it is not, the IP address will not be set.
      */
     void easy_mode(
             std::string ip)
@@ -2751,7 +2754,9 @@ public:
     }
 
     /**
-     * Getter for ROS 2 Easy Mode IP
+     * @brief Getter for ROS 2 Easy Mode IP
+     *
+     * @return IP address if set, empty string otherwise
      */
     const std::string& easy_mode() const
     {

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2734,6 +2734,15 @@ public:
     void easy_mode(
             std::string ip)
     {
+        // Check if the input is a valid IP
+        if (!rtps::IPLocator::isIPv4(ip))
+        {
+            EPROSIMA_LOG_ERROR(
+                WIREPROTOCOLQOS, "Invalid IP address format for ROS 2 Easy Mode. It must be an IPv4 address.");
+
+            return;
+        }
+
         easy_mode_ = ip;
     }
 

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2734,6 +2734,9 @@ public:
      *
      * @param ip IP address to set
      * @note The IP address must be an IPv4 address. If it is not, the IP address will not be set.
+     *
+     * @return RETCODE_OK if the IP address is set, an specific error code otherwise:
+     * RETCODE_BAD_PARAMETER if the IP address is not an IPv4 address.
      */
     ReturnCode_t easy_mode(
             const std::string& ip)

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -23,11 +23,13 @@
 #include <bitset>
 #include <vector>
 
+#include <fastdds/dds/core/detail/DDSReturnCode.hpp>
 #include <fastdds/dds/core/policy/ParameterTypes.hpp>
 #include <fastdds/dds/core/Types.hpp>
 #include <fastdds/dds/xtypes/type_representation/detail/dds_xtypes_typeobject.hpp>
 #include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/attributes/PropertyPolicy.hpp>
+#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAllocationAttributes.hpp>
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
 #include <fastdds/rtps/attributes/ThreadSettings.hpp>
@@ -35,7 +37,6 @@
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/common/Types.hpp>
 #include <fastdds/rtps/flowcontrol/FlowControllerConsts.hpp>
-#include <fastdds/rtps/attributes/ResourceManagement.hpp>
 #include <fastdds/rtps/transport/network/NetmaskFilterKind.hpp>
 
 #include <fastdds/utils/collections/ResourceLimitedVector.hpp>
@@ -2734,8 +2735,8 @@ public:
      * @param ip IP address to set
      * @note The IP address must be an IPv4 address. If it is not, the IP address will not be set.
      */
-    void easy_mode(
-            std::string ip)
+    ReturnCode_t easy_mode(
+            const std::string& ip)
     {
         // Check if the input is empty
         if (!ip.empty())
@@ -2746,11 +2747,13 @@ public:
                 EPROSIMA_LOG_ERROR(
                     WIREPROTOCOLQOS, "Invalid IP address format for ROS 2 Easy Mode. It must be an IPv4 address.");
 
-                return;
+                return RETCODE_BAD_PARAMETER;
             }
         }
 
         easy_mode_ = ip;
+
+        return RETCODE_OK;
     }
 
     /**

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2734,13 +2734,17 @@ public:
     void easy_mode(
             std::string ip)
     {
-        // Check if the input is a valid IP
-        if (!rtps::IPLocator::isIPv4(ip))
+        // Check if the input is empty
+        if (!ip.empty())
         {
-            EPROSIMA_LOG_ERROR(
-                WIREPROTOCOLQOS, "Invalid IP address format for ROS 2 Easy Mode. It must be an IPv4 address.");
+            // Check if the input is a valid IP
+            if (!rtps::IPLocator::isIPv4(ip))
+            {
+                EPROSIMA_LOG_ERROR(
+                    WIREPROTOCOLQOS, "Invalid IP address format for ROS 2 Easy Mode. It must be an IPv4 address.");
 
-            return;
+                return;
+            }
         }
 
         easy_mode_ = ip;

--- a/include/fastdds/dds/core/policy/QosPolicies.hpp
+++ b/include/fastdds/dds/core/policy/QosPolicies.hpp
@@ -2731,7 +2731,8 @@ public:
     /**
      * Setter for ROS 2 Easy Mode IP
      */
-    void easy_mode(std::string ip)
+    void easy_mode(
+            std::string ip)
     {
         easy_mode_ = ip;
     }

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -444,6 +444,7 @@ public:
                (this->port == b.port) &&
                (this->userData == b.userData) &&
                (this->participantID == b.participantID) &&
+               (this->easy_mode_ip == b.easy_mode_ip) &&
                (this->useBuiltinTransports == b.useBuiltinTransports) &&
                (this->properties == b.properties) &&
                (this->prefix == b.prefix) &&
@@ -526,6 +527,9 @@ public:
 
     //! Participant ID
     int32_t participantID = -1;
+
+    //! IP of the Host where master Server is located (EASY_MODE context)
+    std::string easy_mode_ip = "";
 
     //! User defined transports to use alongside or in place of builtins.
     std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> userTransports;

--- a/resources/xsd/fastdds_profiles.xsd
+++ b/resources/xsd/fastdds_profiles.xsd
@@ -131,6 +131,7 @@
             ├ builtin                              [0~1],
             ├ port                                 [0~1],
             ├ participantID                        [int32],
+            ├ easy_mode_ip                         [string],
             ├ userTransports                       [0~1],
             |   └ transport_id                     [1~*] [string],
             ├ useBuiltinTransports                 [bool],
@@ -172,6 +173,7 @@
                         <xs:element name="builtin" type="builtinAttributesType" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="port" type="portType" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="participantID" type="int32" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="easy_mode_ip" type="string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="userTransports" minOccurs="0" maxOccurs="1">
                             <xs:complexType>
                                 <xs:sequence>

--- a/src/cpp/fastdds/utils/QosConverters.cpp
+++ b/src/cpp/fastdds/utils/QosConverters.cpp
@@ -148,6 +148,7 @@ void set_qos_from_attributes(
     qos.wire_protocol().default_multicast_locator_list = attr.defaultMulticastLocatorList;
     qos.wire_protocol().default_external_unicast_locators = attr.default_external_unicast_locators;
     qos.wire_protocol().ignore_non_matching_locators = attr.ignore_non_matching_locators;
+    qos.wire_protocol().easy_mode(attr.easy_mode_ip);
     qos.transport().user_transports = attr.userTransports;
     qos.transport().use_builtin_transports = attr.useBuiltinTransports;
     qos.transport().send_socket_buffer_size = attr.sendSocketBufferSize;
@@ -198,6 +199,7 @@ void set_attributes_from_qos(
     attr.setName(qos.name());
     attr.prefix = qos.wire_protocol().prefix;
     attr.participantID = qos.wire_protocol().participant_id;
+    attr.easy_mode_ip = qos.wire_protocol().easy_mode();
     attr.builtin = qos.wire_protocol().builtin;
     attr.port = qos.wire_protocol().port;
     attr.defaultUnicastLocatorList = qos.wire_protocol().default_unicast_locator_list;

--- a/src/cpp/rtps/attributes/ServerAttributes.cpp
+++ b/src/cpp/rtps/attributes/ServerAttributes.cpp
@@ -79,7 +79,7 @@ const std::string& ros_easy_mode_env()
         // Check that the value is a valid IPv4 address
         if (!IPLocator::isIPv4(ip_value))
         {
-            EPROSIMA_LOG_ERROR(
+            EPROSIMA_LOG_WARNING(
                 SERVERATTRIBUTES,
                 "Invalid format: Easy Mode IP must be a valid IPv4 address. "
                 "Ignoring " << ROS2_EASY_MODE_URI << " value.");

--- a/src/cpp/rtps/attributes/ServerAttributes.cpp
+++ b/src/cpp/rtps/attributes/ServerAttributes.cpp
@@ -73,6 +73,20 @@ const std::string& ros_easy_mode_env()
 {
     static std::string ip_value;
     SystemInfo::get_env(ROS2_EASY_MODE_URI, ip_value);
+
+    if (!ip_value.empty())
+    {
+        // Check that the value is a valid IPv4 address
+        if (!IPLocator::isIPv4(ip_value))
+        {
+            EPROSIMA_LOG_ERROR(
+                SERVERATTRIBUTES,
+                "Invalid format: Easy Mode IP must be a valid IPv4 address. "
+                "Ignoring " << ROS2_EASY_MODE_URI << " value.");
+
+            ip_value = "";
+        }
+    }
     return ip_value;
 }
 

--- a/src/cpp/rtps/attributes/ServerAttributes.hpp
+++ b/src/cpp/rtps/attributes/ServerAttributes.hpp
@@ -198,7 +198,8 @@ const std::string& ros_discovery_server_env();
 
 /**
  * Get the value of environment variable ROS2_EASY_MODE_URI
- * @return The value of environment variable ROS2_EASY_MODE_URI. Empty string if the variable is not defined.
+ * @return The value of environment variable ROS2_EASY_MODE_URI.
+ * Empty string if the variable is not defined or does not have a valid IPv4 format.
  */
 const std::string& ros_easy_mode_env();
 

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -2246,6 +2246,7 @@ XMLP_ret XMLParser::fillDataNode(
                 <xs:element name="port" type="portType" minOccurs="0"/>
                 <xs:element name="userData" type="octetVectorType" minOccurs="0"/>
                 <xs:element name="participantID" type="int32Type" minOccurs="0"/>
+                <xs:element name="easy_mode_ip" type="stringType" minOccurs="0"/>
                 <xs:element name="flow_controller_descriptors" type="flowControllerDescriptorsType" minOccurs="0"/>
                 <xs:element name="userTransports" type="stringListType" minOccurs="0"/>
                 <xs:element name="useBuiltinTransports" type="boolType" minOccurs="0"/>
@@ -2442,6 +2443,14 @@ XMLP_ret XMLParser::fillDataNode(
         {
             // participantID - int32Type
             if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &participant_node.get()->rtps.participantID, ident))
+            {
+                return XMLP_ret::XML_ERROR;
+            }
+        }
+        else if (strcmp(name, EASY_MODE_IP) == 0)
+        {
+            // easy_mode_ip - stringType
+            if (XMLP_ret::XML_OK != getXMLString(p_aux0, &participant_node.get()->rtps.easy_mode_ip, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -2450,10 +2450,20 @@ XMLP_ret XMLParser::fillDataNode(
         else if (strcmp(name, EASY_MODE_IP) == 0)
         {
             // easy_mode_ip - stringType
-            if (XMLP_ret::XML_OK != getXMLString(p_aux0, &participant_node.get()->rtps.easy_mode_ip, ident))
+            std::string str_aux;
+            if (XMLP_ret::XML_OK != getXMLString(p_aux0, &str_aux, ident))
             {
                 return XMLP_ret::XML_ERROR;
             }
+
+            // Check that the string is a valid IPv4 address
+            if (!fastdds::rtps::IPLocator::isIPv4(str_aux))
+            {
+                EPROSIMA_LOG_ERROR(XMLPARSER, "'easy_mode_ip' is not a valid IPv4 address.");
+                return XMLP_ret::XML_ERROR;
+            }
+
+            participant_node.get()->rtps.easy_mode_ip = str_aux;
         }
         else if (strcmp(name, FLOW_CONTROLLER_DESCRIPTOR_LIST) == 0)
         {

--- a/src/cpp/xmlparser/XMLParser.cpp
+++ b/src/cpp/xmlparser/XMLParser.cpp
@@ -2230,28 +2230,55 @@ XMLP_ret XMLParser::fillDataNode(
         DataNode<fastdds::xmlparser::ParticipantAttributes>& participant_node)
 {
     /*
-        <xs:complexType name="rtpsParticipantAttributesType">
-            <xs:all minOccurs="0">
-                <xs:element name="domainId" type="uint32Type" minOccurs="0"/>
-                <xs:element name="allocation" type="rtpsParticipantAllocationAttributesType" minOccurs="0"/>
-                <xs:element name="prefix" type="guid" minOccurs="0"/>
-                <xs:element name="default_external_unicast_locators" type="externalLocatorListType" minOccurs="0"/>
-                <xs:element name="ignore_non_matching_locators" type="boolType" minOccurs="0"/>
-                <xs:element name="defaultUnicastLocatorList" type="locatorListType" minOccurs="0"/>
-                <xs:element name="defaultMulticastLocatorList" type="locatorListType" minOccurs="0"/>
-                <xs:element name="sendSocketBufferSize" type="uint32Type" minOccurs="0"/>
-                <xs:element name="listenSocketBufferSize" type="uint32Type" minOccurs="0"/>
-                <xs:element name="netmask_filter" type="netmaskFilterType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="builtin" type="builtinAttributesType" minOccurs="0"/>
-                <xs:element name="port" type="portType" minOccurs="0"/>
-                <xs:element name="userData" type="octetVectorType" minOccurs="0"/>
-                <xs:element name="participantID" type="int32Type" minOccurs="0"/>
-                <xs:element name="easy_mode_ip" type="stringType" minOccurs="0"/>
-                <xs:element name="flow_controller_descriptors" type="flowControllerDescriptorsType" minOccurs="0"/>
-                <xs:element name="userTransports" type="stringListType" minOccurs="0"/>
-                <xs:element name="useBuiltinTransports" type="boolType" minOccurs="0"/>
-                <xs:element name="propertiesPolicy" type="propertyPolicyType" minOccurs="0"/>
-                <xs:element name="name" type="stringType" minOccurs="0"/>
+        <xs:complexType name="participantProfileType">
+            <xs:all>
+                <xs:element name="domainId" type="domainIDType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="rtps" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:all>
+                            <xs:element name="name" type="string" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="defaultUnicastLocatorList" type="locatorListType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="defaultMulticastLocatorList" type="locatorListType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="default_external_unicast_locators" type="externalLocatorListType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="ignore_non_matching_locators" type="boolean" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="sendSocketBufferSize" type="uint32" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="listenSocketBufferSize" type="uint32" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="netmask_filter" minOccurs="0" maxOccurs="1">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:enumeration value="OFF"/>
+                                        <xs:enumeration value="AUTO"/>
+                                        <xs:enumeration value="ON"/>
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="builtin" type="builtinAttributesType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="port" type="portType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="participantID" type="int32" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="easy_mode_ip" type="string" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="userTransports" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="transport_id" type="string" minOccurs="1" maxOccurs="unbounded"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="useBuiltinTransports" type="boolean" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="builtinTransports" type="builtinTransportsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="propertiesPolicy" type="propertyPolicyType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="allocation" type="rtpsParticipantAllocationAttributesType"  minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="userData" type="octectVectorQosPolicyType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="prefix" type="prefixType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="flow_controller_descriptor_list" type="flowControllerDescriptorListType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="builtin_controllers_sender_thread" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="timed_events_thread" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="discovery_server_thread" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="typelookup_service_thread" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="builtin_transports_reception_threads" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                            <xs:element name="security_log_thread" type="threadSettingsType" minOccurs="0" maxOccurs="1"/>
+                        </xs:all>
+                    </xs:complexType>
+                </xs:element>
             </xs:all>
         </xs:complexType>
      */
@@ -2287,7 +2314,7 @@ XMLP_ret XMLParser::fillDataNode(
 
         if (strcmp(p_element->Name(), DOMAIN_ID) == 0)
         {
-            // domainId - uint32Type
+            // domainId - uint32
             if (XMLP_ret::XML_OK != getXMLUint(p_element, &participant_node.get()->domainId, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2344,7 +2371,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, IGN_NON_MATCHING_LOCS) == 0)
         {
-            // ignore_non_matching_locators - boolType
+            // ignore_non_matching_locators - boolean
             if (XMLP_ret::XML_OK !=
                     getXMLBool(p_aux0, &participant_node.get()->rtps.ignore_non_matching_locators, ident))
             {
@@ -2381,7 +2408,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, SEND_SOCK_BUF_SIZE) == 0)
         {
-            // sendSocketBufferSize - uint32Type
+            // sendSocketBufferSize - uint32
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &participant_node.get()->rtps.sendSocketBufferSize, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2389,7 +2416,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, LIST_SOCK_BUF_SIZE) == 0)
         {
-            // listenSocketBufferSize - uint32Type
+            // listenSocketBufferSize - uint32
             if (XMLP_ret::XML_OK != getXMLUint(p_aux0, &participant_node.get()->rtps.listenSocketBufferSize, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2441,7 +2468,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, PART_ID) == 0)
         {
-            // participantID - int32Type
+            // participantID - int32
             if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &participant_node.get()->rtps.participantID, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2449,7 +2476,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, EASY_MODE_IP) == 0)
         {
-            // easy_mode_ip - stringType
+            // easy_mode_ip - string
             std::string str_aux;
             if (XMLP_ret::XML_OK != getXMLString(p_aux0, &str_aux, ident))
             {
@@ -2484,7 +2511,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, USE_BUILTIN_TRANS) == 0)
         {
-            // useBuiltinTransports - boolType
+            // useBuiltinTransports - boolean
             if (XMLP_ret::XML_OK != getXMLBool(p_aux0, &participant_node.get()->rtps.useBuiltinTransports, ident))
             {
                 return XMLP_ret::XML_ERROR;
@@ -2511,7 +2538,7 @@ XMLP_ret XMLParser::fillDataNode(
         }
         else if (strcmp(name, NAME) == 0)
         {
-            // name - stringType
+            // name - string
             std::string s;
             if (XMLP_ret::XML_OK != getXMLString(p_aux0, &s, ident))
             {

--- a/src/cpp/xmlparser/XMLParserCommon.cpp
+++ b/src/cpp/xmlparser/XMLParserCommon.cpp
@@ -123,6 +123,7 @@ const char* LOGICAL_PORT = "logical_port";
 const char* PHYSICAL_PORT = "physical_port";
 const char* USER_DATA = "userData";
 const char* PART_ID = "participantID";
+const char* EASY_MODE_IP = "easy_mode_ip";
 const char* FLOW_CONTROLLER_DESCRIPTOR_LIST = "flow_controller_descriptor_list";
 const char* USER_TRANS = "userTransports";
 const char* USE_BUILTIN_TRANS = "useBuiltinTransports";

--- a/src/cpp/xmlparser/XMLParserCommon.h
+++ b/src/cpp/xmlparser/XMLParserCommon.h
@@ -137,6 +137,7 @@ extern const char* LOGICAL_PORT;
 extern const char* PHYSICAL_PORT;
 extern const char* USER_DATA;
 extern const char* PART_ID;
+extern const char* EASY_MODE_IP;
 extern const char* IP4_TO_SEND;
 extern const char* IP6_TO_SEND;
 extern const char* FLOW_CONTROLLER_DESCRIPTOR_LIST;

--- a/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
@@ -433,7 +433,7 @@ TEST(DSEasyMode, wire_protocol_qos_params_invalid)
     eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol_qos;
 
     // Try to set easy mode IP using an invalid IP address
-    wire_protocol_qos.easy_mode("Foo");
+    ASSERT_EQ(wire_protocol_qos.easy_mode("Foo"), eprosima::fastdds::dds::RETCODE_BAD_PARAMETER);
 
     ASSERT_TRUE(wire_protocol_qos.easy_mode().empty());
 }

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -433,6 +433,7 @@ public:
                (this->port == b.port) &&
                (this->userData == b.userData) &&
                (this->participantID == b.participantID) &&
+               (this->easy_mode_ip == b.easy_mode_ip) &&
                (this->useBuiltinTransports == b.useBuiltinTransports) &&
                (this->properties == b.properties) &&
                (this->prefix == b.prefix) &&
@@ -552,6 +553,9 @@ public:
 
     //! Participant ID
     int32_t participantID = -1;
+
+    //! IP of the Host where master Server is located (EASY_MODE context)
+    std::string easy_mode_ip = "";
 
     //! User defined transports to use alongside or in place of builtins.
     std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> userTransports;

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -543,6 +543,7 @@ TEST_F(XMLParserTests, Data)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -638,6 +639,7 @@ TEST_F(XMLParserTests, DataDeprecated)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -733,6 +735,7 @@ TEST_F(XMLParserTests, DataBuffer)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -828,6 +831,7 @@ TEST_F(XMLParserTests, DataBufferDeprecated)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -1862,6 +1866,7 @@ TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
             "<builtin><bad_element></bad_element></builtin>",
             "<port><bad_element></bad_element></port>",
             "<participantID><bad_element></bad_element></participantID>",
+            "<easy_mode_ip><bad_element></bad_element></easy_mode_ip>",
             "<flow_controller_descriptor_list><bad_element></bad_element></flow_controller_descriptor_list>",
             "<userTransports><bad_element></bad_element></userTransports>",
             "<useBuiltinTransports><bad_element></bad_element></useBuiltinTransports>",

--- a/test/unittest/xmlparser/XMLParserTests.cpp
+++ b/test/unittest/xmlparser/XMLParserTests.cpp
@@ -1813,6 +1813,7 @@ TEST_F(XMLParserTests, parseLogConfig)
  * 2. Check missing DomainId value in tag
  * 3. Check bad values for all attributes
  * 4. Check a non existant attribute tag
+ * 5. Check a non valid Easy Mode IP
  */
 TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
 {
@@ -1885,6 +1886,13 @@ TEST_F(XMLParserTests, fillDataNodeParticipantNegativeClauses)
             EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *participant_node));
 
         }
+
+        // Check invalid easy_mode_ip value (not a valid IPv4 address)
+        std::string invalid_easy_mode_ip = "<easy_mode_ip>Foo</easy_mode_ip>";
+        snprintf(xml, xml_len, xml_p, invalid_easy_mode_ip.c_str());
+        ASSERT_EQ(tinyxml2::XMLError::XML_SUCCESS, xml_doc.Parse(xml));
+        titleElement = xml_doc.RootElement();
+        EXPECT_EQ(XMLP_ret::XML_ERROR, XMLParserTest::fillDataNode_wrapper(titleElement, *participant_node));
     }
 }
 

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -136,7 +136,7 @@ protected:
 
     std::string xml_filename_ = "test_xml_profile.xml";
 
-    const std::pair<std::string, std::string> c_environment_values_[168]
+    const std::pair<std::string, std::string> c_environment_values_[169]
     {
         {"XML_PROFILES_ENV_VAR_1",   "123"},
         {"XML_PROFILES_ENV_VAR_2",   "4"},
@@ -305,7 +305,8 @@ protected:
         {"XML_PROFILES_ENV_VAR_165", "2048"},
         {"XML_PROFILES_ENV_VAR_166",  "45"},
         {"XML_PROFILES_ENV_VAR_167",  "test_flow_controller"},
-        {"XML_PROFILES_ENV_VAR_168",  "251"}
+        {"XML_PROFILES_ENV_VAR_168",  "251"},
+        {"XML_PROFILES_ENV_VAR_169",  "127.0.0.1"}
     };
 
 };
@@ -568,6 +569,7 @@ TEST_P(XMLProfileParserTests, XMLParserParticipant)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -669,6 +671,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserParticipantDeprecated)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -753,6 +756,7 @@ TEST_P(XMLProfileParserTests, XMLParserDefaultParticipantProfile)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);
@@ -837,6 +841,7 @@ TEST_F(XMLProfileParserBasicTests, XMLParserDefaultParticipantProfileDeprecated)
     EXPECT_EQ(port.offsetd3, 456);
     EXPECT_EQ(port.offsetd4, 251);
     EXPECT_EQ(rtps_atts.participantID, 9898);
+    EXPECT_EQ(rtps_atts.easy_mode_ip, "127.0.0.1");
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->max_bytes_per_period, 2048);
     EXPECT_EQ(rtps_atts.flow_controllers.at(0)->period_ms, 45u);
     EXPECT_EQ(rtps_atts.useBuiltinTransports, true);

--- a/test/unittest/xmlparser/test_xml_deprecated.xml
+++ b/test/unittest/xmlparser/test_xml_deprecated.xml
@@ -144,6 +144,7 @@
                     <offsetd4>251</offsetd4>
                 </port>
                 <participantID>9898</participantID>
+                <easy_mode_ip>127.0.0.1</easy_mode_ip>
                 <flow_controller_descriptor_list>
                     <flow_controller_descriptor>
                         <name>test_flow_controller</name>

--- a/test/unittest/xmlparser/test_xml_profile.xml
+++ b/test/unittest/xmlparser/test_xml_profile.xml
@@ -163,6 +163,7 @@
                     <offsetd4>251</offsetd4>
                 </port>
                 <participantID>9898</participantID>
+                <easy_mode_ip>127.0.0.1</easy_mode_ip>
                 <useBuiltinTransports>true</useBuiltinTransports>
                 <netmask_filter>ON</netmask_filter>
                 <name>test_name</name>

--- a/test/unittest/xmlparser/test_xml_profile_env_var.xml
+++ b/test/unittest/xmlparser/test_xml_profile_env_var.xml
@@ -144,6 +144,7 @@
                     <offsetd4>${XML_PROFILES_ENV_VAR_168}</offsetd4>
                 </port>
                 <participantID>${XML_PROFILES_ENV_VAR_63}</participantID>
+                <easy_mode_ip>${XML_PROFILES_ENV_VAR_169}</easy_mode_ip>
                 <useBuiltinTransports>${XML_PROFILES_ENV_VAR_64}</useBuiltinTransports>
                 <netmask_filter>${XML_PROFILES_ENV_VAR_162}</netmask_filter>
                 <name>${XML_PROFILES_ENV_VAR_65}</name>

--- a/test/unittest/xmlparser/test_xml_rooted_deprecated.xml
+++ b/test/unittest/xmlparser/test_xml_rooted_deprecated.xml
@@ -117,6 +117,7 @@
                     <offsetd4>251</offsetd4>
                 </port>
                 <participantID>9898</participantID>
+                <easy_mode_ip>127.0.0.1</easy_mode_ip>
                 <flow_controller_descriptor_list>
                     <flow_controller_descriptor>
                         <name>test_flow_controller</name>

--- a/test/unittest/xmlparser/test_xml_rooted_profile.xml
+++ b/test/unittest/xmlparser/test_xml_rooted_profile.xml
@@ -136,6 +136,7 @@
                     <offsetd4>251</offsetd4>
                 </port>
                 <participantID>9898</participantID>
+                <easy_mode_ip>127.0.0.1</easy_mode_ip>
                 <useBuiltinTransports>true</useBuiltinTransports>
                 <name>test_name</name>
                 <builtin_controllers_sender_thread>

--- a/versions.md
+++ b/versions.md
@@ -17,6 +17,7 @@ Forthcoming
   * New `ROS2_EASY_MODE` environment variable
   * Extended CLI ``discovery`` command to handle Fast DDS daemon.
   * Added P2P builtin transport.
+  * Added new `easy_mode_ip` XML tag and `easy_mode_` member in `WireProtocolConfigQos` for Discovery Server IP configuration. 
 
 Version v3.1.0
 --------------

--- a/versions.md
+++ b/versions.md
@@ -17,7 +17,7 @@ Forthcoming
   * New `ROS2_EASY_MODE` environment variable
   * Extended CLI ``discovery`` command to handle Fast DDS daemon.
   * Added P2P builtin transport.
-  * Added new `easy_mode_ip` XML tag and `easy_mode_` member in `WireProtocolConfigQos` for Discovery Server IP configuration. 
+  * Added new `easy_mode_ip` XML tag and `easy_mode` setter in `WireProtocolConfigQos` for Easy Mode IP configuration through XML and code.
 
 Version v3.1.0
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR adds a new member in RTPSParticipant attributes to store the IP of the Discovery Server when using ROS 2 Easy Mode.
- IP can be configured through C++ using WireProtocolConfigQos `easy_mode` setter.
- IP can be configured through XML using `easy_mode_ip` tag.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
     - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1043
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
