### PR TITLE
[22903] Remove SHM option from discovery server example

### DIFF
--- a/examples/cpp/discovery_server/CLIParser.hpp
+++ b/examples/cpp/discovery_server/CLIParser.hpp
@@ -164,7 +164,7 @@ public:
         std::cout << "  -p <num>, --connection-port <num>    Port of the Server to connect to"         << std::endl;
         std::cout << "                                       (Default port: 16166)."                   << std::endl;
         std::cout << "                                       (0 by default)."                          << std::endl;
-        std::cout << "            --transport <str>          [udpv4|udpv6|tcpv4|tcpv6|shm] "           << std::endl;
+        std::cout << "            --transport <str>          [udpv4|udpv6|tcpv4|tcpv6] "               << std::endl;
         std::cout << "                                       (udpv4 by default)."                      << std::endl;
         std::cout << ""                                                                                << std::endl;
         std::cout << "Publisher options:"                                                              << std::endl;
@@ -288,12 +288,6 @@ public:
                         config.sub_config.transport_kind = TransportKind::TCPv6;
                         config.srv_config.transport_kind = TransportKind::TCPv6;
                         uses_ipv6 = true;
-                    }
-                    else if (input == "shm")
-                    {
-                        config.pub_config.transport_kind = TransportKind::SHM;
-                        config.sub_config.transport_kind = TransportKind::SHM;
-                        config.srv_config.transport_kind = TransportKind::SHM;
                     }
                     else
                     {

--- a/examples/cpp/discovery_server/ClientPublisherApp.cpp
+++ b/examples/cpp/discovery_server/ClientPublisherApp.cpp
@@ -87,11 +87,6 @@ ClientPublisherApp::ClientPublisherApp(
 
     switch (config.transport_kind)
     {
-        case TransportKind::SHM:
-            descriptor = std::make_shared<eprosima::fastdds::rtps::SharedMemTransportDescriptor>();
-            server_locator.kind = LOCATOR_KIND_SHM;
-            break;
-
         case TransportKind::UDPv4:
         {
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();

--- a/examples/cpp/discovery_server/ClientPublisherApp.cpp
+++ b/examples/cpp/discovery_server/ClientPublisherApp.cpp
@@ -27,7 +27,6 @@
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
-#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>

--- a/examples/cpp/discovery_server/ClientSubscriberApp.cpp
+++ b/examples/cpp/discovery_server/ClientSubscriberApp.cpp
@@ -29,7 +29,6 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/SampleInfo.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
-#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>

--- a/examples/cpp/discovery_server/ClientSubscriberApp.cpp
+++ b/examples/cpp/discovery_server/ClientSubscriberApp.cpp
@@ -84,11 +84,6 @@ ClientSubscriberApp::ClientSubscriberApp(
 
     switch (config.transport_kind)
     {
-        case TransportKind::SHM:
-            descriptor = std::make_shared<eprosima::fastdds::rtps::SharedMemTransportDescriptor>();
-            server_locator.kind = LOCATOR_KIND_SHM;
-            break;
-
         case TransportKind::UDPv4:
         {
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();

--- a/examples/cpp/discovery_server/Helpers.hpp
+++ b/examples/cpp/discovery_server/Helpers.hpp
@@ -30,7 +30,6 @@ enum class TransportKind : uint8_t
     UDPv6,
     TCPv4,
     TCPv6,
-    SHM,
 };
 
 inline bool is_ip(

--- a/examples/cpp/discovery_server/ServerApp.cpp
+++ b/examples/cpp/discovery_server/ServerApp.cpp
@@ -87,12 +87,6 @@ ServerApp::ServerApp(
 
     switch (config.transport_kind)
     {
-        case TransportKind::SHM:
-            descriptor = std::make_shared<eprosima::fastdds::rtps::SharedMemTransportDescriptor>();
-            listening_locator.kind = LOCATOR_KIND_SHM;
-            connection_locator.kind = LOCATOR_KIND_SHM;
-            break;
-
         case TransportKind::UDPv4:
         {
             auto descriptor_tmp = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();

--- a/examples/cpp/discovery_server/ServerApp.cpp
+++ b/examples/cpp/discovery_server/ServerApp.cpp
@@ -27,7 +27,6 @@
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
-#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.hpp>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Remove SHM option from discovery server example.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #5670 

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
