### PR TITLE
Support discovery of TinyXML2 by pkgconfig

### DIFF
--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -15,6 +15,13 @@ endif()
 
 if(NOT (TINYXML2_FROM_SOURCE OR TINYXML2_FROM_THIRDPARTY))
     find_package(TinyXML2 CONFIG QUIET)
+    if(NOT TinyXML2_FOUND)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(TinyXML2 REQUIRED IMPORTED_TARGET tinyxml2)
+        if(TARGET PkgConfig::TinyXML2)
+            add_library(tinyxml2::tinyxml2 ALIAS PkgConfig::TinyXML2)
+        endif()
+    endif()
 endif()
 
 if(TinyXML2_FOUND AND NOT TINYXML2_FROM_THIRDPARTY)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -25,6 +25,13 @@ set_and_check(@PROJECT_NAME@_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 find_package(fastcdr REQUIRED)
 find_package(foonathan_memory REQUIRED)
 find_package(TinyXML2 QUIET)
+if(NOT TinyXML2_FOUND)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(TinyXML2 IMPORTED_TARGET tinyxml2)
+    if(TARGET PkgConfig::TinyXML2)
+        add_library(tinyxml2::tinyxml2 ALIAS PkgConfig::TinyXML2)
+    endif()
+endif()
 @FASTDDS_INSTALLER_DEPS_ANCILLARY@
 @FASTDDS_PACKAGE_UNIX_OPT_DEPS@
 


### PR DESCRIPTION
Allow to discovery TinyXML2 by pkg-config is a `-config.cmake` file is not available.

Since tinyxml2 is built with meson in Yocto it's configuration gets deployed by `pkg-config` (because meson cannot generate CMake target files). In this case, the current `FindTinyXML2.cmake` will find out the path of `tinyxml2.h` and of `tinyxml2.so` by looking into the `recipe-sysroot` folder, which path in going to get expanded into the `fastrtps-target.cmake` generated when fastdds is built. The end result is that we're going to have a system-wide deployed config mode package that points to a directory that won't (probably) not exist anymore when other dependent targets are built.

Since it's not possible to force meson to produce a `tinyxml2-target.cmake` file, the most reasonable solution is trying to look for the library by pkg-config.

With this patch applied, the generated `fastrtps-target.cmake` will have a reference to the target `PkgConfig::TinyXML2` instead of a full path.

Note that embedding TinyXML2 without symbol leaking it's not possible since they declare interfaces with `default` visibility. Which means that while creating an image we must have one and only one version of TinyXML2 around. Which basically makes impossible to use the bundled one in thirdparty


## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
-  ❌ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
-  ❌ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
-  ❌ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
-  ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
-  ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
-  ❌ New feature has been added to the `versions.md` file (if applicable).
-  ❌ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
-  ❌ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
