### PR TITLE
[22917] Add definitions for remote exceptions

### DIFF
--- a/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
+++ b/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
@@ -26,7 +26,7 @@ namespace rpc {
  * Enumeration of possible error codes that can be returned by a remote service.
  * Extracted from DDS-RPV v1.0 - 7.5.2 Mapping of Error Codes.
  */
-enum class RemoteExceptionCode_t : uint32_t
+enum class RemoteExceptionCode_t : int32_t
 {
     /// The request was executed successfully.
     REMOTE_EX_OK,

--- a/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
+++ b/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
@@ -24,7 +24,7 @@ namespace rpc {
 
 /**
  * Enumeration of possible error codes that can be returned by a remote service.
- * Extracted from DDS-RPV v1.0 - 7.5.2 Mapping of Error Codes.
+ * Extracted from DDS-RPC v1.0 - 7.5.2 Mapping of Error Codes.
  */
 enum class RemoteExceptionCode_t : int32_t
 {

--- a/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
+++ b/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
@@ -1,0 +1,49 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FASTDDS_DDS_RPC__REMOTEEXCEPTIONCODE_T_HPP
+#define FASTDDS_DDS_RPC__REMOTEEXCEPTIONCODE_T_HPP
+
+#include <cstdint>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Enumeration of possible error codes that can be returned by a remote service.
+ */
+enum class RemoteExceptionCode_t : uint32_t
+{
+    /// The request was executed successfully.
+    REMOTE_EX_OK,
+    /// Operation is valid but it is unsupported (a.k.a. not implemented).
+    REMOTE_EX_UNSUPPORTED,
+    /// The value of a parameter passed has an illegal value.
+    REMOTE_EX_INVALID_ARGUMENT,
+    /// The remote service ran out of resources while processing the request.
+    REMOTE_EX_OUT_OF_RESOURCES,
+    /// The operation called is unknown.
+    REMOTE_EX_UNKNOWN_OPERATION,
+    /// A generic, unspecified exception was raised by the service implementation.
+    REMOTE_EX_UNKNOWN_EXCEPTION
+};
+
+} // namespace rpc
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // FASTDDS_DDS_RPC__REMOTEEXCEPTIONCODE_T_HPP

--- a/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
+++ b/include/fastdds/dds/rpc/RemoteExceptionCode_t.hpp
@@ -24,6 +24,7 @@ namespace rpc {
 
 /**
  * Enumeration of possible error codes that can be returned by a remote service.
+ * Extracted from DDS-RPV v1.0 - 7.5.2 Mapping of Error Codes.
  */
 enum class RemoteExceptionCode_t : uint32_t
 {

--- a/include/fastdds/dds/rpc/exceptions.hpp
+++ b/include/fastdds/dds/rpc/exceptions.hpp
@@ -19,6 +19,11 @@
 #ifndef FASTDDS_DDS_RPC__EXCEPTIONS_HPP
 #define FASTDDS_DDS_RPC__EXCEPTIONS_HPP
 
+#include <fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp>
+#include <fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp>
+#include <fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp>
+#include <fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp>
+#include <fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcException.hpp>
 #include <fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp>

--- a/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the server reports invalid arguments.
  */
-class FASTDDS_EXPORTED_API RemoteInvalidArgumentError : public RpcRemoteException
+class RemoteInvalidArgumentError : public RpcRemoteException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
@@ -40,8 +40,7 @@ public:
      * Constructor.
      */
     RemoteInvalidArgumentError()
-        : RemoteInvalidArgumentError(
-                "The value of a parameter passed has an illegal value")
+        : RemoteInvalidArgumentError("The value of a parameter passed has an illegal value")
     {
     }
 

--- a/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteInvalidArgumentError.hpp
@@ -1,0 +1,83 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RemoteInvalidArgumentError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEINVALIDARGUMENTERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEINVALIDARGUMENTERROR_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcRemoteException.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the server reports invalid arguments.
+ */
+class FASTDDS_EXPORTED_API RemoteInvalidArgumentError : public RpcRemoteException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RemoteInvalidArgumentError()
+        : RemoteInvalidArgumentError(
+                "The value of a parameter passed has an illegal value")
+    {
+    }
+
+    /**
+     * Constructor with custom message.
+     *
+     * @param msg The exception message.
+     */
+    RemoteInvalidArgumentError(
+            const char* msg)
+        : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT, msg)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RemoteInvalidArgumentError(
+            const RemoteInvalidArgumentError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RemoteInvalidArgumentError& operator =(
+            const RemoteInvalidArgumentError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RemoteInvalidArgumentError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEINVALIDARGUMENTERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the server reports out of resources.
  */
-class FASTDDS_EXPORTED_API RemoteOutOfResourcesError : public RpcRemoteException
+class RemoteOutOfResourcesError : public RpcRemoteException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
@@ -1,0 +1,83 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RemoteOutOfResourcesError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEOUTOFRESOURCESERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEOUTOFRESOURCESERROR_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcRemoteException.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the server reports out of resources.
+ */
+class FASTDDS_EXPORTED_API RemoteOutOfResourcesError : public RpcRemoteException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RemoteOutOfResourcesError()
+        : RemoteOutOfResourcesError(
+                "The remote service ran out of resources while processing the request")
+    {
+    }
+
+    /**
+     * Constructor with custom message.
+     *
+     * @param msg The exception message.
+     */
+    RemoteOutOfResourcesError(
+            const char* msg)
+        : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES, msg)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RemoteOutOfResourcesError(
+            const RemoteOutOfResourcesError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RemoteOutOfResourcesError& operator =(
+            const RemoteOutOfResourcesError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RemoteOutOfResourcesError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEOUTOFRESOURCESERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteOutOfResourcesError.hpp
@@ -40,8 +40,7 @@ public:
      * Constructor.
      */
     RemoteOutOfResourcesError()
-        : RemoteOutOfResourcesError(
-                "The remote service ran out of resources while processing the request")
+        : RemoteOutOfResourcesError("The remote service ran out of resources while processing the request")
     {
     }
 

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the service implementation raises an unspecified exception.
  */
-class FASTDDS_EXPORTED_API RemoteUnknownExceptionError : public RpcRemoteException
+class RemoteUnknownExceptionError : public RpcRemoteException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
@@ -40,8 +40,7 @@ public:
      * Constructor.
      */
     RemoteUnknownExceptionError()
-        : RemoteUnknownExceptionError(
-                "A generic, unspecified exception was raised by the service implementation")
+        : RemoteUnknownExceptionError("A generic, unspecified exception was raised by the service implementation")
     {
     }
 

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownExceptionError.hpp
@@ -1,0 +1,83 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RemoteUnknownExceptionError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNEXCEPTIONERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNEXCEPTIONERROR_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcRemoteException.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the service implementation raises an unspecified exception.
+ */
+class FASTDDS_EXPORTED_API RemoteUnknownExceptionError : public RpcRemoteException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RemoteUnknownExceptionError()
+        : RemoteUnknownExceptionError(
+                "A generic, unspecified exception was raised by the service implementation")
+    {
+    }
+
+    /**
+     * Constructor with custom message.
+     *
+     * @param msg The exception message.
+     */
+    RemoteUnknownExceptionError(
+            const char* msg)
+        : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_EXCEPTION, msg)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RemoteUnknownExceptionError(
+            const RemoteUnknownExceptionError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RemoteUnknownExceptionError& operator =(
+            const RemoteUnknownExceptionError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RemoteUnknownExceptionError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNEXCEPTIONERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the server does not recognize the invoked operation.
  */
-class FASTDDS_EXPORTED_API RemoteUnknownOperationError : public RpcRemoteException
+class RemoteUnknownOperationError : public RpcRemoteException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RemoteUnknownOperationError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNOPERATIONERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNOPERATIONERROR_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcRemoteException.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the server does not recognize the invoked operation.
+ */
+class FASTDDS_EXPORTED_API RemoteUnknownOperationError : public RpcRemoteException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RemoteUnknownOperationError()
+        : RemoteUnknownOperationError(
+                "The operation called is unknown")
+    {
+    }
+
+    /**
+     * Constructor with custom message.
+     *
+     * @param msg The exception message.
+     */
+    RemoteUnknownOperationError(
+            const char* msg)
+        : RemoteUnknownOperationError(
+                RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION,
+                msg)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RemoteUnknownOperationError(
+            const RemoteUnknownOperationError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RemoteUnknownOperationError& operator =(
+            const RemoteUnknownOperationError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RemoteUnknownOperationError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNKNOWNOPERATIONERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnknownOperationError.hpp
@@ -40,8 +40,7 @@ public:
      * Constructor.
      */
     RemoteUnknownOperationError()
-        : RemoteUnknownOperationError(
-                "The operation called is unknown")
+        : RemoteUnknownOperationError("The operation called is unknown")
     {
     }
 
@@ -52,9 +51,7 @@ public:
      */
     RemoteUnknownOperationError(
             const char* msg)
-        : RemoteUnknownOperationError(
-                RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION,
-                msg)
+        : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION, msg)
     {
     }
 

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
@@ -1,0 +1,83 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RemoteUnsupportedError.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNSUPPORTEDERROR_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNSUPPORTEDERROR_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcRemoteException.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Exception thrown by the RPC API when the server reports an unsupported operation.
+ */
+class FASTDDS_EXPORTED_API RemoteUnsupportedError : public RpcRemoteException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RemoteUnsupportedError()
+        : RemoteUnsupportedError(
+                "Operation is valid but it is unsupported (i.e. is not implemented)")
+    {
+    }
+
+    /**
+     * Constructor with custom message.
+     *
+     * @param msg The exception message.
+     */
+    RemoteUnsupportedError(
+            const char* msg)
+        : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED, msg)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RemoteUnsupportedError(
+            const RemoteUnsupportedError& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RemoteUnsupportedError& operator =(
+            const RemoteUnsupportedError& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RemoteUnsupportedError() noexcept = default;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__REMOTEUNSUPPORTEDERROR_HPP

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
@@ -40,8 +40,7 @@ public:
      * Constructor.
      */
     RemoteUnsupportedError()
-        : RemoteUnsupportedError(
-                "Operation is valid but it is unsupported (i.e. is not implemented)")
+        : RemoteUnsupportedError("Operation is valid but it is unsupported (i.e. is not implemented)")
     {
     }
 

--- a/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RemoteUnsupportedError.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the server reports an unsupported operation.
  */
-class FASTDDS_EXPORTED_API RemoteUnsupportedError : public RpcRemoteException
+class RemoteUnsupportedError : public RpcRemoteException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcBrokenPipeException.hpp
@@ -30,7 +30,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the communication with the remote endpoint breaks.
  */
-class FASTDDS_EXPORTED_API RpcBrokenPipeException : public RpcException
+class RpcBrokenPipeException : public RpcException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcException.hpp
@@ -32,7 +32,7 @@ namespace rpc {
 /**
  * Base class for all exceptions thrown by the RPC API.
  */
-class FASTDDS_EXPORTED_API RpcException
+class RpcException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcFeedCancelledException.hpp
@@ -33,7 +33,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when the client cancels an input feed.
  */
-class FASTDDS_EXPORTED_API RpcFeedCancelledException : public RpcException
+class RpcFeedCancelledException : public RpcException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcOperationError.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcOperationError.hpp
@@ -32,7 +32,7 @@ namespace rpc {
 /**
  * Base class for exceptions thrown by the RPC API when the server communicates an error.
  */
-class FASTDDS_EXPORTED_API RpcOperationError : public RpcException
+class RpcOperationError : public RpcException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcRemoteException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcRemoteException.hpp
@@ -1,0 +1,89 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcRemoteException.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_EXCEPTIONS__RPCREMOTEEXCEPTION_HPP
+#define FASTDDS_DDS_RPC_EXCEPTIONS__RPCREMOTEEXCEPTION_HPP
+
+#include <fastdds/fastdds_dll.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+#include <fastdds/dds/rpc/exceptions/RpcException.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * Base class for exceptions that map to a RpcExceptionCode_t.
+ */
+class FASTDDS_EXPORTED_API RpcRemoteException : public RpcException
+{
+
+public:
+
+    /**
+     * Constructor.
+     */
+    RpcRemoteException(
+            RemoteExceptionCode_t code,
+            const char* msg)
+        : RpcException(msg)
+        , code_(code)
+    {
+    }
+
+    /**
+     * Copy constructor.
+     */
+    RpcRemoteException(
+            const RpcRemoteException& other) noexcept = default;
+
+    /**
+     * Copy assignment.
+     */
+    RpcRemoteException& operator =(
+            const RpcRemoteException& other) noexcept = default;
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcRemoteException() noexcept = default;
+
+    /**
+     * Get the exception code.
+     *
+     * @return The exception code.
+     */
+    RemoteExceptionCode_t code() const noexcept
+    {
+        return code_;
+    }
+
+private:
+
+    /// The exception code.
+    RemoteExceptionCode_t code_;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_EXCEPTIONS__RPCREMOTEEXCEPTION_HPP

--- a/include/fastdds/dds/rpc/exceptions/RpcRemoteException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcRemoteException.hpp
@@ -31,7 +31,7 @@ namespace rpc {
 /**
  * Base class for exceptions that map to a RpcExceptionCode_t.
  */
-class FASTDDS_EXPORTED_API RpcRemoteException : public RpcException
+class RpcRemoteException : public RpcException
 {
 
 public:

--- a/include/fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp
+++ b/include/fastdds/dds/rpc/exceptions/RpcTimeoutException.hpp
@@ -30,7 +30,7 @@ namespace rpc {
 /**
  * Exception thrown by the RPC API when an operation times out.
  */
-class FASTDDS_EXPORTED_API RpcTimeoutException : public RpcException
+class RpcTimeoutException : public RpcException
 {
 
 public:

--- a/test/blackbox/common/DDSBlackboxTestsRPC.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsRPC.cpp
@@ -1,0 +1,84 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/rpc/exceptions.hpp>
+#include <fastdds/dds/rpc/interfaces.hpp>
+#include <fastdds/dds/rpc/RemoteExceptionCode_t.hpp>
+
+namespace rpc = eprosima::fastdds::dds::rpc;
+
+TEST(RPC, ExceptionCodes)
+{
+    rpc::RemoteInvalidArgumentError invalid_argument_error;
+    EXPECT_EQ(invalid_argument_error.code(), rpc::RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT);
+
+    rpc::RemoteOutOfResourcesError out_of_resources_error;
+    EXPECT_EQ(out_of_resources_error.code(), rpc::RemoteExceptionCode_t::REMOTE_EX_OUT_OF_RESOURCES);
+
+    rpc::RemoteUnknownExceptionError unknown_exception_error;
+    EXPECT_EQ(unknown_exception_error.code(), rpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_EXCEPTION);
+
+    rpc::RemoteUnknownOperationError unknown_operation_error;
+    EXPECT_EQ(unknown_operation_error.code(), rpc::RemoteExceptionCode_t::REMOTE_EX_UNKNOWN_OPERATION);
+
+    rpc::RemoteUnsupportedError unsupported_error;
+    EXPECT_EQ(unsupported_error.code(), rpc::RemoteExceptionCode_t::REMOTE_EX_UNSUPPORTED);
+}
+
+TEST(RPC, Exceptions)
+{
+    rpc::RpcBrokenPipeException broken_pipe_exception(true);
+    EXPECT_NE(broken_pipe_exception.what(), nullptr);
+
+    rpc::RpcBrokenPipeException broken_pipe_exception_2(false);
+    EXPECT_NE(broken_pipe_exception_2.what(), nullptr);
+
+    rpc::RpcException rpc_exception("Generic exception");
+    EXPECT_NE(rpc_exception.what(), nullptr);
+
+    rpc::RpcException rpc_exception_2(std::string("Generic exception"));
+    EXPECT_NE(rpc_exception_2.what(), nullptr);
+
+    rpc::RpcFeedCancelledException feed_cancelled_exception(rpc::RPC_STATUS_CODE_OK);
+    EXPECT_NE(feed_cancelled_exception.what(), nullptr);
+
+    rpc::RpcOperationError operation_error("Operation error");
+    EXPECT_NE(operation_error.what(), nullptr);
+
+    rpc::RpcOperationError operation_error_2(std::string("Operation error"));
+    EXPECT_NE(operation_error_2.what(), nullptr);
+
+    rpc::RpcTimeoutException timeout_exception;
+    EXPECT_NE(timeout_exception.what(), nullptr);
+
+    rpc::RpcRemoteException remote_exception(rpc::RemoteExceptionCode_t::REMOTE_EX_OK, "Remote exception");
+    EXPECT_NE(remote_exception.what(), nullptr);
+
+    rpc::RemoteInvalidArgumentError invalid_argument_error("Invalid argument");
+    EXPECT_NE(invalid_argument_error.what(), nullptr);
+
+    rpc::RemoteOutOfResourcesError out_of_resources_error("Not enough memory");
+    EXPECT_NE(out_of_resources_error.what(), nullptr);
+
+    rpc::RemoteUnknownExceptionError unknown_exception_error("std::exception");
+    EXPECT_NE(unknown_exception_error.what(), nullptr);
+
+    rpc::RemoteUnknownOperationError unknown_operation_error("Operation hash 0123456789abcdef");
+    EXPECT_NE(unknown_operation_error.what(), nullptr);
+
+    rpc::RemoteUnsupportedError unsupported_error("Still not implemented");
+    EXPECT_NE(unsupported_error.what(), nullptr);
+}

--- a/test/blackbox/common/DDSBlackboxTestsRPC.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsRPC.cpp
@@ -82,3 +82,49 @@ TEST(RPC, Exceptions)
     rpc::RemoteUnsupportedError unsupported_error("Still not implemented");
     EXPECT_NE(unsupported_error.what(), nullptr);
 }
+
+TEST(RPC, ThrowExceptions)
+{
+    EXPECT_THROW(throw rpc::RpcException("Generic exception"), rpc::RpcException);
+    EXPECT_THROW(throw rpc::RpcException(std::string("Generic exception")), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RpcBrokenPipeException(true), rpc::RpcBrokenPipeException);
+    EXPECT_THROW(throw rpc::RpcBrokenPipeException(false), rpc::RpcBrokenPipeException);
+    EXPECT_THROW(throw rpc::RpcBrokenPipeException(false), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RpcFeedCancelledException(rpc::RPC_STATUS_CODE_OK), rpc::RpcFeedCancelledException);
+    EXPECT_THROW(throw rpc::RpcFeedCancelledException(rpc::RPC_STATUS_CODE_OK), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RpcOperationError("Operation error"), rpc::RpcOperationError);
+    EXPECT_THROW(throw rpc::RpcOperationError(std::string("Operation error")), rpc::RpcOperationError);
+    EXPECT_THROW(throw rpc::RpcOperationError("Operation error"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RpcTimeoutException(), rpc::RpcTimeoutException);
+    EXPECT_THROW(throw rpc::RpcTimeoutException(), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RpcRemoteException(rpc::RemoteExceptionCode_t::REMOTE_EX_OK,
+            "Remote exception"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RpcRemoteException(rpc::RemoteExceptionCode_t::REMOTE_EX_OK,
+            "Remote exception"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RemoteInvalidArgumentError("Invalid argument"), rpc::RemoteInvalidArgumentError);
+    EXPECT_THROW(throw rpc::RemoteInvalidArgumentError("Invalid argument"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RemoteInvalidArgumentError("Invalid argument"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RemoteOutOfResourcesError("Not enough memory"), rpc::RemoteOutOfResourcesError);
+    EXPECT_THROW(throw rpc::RemoteOutOfResourcesError("Not enough memory"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RemoteOutOfResourcesError("Not enough memory"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RemoteUnknownExceptionError("std::exception"), rpc::RemoteUnknownExceptionError);
+    EXPECT_THROW(throw rpc::RemoteUnknownExceptionError("std::exception"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RemoteUnknownExceptionError("std::exception"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RemoteUnknownOperationError(
+                "Operation hash 0123456789abcdef"), rpc::RemoteUnknownOperationError);
+    EXPECT_THROW(throw rpc::RemoteUnknownOperationError("Operation hash 0123456789abcdef"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RemoteUnknownOperationError("Operation hash 0123456789abcdef"), rpc::RpcException);
+
+    EXPECT_THROW(throw rpc::RemoteUnsupportedError("Still not implemented"), rpc::RemoteUnsupportedError);
+    EXPECT_THROW(throw rpc::RemoteUnsupportedError("Still not implemented"), rpc::RpcRemoteException);
+    EXPECT_THROW(throw rpc::RemoteUnsupportedError("Still not implemented"), rpc::RpcException);
+}

--- a/test/blackbox/common/DDSBlackboxTestsRPC.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsRPC.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds definitions for the remote exceptions mentioned in DDS-RPC 1.0

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
