### PR TITLE
[22873] Setup ROS 2 Easy Mode at participant creation

### DIFF
--- a/include/fastdds/rtps/RTPSDomain.hpp
+++ b/include/fastdds/rtps/RTPSDomain.hpp
@@ -111,6 +111,26 @@ public:
             RTPSParticipantListener* plisten = nullptr);
 
     /**
+     * @brief Create a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
+     * It also configures ROS 2 Easy Mode IP if ROS2_EASY_MODE_URI environment variable is set
+     * and it was empty in the input attributes.
+     *
+     * @param domain_id DomainId to be used by the RTPSParticipant.
+     * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
+     * @param attrs RTPSParticipant Attributes.
+     * @param plisten Pointer to the ParticipantListener.
+     * @return Pointer to the RTPSParticipant.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
+     *          so its use may result in undefined behaviour.
+     */
+    static RTPSParticipant* create_client_server_participant(
+            uint32_t domain_id,
+            bool enabled,
+            const RTPSParticipantAttributes& attrs,
+            RTPSParticipantListener* plisten = nullptr);
+
+    /**
      * Create a RTPSWriter in a participant.
      *
      * @param p       Pointer to the RTPSParticipant.

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -291,8 +291,6 @@ ReturnCode_t DomainParticipantImpl::enable()
     utils::set_attributes_from_qos(rtps_attr, qos_);
     rtps_attr.participantID = participant_id_;
 
-    // If DEFAULT_ROS2_MASTER_URI is specified then try to create default client if
-    // that already exists.
     RTPSParticipant* part = RTPSDomain::createParticipant(
         domain_id_,
         false,

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -293,7 +293,7 @@ ReturnCode_t DomainParticipantImpl::enable()
 
     // If DEFAULT_ROS2_MASTER_URI is specified then try to create default client if
     // that already exists.
-    RTPSParticipant* part = RTPSDomainImpl::clientServerEnvironmentCreationOverride(
+    RTPSParticipant* part = RTPSDomain::createParticipant(
         domain_id_,
         false,
         rtps_attr,
@@ -301,13 +301,8 @@ ReturnCode_t DomainParticipantImpl::enable()
 
     if (part == nullptr)
     {
-        part = RTPSDomain::createParticipant(domain_id_, false, rtps_attr, &rtps_listener_);
-
-        if (part == nullptr)
-        {
-            EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Problem creating RTPSParticipant");
-            return RETCODE_ERROR;
-        }
+        EPROSIMA_LOG_ERROR(DOMAIN_PARTICIPANT, "Problem creating RTPSParticipant");
+        return RETCODE_ERROR;
     }
 
     guid_ = part->getGuid();

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -536,10 +536,23 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
     // Is up to the caller guarantee the att argument is not modified during the call
     RTPSParticipantAttributes client_att(att);
 
-    // Check whether we need to initialize in easy mode
-    const std::string& ros_easy_mode_env_value = ros_easy_mode_env();
+    /* Check whether we need to initialize in easy mode */
 
-    if (ros_easy_mode_env_value.empty())
+    // Get the IP of the remote discovery server.
+    // 1. Check if it is configured in RTPSParticipantAttributes
+    // 2. If not, check if it is configured in the environment variable
+    std::string ros_easy_mode_ip_value;
+
+    if (!att.easy_mode_ip.empty())
+    {
+        ros_easy_mode_ip_value = att.easy_mode_ip;
+    }
+    else
+    {
+        ros_easy_mode_ip_value = ros_easy_mode_env();
+    }
+
+    if (ros_easy_mode_ip_value.empty())
     {
         // Retrieve the info from the environment variable
         LocatorList_t& server_list = client_att.builtin.discovery_config.m_DiscoveryServers;
@@ -655,7 +668,7 @@ RTPSParticipant* RTPSDomainImpl::clientServerEnvironmentCreationOverride(
                         .verb(FAST_DDS_DEFAULT_CLI_AUTO_VERB)
                         .arg("-d")
                         .value(std::to_string(domain_id))
-                        .value(ros_easy_mode_env_value + ":" + std::to_string(domain_id))
+                        .value(ros_easy_mode_ip_value + ":" + std::to_string(domain_id))
                         .build_and_call();
 #ifndef _WIN32
         // Adecuate Python subprocess return

--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -377,7 +377,15 @@ RTPSParticipant* RTPSDomainImpl::create_client_server_participant(
                     part = nullptr;
                     return nullptr;
                 }
+
+                EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Easy Mode discovery server launched successfully");
             }
+
+            EPROSIMA_LOG_INFO(RTPS_DOMAIN, "Auto default server-client setup: Default client created.");
+
+            // At this point, Discovery Protocol has changed from SIMPLE to CLIENT or SUPER_CLIENT.
+            // Set client_override_ flag to true (Simple Participant turned into a Client Participant).
+            part->mp_impl->client_override(true);
 
             return part;
         }

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -91,6 +91,26 @@ public:
             RTPSParticipantListener* plisten);
 
     /**
+     * @brief Create a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
+     * It also configures ROS 2 Easy Mode IP if ROS2_EASY_MODE_URI environment variable is set
+     * and it was empty in the input attributes.
+     *
+     * @param domain_id DomainId to be used by the RTPSParticipant.
+     * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
+     * @param attrs RTPSParticipant Attributes.
+     * @param plisten Pointer to the ParticipantListener.
+     * @return Pointer to the RTPSParticipant.
+     *
+     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
+     *          so its use may result in undefined behaviour.
+     */
+    static RTPSParticipant* create_client_server_participant(
+            uint32_t domain_id,
+            bool enabled,
+            const RTPSParticipantAttributes& attrs,
+            RTPSParticipantListener* plisten);
+
+    /**
      * Remove a RTPSWriter.
      * @param writer Pointer to the writer you want to remove.
      * @return  True if correctly removed.

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -92,8 +92,9 @@ public:
 
     /**
      * @brief Create a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
-     * It also configures ROS 2 Easy Mode IP if ROS2_EASY_MODE_URI environment variable is set
-     * and it was empty in the input attributes.
+     * It also configures ROS 2 Easy Mode IP if the following conditions are met:
+     * 1. ROS2_EASY_MODE_URI environment variable is set.
+     * 2. `easy_mode_ip` member of the input RTPSParticipantAttributes is an empty string.
      *
      * @param domain_id DomainId to be used by the RTPSParticipant.
      * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -115,21 +115,18 @@ public:
             RTPSParticipant* p);
 
     /**
-     * Creates a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
-     * @param domain_id DDS domain associated
-     * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
-     * @param attrs RTPSParticipant Attributes.
-     * @param listen Pointer to the ParticipantListener.
-     * @return Pointer to the RTPSParticipant.
+     * Fills RTPSParticipantAttributes to create a RTPSParticipant as default server or client
+     * if ROS_MASTER_URI environment variable is set.
      *
-     * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
-     *          so its use may result in undefined behaviour.
+     * @param domain_id DDS domain associated
+     * @param [in, out] attrs RTPSParticipant Attributes.
+     * @return True if the attributes were successfully modified,
+     * false if an error occurred or environment variable not set
+     *
      */
-    static RTPSParticipant* clientServerEnvironmentCreationOverride(
+    static bool client_server_environment_attributes_override(
             uint32_t domain_id,
-            bool enabled,
-            const RTPSParticipantAttributes& attrs,
-            RTPSParticipantListener* listen /*= nullptr*/);
+            RTPSParticipantAttributes& attrs);
 
     /**
      * Create a RTPSWriter in a participant.

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -117,6 +117,8 @@ public:
     /**
      * Fills RTPSParticipantAttributes to create a RTPSParticipant as default server or client
      * if ROS_MASTER_URI environment variable is set.
+     * It also configures ROS 2 Easy Mode IP if ROS2_EASY_MODE_URI environment variable is set
+     * and it was empty in the input attributes.
      *
      * @param domain_id DDS domain associated
      * @param [in, out] attrs RTPSParticipant Attributes.
@@ -251,6 +253,18 @@ public:
      * @return const xtypes::TypeObjectRegistry reference.
      */
     static fastdds::dds::xtypes::TypeObjectRegistry& type_object_registry_observer();
+
+    /**
+     * @brief Run the Easy Mode discovery server using the Fast DDS CLI command
+     *
+     * @param domain_id Domain ID to use for the discovery server
+     * @param easy_mode_ip IP address to use for the discovery server
+     *
+     * @return True if the server was successfully started, false otherwise.
+     */
+    static bool run_easy_mode_discovery_server(
+            uint32_t domain_id,
+            const std::string& easy_mode_ip);
 
 private:
 

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -92,15 +92,32 @@ public:
 
     /**
      * @brief Create a RTPSParticipant as default server or client if ROS_MASTER_URI environment variable is set.
-     * It also configures ROS 2 Easy Mode IP if the following conditions are met:
-     * 1. ROS2_EASY_MODE_URI environment variable is set.
-     * 2. `easy_mode_ip` member of the input RTPSParticipantAttributes is an empty string.
+     * The RTPSParticipant is created as a ros easy mode client and its corresponding easy mode server is spawned
+     * if at least one of the following conditions are met:
+     *
+     * CONDITION_A:
+     *  - `easy_mode_ip` member of the input RTPSParticipantAttributes is a non-empty string.
+     *
+     * CONDITION_B:
+     *  - ROS2_EASY_MODE_URI environment variable is set.
+     *
+     * In case of both conditions are met at the same time, the value of `easy_mode_ip` member is used
+     * as the easy mode server IP and ROS2_EASY_MODE_URI value is ignored. A warning log is displayed in this case.
      *
      * @param domain_id DomainId to be used by the RTPSParticipant.
      * @param enabled True if the RTPSParticipant should be enabled on creation. False if it will be enabled later with RTPSParticipant::enable()
      * @param attrs RTPSParticipant Attributes.
      * @param plisten Pointer to the ParticipantListener.
-     * @return Pointer to the RTPSParticipant.
+     * @return Pointer to the RTPSParticipant or nullptr in the following cases:
+     *
+     *        - The input attributes are not overriden by the environment variables.
+     *          In this case no errors ocurred,
+     *          but preconditions are not met and the entire Participant setup is skipped.
+     *
+     *        - An error ocurred during the RTPSParticipant creation.
+     *
+     *        - RTPSParticipant is created correctly, but an error ocurred during the Easy Mode discovery server launch.
+     *          In this case, the RTPSParticipant is removed before returning.
      *
      * \warning The returned pointer is invalidated after a call to removeRTPSParticipant() or stopAll(),
      *          so its use may result in undefined behaviour.

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -645,6 +645,16 @@ public:
         return sub_times_liveliness_lost_;
     }
 
+    void sub_wait_data_received(
+            unsigned int num_received)
+    {
+        std::unique_lock<std::mutex> lock(sub_data_mutex_);
+        sub_data_cv_.wait(lock, [&]()
+                {
+                    return sub_times_data_received_ >= num_received;
+                });
+    }
+
     PubSubParticipant& property_policy(
             const eprosima::fastdds::rtps::PropertyPolicy property_policy)
     {

--- a/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
@@ -21,6 +21,7 @@
 #include <fastdds/rtps/RTPSDomain.hpp>
 
 #include "BlackboxTests.hpp"
+#include "PubSubParticipant.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
 
@@ -421,19 +422,139 @@ TEST(DSEasyMode, easy_discovery_mode_env_invalid)
 }
 
 /**
- * Check that easy mode configuration is ignored when setting it
- * with code using WireProtocolConfigQos.
- *
- * Note: This test only checks that the configuration is ignored.
- * Probably it should be extended similarly to easy_discovery_mode_env_invalid
- * when Configuring Easy Mode via c++ and XML is implemented.
+ * Test that Easy Mode launches correctly when setting it with code
+ * using WireProtocolConfigQos.
  */
-TEST(DSEasyMode, wire_protocol_qos_params_invalid)
+TEST(DSEasyMode, easy_mode_from_qos_valid)
 {
-    eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol_qos;
+#ifndef _WIN32 // The feature is not supported on Windows yet
 
-    // Try to set easy mode IP using an invalid IP address
-    ASSERT_EQ(wire_protocol_qos.easy_mode("Foo"), eprosima::fastdds::dds::RETCODE_BAD_PARAMETER);
+    // Create one participant for each endpoint
+    PubSubParticipant<HelloWorldPubSubType> participant_writer(1u, 0u, 1u, 0u);
+    PubSubParticipant<HelloWorldPubSubType> participant_reader(0u, 1u, 0u, 1u);
 
-    ASSERT_TRUE(wire_protocol_qos.easy_mode().empty());
+    // Setting Easy Mode manually using WireProtocolConfigQos
+    eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol;
+    wire_protocol.easy_mode("127.0.0.1");
+    participant_writer.wire_protocol(wire_protocol);
+    participant_writer.pub_topic_name(TEST_TOPIC_NAME);
+    participant_reader.wire_protocol(wire_protocol);
+    participant_reader.sub_topic_name(TEST_TOPIC_NAME);
+
+    std::atomic<bool> participant_writer_background_ds_discovered(false);
+    std::atomic<bool> participant_reader_background_ds_discovered(false);
+
+    participant_writer.set_on_discovery_function(
+        [&participant_writer_background_ds_discovered](
+            const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                participant_writer_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+
+    participant_reader.set_on_discovery_function(
+        [&participant_reader_background_ds_discovered](
+            const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                participant_reader_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+
+    ASSERT_TRUE(participant_writer.init_participant());
+    ASSERT_TRUE(participant_writer.init_publisher(0));
+    ASSERT_TRUE(participant_reader.init_participant());
+    ASSERT_TRUE(participant_reader.init_subscriber(0));
+
+    // Two DomainParticipants should be discovered:
+    // Background DS and the other reader/writer
+    participant_writer.wait_discovery(std::chrono::seconds::zero(), 2);
+    participant_reader.wait_discovery(std::chrono::seconds::zero(), 2);
+
+    // ASSERT_GE(writer.get_participants_matched(), 2u);
+    // ASSERT_GE(reader.get_participants_matched(), 2u);
+    ASSERT_TRUE(participant_writer_background_ds_discovered.load());
+    ASSERT_TRUE(participant_reader_background_ds_discovered.load());
+
+    participant_writer.pub_wait_discovery();
+    participant_reader.sub_wait_discovery();
+
+    size_t num_samples = 10;
+    auto data = default_helloworld_data_generator(num_samples);
+
+    for (auto& sample : data)
+    {
+        ASSERT_TRUE(participant_writer.send_sample(sample, 0));
+    }
+
+    participant_reader.sub_wait_data_received(num_samples);
+
+    // Stop server
+    stop_background_servers();
+#endif // _WIN32
+}
+
+/**
+ * Check that the configuration is ignored when set with invalid values using `WireProtocolConfigQos`.
+ */
+TEST(DSEasyMode, easy_mode_from_qos_invalid)
+{
+#ifndef _WIN32 // The feature is not supported on Windows yet
+
+    // Create one participant for each endpoint
+    PubSubParticipant<HelloWorldPubSubType> participant_writer(1u, 0u, 1u, 0u);
+    PubSubParticipant<HelloWorldPubSubType> participant_reader(0u, 1u, 0u, 1u);
+
+    // Trying to set Easy Mode manually using a non-valid IPv4 address
+    eprosima::fastdds::dds::WireProtocolConfigQos wire_protocol;
+    wire_protocol.easy_mode("Foo");
+    participant_writer.wire_protocol(wire_protocol);
+    participant_writer.pub_topic_name(TEST_TOPIC_NAME);
+    participant_reader.wire_protocol(wire_protocol);
+    participant_reader.sub_topic_name(TEST_TOPIC_NAME);
+
+    std::atomic<bool> participant_writer_background_ds_discovered(false);
+    std::atomic<bool> participant_reader_background_ds_discovered(false);
+
+    participant_writer.set_on_discovery_function(
+        [&participant_writer_background_ds_discovered](
+            const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                participant_writer_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+
+    participant_reader.set_on_discovery_function(
+        [&participant_reader_background_ds_discovered](
+            const eprosima::fastdds::rtps::ParticipantBuiltinTopicData& data)
+        {
+            if (data.participant_name == "DiscoveryServerAuto")
+            {
+                participant_reader_background_ds_discovered.store(true);
+            }
+            return true;
+        });
+
+    ASSERT_TRUE(participant_writer.init_participant());
+    ASSERT_TRUE(participant_reader.init_participant());
+
+    // Only one DomainParticipant should be discovered:
+    // Participant associated to the other reader/writer
+    // No Background DS Participant should be discovered
+    std::chrono::seconds timeout(5);
+    // Timeout should be reached as no Background DS is expected
+    participant_writer.wait_discovery(timeout, 2);
+    participant_reader.wait_discovery(timeout, 2);
+    ASSERT_FALSE(participant_writer_background_ds_discovered.load());
+    ASSERT_FALSE(participant_reader_background_ds_discovered.load());
+
+#endif // _WIN32
 }

--- a/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDSEasyMode.cpp
@@ -476,8 +476,6 @@ TEST(DSEasyMode, easy_mode_from_qos_valid)
     participant_writer.wait_discovery(std::chrono::seconds::zero(), 2);
     participant_reader.wait_discovery(std::chrono::seconds::zero(), 2);
 
-    // ASSERT_GE(writer.get_participants_matched(), 2u);
-    // ASSERT_GE(reader.get_participants_matched(), 2u);
     ASSERT_TRUE(participant_writer_background_ds_discovered.load());
     ASSERT_TRUE(participant_reader_background_ds_discovered.load());
 

--- a/test/unittest/dds/participant/CMakeLists.txt
+++ b/test/unittest/dds/participant/CMakeLists.txt
@@ -20,6 +20,10 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_service_easy_mod
     ${CMAKE_CURRENT_BINARY_DIR}/test_xml_service_easy_mode.xml
     COPYONLY)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../profiles/test_xml_easy_mode_config.xml
+    ${CMAKE_CURRENT_BINARY_DIR}/test_xml_easy_mode_config.xml
+    COPYONLY)
+
 set(PARTICIPANTTESTS_SOURCE
         ParticipantTests.cpp
     )

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1578,6 +1578,8 @@ TEST(ParticipantTests, EasyModeParticipantDoNotOverwriteCustomDataWriterQos)
  */
 TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
 {
+// Easy Mode is currently not supported on Windows
+#ifndef _WIN32
     set_easy_mode_environment_variable("1.1.1.1");
 
     // Set Easy Mode manually using WireProtocolConfigQos with a different value
@@ -1605,6 +1607,7 @@ TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
 
     ASSERT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
     stop_background_servers();
+#endif // _WIN32
 }
 
 /**
@@ -1612,6 +1615,8 @@ TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
  */
 TEST(ParticipantTests, EasyModeIPConfigFromXML)
 {
+// Easy Mode is currently not supported on Windows
+#ifndef _WIN32
     DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_easy_mode_config.xml");
     uint32_t domain_id = (uint32_t)GET_PID() % 230;
 
@@ -1638,6 +1643,7 @@ TEST(ParticipantTests, EasyModeIPConfigFromXML)
 
     ASSERT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
     stop_background_servers();
+#endif // _WIN32
 }
 /**
  * Dynamic modification of servers. Replacing previous servers with new ones.

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1578,7 +1578,7 @@ TEST(ParticipantTests, EasyModeParticipantDoNotOverwriteCustomDataWriterQos)
  */
 TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
 {
-// Easy Mode is currently not supported on Windows
+    // Easy Mode is currently not supported on Windows
 #ifndef _WIN32
     set_easy_mode_environment_variable("1.1.1.1");
 
@@ -1615,7 +1615,7 @@ TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
  */
 TEST(ParticipantTests, EasyModeIPConfigFromXML)
 {
-// Easy Mode is currently not supported on Windows
+    // Easy Mode is currently not supported on Windows
 #ifndef _WIN32
     DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_easy_mode_config.xml");
     uint32_t domain_id = (uint32_t)GET_PID() % 230;

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1573,6 +1573,73 @@ TEST(ParticipantTests, EasyModeParticipantDoNotOverwriteCustomDataWriterQos)
 }
 
 /**
+ * Check that, in case of configuring Easy Mode via WireProtocolConfigQos and
+ * ROS2_EASY_MODE environment variable, the first takes precedence.
+ */
+TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
+{
+    set_easy_mode_environment_variable("1.1.1.1");
+
+    // Set Easy Mode manually using WireProtocolConfigQos with a different value
+    DomainParticipantQos qos;
+    qos.wire_protocol().easy_mode("2.2.2.2");
+    DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
+        (uint32_t)GET_PID() % 230, qos);
+    ASSERT_NE(nullptr, participant);
+
+    // Verify that the localhost Discovery Server is created and the configured remote IP
+    // is the one set by the QoS (i.e., ROS2_EASY_MODE environment variable is ignored).
+    rtps::RTPSParticipantAttributes rtps_attr;
+    get_rtps_attributes(participant, rtps_attr);
+    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
+
+    rtps::Locator_t expected_locator;
+    rtps::IPLocator::setIPv4(expected_locator, "127.0.0.1");
+
+    ASSERT_TRUE(
+        rtps::IPLocator::compareAddress(
+            *(rtps_attr.builtin.discovery_config.m_DiscoveryServers.begin()),
+            expected_locator,
+            false));
+    ASSERT_EQ(rtps_attr.easy_mode_ip, "2.2.2.2");
+
+    ASSERT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+    stop_background_servers();
+}
+
+/**
+ * Check that Easy Mode IP is configured correctly when loading a qos profile from XML.
+ */
+TEST(ParticipantTests, EasyModeIPConfigFromXML)
+{
+    DomainParticipantFactory::get_instance()->load_XML_profiles_file("test_xml_easy_mode_config.xml");
+    uint32_t domain_id = (uint32_t)GET_PID() % 230;
+
+    //participant using the default profile
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Verify that the localhost Discovery Server is created and the configured remote IP
+    // is the one set by the QoS
+    rtps::RTPSParticipantAttributes rtps_attr;
+    get_rtps_attributes(participant, rtps_attr);
+    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
+
+    rtps::Locator_t expected_locator;
+    rtps::IPLocator::setIPv4(expected_locator, "127.0.0.1");
+
+    ASSERT_TRUE(
+        rtps::IPLocator::compareAddress(
+            *(rtps_attr.builtin.discovery_config.m_DiscoveryServers.begin()),
+            expected_locator,
+            false));
+    ASSERT_EQ(rtps_attr.easy_mode_ip, "2.2.2.2"); // XML value
+
+    ASSERT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+    stop_background_servers();
+}
+/**
  * Dynamic modification of servers. Replacing previous servers with new ones.
  */
 TEST(ParticipantTests, ServerParticipantReplaceRemoteServerListConfiguration)

--- a/test/unittest/dds/profiles/test_xml_easy_mode_config.xml
+++ b/test/unittest/dds/profiles/test_xml_easy_mode_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"  ?>
+<dds xmlns="http://www.eprosima.com">
+    <profiles>
+        <participant profile_name="test_default_participant_profile" is_default_profile="true">
+            <domainId>123</domainId>
+            <rtps>
+                <easy_mode_ip>2.2.2.2</easy_mode_ip>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR adds support for manually configuring ROS 2 Easy Mode using easy_mode_ip in RTPSParticipantAttributes. If the Easy Mode IP is manually configured, the value of the ROS2_EASY_MODE environment variable is ignored.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
This PR depends on 
- https://github.com/eProsima/Fast-DDS/pull/5689

and must be merged after that one.

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
- Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1045
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
