### PR TITLE
[21614] Fix Security tag in DS CLI

### DIFF
--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -595,9 +595,9 @@ int fastdds_discovery_server(
 #endif // ifndef _WIN32
 
         bool has_security = false;
-        auto check_qos = pServer->get_qos();
+        const auto& check_qos = pServer->get_qos();
         // Access the properties of the participant QoS
-        for (auto prop : check_qos.properties().properties())
+        for (const auto& prop : check_qos.properties().properties())
         {
             if (prop.name() == "dds.sec.auth.builtin.PKI-DH.identity_ca" && prop.value() != "")
             {

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -571,7 +571,6 @@ int fastdds_discovery_server(
         }
     }
 
-    fastdds::rtps::GuidPrefix_t guid_prefix = participantQos.wire_protocol().prefix;
     participantQos.transport().use_builtin_transports = udp_server_initialized || options[XML_FILE] != nullptr;
 
     // Create the server
@@ -596,9 +595,15 @@ int fastdds_discovery_server(
 #endif // ifndef _WIN32
 
         bool has_security = false;
-        if (guid_prefix != pServer->guid().guidPrefix)
+        auto participantQos = pServer->get_qos();
+        // Access the properties of the participant QoS
+        for (auto prop : participantQos.properties().properties())
         {
-            has_security = true;
+            if (prop.name() == "dds.sec.auth.builtin.PKI-DH.identity_ca" && prop.value() != "")
+            {
+                has_security = true;
+                break;
+            }
         }
 
         // Print running server attributes

--- a/tools/fds/server.cpp
+++ b/tools/fds/server.cpp
@@ -595,9 +595,9 @@ int fastdds_discovery_server(
 #endif // ifndef _WIN32
 
         bool has_security = false;
-        auto participantQos = pServer->get_qos();
+        auto check_qos = pServer->get_qos();
         // Access the properties of the participant QoS
-        for (auto prop : participantQos.properties().properties())
+        for (auto prop : check_qos.properties().properties())
         {
             if (prop.name() == "dds.sec.auth.builtin.PKI-DH.identity_ca" && prop.value() != "")
             {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes Issue (https://github.com/eProsima/Fast-DDS/issues/5214) in which the SECURITY field does not show the real state of the Discovery Server initialized.

In 3.2.0 the CLI display was modified and 3.0.2 was the EOL, so no backports are needed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
