### PR TITLE
Remove unnecessary validations in ReplierQos and RequesterQos

### DIFF
--- a/include/fastdds/dds/domain/qos/ReplierQos.hpp
+++ b/include/fastdds/dds/domain/qos/ReplierQos.hpp
@@ -36,7 +36,12 @@ public:
     /**
      * @brief Constructor
      */
-    FASTDDS_EXPORTED_API ReplierQos() = default;
+    FASTDDS_EXPORTED_API ReplierQos()
+    {
+        // Set reliability to RELIABLE_RELIABILITY_QOS by default
+        writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+        reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    }
 
     /**
      * @brief Equal comparison operator

--- a/include/fastdds/dds/domain/qos/RequesterQos.hpp
+++ b/include/fastdds/dds/domain/qos/RequesterQos.hpp
@@ -36,7 +36,12 @@ public:
     /**
      * @brief Constructor
      */
-    FASTDDS_EXPORTED_API RequesterQos() = default;
+    FASTDDS_EXPORTED_API RequesterQos()
+    {
+        // Set reliability to RELIABLE_RELIABILITY_QOS by default
+        writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+        reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
+    }
 
     /**
      * @brief Equal comparison operator

--- a/src/cpp/fastdds/rpc/ServiceImpl.hpp
+++ b/src/cpp/fastdds/rpc/ServiceImpl.hpp
@@ -166,36 +166,6 @@ public:
 
         bool valid = true;
 
-        if (qos.service_name != service_name_)
-        {
-            EPROSIMA_LOG_ERROR(SERVICE, "Service name in QoS does not match the service name");
-            valid = false;
-        }
-
-        if (qos.request_type != request_type_name_)
-        {
-            EPROSIMA_LOG_ERROR(SERVICE, "Request type in QoS does not match the service type name");
-            valid = false;
-        }
-
-        if (qos.reply_type != reply_type_name_)
-        {
-            EPROSIMA_LOG_ERROR(SERVICE, "Reply type in QoS does not match the service type name");
-            valid = false;
-        }
-
-        if (qos.request_topic_name != request_topic_name_)
-        {
-            EPROSIMA_LOG_ERROR(SERVICE, "Request topic name in QoS does not match the request topic name");
-            valid = false;
-        }
-
-        if (qos.reply_topic_name != reply_topic_name_)
-        {
-            EPROSIMA_LOG_ERROR(SERVICE, "Reply topic name in QoS does not match the reply topic name");
-            valid = false;
-        }
-
         if (qos.writer_qos.reliability().kind != RELIABLE_RELIABILITY_QOS)
         {
             EPROSIMA_LOG_ERROR(SERVICE, "Writer QoS reliability must be RELIABLE_RELIABILITY_QOS");

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldReplier.cpp
@@ -249,9 +249,6 @@ ReplierQos ReqRepHelloWorldReplier::create_replier_qos()
     reader_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
-    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     writer_qos.reliable_writer_qos().times.heartbeat_period.seconds = 1;
     writer_qos.reliable_writer_qos().times.heartbeat_period.nanosec = 0;
 
@@ -271,11 +268,6 @@ ReplierQos ReqRepHelloWorldReplier::create_replier_qos()
         writer_qos.properties().properties().emplace_back("fastdds.push_mode", "false");
     }
 
-    replier_qos.service_name = service.service_name();
-    replier_qos.request_topic_name = service.service_name() + "_Request";
-    replier_qos.reply_topic_name = service.service_name() + "_Reply";
-    replier_qos.request_type = service.service_type_name() + "_Request";
-    replier_qos.reply_type = service.service_type_name() + "_Reply";
     replier_qos.writer_qos = writer_qos;
     replier_qos.reader_qos = reader_qos;
 

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.cpp
@@ -312,9 +312,6 @@ RequesterQos ReqRepHelloWorldRequester::create_requester_qos(
     reader_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
-    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     if (volatile_durability_qos)
     {
         reader_qos.durability().kind = VOLATILE_DURABILITY_QOS;
@@ -340,11 +337,6 @@ RequesterQos ReqRepHelloWorldRequester::create_requester_qos(
         writer_qos.properties().properties().emplace_back("fastdds.push_mode", "false");
     }
 
-    requester_qos.service_name = service.service_name();
-    requester_qos.request_topic_name = service.service_name() + "_Request";
-    requester_qos.reply_topic_name = service.service_name() + "_Reply";
-    requester_qos.request_type = service.service_type_name() + "_Request";
-    requester_qos.reply_type = service.service_type_name() + "_Reply";
     requester_qos.writer_qos = writer_qos;
     requester_qos.reader_qos = reader_qos;
 

--- a/test/blackbox/api/dds-pim/TCPReqRepHelloWorldReplier.cpp
+++ b/test/blackbox/api/dds-pim/TCPReqRepHelloWorldReplier.cpp
@@ -352,18 +352,10 @@ ReplierQos TCPReqRepHelloWorldReplier::create_replier_qos()
     reader_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
 
-    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     //Increase default max_blocking_time to 1s in case the CPU is overhead
     reader_qos.reliability().max_blocking_time = Duration_t(1, 0);
     writer_qos.reliability().max_blocking_time = Duration_t(1, 0);
 
-    replier_qos.service_name = service.service_name();
-    replier_qos.request_topic_name = service.service_name() + "_Request";
-    replier_qos.reply_topic_name = service.service_name() + "_Reply";
-    replier_qos.request_type = service.service_type_name() + "_Request";
-    replier_qos.reply_type = service.service_type_name() + "_Reply";
     replier_qos.writer_qos = writer_qos;
     replier_qos.reader_qos = reader_qos;
 

--- a/test/blackbox/api/dds-pim/TCPReqRepHelloWorldRequester.cpp
+++ b/test/blackbox/api/dds-pim/TCPReqRepHelloWorldRequester.cpp
@@ -396,17 +396,10 @@ RequesterQos TCPReqRepHelloWorldRequester::create_requester_qos()
 
     reader_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
     writer_qos.endpoint().history_memory_policy = PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
-    reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     //Increase default max_blocking_time to 1s in case the CPU is overhead
     reader_qos.reliability().max_blocking_time = Duration_t(1, 0);
     writer_qos.reliability().max_blocking_time = Duration_t(1, 0);
 
-    requester_qos.service_name = service.service_name();
-    requester_qos.request_topic_name = service.service_name() + "_Request";
-    requester_qos.reply_topic_name = service.service_name() + "_Reply";
-    requester_qos.request_type = service.service_type_name() + "_Request";
-    requester_qos.reply_type = service.service_type_name() + "_Reply";
     requester_qos.writer_qos = writer_qos;
     requester_qos.reader_qos = reader_qos;
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -3326,21 +3326,7 @@ TEST(ParticipantTests, CreateRequesterReplierOnExternalService)
     ASSERT_NE(service_1, nullptr);
 
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     // Error: Trying to create a requester/replier on a service that belongs to another participant
     ASSERT_EQ(participant_0->create_service_requester(service_1, requester_qos), nullptr);
@@ -3376,21 +3362,7 @@ TEST(ParticipantTests, DeleteRequesterReplierOnExternalService)
     ASSERT_NE(service_1, nullptr);
 
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     rpc::Requester* requester_0 = participant_0->create_service_requester(service_0, requester_qos);
     rpc::Requester* requester_1 = participant_1->create_service_requester(service_1, requester_qos);

--- a/test/unittest/dds/rpc/ServiceTests.cpp
+++ b/test/unittest/dds/rpc/ServiceTests.cpp
@@ -149,13 +149,6 @@ TEST(ServiceTests, CreateRequesterValidParams)
     ASSERT_NE(service, nullptr);
 
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Requester* requester = participant->create_service_requester(service, requester_qos);
     ASSERT_NE(requester, nullptr);
@@ -176,156 +169,6 @@ TEST(ServiceTests, CreateRequesterValidParams)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
-TEST(ServiceTests, CreateRequesterInvalidServiceName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    RequesterQos requester_qos;
-    requester_qos.service_name = "InvalidService";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Requester* requester = participant->create_service_requester(service, requester_qos);
-    ASSERT_EQ(requester, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateRequesterInvalidRequestType)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "InvalidType";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Requester* requester = participant->create_service_requester(service, requester_qos);
-    ASSERT_EQ(requester, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateRequesterInvalidReplyType)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "InvalidType";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Requester* requester = participant->create_service_requester(service, requester_qos);
-    ASSERT_EQ(requester, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateRequesterInvalidRequestTopicName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "InvalidRequestTopic";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Requester* requester = participant->create_service_requester(service, requester_qos);
-    ASSERT_EQ(requester, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateRequesterInvalidReplyTopicName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "InvalidReplyTopic";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Requester* requester = participant->create_service_requester(service, requester_qos);
-    ASSERT_EQ(requester, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
 TEST(ServiceTests, CreateRequesterInvalidWriterQos)
 {
     DomainParticipant* participant =
@@ -340,13 +183,7 @@ TEST(ServiceTests, CreateRequesterInvalidWriterQos)
     ASSERT_NE(service, nullptr);
 
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
     requester_qos.writer_qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Requester* requester = participant->create_service_requester(service, requester_qos);
     ASSERT_EQ(requester, nullptr);
@@ -370,12 +207,6 @@ TEST(ServiceTests, CreateRequesterInvalidReaderQos)
     ASSERT_NE(service, nullptr);
 
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     requester_qos.reader_qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
 
     Requester* requester = participant->create_service_requester(service, requester_qos);
@@ -400,13 +231,6 @@ TEST(ServiceTests, CreateReplierValidParams)
     ASSERT_NE(service, nullptr);
 
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
     ASSERT_NE(replier, nullptr);
@@ -427,156 +251,6 @@ TEST(ServiceTests, CreateReplierValidParams)
     ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
 }
 
-TEST(ServiceTests, CreateReplierInvalidServiceName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    ReplierQos replier_qos;
-    replier_qos.service_name = "InvalidService";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Replier* replier = participant->create_service_replier(service, replier_qos);
-    ASSERT_EQ(replier, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateReplierInvalidRequestType)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "InvalidType";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Replier* replier = participant->create_service_replier(service, replier_qos);
-    ASSERT_EQ(replier, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateReplierInvalidReplyType)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "InvalidType";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Replier* replier = participant->create_service_replier(service, replier_qos);
-    ASSERT_EQ(replier, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateReplierInvalidRequestTopicName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "InvalidRequestTopic";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Replier* replier = participant->create_service_replier(service, replier_qos);
-    ASSERT_EQ(replier, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
-TEST(ServiceTests, CreateReplierInvalidReplyTopicName)
-{
-    DomainParticipant* participant =
-            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
-    ASSERT_NE(participant, nullptr);
-
-    TypeSupport type(new TopicDataTypeMock());
-    ServiceTypeSupport service_type(type, type);
-    ASSERT_EQ(participant->register_service_type(service_type, "ServiceType"), RETCODE_OK);
-
-    Service* service = participant->create_service("Service", "ServiceType");
-    ASSERT_NE(service, nullptr);
-
-    ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "InvalidReplyTopic";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
-    Replier* replier = participant->create_service_replier(service, replier_qos);
-    ASSERT_EQ(replier, nullptr);
-
-    ASSERT_EQ(participant->delete_service(service), RETCODE_OK);
-    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
-    ASSERT_EQ(DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
-}
-
 TEST(ServiceTests, CreateReplierInvalidWriterQos)
 {
     DomainParticipant* participant =
@@ -591,13 +265,7 @@ TEST(ServiceTests, CreateReplierInvalidWriterQos)
     ASSERT_NE(service, nullptr);
 
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
     replier_qos.writer_qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
     ASSERT_EQ(replier, nullptr);
@@ -621,12 +289,6 @@ TEST(ServiceTests, CreateReplierInvalidReaderQos)
     ASSERT_NE(service, nullptr);
 
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     replier_qos.reader_qos.reliability().kind = BEST_EFFORT_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
@@ -662,22 +324,7 @@ TEST(ServiceTests, ChangeEnabledState)
     ASSERT_EQ(participant->delete_topic(reply_topic), RETCODE_OK);
 
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
     ASSERT_NE(replier, nullptr);
@@ -772,22 +419,7 @@ TEST(ServiceTests, EnableEntityOnDisabledService)
     // Create a requester and a replier, and try to enable them
     // They should not be enabled because the service is disabled
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
     ASSERT_NE(replier, nullptr);
@@ -829,22 +461,7 @@ TEST(ServiceTests, SendOrTakeOnDisabledRequesterReplier)
     // Create a requester and a replier, and try to send/take on them
     // It should return RETCODE_PRECONDITION_NOT_MET because the service is disabled
     ReplierQos replier_qos;
-    replier_qos.service_name = "Service";
-    replier_qos.request_type = "ServiceType_Request";
-    replier_qos.reply_type = "ServiceType_Reply";
-    replier_qos.request_topic_name = "Service_Request";
-    replier_qos.reply_topic_name = "Service_Reply";
-    replier_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    replier_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-
     RequesterQos requester_qos;
-    requester_qos.service_name = "Service";
-    requester_qos.request_type = "ServiceType_Request";
-    requester_qos.reply_type = "ServiceType_Reply";
-    requester_qos.request_topic_name = "Service_Request";
-    requester_qos.reply_topic_name = "Service_Reply";
-    requester_qos.writer_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
-    requester_qos.reader_qos.reliability().kind = RELIABLE_RELIABILITY_QOS;
 
     Replier* replier = participant->create_service_replier(service, replier_qos);
     ASSERT_NE(replier, nullptr);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR removes validations for Service, types and topic name fields of ReplierQos and RequesterQos structures.
This checks are unnecessary: all required information about Service or DDS entities can be obtained from the associated RPC Service instance. Unnecessary unit tests has been deleted.

ReplierQos and RequesterQos contructors have been also modified to set Reliability Qos as Reliable by default in both dds endpoints.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x]: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- _N/A_: Check CI results: changes do not issue any warning.
- _N/A_: Check CI results: failing tests are unrelated with the changes.
