### PR TITLE
[22974] Improve SHM configuration on large data transports

### DIFF
--- a/include/fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp
+++ b/include/fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.hpp
@@ -52,6 +52,7 @@ struct SharedMemTransportDescriptor : public PortBasedTransportDescriptor
     static constexpr uint32_t shm_default_segment_size = 0;
     static constexpr uint32_t shm_default_port_queue_capacity = 512;
     static constexpr uint32_t shm_default_healthy_check_timeout_ms = 1000;
+    static constexpr uint32_t shm_implicit_segment_size = 512 * 1024;
 
     //! Destructor
     virtual ~SharedMemTransportDescriptor() = default;

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -367,8 +367,12 @@ void RTPSParticipantAttributes::setup_transports(
     }
     bool intraprocess_only = is_intraprocess_only(*this);
 
-    sendSocketBufferSize = (sendSocketBufferSize == 0) ? options.sockets_buffer_size : sendSocketBufferSize;
-    listenSocketBufferSize = (listenSocketBufferSize == 0) ? options.sockets_buffer_size : listenSocketBufferSize;
+    // Override the default send and receive buffer sizes when set in the options
+    if (options.sockets_buffer_size != 0)
+    {
+        sendSocketBufferSize = options.sockets_buffer_size;
+        listenSocketBufferSize = options.sockets_buffer_size;
+    }
 
     switch (transports)
     {

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -237,6 +237,13 @@ static void setup_large_data_shm_transport(
         segment_size = 8500 * 1024;  // 8500 KiBytes
         descriptor->segment_size(segment_size);
     }
+    // Configure port queue capacity to hold the maximum allocations on the segment
+    constexpr auto mean_message_size =
+            SharedMemTransportDescriptor::shm_implicit_segment_size /
+            SharedMemTransportDescriptor::shm_default_port_queue_capacity;
+    auto max_allocations = segment_size / mean_message_size;
+    descriptor->port_queue_capacity(max_allocations);
+    // Add descriptor to the list of user transports
     att.userTransports.push_back(descriptor);
 
     auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -351,8 +351,8 @@ void RTPSParticipantAttributes::setup_transports(
     }
     bool intraprocess_only = is_intraprocess_only(*this);
 
-    sendSocketBufferSize = options.sockets_buffer_size;
-    listenSocketBufferSize = options.sockets_buffer_size;
+    sendSocketBufferSize = (sendSocketBufferSize == 0) ? options.sockets_buffer_size : sendSocketBufferSize;
+    listenSocketBufferSize = (listenSocketBufferSize == 0) ? options.sockets_buffer_size : listenSocketBufferSize;
 
     switch (transports)
     {

--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -228,6 +228,15 @@ static void setup_large_data_shm_transport(
             "TCP for communications on the same host.");
 #else
     auto descriptor = create_shm_transport(att, options);
+    auto segment_size = descriptor->segment_size();
+    if (segment_size == 0)
+    {
+        // The user did not configure a buffer size. The correct approach here would
+        // be to create a socket and querying its output buffer size via get socket option.
+        // As a workaround, use a value that allows for some big images to be sent.
+        segment_size = 8500 * 1024;  // 8500 KiBytes
+        descriptor->segment_size(segment_size);
+    }
     att.userTransports.push_back(descriptor);
 
     auto shm_loc = fastdds::rtps::SHMLocator::create_locator(0, fastdds::rtps::SHMLocator::Type::UNICAST);

--- a/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemTransport.cpp
@@ -48,7 +48,7 @@ namespace fastdds {
 namespace rtps {
 
 // TODO(Adolfo): Calculate this value from UDP sockets buffers size.
-static constexpr uint32_t shm_default_segment_size = 512 * 1024;
+static constexpr uint32_t shm_default_segment_size = SharedMemTransportDescriptor::shm_implicit_segment_size;
 
 TransportInterface* SharedMemTransportDescriptor::create_transport() const
 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This improves the segment size and port queue capacity configuration on LARGE_DATA and EASY_MODE. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _NA_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **NO**: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
