### PR TITLE
IDL parsing tests included paths

### DIFF
--- a/test/feature/idl_parser/CMakeLists.txt
+++ b/test/feature/idl_parser/CMakeLists.txt
@@ -66,4 +66,5 @@ message(STATUS "Copying IDL directory from ${PROJECT_SOURCE_DIR}/thirdparty/dds-
 add_custom_command(
     TARGET IdlParserTests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/thirdparty/dds-types-test/IDL ${CMAKE_CURRENT_BINARY_DIR}/IDL
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/no_path_included.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
 )

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -1258,9 +1258,9 @@ TEST_F(IdlParserTests, relative_path_include)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
-    include_paths.push_back("IDL/helpers/basic_inner_types.idl");
+    include_paths.push_back("IDL/helpers");
 
-    DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/relative_path_include.idl",
+    DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/no_path_included.idl",
                     "RelativePathIncludeStruct", include_paths);
     EXPECT_TRUE(builder1);
     DynamicType::_ref_type type1 = builder1->build();

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -240,7 +240,7 @@ TEST_F(IdlParserTests, structures)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
-    include_paths.push_back("IDL/helpers/basic_inner_types.idl");
+    include_paths.push_back("IDL/helpers");
 
     DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/structures.idl", "StructShort",
                     include_paths);
@@ -423,7 +423,7 @@ TEST_F(IdlParserTests, aliases)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
-    include_paths.push_back("IDL/helpers/basic_inner_types.idl");
+    include_paths.push_back("IDL/helpers");
 
     DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/aliases.idl", "AliasInt16", include_paths);
     EXPECT_TRUE(builder1);
@@ -581,7 +581,7 @@ TEST_F(IdlParserTests, arrays)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
-    include_paths.push_back("IDL/helpers/basic_inner_types.idl");
+    include_paths.push_back("IDL/helpers");
 
     DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/arrays.idl", "ArrayShort", include_paths);
     EXPECT_TRUE(builder1);
@@ -1254,7 +1254,7 @@ TEST_F(IdlParserTests, arrays)
     ASSERT_TRUE(type105);
 }
 
-TEST_F(IdlParserTests, relative_path_include)
+TEST_F(IdlParserTests, no_path_included)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
@@ -1273,11 +1273,30 @@ TEST_F(IdlParserTests, relative_path_include)
     EXPECT_EQ(test1, 2);
 }
 
+TEST_F(IdlParserTests, relative_path_include)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+    std::vector<std::string> include_paths;
+    include_paths.push_back("IDL/helpers");
+
+    DynamicTypeBuilder::_ref_type builder1 = factory->create_type_w_uri("IDL/relative_path_include.idl",
+                    "RelativePathIncludeStruct", include_paths);
+    EXPECT_TRUE(builder1);
+    DynamicType::_ref_type type1 = builder1->build();
+    ASSERT_TRUE(type1);
+    DynamicData::_ref_type data1 {DynamicDataFactory::get_instance()->create_data(type1)};
+    ASSERT_TRUE(data1);
+    int32_t test1 {0};
+    EXPECT_EQ(data1->set_int32_value(0, 2), RETCODE_OK);
+    EXPECT_EQ(data1->get_int32_value(test1, 0), RETCODE_OK);
+    EXPECT_EQ(test1, 2);
+}
+
 TEST_F(IdlParserTests, unions)
 {
     DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
     std::vector<std::string> include_paths;
-    include_paths.push_back("IDL/helpers/basic_inner_types.idl");
+    include_paths.push_back("IDL/helpers");
 
     DynamicTypeBuilder::_ref_type builder = factory->create_type_w_uri("IDL/unions.idl", "Union_Short", include_paths);
     EXPECT_TRUE(builder);

--- a/test/feature/idl_parser/no_path_included.idl
+++ b/test/feature/idl_parser/no_path_included.idl
@@ -1,0 +1,6 @@
+#include "basic_inner_types.idl"
+
+struct RelativePathIncludeStruct
+{
+    InnerEnumHelper value;
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

This PR modifies the IDL parsing tests to make sure the **include_paths** parameter is actually required in the corresponding tests.

@Mergifyio backport 3.1.x

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- __NO__: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- __NO__: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- __NO__: New feature has been added to the `versions.md` file (if applicable).
- __NO__: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
