### PR TITLE
[23008] Update CLI commands for Easy Mode

### DIFF
--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -64,21 +64,28 @@ if(Python3_Interpreter_FOUND)
         set(DISCOVERY_PARSER_TESTS
             TestDiscoveryParser.test_parser_shutdown_when_on
             TestDiscoveryParser.test_parser_shutdown_when_off
+            TestDiscoveryParser.test_parser_auto_fails_ip
+            TestDiscoveryParser.test_parser_auto_fails_domain
+            TestDiscoveryParser.test_parser_auto_fails_extra_arg
             TestDiscoveryParser.test_parser_auto
-            TestDiscoveryParser.test_parser_auto_domain_arg
+            TestDiscoveryParser.test_parser_auto_reverse
             TestDiscoveryParser.test_parser_auto_domain_env
-            TestDiscoveryParser.test_parser_auto_easy_mode_domain_env
-            TestDiscoveryParser.test_parser_auto_ros_static_peers
+            TestDiscoveryParser.test_parser_start_fails_ip
+            TestDiscoveryParser.test_parser_start_fails_domain
+            TestDiscoveryParser.test_parser_start_fails_extra_arg
             TestDiscoveryParser.test_parser_start
-            TestDiscoveryParser.test_parser_start_ros_static_peers
-            TestDiscoveryParser.test_parser_start_with_arg
+            TestDiscoveryParser.test_parser_start_domain_env
             TestDiscoveryParser.test_parser_stop_when_off
             TestDiscoveryParser.test_parser_stop_when_on
             TestDiscoveryParser.test_parser_stop_whith_unknown_args
             TestDiscoveryParser.test_parser_list_when_off
             TestDiscoveryParser.test_parser_list_when_on
+            TestDiscoveryParser.test_parser_add_fails_domain
+            TestDiscoveryParser.test_parser_add_fails_ip
             TestDiscoveryParser.test_parser_add_when_off
             TestDiscoveryParser.test_parser_add_when_on
+            TestDiscoveryParser.test_parser_set_fails_domain
+            TestDiscoveryParser.test_parser_set_fails_ip
             TestDiscoveryParser.test_parser_set_when_off
             TestDiscoveryParser.test_parser_set_when_on
         )

--- a/test/system/tools/fastdds/test_discovery_parser.py
+++ b/test/system/tools/fastdds/test_discovery_parser.py
@@ -117,7 +117,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_auto_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
-        """ Test that the auto command calls 'run_request_nb' with domain 0 if no domain is specified. """
+        """ Test that the auto command fails to call 'run_request_nb' if no ip arg is passed. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -271,7 +271,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_start_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
-        """ Test that the start command calls 'run_request_nb' with domain 0 if no domain is specified. """
+        """ Test that the start command fails to call 'run_request_nb' if no ip arg is passed. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'

--- a/test/system/tools/fastdds/test_discovery_parser.py
+++ b/test/system/tools/fastdds/test_discovery_parser.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import sys
 import os
 from pathlib import Path
@@ -25,7 +25,10 @@ sys.path.insert(0, str(Path(os.getenv('TOOL_PATH'), 'bin')))
 # Import the Parser class from the parser module
 from parser import Parser, command_to_int, Command
 
-
+# This test class is used to test that the parser module produces the expected
+# commands and calls to the daemon when the user runs the command line tool.
+# It does not check the daemon behavior, which should be tested in separate
+# blackbox tests, like the ones in the discovery server repo.
 class TestDiscoveryParser(unittest.TestCase):
     def __init__(self, methodName = "test_fastdds_daemon"):
         super().__init__(methodName)
@@ -37,14 +40,19 @@ class TestDiscoveryParser(unittest.TestCase):
         self.third_attr = ''
 
     def side_effect_rpc(self, *args, **kwargs):
-        domain = args[0]
-        used_cmd = args[1]
-        third_attr = args[2]
-        assert(domain == self.domain)
-        assert(len(used_cmd) == len(self.check_command))
-        assert(third_attr == self.third_attr)
-        for i in range(len(self.check_command)):
-            assert(used_cmd[i] == self.check_command[i])
+        try:
+            domain = args[0]
+            used_cmd = args[1]
+            third_attr = args[2]
+            assert(domain == self.domain)
+            assert(len(used_cmd) == len(self.check_command))
+            for i in range(len(self.check_command)):
+                assert(used_cmd[i] == self.check_command[i])
+            assert(third_attr == self.third_attr)
+        except Exception as e:
+            print(f"Error in mock 'side_effect_rpc': {e}")
+            # Raise exception to detect error in the test
+            raise e
         return 'Mocked request'
 
     def set_env_values(self, env_var_name, value):
@@ -57,6 +65,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_shutdown_when_on(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_shutdown, mock_is_running, mock_exit):
+        """ Test that the stop command shutdowns the daemon when it is running """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -80,6 +89,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_shutdown_when_off(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_shutdown, mock_is_running, mock_exit):
+        """ Test that the stop command does nothing when it is not running """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -106,16 +116,87 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
-    def test_parser_auto(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+    def test_parser_auto_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command calls 'run_request_nb' with domain 0 if no domain is specified. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
-        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '0']
+        argv = ['auto', '-d', '42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_auto_fails_domain(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command fails to call 'run_request_nb' if no domain arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['auto', '127.0.0.1:42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_auto_fails_extra_arg(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command does not allow extra arguments. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+        mock_spawn.return_value = True
+
+        argv = ['auto', '-d', '42', '127.0.0.1:42', 'extra_arg']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_auto(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command can parse the arg '-d' correctly. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+        mock_spawn.return_value = True
+
+        self.domain = 7
+        self.third_attr = '192.168.1.42'
+        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '7', '192.168.1.42:42']
         mock_rpc_nbrequest.side_effect = self.side_effect_rpc
 
-        argv = ['auto']
+        argv = ['auto', '-d', '7', '192.168.1.42:42']
         parser = Parser(argv)
 
         mock_is_running.assert_not_called()
@@ -131,19 +212,20 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
-    def test_parser_auto_domain_arg(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+    def test_parser_auto_reverse(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command can parse the arg '-d' correctly. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
         self.domain = 7
-        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '7']
+        self.third_attr = '192.168.1.42'
+        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '7', '192.168.1.42:42']
         mock_rpc_nbrequest.side_effect = self.side_effect_rpc
 
-        argv = ['auto', '-d', '7']
+        argv = ['auto', '192.168.1.42:42', '-d', '7']
         parser = Parser(argv)
-        print('End of test')
 
         mock_is_running.assert_not_called()
         mock_spawn.assert_called_once()
@@ -159,47 +241,20 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_auto_domain_env(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the auto command ignores the ROS_DOMAIN_ID env var correctly. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
         self.set_env_values('ROS_DOMAIN_ID', '42')
-        self.domain = 42
-        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '42']
-        mock_rpc_nbrequest.side_effect = self.side_effect_rpc
-
-        argv = ['auto']
-        parser = Parser(argv)
-
-        mock_is_running.assert_not_called()
-        mock_spawn.assert_called_once()
-        mock_rpc_stopall.assert_not_called()
-        mock_rpc_nbrequest.assert_called_once()
-        mock_rpc_brequest.assert_not_called()
-        mock_exit.assert_not_called()
-
-    @patch('parser.sys.exit')
-    @patch('parser.is_daemon_running')
-    @patch('parser.spawn_daemon')
-    @patch('parser.client_cli.run_request_b')
-    @patch('parser.client_cli.run_request_nb')
-    @patch('parser.client_cli.stop_all_request')
-    def test_parser_auto_easy_mode_domain_env(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
-        mock_rpc_stopall.return_value = 'Mocked request'
-        mock_rpc_nbrequest.return_value = 'Mocked request'
-        mock_rpc_brequest.return_value = 'Mocked request'
-        mock_spawn.return_value = True
-
-        self.set_env_values('ROS2_EASY_MODE', '127.0.0.1')
-        self.domain = 42
+        self.set_env_values('ROS2_EASY_MODE', '1.1.1.1')
+        self.domain = 7
         self.third_attr = '127.0.0.1'
-        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '42', '127.0.0.1:42']
+        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '7', '127.0.0.1:7']
         mock_rpc_nbrequest.side_effect = self.side_effect_rpc
 
-        # The parser is not responsible of adding the ROS2_EASY_MODE argument to the command. This is done in Fast DDS.
-        # The parser only checks if the ROS2_EASY_MODE variable is set to pass it to the RPC server as third argument
-        argv = ['auto', '-d', '42', '127.0.0.1:42']
+        argv = ['auto', '-d', '7', '127.0.0.1:7']
         parser = Parser(argv)
 
         mock_is_running.assert_not_called()
@@ -215,25 +270,67 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
-    def test_parser_auto_ros_static_peers(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+    def test_parser_start_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the start command calls 'run_request_nb' with domain 0 if no domain is specified. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
-        self.set_env_values('ROS_STATIC_PEERS', '127.0.0.1:1')
-        self.check_command = [str(command_to_int[Command.AUTO]), '-d', '0', '127.0.0.1:1']
-        mock_rpc_nbrequest.side_effect = self.side_effect_rpc
-
-        argv = ['auto']
+        argv = ['start', '-d', '42']
         parser = Parser(argv)
 
         mock_is_running.assert_not_called()
-        mock_spawn.assert_called_once()
+        mock_spawn.assert_not_called()
         mock_rpc_stopall.assert_not_called()
-        mock_rpc_nbrequest.assert_called_once()
+        mock_rpc_nbrequest.assert_not_called()
         mock_rpc_brequest.assert_not_called()
-        mock_exit.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_start_fails_domain(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the start command fails to call 'run_request_nb' if no domain arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['start', '127.0.0.1:42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_start_fails_extra_arg(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the start command does not allow extra arguments. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+        mock_spawn.return_value = True
+
+        argv = ['start', '-d', '42', '127.0.0.1:42', 'extra_arg']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
 
     @patch('parser.sys.exit')
     @patch('parser.is_daemon_running')
@@ -242,15 +339,18 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_start(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the start command can parse the arg '-d' correctly. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
-        self.check_command = [str(command_to_int[Command.START]), '-d', '0']
+        self.domain = 7
+        self.third_attr = '192.168.1.42'
+        self.check_command = [str(command_to_int[Command.START]), '-d', '7', '192.168.1.42:42']
         mock_rpc_nbrequest.side_effect = self.side_effect_rpc
 
-        argv = ['start']
+        argv = ['start', '-d', '7', '192.168.1.42:42']
         parser = Parser(argv)
 
         mock_is_running.assert_not_called()
@@ -266,42 +366,21 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
-    def test_parser_start_ros_static_peers(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+    def test_parser_start_domain_env(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the start command ignores the ROS_DOMAIN_ID env var correctly. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
         mock_spawn.return_value = True
 
-        self.set_env_values('ROS_STATIC_PEERS', '127.0.0.1:1;127.0.0.1:2')
-        self.check_command = [str(command_to_int[Command.START]), '-d', '0', '127.0.0.1:1;127.0.0.1:2']
+        self.set_env_values('ROS_DOMAIN_ID', '42')
+        self.set_env_values('ROS2_EASY_MODE', '1.1.1.1')
+        self.domain = 7
+        self.third_attr = '127.0.0.1'
+        self.check_command = [str(command_to_int[Command.START]), '-d', '7', '127.0.0.1:7']
         mock_rpc_nbrequest.side_effect = self.side_effect_rpc
 
-        argv = ['start']
-        parser = Parser(argv)
-
-        mock_is_running.assert_not_called()
-        mock_spawn.assert_called_once()
-        mock_rpc_stopall.assert_not_called()
-        mock_rpc_nbrequest.assert_called_once()
-        mock_rpc_brequest.assert_not_called()
-        mock_exit.assert_not_called()
-
-    @patch('parser.sys.exit')
-    @patch('parser.is_daemon_running')
-    @patch('parser.spawn_daemon')
-    @patch('parser.client_cli.run_request_b')
-    @patch('parser.client_cli.run_request_nb')
-    @patch('parser.client_cli.stop_all_request')
-    def test_parser_start_with_arg(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
-        mock_rpc_stopall.return_value = 'Mocked request'
-        mock_rpc_nbrequest.return_value = 'Mocked request'
-        mock_rpc_brequest.return_value = 'Mocked request'
-        mock_spawn.return_value = True
-
-        self.check_command = [str(command_to_int[Command.START]), '-d', '0', '127.0.0.1:4;127.0.0.1:2']
-        mock_rpc_nbrequest.side_effect = self.side_effect_rpc
-
-        argv = ['start', '127.0.0.1:4;127.0.0.1:2']
+        argv = ['start', '-d', '7', '127.0.0.1:7']
         parser = Parser(argv)
 
         mock_is_running.assert_not_called()
@@ -318,6 +397,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_request')
     def test_parser_stop_when_off(self, mock_rpc_stop_once, mock_rpc_nbrequest, mock_rpc_brequest, mock_shutdown, mock_is_running, mock_exit):
+        """ Test that the stop command with arg does nothing when it is not running """
         mock_rpc_stop_once.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -348,6 +428,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_request')
     def test_parser_stop_when_on(self, mock_rpc_stop_once, mock_rpc_nbrequest, mock_rpc_brequest, mock_shutdown, mock_is_running, mock_exit):
+        """ Test that the stop command calls 'stop_request' the daemon when it is running. """
         mock_rpc_stop_once.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -374,6 +455,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_request')
     def test_parser_stop_whith_unknown_args(self, mock_rpc_stop_once, mock_rpc_nbrequest, mock_rpc_brequest, mock_shutdown, mock_is_running, mock_exit):
+        """ Test that the stop command exits when called with unknown args. """
         mock_rpc_stop_once.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -400,6 +482,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_list_when_off(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the list command does nothing if the daemon is not running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -431,6 +514,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_list_when_on(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the list command calls 'run_request_b' if the daemon is running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -457,7 +541,52 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
+    def test_parser_add_fails_domain(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the add command fails to call 'run_request_b' if no domain arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['add', '127.0.0.1:42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_add_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the add command fails to call 'run_request_b' if no ip arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['add', '-d', '42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
     def test_parser_add_when_off(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the add command does nothing if the daemon is not running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -468,7 +597,7 @@ class TestDiscoveryParser(unittest.TestCase):
         self.check_command = [str(command_to_int[Command.ADD]), '-d', '0']
         mock_rpc_brequest.side_effect = self.side_effect_rpc
 
-        argv = ['add']
+        argv = ['add', '-d', '0', '127.0.0.1:42']
         try:
             parser = Parser(argv)
         except SystemExit as e:
@@ -489,6 +618,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_add_when_on(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the add command calls 'run_request_b' if the daemon is running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -496,10 +626,10 @@ class TestDiscoveryParser(unittest.TestCase):
         mock_spawn.return_value = True
 
         self.third_attr = True
-        self.check_command = [str(command_to_int[Command.ADD]), '-d', '0']
+        self.check_command = [str(command_to_int[Command.ADD]), '-d', '0', '127.0.0.1:42']
         mock_rpc_brequest.side_effect = self.side_effect_rpc
 
-        argv = ['add']
+        argv = ['add', '-d', '0', '127.0.0.1:42']
         parser = Parser(argv)
 
         mock_is_running.assert_called_once()
@@ -515,7 +645,52 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_b')
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
+    def test_parser_set_fails_domain(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the set command fails to call 'run_request_b' if no domain arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['set', '127.0.0.1:42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
+    def test_parser_set_fails_ip(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the set command fails to call 'run_request_b' if no ip arg is passed. """
+        mock_rpc_stopall.return_value = 'Mocked request'
+        mock_rpc_nbrequest.return_value = 'Mocked request'
+        mock_rpc_brequest.return_value = 'Mocked request'
+
+        argv = ['set', '-d', '42']
+        parser = Parser(argv)
+
+        mock_is_running.assert_not_called()
+        mock_spawn.assert_not_called()
+        mock_rpc_stopall.assert_not_called()
+        mock_rpc_nbrequest.assert_not_called()
+        mock_rpc_brequest.assert_not_called()
+        mock_exit.assert_called_once()
+
+    @patch('parser.sys.exit')
+    @patch('parser.is_daemon_running')
+    @patch('parser.spawn_daemon')
+    @patch('parser.client_cli.run_request_b')
+    @patch('parser.client_cli.run_request_nb')
+    @patch('parser.client_cli.stop_all_request')
     def test_parser_set_when_off(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the set command does nothing if the daemon is not running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -523,10 +698,10 @@ class TestDiscoveryParser(unittest.TestCase):
         mock_spawn.return_value = True
 
         self.third_attr = True
-        self.check_command = [str(command_to_int[Command.SET]), '-d', '0']
+        self.check_command = [str(command_to_int[Command.SET]), '-d', '0', '127.0.0.1:42']
         mock_rpc_brequest.side_effect = self.side_effect_rpc
 
-        argv = ['set']
+        argv = ['set', '-d', '0', '127.0.0.1:42']
         try:
             parser = Parser(argv)
         except SystemExit as e:
@@ -547,6 +722,7 @@ class TestDiscoveryParser(unittest.TestCase):
     @patch('parser.client_cli.run_request_nb')
     @patch('parser.client_cli.stop_all_request')
     def test_parser_set_when_on(self, mock_rpc_stopall, mock_rpc_nbrequest, mock_rpc_brequest, mock_spawn, mock_is_running, mock_exit):
+        """ Test that the set command calls 'run_request_b' if the daemon is running. """
         mock_rpc_stopall.return_value = 'Mocked request'
         mock_rpc_nbrequest.return_value = 'Mocked request'
         mock_rpc_brequest.return_value = 'Mocked request'
@@ -554,10 +730,10 @@ class TestDiscoveryParser(unittest.TestCase):
         mock_spawn.return_value = True
 
         self.third_attr = True
-        self.check_command = [str(command_to_int[Command.SET]), '-d', '0']
+        self.check_command = [str(command_to_int[Command.SET]), '-d', '0', '127.0.0.1:42']
         mock_rpc_brequest.side_effect = self.side_effect_rpc
 
-        argv = ['set']
+        argv = ['set', '-d', '0', '127.0.0.1:42']
         parser = Parser(argv)
 
         mock_is_running.assert_called_once()

--- a/tools/fastdds/discovery/fastdds_daemon/process_handler/process_handler.py
+++ b/tools/fastdds/discovery/fastdds_daemon/process_handler/process_handler.py
@@ -47,15 +47,11 @@ class ProcessHandler:
     def run_process_nb(self, domain: int, command: list, easy_mode: str):
         """
         Used for starting new servers. Commands 'start' and 'auto'.
-        If @easy_mode is empty, it means the 'ROS2_EASY_MODE' variable was not set, that is,
-        it is a direct call from the CLI.
-        Note that 'easy_mode' has already been added to the command string in the parser,
-        it is only used here to avoid using regex to find its value and differentiate
-        'auto' and 'start' commands.
+        Param @easy_mode indicates the remote_connection that should be used.
         """
         with self._lock:
             if domain in self.processes:
-                if easy_mode != '' and easy_mode != self.remote_connections[domain]:
+                if easy_mode != self.remote_connections[domain]:
                     return f"Error: DS for Domain '{domain}' already points to '{self.remote_connections[domain]}'."
                 return f"Discovery server for Domain '{domain}' is already running."
             # Start a new subprocess in a non-blocking way
@@ -64,7 +60,7 @@ class ProcessHandler:
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        preexec_fn=os.setsid)
-            # Check output to see if the process started correctly or it issued an error
+            # Check output to see if the process started correctly or if it issued an error
             try:
                 output = os.read(process.stdout.fileno(), 1024).decode('utf-8')
             except Exception as e:
@@ -72,16 +68,7 @@ class ProcessHandler:
 
             if 'started' in output:
                 self.processes[domain] = process
-                # Remote connections are always the last element of the command
-                # Cpp tool should fail if more than one argument is received
-                remote_connection = ''
-                if len(command) > 4:
-                    ip_re = r"(\d{1,3}(?:\.\d{1,3}){3})"
-                    match = re.search(ip_re, command[-1])
-                    if match:
-                        ip = match.group(1)
-                        remote_connection = ip
-                self.remote_connections[domain] = remote_connection
+                self.remote_connections[domain] = easy_mode
             else:
                 # Strip ANSI colors from the error message
                 stderr = os.read(process.stderr.fileno(), 1024).decode('utf-8')
@@ -104,9 +91,29 @@ class ProcessHandler:
                                         stderr=subprocess.PIPE,
                                         text=True,
                                         check=True)
-                return result.stdout
+
+                output = result.stdout
+                if command[1] == '4':
+                    # Remote connections are always the last element of the command
+                    # Cpp tool should fail if more than one argument is received
+                    remote_connection = ''
+                    if len(command) > 4:
+                        ip_re = r"(\d{1,3}(?:\.\d{1,3}){3})"
+                        match = re.search(ip_re, command[-1])
+                        if match:
+                            ip = match.group(1)
+                            remote_connection = ip
+                            output += f"Remote connection modified to {command[-1]}. Use this value for the ROS2_EASY_MODE. "
+                        else:
+                            output += f"Not able to modify the remote connection to {command[-1]}. "
+                    self.remote_connections[domain] = remote_connection
+                return output
             except subprocess.CalledProcessError as e:
-                return e.stdout
+                # Strip ANSI colors from the error message
+                ansi_escape = re.compile(r'\x1b[^m]*m')
+                stripped_output = ansi_escape.sub('', e.stderr)
+                output = f"Command not executed: {stripped_output}"
+                return output
 
     def stop_process(self, domain: int, sig: int):
         with self._lock:

--- a/tools/fastdds/discovery/fastdds_daemon/process_handler/process_handler.py
+++ b/tools/fastdds/discovery/fastdds_daemon/process_handler/process_handler.py
@@ -93,6 +93,7 @@ class ProcessHandler:
                                         check=True)
 
                 output = result.stdout
+                # When the command received matches the Command.SET value (4), the remote connection needs to be modified
                 if command[1] == '4':
                     # Remote connections are always the last element of the command
                     # Cpp tool should fail if more than one argument is received

--- a/tools/fds/CliDiscoveryEntrypoint.cpp
+++ b/tools/fds/CliDiscoveryEntrypoint.cpp
@@ -61,8 +61,6 @@ int main (
     switch (command_int)
     {
         case ToolCommand::AUTO:
-            return cli_manager.fastdds_discovery_auto_start(options, parse);
-            break;
         case ToolCommand::START:
             return cli_manager.fastdds_discovery_auto_start(options, parse);
             break;

--- a/tools/fds/CliDiscoveryManager.hpp
+++ b/tools/fds/CliDiscoveryManager.hpp
@@ -24,7 +24,6 @@
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 
-constexpr const char* domain_env_var = "ROS_DOMAIN_ID";
 constexpr const char* remote_servers_env_var = "ROS_STATIC_PEERS";
 constexpr const char* default_ip = "0.0.0.0";
 
@@ -271,7 +270,7 @@ public:
     /**
      * @brief Launch the AUTO mode of the CLI. It checks if a new Discovery Server exists in the
      * specified domain. It it does not exist, it creates a new one. If it exists, it does nothing.
-     * Remote servers are added with the ROS_STATIC_PEERS environment variable or directly from the CLI.
+     * Remote server is added directly from the argument passed to the CLI, which is mandatory.
      * @param options The options received from the CLI
      * @param parse The parser object to be used
      */

--- a/tools/fds/CliDiscoveryParser.hpp
+++ b/tools/fds/CliDiscoveryParser.hpp
@@ -211,12 +211,8 @@ const option::Descriptor usage[] = {
       "\t               tool.\n"},
 
     { UNKNOWN,   0, "",   "",             Arg::None,
-      "\nDaemon options:\n  auto\t Handle the daemon start-up automatically. It will create\n"
-      "\t a Discovery Server in the specified domain."},
-
-    { UNKNOWN,   0, "",   "",             Arg::None,
-      "\n  start\t Start the Discovery Server daemon with the remote connections\n"
-      "\t specified. (Example: start -d 1 \"127.0.0.1:2;10.0.0.3:42\")."},
+      "\nDaemon options:\n  start\t Start the Discovery Server daemon with the remote connections\n"
+      "\t specified. (Example: start -d 1 \"10.0.0.1:1\")."},
 
     { UNKNOWN,   0, "",   "",             Arg::None,
       "\n  stop\t Stop the Discovery Server daemon if it is active. If a domain\n"
@@ -298,8 +294,8 @@ const std::string EXAMPLES =
 
         "Daemon Examples:\n"
 
-        "\t1.  Start a DS in the default domain 0:\n\n"
-        "\t    $ " FAST_SERVER_BINARY " auto\n\n"
+        "\t1.  Start a DS in domain 0:\n\n"
+        "\t    $ " FAST_SERVER_BINARY " start -d 0 127.0.0.1:0\n\n"
 
         "\t2.  Stop all running DS and shut down Fast DDS daemon:\n\n"
         "\t    $ " FAST_SERVER_BINARY " stop\n\n"
@@ -307,21 +303,16 @@ const std::string EXAMPLES =
         "\t3.  Stop DS running in domain 0:\n\n"
         "\t    $ " FAST_SERVER_BINARY " stop -d 0\n\n"
 
-        "\t4.  Start a DS in the domain 42:\n\n"
-        "\t    $ " FAST_SERVER_BINARY " auto -d 42\n"
-        "\t    OR\n"
-        "\t    $ ROS_DOMAIN_ID=42 " FAST_SERVER_BINARY " auto\n\n"
-
-        "\t5.  Start a DS in domain 4 pointing to remote DS in domain 4:\n\n"
+        "\t4.  Start a DS in domain 4 pointing to remote DS in domain 4:\n\n"
         "\t    $ " FAST_SERVER_BINARY " start -d 4 10.0.0.7:4\n\n"
 
-        "\t6.  Add a new remote server to DS running in domain 4 :\n\n"
+        "\t5.  Add a new remote server to DS running in domain 4 :\n\n"
         "\t    $ " FAST_SERVER_BINARY " add -d 4 10.0.0.7:4\n\n"
 
-        "\t7.  List all servers running locally:\n\n"
+        "\t6.  List all servers running locally:\n\n"
         "\t    $ " FAST_SERVER_BINARY " list\n\n"
 
-        "\t8.  Starts a DS in domain 3 pointing to local DS in domain 6:\n\n"
+        "\t7.  Starts a DS in domain 3 pointing to local DS in domain 6:\n\n"
         "\t    $ " FAST_SERVER_BINARY " start -d 3 127.0.0.1:6\n\n"
 ;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR modifies the behavior of certain commands of the CLI:

- `auto` and `start` are now equivalent.
- A `domain` argument and an `IP:domain` pair are now mandatory for `auto`, `start`, `add` and `set` commands.
- `set` command modifies the active remote connection, so ROS2_EASY_MODE needs to be updated after running it.

It also improves the CLI error notification

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally.
     - Related tests: https://github.com/eProsima/Discovery-Server/pull/114
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1052
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
