### PR TITLE
[23048] Fix `related_sample_identity` handling in RPC entities

### DIFF
--- a/src/cpp/fastdds/rpc/ReplierImpl.cpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.cpp
@@ -32,6 +32,14 @@ namespace fastdds {
 namespace dds {
 namespace rpc {
 
+static void fill_related_sample_identity(
+        RequestInfo& info)
+{
+    // When sending a reply, the code here expects that related_sample_identity
+    // has the sample_identity of the corresponding request.
+    info.related_sample_identity = info.sample_identity;
+}
+
 ReplierImpl::ReplierImpl(
         ServiceImpl* service,
         const ReplierQos& qos)
@@ -87,8 +95,7 @@ ReturnCode_t ReplierImpl::take_request(
     }
 
     retcode = replier_reader_->take_next_sample(data, &info);
-    // Related sample identity is stored in sample_indentity member of info. Change it to related_sample_identity
-    info.related_sample_identity = info.sample_identity;
+    fill_related_sample_identity(info);
 
     return retcode;
 }
@@ -112,7 +119,7 @@ ReturnCode_t ReplierImpl::take_request(
     // Fill related_sample_identity attribute
     for (LoanableCollection::size_type i = 0; i < info.length(); ++i)
     {
-        info[i].related_sample_identity = info[i].sample_identity;
+        fill_related_sample_identity(info[i]);
     }
 
     return retcode;

--- a/src/cpp/fastdds/rpc/ReplierImpl.cpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.cpp
@@ -33,6 +33,14 @@ namespace fastdds {
 namespace dds {
 namespace rpc {
 
+/**
+ * @brief Fills the related sample identity of the request.
+ *
+ * This will fill the related sample identity of the request with values taken from the sample identity.
+ * Values different from unknown are preserved.
+ *
+ * @param info [in,out] The request information to update.
+ */
 static void fill_related_sample_identity(
         RequestInfo& info)
 {

--- a/src/cpp/fastdds/rpc/ReplierImpl.cpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.cpp
@@ -12,11 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ReplierImpl.hpp"
+
+#include <string>
+
+#include <fastdds/dds/core/detail/DDSReturnCode.hpp>
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
+#include <fastdds/dds/domain/qos/ReplierQos.hpp>
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/rpc/RequestInfo.hpp>
 #include <fastdds/rtps/common/WriteParams.hpp>
 
-#include "ReplierImpl.hpp"
 #include "ServiceImpl.hpp"
 
 namespace eprosima {

--- a/src/cpp/fastdds/rpc/RequesterImpl.cpp
+++ b/src/cpp/fastdds/rpc/RequesterImpl.cpp
@@ -59,11 +59,24 @@ ReturnCode_t RequesterImpl::send_request(
     }
 
     rtps::WriteParams wparams;
+    wparams.related_sample_identity(info.related_sample_identity);
     ReturnCode_t ret = requester_writer_->write(data, wparams);
     if (RETCODE_OK == ret)
     {
         // Fill RequestInfo's related sample identity with the information expected for the corresponding reply
-        info.related_sample_identity = wparams.related_sample_identity();
+        info.sample_identity = wparams.sample_identity();
+
+        // Set the full related sample identity when the writer guid is unknown
+        if (rtps::GUID_t::unknown() == info.related_sample_identity.writer_guid())
+        {
+            info.related_sample_identity = wparams.related_sample_identity();
+        }
+        
+        // Set the sequence number of the related sample identity when it is unknown
+        if (rtps::SequenceNumber_t::unknown() == info.related_sample_identity.sequence_number())
+        {
+            info.related_sample_identity.sequence_number() = wparams.related_sample_identity().sequence_number();
+        }
     }
     return ret;
 }

--- a/src/cpp/fastdds/rpc/RequesterImpl.cpp
+++ b/src/cpp/fastdds/rpc/RequesterImpl.cpp
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "RequesterImpl.hpp"
+
+#include <string>
+
+#include <fastdds/dds/core/detail/DDSReturnCode.hpp>
+#include <fastdds/dds/core/LoanableCollection.hpp>
+#include <fastdds/dds/core/LoanableSequence.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
+#include <fastdds/dds/domain/qos/RequesterQos.hpp>
 #include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/rpc/RequestInfo.hpp>
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/SequenceNumber.hpp>
 #include <fastdds/rtps/common/WriteParams.hpp>
 
-#include "RequesterImpl.hpp"
 #include "ServiceImpl.hpp"
 
 namespace eprosima {

--- a/src/cpp/fastdds/rpc/RequesterImpl.cpp
+++ b/src/cpp/fastdds/rpc/RequesterImpl.cpp
@@ -71,7 +71,7 @@ ReturnCode_t RequesterImpl::send_request(
         {
             info.related_sample_identity = wparams.related_sample_identity();
         }
-        
+
         // Set the sequence number of the related sample identity when it is unknown
         if (rtps::SequenceNumber_t::unknown() == info.related_sample_identity.sequence_number())
         {

--- a/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.hpp
+++ b/test/blackbox/api/dds-pim/ReqRepHelloWorldRequester.hpp
@@ -32,6 +32,7 @@
 #include <fastdds/dds/rpc/Requester.hpp>
 #include <fastdds/dds/rpc/RequestInfo.hpp>
 #include <fastdds/dds/rpc/Service.hpp>
+#include <fastdds/rtps/common/SampleIdentity.hpp>
 
 #include "../../common/BlackboxTests.hpp"
 
@@ -80,12 +81,20 @@ public:
     void send(
             const uint16_t number);
 
+    void send(
+            const uint16_t number,
+            const eprosima::fastdds::rtps::SampleIdentity& related_sample_identity);
+
     const eprosima::fastdds::dds::Duration_t datawriter_latency_budget_duration() const;
 
     const eprosima::fastdds::dds::Duration_t datareader_latency_budget_duration() const;
 
     eprosima::fastdds::dds::RequesterQos create_requester_qos(
             bool volatile_durability_qos = false);
+
+    const eprosima::fastdds::rtps::GUID_t& get_reader_guid() const;
+
+    const eprosima::fastdds::rtps::SampleIdentity& get_last_related_sample_identity() const;
 
 private:
 

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -284,6 +284,62 @@ TEST_P(PubSubBasic, ReqRepAsReliableHelloworld)
     }
 }
 
+TEST_P(PubSubBasic, ReqRepAsReliableHelloworldReaderGUID)
+{
+    ReqRepHelloWorldRequester requester;
+    ReqRepHelloWorldReplier replier;
+    const uint16_t nmsgs = 10;
+
+    requester.init();
+
+    ASSERT_TRUE(requester.isInitialized());
+
+    replier.init();
+
+    requester.wait_discovery();
+    replier.wait_discovery();
+
+    ASSERT_TRUE(replier.isInitialized());
+
+    for (uint16_t count = 0; count < nmsgs; ++count)
+    {
+        eprosima::fastdds::rtps::SampleIdentity related_sample_identity{};
+        related_sample_identity.writer_guid(requester.get_reader_guid());
+        requester.send(count, related_sample_identity);
+        requester.block(std::chrono::seconds(5));
+    }
+}
+
+TEST_P(PubSubBasic, ReqRepAsReliableHelloworldConsecutive)
+{
+    ReqRepHelloWorldRequester requester;
+    ReqRepHelloWorldReplier replier;
+    const uint16_t nmsgs = 10;
+
+    requester.init();
+
+    ASSERT_TRUE(requester.isInitialized());
+
+    replier.init();
+
+    requester.wait_discovery();
+    replier.wait_discovery();
+
+    ASSERT_TRUE(replier.isInitialized());
+
+    requester.send(0);
+    requester.block(std::chrono::seconds(5));
+
+    eprosima::fastdds::rtps::SampleIdentity related_sample_identity{};
+    related_sample_identity = requester.get_last_related_sample_identity();
+
+    for (uint16_t count = 1; count < nmsgs; ++count)
+    {
+        requester.send(count, related_sample_identity);
+        requester.block(std::chrono::seconds(5));
+    }
+}
+
 TEST_P(PubSubBasic, PubSubAsReliableData64kb)
 {
     PubSubReader<Data64kbPubSubType> reader(TEST_TOPIC_NAME);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes the way `related_sample_identity` is handled in `ReplierImpl` and `RequesterImpl` for cases where it already has a value when the request is performed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
