### PR TITLE
[22814] Improve DS routines

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -282,8 +282,8 @@ void DiscoveryDataBase::update_change_and_unmatch_(
     changes_to_release_.push_back(entity.update_and_unmatch(new_change));
     // Manually set relevant participants ACK status of this server, and of the participant that sent the
     // change, to 1. This way, we avoid backprogation of the data.
-    entity.add_or_update_ack_participant(server_guid_prefix_, ParticipantState::MATCHED);
-    entity.add_or_update_ack_participant(new_change->writerGUID.guidPrefix, ParticipantState::MATCHED);
+    entity.add_or_update_ack_participant(server_guid_prefix_, ParticipantState::ACKED);
+    entity.add_or_update_ack_participant(new_change->writerGUID.guidPrefix, ParticipantState::ACKED);
 }
 
 void DiscoveryDataBase::add_ack_(
@@ -307,7 +307,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::ACKED);
             }
         }
     }
@@ -322,7 +322,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::ACKED);
             }
         }
     }
@@ -337,7 +337,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::ACKED);
             }
         }
     }
@@ -639,7 +639,7 @@ void DiscoveryDataBase::match_new_server_(
                         if (server != participant_prefix)
                         {
                             // Make all known servers relevant to the new server, but not matched
-                            part.second.add_or_update_ack_participant(server, ParticipantState::UNMATCHED);
+                            part.second.add_or_update_ack_participant(server, ParticipantState::PENDING_SEND);
                             resend_new_pdp = true;
                         }
                     }
@@ -652,7 +652,7 @@ void DiscoveryDataBase::match_new_server_(
                 else
                 {
                     // Make the new server relevant to all known servers
-                    part.second.add_or_update_ack_participant(participant_prefix, ParticipantState::UNMATCHED);
+                    part.second.add_or_update_ack_participant(participant_prefix, ParticipantState::PENDING_SEND);
                     // Send DATA(p) of all known servers to the new participant
                     add_pdp_to_send_(part.second.change());
                 }
@@ -754,7 +754,7 @@ void DiscoveryDataBase::create_new_participant_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+        ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
 
         // If the DATA(p) it's from this server, it is already in history and we do nothing here
         if (change_guid.guidPrefix != server_guid_prefix_)
@@ -856,7 +856,7 @@ void DiscoveryDataBase::update_participant_from_change_(
         if (ch->write_params.sample_identity().sequence_number() ==
                 participant_info.change()->write_params.sample_identity().sequence_number())
         {
-            participant_info.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+            participant_info.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
         }
 
         // we release it if it's the same or if it is lower
@@ -906,7 +906,7 @@ void DiscoveryDataBase::create_writers_from_change_(
             if (ch->write_params.sample_identity().sequence_number() ==
                     writer_it->second.change()->write_params.sample_identity().sequence_number())
             {
-                writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+                writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
             }
 
             // we release it if it's the same or if it is lower
@@ -954,7 +954,7 @@ void DiscoveryDataBase::create_writers_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+        writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
 
         // if topic is virtual, it must iterate over all readers
         if (topic_name == virtual_topic_)
@@ -1024,7 +1024,7 @@ void DiscoveryDataBase::create_readers_from_change_(
             if (ch->write_params.sample_identity().sequence_number() ==
                     reader_it->second.change()->write_params.sample_identity().sequence_number())
             {
-                reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+                reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
             }
 
             // we release it if it's the same or if it is lower
@@ -1072,7 +1072,7 @@ void DiscoveryDataBase::create_readers_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
+        reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::ACKED);
 
         // If topic is virtual, it must iterate over all readers
         if (topic_name == virtual_topic_)
@@ -1469,10 +1469,6 @@ bool DiscoveryDataBase::process_dirty_topics()
                 // Find participants with writer info and participant with reader info in participants_
                 parts_reader_it = participants_.find(reader.guidPrefix);
                 parts_writer_it = participants_.find(writer.guidPrefix);
-                // Find reader info in readers_
-                readers_it = readers_.find(reader);
-                // Find writer info in writers_
-                writers_it = writers_.find(writer);
 
                 // Check in `participants_` whether the client with the reader has acknowledge the PDP of the client
                 // with the writer.
@@ -1480,10 +1476,12 @@ bool DiscoveryDataBase::process_dirty_topics()
                 {
                     if (parts_reader_it->second.is_matched(writer.guidPrefix))
                     {
+                        // Find reader info in readers_
+                        readers_it = readers_.find(reader);
                         // Check the status of the writer in `readers_[reader]::relevant_participants_builtin_ack_status`.
                         if (readers_it != readers_.end() &&
                                 readers_it->second.is_relevant_participant(writer.guidPrefix) &&
-                                !readers_it->second.is_sent(writer.guidPrefix))
+                                !readers_it->second.is_waiting_ack(writer.guidPrefix))
                         {
                             // If the status is 0, add DATA(r) to a `edp_publications_to_send_` (if it's not there).
                             if (add_edp_subscriptions_to_send_(readers_it->second.change()))
@@ -1491,13 +1489,13 @@ bool DiscoveryDataBase::process_dirty_topics()
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding DATA(r) to send: "
                                         << readers_it->second.change()->instanceHandle);
                                 readers_it->second.add_or_update_ack_participant(writer.guidPrefix,
-                                        ParticipantState::SENT);
+                                        ParticipantState::WAITING_ACK);
                             }
                         }
                     }
                     else if (parts_reader_it->second.is_relevant_participant(writer.guidPrefix))
                     {
-                        if (!parts_reader_it->second.is_sent(writer.guidPrefix))
+                        if (!parts_reader_it->second.is_waiting_ack(writer.guidPrefix))
                         {
                             // Add DATA(p) of the client with the writer to `pdp_to_send_` (if it's not there).
                             if (add_pdp_to_send_(parts_reader_it->second.change()))
@@ -1505,7 +1503,7 @@ bool DiscoveryDataBase::process_dirty_topics()
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding readers' DATA(p) to send: "
                                         << parts_reader_it->second.change()->instanceHandle);
                                 parts_reader_it->second.add_or_update_ack_participant(writer.guidPrefix,
-                                        ParticipantState::SENT);
+                                        ParticipantState::WAITING_ACK);
                             }
                         }
                         // Set topic as not-clearable.
@@ -1519,10 +1517,12 @@ bool DiscoveryDataBase::process_dirty_topics()
                 {
                     if (parts_writer_it->second.is_matched(reader.guidPrefix))
                     {
+                        // Find writer info in writers_
+                        writers_it = writers_.find(writer);
                         // Check the status of the reader in `writers_[writer]::relevant_participants_builtin_ack_status`.
                         if (writers_it != writers_.end() &&
                                 writers_it->second.is_relevant_participant(reader.guidPrefix) &&
-                                !writers_it->second.is_sent(reader.guidPrefix))
+                                !writers_it->second.is_waiting_ack(reader.guidPrefix))
                         {
                             // If the status is 0, add DATA(w) to a `edp_subscriptions_to_send_` (if it's not there).
                             if (add_edp_publications_to_send_(writers_it->second.change()))
@@ -1530,13 +1530,13 @@ bool DiscoveryDataBase::process_dirty_topics()
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding DATA(w) to send: "
                                         << writers_it->second.change()->instanceHandle);
                                 writers_it->second.add_or_update_ack_participant(reader.guidPrefix,
-                                        ParticipantState::SENT);
+                                        ParticipantState::WAITING_ACK);
                             }
                         }
                     }
                     else if (parts_writer_it->second.is_relevant_participant(reader.guidPrefix))
                     {
-                        if (!parts_writer_it->second.is_sent(reader.guidPrefix))
+                        if (!parts_writer_it->second.is_waiting_ack(reader.guidPrefix))
                         {
                             // Add DATA(p) of the client with the reader to `pdp_to_send_` (if it's not there).
                             if (add_pdp_to_send_(parts_writer_it->second.change()))
@@ -1544,7 +1544,7 @@ bool DiscoveryDataBase::process_dirty_topics()
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding writers' DATA(p) to send: "
                                         << parts_writer_it->second.change()->instanceHandle);
                                 parts_writer_it->second.add_or_update_ack_participant(reader.guidPrefix,
-                                        ParticipantState::SENT);
+                                        ParticipantState::WAITING_ACK);
                             }
                         }
                         // Set topic as not-clearable.

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -2366,18 +2366,6 @@ bool DiscoveryDataBase::add_pdp_to_send_(
     return false;
 }
 
-bool DiscoveryDataBase::add_own_pdp_to_send_()
-{
-    if (!backup_in_progress())
-    {
-        auto our_data_it = participants_.find(server_guid_prefix_);
-        assert(our_data_it != participants_.end());
-
-        return add_pdp_to_send_(our_data_it->second.change());
-    }
-    return false;
-}
-
 bool DiscoveryDataBase::add_edp_publications_to_send_(
         eprosima::fastdds::rtps::CacheChange_t* change)
 {

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -36,6 +36,8 @@ namespace fastdds {
 namespace rtps {
 namespace ddb {
 
+using ParticipantState = DiscoveryParticipantsAckStatus::ParticipantState;
+
 DiscoveryDataBase::DiscoveryDataBase(
         const fastdds::rtps::GuidPrefix_t& server_guid_prefix)
     : server_guid_prefix_(server_guid_prefix)
@@ -280,8 +282,8 @@ void DiscoveryDataBase::update_change_and_unmatch_(
     changes_to_release_.push_back(entity.update_and_unmatch(new_change));
     // Manually set relevant participants ACK status of this server, and of the participant that sent the
     // change, to 1. This way, we avoid backprogation of the data.
-    entity.add_or_update_ack_participant(server_guid_prefix_, true);
-    entity.add_or_update_ack_participant(new_change->writerGUID.guidPrefix, true);
+    entity.add_or_update_ack_participant(server_guid_prefix_, ParticipantState::MATCHED);
+    entity.add_or_update_ack_participant(new_change->writerGUID.guidPrefix, ParticipantState::MATCHED);
 }
 
 void DiscoveryDataBase::add_ack_(
@@ -305,7 +307,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, true);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
             }
         }
     }
@@ -320,7 +322,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, true);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
             }
         }
     }
@@ -335,7 +337,7 @@ void DiscoveryDataBase::add_ack_(
             // database has been updated, so this ACK is not relevant anymore
             if (it->second.change()->write_params.sample_identity() == change->write_params.sample_identity())
             {
-                it->second.add_or_update_ack_participant(acked_entity, true);
+                it->second.add_or_update_ack_participant(acked_entity, ParticipantState::MATCHED);
             }
         }
     }
@@ -637,7 +639,7 @@ void DiscoveryDataBase::match_new_server_(
                         if (server != participant_prefix)
                         {
                             // Make all known servers relevant to the new server, but not matched
-                            part.second.add_or_update_ack_participant(server, false);
+                            part.second.add_or_update_ack_participant(server, ParticipantState::UNMATCHED);
                             resend_new_pdp = true;
                         }
                     }
@@ -650,7 +652,7 @@ void DiscoveryDataBase::match_new_server_(
                 else
                 {
                     // Make the new server relevant to all known servers
-                    part.second.add_or_update_ack_participant(participant_prefix, false);
+                    part.second.add_or_update_ack_participant(participant_prefix, ParticipantState::UNMATCHED);
                     // Send DATA(p) of all known servers to the new participant
                     add_pdp_to_send_(part.second.change());
                 }
@@ -752,7 +754,7 @@ void DiscoveryDataBase::create_new_participant_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+        ret.first->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
 
         // If the DATA(p) it's from this server, it is already in history and we do nothing here
         if (change_guid.guidPrefix != server_guid_prefix_)
@@ -854,7 +856,7 @@ void DiscoveryDataBase::update_participant_from_change_(
         if (ch->write_params.sample_identity().sequence_number() ==
                 participant_info.change()->write_params.sample_identity().sequence_number())
         {
-            participant_info.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+            participant_info.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
         }
 
         // we release it if it's the same or if it is lower
@@ -904,7 +906,7 @@ void DiscoveryDataBase::create_writers_from_change_(
             if (ch->write_params.sample_identity().sequence_number() ==
                     writer_it->second.change()->write_params.sample_identity().sequence_number())
             {
-                writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+                writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
             }
 
             // we release it if it's the same or if it is lower
@@ -952,7 +954,7 @@ void DiscoveryDataBase::create_writers_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+        writer_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
 
         // if topic is virtual, it must iterate over all readers
         if (topic_name == virtual_topic_)
@@ -1022,7 +1024,7 @@ void DiscoveryDataBase::create_readers_from_change_(
             if (ch->write_params.sample_identity().sequence_number() ==
                     reader_it->second.change()->write_params.sample_identity().sequence_number())
             {
-                reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+                reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
             }
 
             // we release it if it's the same or if it is lower
@@ -1070,7 +1072,7 @@ void DiscoveryDataBase::create_readers_from_change_(
 
         // Manually set to 1 the relevant participants ACK status of the participant that sent the change. This way,
         // we avoid backprogation of the data.
-        reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, true);
+        reader_it->second.add_or_update_ack_participant(ch->writerGUID.guidPrefix, ParticipantState::MATCHED);
 
         // If topic is virtual, it must iterate over all readers
         if (topic_name == virtual_topic_)
@@ -1481,23 +1483,30 @@ bool DiscoveryDataBase::process_dirty_topics()
                         // Check the status of the writer in `readers_[reader]::relevant_participants_builtin_ack_status`.
                         if (readers_it != readers_.end() &&
                                 readers_it->second.is_relevant_participant(writer.guidPrefix) &&
-                                !readers_it->second.is_matched(writer.guidPrefix))
+                                !readers_it->second.is_sent(writer.guidPrefix))
                         {
                             // If the status is 0, add DATA(r) to a `edp_publications_to_send_` (if it's not there).
                             if (add_edp_subscriptions_to_send_(readers_it->second.change()))
                             {
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding DATA(r) to send: "
                                         << readers_it->second.change()->instanceHandle);
+                                readers_it->second.add_or_update_ack_participant(writer.guidPrefix,
+                                        ParticipantState::SENT);
                             }
                         }
                     }
                     else if (parts_reader_it->second.is_relevant_participant(writer.guidPrefix))
                     {
-                        // Add DATA(p) of the client with the writer to `pdp_to_send_` (if it's not there).
-                        if (add_pdp_to_send_(parts_reader_it->second.change()))
+                        if (!parts_reader_it->second.is_sent(writer.guidPrefix))
                         {
-                            EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding readers' DATA(p) to send: "
-                                    << parts_reader_it->second.change()->instanceHandle);
+                            // Add DATA(p) of the client with the writer to `pdp_to_send_` (if it's not there).
+                            if (add_pdp_to_send_(parts_reader_it->second.change()))
+                            {
+                                EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding readers' DATA(p) to send: "
+                                        << parts_reader_it->second.change()->instanceHandle);
+                                parts_reader_it->second.add_or_update_ack_participant(writer.guidPrefix,
+                                        ParticipantState::SENT);
+                            }
                         }
                         // Set topic as not-clearable.
                         is_clearable = false;
@@ -1513,23 +1522,30 @@ bool DiscoveryDataBase::process_dirty_topics()
                         // Check the status of the reader in `writers_[writer]::relevant_participants_builtin_ack_status`.
                         if (writers_it != writers_.end() &&
                                 writers_it->second.is_relevant_participant(reader.guidPrefix) &&
-                                !writers_it->second.is_matched(reader.guidPrefix))
+                                !writers_it->second.is_sent(reader.guidPrefix))
                         {
                             // If the status is 0, add DATA(w) to a `edp_subscriptions_to_send_` (if it's not there).
                             if (add_edp_publications_to_send_(writers_it->second.change()))
                             {
                                 EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding DATA(w) to send: "
                                         << writers_it->second.change()->instanceHandle);
+                                writers_it->second.add_or_update_ack_participant(reader.guidPrefix,
+                                        ParticipantState::SENT);
                             }
                         }
                     }
                     else if (parts_writer_it->second.is_relevant_participant(reader.guidPrefix))
                     {
-                        // Add DATA(p) of the client with the reader to `pdp_to_send_` (if it's not there).
-                        if (add_pdp_to_send_(parts_writer_it->second.change()))
+                        if (!parts_writer_it->second.is_sent(reader.guidPrefix))
                         {
-                            EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding writers' DATA(p) to send: "
-                                    << parts_writer_it->second.change()->instanceHandle);
+                            // Add DATA(p) of the client with the reader to `pdp_to_send_` (if it's not there).
+                            if (add_pdp_to_send_(parts_writer_it->second.change()))
+                            {
+                                EPROSIMA_LOG_INFO(DISCOVERY_DATABASE, "Adding writers' DATA(p) to send: "
+                                        << parts_writer_it->second.change()->instanceHandle);
+                                parts_writer_it->second.add_or_update_ack_participant(reader.guidPrefix,
+                                        ParticipantState::SENT);
+                            }
                         }
                         // Set topic as not-clearable.
                         is_clearable = false;
@@ -2494,7 +2510,7 @@ bool DiscoveryDataBase::from_json(
                 // Populate GuidPrefix_t
                 std::istringstream(it_ack.key()) >> prefix_aux_ack;
 
-                dpi.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<bool>());
+                dpi.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<ParticipantState>());
             }
 
             // Add Participant
@@ -2532,7 +2548,7 @@ bool DiscoveryDataBase::from_json(
                 // Populate GuidPrefix_t
                 std::istringstream(it_ack.key()) >> prefix_aux_ack;
 
-                dei.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<bool>());
+                dei.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<ParticipantState>());
             }
 
             // Add Participant
@@ -2592,7 +2608,7 @@ bool DiscoveryDataBase::from_json(
                 // Populate GuidPrefix_t
                 std::istringstream(it_ack.key()) >> prefix_aux_ack;
 
-                dei.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<bool>());
+                dei.add_or_update_ack_participant(prefix_aux_ack, it_ack.value().get<ParticipantState>());
             }
 
             // Add Participant

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -351,9 +351,6 @@ public:
             fastdds::rtps::WriterHistory* writer_history,
             const fastdds::rtps::GuidPrefix_t& entity_guid_prefix);
 
-    // Add own Data(p) in pdp_to_send if not already in it
-    bool add_own_pdp_to_send_();
-
 protected:
 
     // Change a cacheChange by update or new disposal

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.cpp
@@ -34,7 +34,7 @@ namespace ddb {
 
 void DiscoveryParticipantsAckStatus::add_or_update_participant(
         const GuidPrefix_t& guid_p,
-        ParticipantState status = ParticipantState::UNMATCHED)
+        ParticipantState status = ParticipantState::PENDING_SEND)
 {
     relevant_participants_map_[guid_p] = status;
 }
@@ -45,13 +45,13 @@ void DiscoveryParticipantsAckStatus::remove_participant(
     relevant_participants_map_.erase(guid_p);
 }
 
-bool DiscoveryParticipantsAckStatus::is_sent(
+bool DiscoveryParticipantsAckStatus::is_waiting_ack(
         const GuidPrefix_t& guid_p) const
 {
     auto it = relevant_participants_map_.find(guid_p);
     if (it != relevant_participants_map_.end())
     {
-        return it->second >= ParticipantState::SENT;
+        return it->second >= ParticipantState::WAITING_ACK;
     }
     return false;
 }
@@ -62,7 +62,7 @@ bool DiscoveryParticipantsAckStatus::is_matched(
     auto it = relevant_participants_map_.find(guid_p);
     if (it != relevant_participants_map_.end())
     {
-        return it->second == ParticipantState::MATCHED;
+        return it->second == ParticipantState::ACKED;
     }
     return false;
 }
@@ -71,7 +71,7 @@ void DiscoveryParticipantsAckStatus::unmatch_all()
 {
     for (auto it = relevant_participants_map_.begin(); it != relevant_participants_map_.end(); ++it)
     {
-        it->second = ParticipantState::UNMATCHED;
+        it->second = ParticipantState::PENDING_SEND;
     }
 }
 
@@ -100,7 +100,7 @@ bool DiscoveryParticipantsAckStatus::is_acked_by_all() const
 {
     for (auto it = relevant_participants_map_.begin(); it != relevant_participants_map_.end(); ++it)
     {
-        if (it->second != ParticipantState::MATCHED)
+        if (it->second != ParticipantState::ACKED)
         {
             return false;
         }

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.cpp
@@ -34,7 +34,7 @@ namespace ddb {
 
 void DiscoveryParticipantsAckStatus::add_or_update_participant(
         const GuidPrefix_t& guid_p,
-        bool status = false)
+        ParticipantState status = ParticipantState::UNMATCHED)
 {
     relevant_participants_map_[guid_p] = status;
 }
@@ -45,13 +45,24 @@ void DiscoveryParticipantsAckStatus::remove_participant(
     relevant_participants_map_.erase(guid_p);
 }
 
+bool DiscoveryParticipantsAckStatus::is_sent(
+        const GuidPrefix_t& guid_p) const
+{
+    auto it = relevant_participants_map_.find(guid_p);
+    if (it != relevant_participants_map_.end())
+    {
+        return it->second >= ParticipantState::SENT;
+    }
+    return false;
+}
+
 bool DiscoveryParticipantsAckStatus::is_matched(
         const GuidPrefix_t& guid_p) const
 {
     auto it = relevant_participants_map_.find(guid_p);
     if (it != relevant_participants_map_.end())
     {
-        return it->second;
+        return it->second == ParticipantState::MATCHED;
     }
     return false;
 }
@@ -60,7 +71,7 @@ void DiscoveryParticipantsAckStatus::unmatch_all()
 {
     for (auto it = relevant_participants_map_.begin(); it != relevant_participants_map_.end(); ++it)
     {
-        it->second = false;
+        it->second = ParticipantState::UNMATCHED;
     }
 }
 
@@ -89,7 +100,7 @@ bool DiscoveryParticipantsAckStatus::is_acked_by_all() const
 {
     for (auto it = relevant_participants_map_.begin(); it != relevant_participants_map_.end(); ++it)
     {
-        if (!it->second)
+        if (it->second != ParticipantState::MATCHED)
         {
             return false;
         }

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.hpp
@@ -47,9 +47,9 @@ public:
 
     enum class ParticipantState : uint8_t
     {
-        UNMATCHED,  // Data(p) has not been sent yet
-        SENT,       // Data(p) has already been sent
-        MATCHED     // Data(p) has been acked
+        PENDING_SEND,  // Data(p) has not been sent yet
+        WAITING_ACK,   // Data(p) has already been sent but ACK has not been received
+        ACKED          // Data(p) has been acked
     };
 
     void add_or_update_participant(
@@ -61,7 +61,7 @@ public:
 
     void unmatch_all();
 
-    bool is_sent(
+    bool is_waiting_ack(
             const GuidPrefix_t& guid_p) const;
 
     bool is_matched(
@@ -88,14 +88,14 @@ inline std::ostream& operator <<(
 {
     switch (child)
     {
-        case DiscoveryParticipantsAckStatus::ParticipantState::UNMATCHED:
-            os << "UNMATCHED";
+        case DiscoveryParticipantsAckStatus::ParticipantState::PENDING_SEND:
+            os << "PENDING_SEND";
             break;
-        case DiscoveryParticipantsAckStatus::ParticipantState::SENT:
-            os << "SENT";
+        case DiscoveryParticipantsAckStatus::ParticipantState::WAITING_ACK:
+            os << "WAITING_ACK";
             break;
-        case DiscoveryParticipantsAckStatus::ParticipantState::MATCHED:
-            os << "MATCHED";
+        case DiscoveryParticipantsAckStatus::ParticipantState::ACKED:
+            os << "ACKED";
             break;
         default:
             os << "UNKNOWN";

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryParticipantsAckStatus.hpp
@@ -45,14 +45,24 @@ public:
 
     ~DiscoveryParticipantsAckStatus() = default;
 
+    enum class ParticipantState : uint8_t
+    {
+        UNMATCHED,  // Data(p) has not been sent yet
+        SENT,       // Data(p) has already been sent
+        MATCHED     // Data(p) has been acked
+    };
+
     void add_or_update_participant(
             const GuidPrefix_t& guid_p,
-            bool status);
+            ParticipantState status);
 
     void remove_participant(
             const GuidPrefix_t& guid_p);
 
     void unmatch_all();
+
+    bool is_sent(
+            const GuidPrefix_t& guid_p) const;
 
     bool is_matched(
             const GuidPrefix_t& guid_p) const;
@@ -69,8 +79,30 @@ public:
 
 private:
 
-    std::map<GuidPrefix_t, bool> relevant_participants_map_;
+    std::map<GuidPrefix_t, ParticipantState> relevant_participants_map_;
 };
+
+inline std::ostream& operator <<(
+        std::ostream& os,
+        DiscoveryParticipantsAckStatus::ParticipantState child)
+{
+    switch (child)
+    {
+        case DiscoveryParticipantsAckStatus::ParticipantState::UNMATCHED:
+            os << "UNMATCHED";
+            break;
+        case DiscoveryParticipantsAckStatus::ParticipantState::SENT:
+            os << "SENT";
+            break;
+        case DiscoveryParticipantsAckStatus::ParticipantState::MATCHED:
+            os << "MATCHED";
+            break;
+        default:
+            os << "UNKNOWN";
+            break;
+    }
+    return os;
+}
 
 } /* namespace ddb */
 } /* namespace rtps */

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
@@ -36,7 +36,7 @@ DiscoverySharedInfo::DiscoverySharedInfo(
     : change_(change)
 {
     // the server already knows every message
-    add_or_update_ack_participant(known_participant, true);
+    add_or_update_ack_participant(known_participant, DiscoveryParticipantsAckStatus::ParticipantState::MATCHED);
 }
 
 CacheChange_t* DiscoverySharedInfo::update_and_unmatch(

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.cpp
@@ -36,7 +36,7 @@ DiscoverySharedInfo::DiscoverySharedInfo(
     : change_(change)
 {
     // the server already knows every message
-    add_or_update_ack_participant(known_participant, DiscoveryParticipantsAckStatus::ParticipantState::MATCHED);
+    add_or_update_ack_participant(known_participant, DiscoveryParticipantsAckStatus::ParticipantState::ACKED);
 }
 
 CacheChange_t* DiscoverySharedInfo::update_and_unmatch(

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
@@ -56,7 +56,7 @@ public:
 
     void add_or_update_ack_participant(
             const GuidPrefix_t& guid_p,
-            DiscoveryParticipantsAckStatus::ParticipantState status = DiscoveryParticipantsAckStatus::ParticipantState::UNMATCHED)
+            DiscoveryParticipantsAckStatus::ParticipantState status = DiscoveryParticipantsAckStatus::ParticipantState::PENDING_SEND)
     {
         EPROSIMA_LOG_INFO(
             DISCOVERY_DATABASE,
@@ -72,10 +72,10 @@ public:
         relevant_participants_builtin_ack_status_.remove_participant(guid_p);
     }
 
-    bool is_sent(
+    bool is_waiting_ack(
             const GuidPrefix_t& guid_p) const
     {
-        return relevant_participants_builtin_ack_status_.is_sent(guid_p);
+        return relevant_participants_builtin_ack_status_.is_waiting_ack(guid_p);
     }
 
     bool is_matched(

--- a/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoverySharedInfo.hpp
@@ -56,7 +56,7 @@ public:
 
     void add_or_update_ack_participant(
             const GuidPrefix_t& guid_p,
-            bool status = false)
+            DiscoveryParticipantsAckStatus::ParticipantState status = DiscoveryParticipantsAckStatus::ParticipantState::UNMATCHED)
     {
         EPROSIMA_LOG_INFO(
             DISCOVERY_DATABASE,
@@ -70,6 +70,12 @@ public:
             const GuidPrefix_t& guid_p)
     {
         relevant_participants_builtin_ack_status_.remove_participant(guid_p);
+    }
+
+    bool is_sent(
+            const GuidPrefix_t& guid_p) const
+    {
+        return relevant_participants_builtin_ack_status_.is_sent(guid_p);
     }
 
     bool is_matched(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -642,7 +642,7 @@ void PDPServer::assignRemoteEndpoints(
     // Send the Data(p) to the client
     if (part_type == ParticipantType::CLIENT || part_type == ParticipantType::SUPER_CLIENT)
     {
-        discovery_db().add_own_pdp_to_send_();
+        send_own_pdp(pdata);
     }
 }
 
@@ -1620,7 +1620,26 @@ void PDPServer::send_announcement(
             EPROSIMA_LOG_ERROR(RTPS_PDP_SERVER, "Error sending announcement from server to clients");
         }
     }
+}
 
+void PDPServer::send_own_pdp(
+        ParticipantProxyData* pdata)
+{
+    std::vector<GUID_t> remote_readers;
+    LocatorList locators;
+
+    remote_readers.emplace_back(pdata->guid.guidPrefix, c_EntityId_SPDPReader);
+
+    for (auto& locator : pdata->metatraffic_locators.unicast)
+    {
+        locators.push_back(locator);
+    }
+
+    send_announcement(
+        discovery_db().cache_change_own_participant(),
+        remote_readers,
+        locators
+        );
 }
 
 bool PDPServer::read_backup(

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.hpp
@@ -138,6 +138,14 @@ public:
             bool dispose = false);
 
     /**
+     * Sends own DATA(p) to the participant specified in @p pdata.
+     * Used to send first DATA(p) to new clients after discover them.
+     * @param pdata Pointer to the RTPSParticipantProxyData object.
+     *  */
+    void send_own_pdp(
+            ParticipantProxyData* pdata);
+
+    /**
      * These methods wouldn't be needed under perfect server operation (no need of dynamic endpoint allocation)
      * but must be implemented to solve server shutdown situations.
      * @param pdata Pointer to the RTPSParticipantProxyData object.

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -675,6 +675,13 @@ public:
         return *this;
     }
 
+    PubSubParticipant& setup_transports(
+        eprosima::fastdds::rtps::BuiltinTransports transports)
+    {
+        participant_qos_.setup_transports(transports);
+        return *this;
+    }
+
     PubSubParticipant& user_data(
             const std::vector<eprosima::fastdds::rtps::octet>& user_data)
     {

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -676,7 +676,7 @@ public:
     }
 
     PubSubParticipant& setup_transports(
-        eprosima::fastdds::rtps::BuiltinTransports transports)
+            eprosima::fastdds::rtps::BuiltinTransports transports)
     {
         participant_qos_.setup_transports(transports);
         return *this;

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -2341,15 +2341,15 @@ TEST_P(Discovery, discovery_server_edp_messages_sent)
 
     // Init client 1
     client_1.set_wire_protocol_qos(client_qos)
-                .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
-                .init();
+            .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
+            .init();
 
     // Init client 2
     client_qos.builtin.discovery_config.m_DiscoveryServers.clear();
     client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(locator_server_2);
     client_2.set_wire_protocol_qos(client_qos)
-                .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
-                .init();
+            .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
+            .init();
 
     ASSERT_TRUE(client_1.isInitialized());
     ASSERT_TRUE(client_2.isInitialized());

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -2184,3 +2184,183 @@ TEST_P(Discovery, discovery_server_pdp_messages_sent)
     std::this_thread::sleep_for(std::chrono::seconds(3));
     EXPECT_EQ(num_data_p_sends.load(std::memory_order::memory_order_seq_cst), 3u);
 }
+
+TEST_P(Discovery, discovery_server_edp_messages_sent)
+{
+    // Skip test in intraprocess and datasharing mode
+    if (TRANSPORT != GetParam())
+    {
+        GTEST_SKIP() << "Only makes sense on TRANSPORT";
+        return;
+    }
+
+    using namespace eprosima::fastdds::dds;
+
+    // Two discovery servers will be created, each with a direct client connected to them.
+    // Initial announcements will be disabled and lease announcements will be configured to control discovery sequence.
+    // The main participant will use the test transport to count the number of Data(r/w) sent.
+
+    // Look for the PID_ENDPOINT_GUID in the message as it is only present in Data(r/w) messages
+    auto builtin_msg_is_data_r_w = [](CDRMessage_t& msg, std::atomic<size_t>& num_data_r_w)
+            {
+                uint32_t qos_size = 0;
+                uint32_t original_pos = msg.pos;
+                bool is_sentinel = false;
+                bool inline_qos_msg = false;
+
+                while (!is_sentinel)
+                {
+                    msg.pos = original_pos + qos_size;
+
+                    uint16_t pid = eprosima::fastdds::helpers::cdr_parse_u16(
+                        (char*)&msg.buffer[msg.pos]);
+                    msg.pos += 2;
+                    uint16_t plength = eprosima::fastdds::helpers::cdr_parse_u16(
+                        (char*)&msg.buffer[msg.pos]);
+                    msg.pos += 2;
+                    bool valid = true;
+
+                    if (pid == eprosima::fastdds::dds::PID_RELATED_SAMPLE_IDENTITY)
+                    {
+                        inline_qos_msg = true;
+                    }
+                    else if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+                    {
+                        // PID_SENTINEL is always considered of length 0
+                        plength = 0;
+                        if (!inline_qos_msg)
+                        {
+                            // If the PID is not inline qos, then we need to set the sentinel
+                            // to true, as it is the last PID
+                            is_sentinel = true;
+                        }
+                    }
+
+                    qos_size += (4 + plength);
+
+                    // Align to 4 byte boundary and prepare for next iteration
+                    qos_size = (qos_size + 3) & ~3;
+
+                    if (!valid || ((msg.pos + plength) > msg.length))
+                    {
+                        return false;
+                    }
+                    else if (!is_sentinel)
+                    {
+                        if (pid == eprosima::fastdds::dds::PID_ENDPOINT_GUID)
+                        {
+                            std::cout << "Data (r/w) sent by the server" << std::endl;
+                            num_data_r_w.fetch_add(1u, std::memory_order_seq_cst);
+                            break;
+                        }
+                        else if (pid == eprosima::fastdds::dds::PID_VENDORID)
+                        {
+                            // Vendor ID is present in both Data(p) and Data(r/w) messages
+                            inline_qos_msg = false;
+                        }
+                    }
+                }
+
+                // Do not drop the packet in any case
+                return false;
+            };
+
+    // Declare a test transport that will count the number of Data(r/w) messages sent
+    std::atomic<size_t> num_data_r_w_sends_s1{ 0 };
+    std::atomic<size_t> num_data_r_w_sends_s2{ 0 };
+    auto test_transport_s1 = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport_s1->drop_builtin_data_messages_filter_ = [&](CDRMessage_t& msg)
+            {
+                return builtin_msg_is_data_r_w(msg, num_data_r_w_sends_s1);
+            };
+
+    auto test_transport_s2 = std::make_shared<test_UDPv4TransportDescriptor>();
+    test_transport_s2->drop_builtin_data_messages_filter_ = [&](CDRMessage_t& msg)
+            {
+                return builtin_msg_is_data_r_w(msg, num_data_r_w_sends_s2);
+            };
+
+    // Create server 1
+    auto server_1 = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+
+    Locator_t locator_server_1;  // UDPv4 locator by default
+    eprosima::fastdds::rtps::IPLocator::setIPv4(locator_server_1, 127, 0, 0, 1);
+    eprosima::fastdds::rtps::IPLocator::setPhysicalPort(locator_server_1, global_port);
+
+    WireProtocolConfigQos server_wp_qos_1;
+    server_wp_qos_1.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::SERVER;
+    server_wp_qos_1.builtin.metatrafficUnicastLocatorList.push_back(locator_server_1);
+
+    server_wp_qos_1.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    server_wp_qos_1.builtin.discovery_config.leaseDuration_announcementperiod = c_TimeInfinite;
+    server_wp_qos_1.builtin.discovery_config.initial_announcements.count = 0;
+
+    // The main participant will use the test transport and a specific announcements configuration
+    server_1->disable_builtin_transport().add_user_transport_to_pparams(test_transport_s1)
+            .wire_protocol(server_wp_qos_1);
+
+    // Start the main participant
+    ASSERT_TRUE(server_1->init_participant());
+
+    // Create server 2
+    auto server_2 = std::make_shared<PubSubParticipant<HelloWorldPubSubType>>(0, 0, 0, 0);
+
+    Locator_t locator_server_2 = locator_server_1;  // UDPv4 locator by default
+    eprosima::fastdds::rtps::IPLocator::setPhysicalPort(locator_server_2, global_port + 1);
+
+    WireProtocolConfigQos server_wp_qos_2 = server_wp_qos_1;
+    server_wp_qos_2.builtin.metatrafficUnicastLocatorList.clear();
+    server_wp_qos_2.builtin.metatrafficUnicastLocatorList.push_back(locator_server_2);
+    // Configure 1 initial announcement as this Server will connect to the first one
+    server_wp_qos_2.builtin.discovery_config.initial_announcements.count = 1;
+    server_wp_qos_2.builtin.discovery_config.m_DiscoveryServers.push_back(locator_server_1);
+
+    // The main participant will use the test transport and a specific announcements configuration
+    server_2->disable_builtin_transport().add_user_transport_to_pparams(test_transport_s2)
+            .wire_protocol(server_wp_qos_2);
+
+    // Start the main participant
+    ASSERT_TRUE(server_2->init_participant());
+
+    // Both servers match
+    server_1->wait_discovery(std::chrono::seconds(5), 1, true);
+    server_2->wait_discovery(std::chrono::seconds(5), 1, true);
+    // Let some time for the server to run the internal routine and match virtual endpoints
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Create a client that connects to their corresponding server
+    PubSubWriter<HelloWorldPubSubType> client_1(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> client_2(TEST_TOPIC_NAME);
+    // Set participant as client
+    WireProtocolConfigQos client_qos;
+    client_qos.builtin.discovery_config.discoveryProtocol = DiscoveryProtocol::CLIENT;
+    client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(locator_server_1);
+    client_qos.builtin.discovery_config.leaseDuration = c_TimeInfinite;
+    client_qos.builtin.discovery_config.leaseDuration_announcementperiod = { 15, 0 };
+    client_qos.builtin.discovery_config.initial_announcements.count = 0;
+
+    // Init client 1
+    client_1.set_wire_protocol_qos(client_qos)
+                .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
+                .init();
+
+    // Init client 2
+    client_qos.builtin.discovery_config.m_DiscoveryServers.clear();
+    client_qos.builtin.discovery_config.m_DiscoveryServers.push_back(locator_server_2);
+    client_2.set_wire_protocol_qos(client_qos)
+                .setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4)
+                .init();
+
+    ASSERT_TRUE(client_1.isInitialized());
+    ASSERT_TRUE(client_2.isInitialized());
+
+    // Wait the lease announcement period to discover endpoints
+    server_1->wait_discovery(std::chrono::seconds(5), 2, true);
+    server_2->wait_discovery(std::chrono::seconds(5), 2, true);
+
+    // Ensure that no additional Data(r/w) messages are sent by DS routine
+    std::this_thread::sleep_for(std::chrono::seconds(15));
+
+    EXPECT_EQ(num_data_r_w_sends_s1.load(std::memory_order::memory_order_seq_cst), 2u);
+    EXPECT_EQ(num_data_r_w_sends_s2.load(std::memory_order::memory_order_seq_cst), 2u);
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR aims to improve efficiency of DS routines by reducing the number of messages sent (Data(p), Data(r) and Data(w)). It does so by:

- Avoiding re-sending the server's Data(p) to relevant participants every time its own Data(p) is added to the `pdp_queue` (when a new client is discovered). Now a direct message to the new discovered client is sent instead of adding the server's Data(p) to the queue, which led to multiple sends to all direct clients. 
- Sending just one Data(p) and Data(r/w) to direct clients by considering a three-state value (unmatched, sent & matched) for `DiscoveryParticipantsAckStatus` instead of just a boolean. In this way the Discovery DB avoids re-sending repeated data when processing topics.

Related PR: 

- https://github.com/eProsima/Discovery-Server/pull/115

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 2.14.x 2.10.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
