### PR TITLE
[23088] Solve Discovery Server race conditions

### DIFF
--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -956,12 +956,14 @@ void DiscoveryDataBase::create_writers_from_change_(
         {
             EPROSIMA_LOG_ERROR(DISCOVERY_DATABASE,
                     "Writer " << writer_guid << " has no associated participant. Skipping");
+            changes_to_release_.push_back(ch); // Release change so it can be reused
             return;
         }
         else if (writer_part_it->second.change()->kind != fastdds::rtps::ChangeKind_t::ALIVE)
         {
             EPROSIMA_LOG_WARNING(DISCOVERY_DATABASE,
                     "Writer " << writer_guid << " is associated to a removed participant. Skipping");
+            changes_to_release_.push_back(ch); // Release change so it can be reused
             return;
         }
 
@@ -1082,12 +1084,14 @@ void DiscoveryDataBase::create_readers_from_change_(
         {
             EPROSIMA_LOG_ERROR(DISCOVERY_DATABASE,
                     "Reader " << reader_guid << " has no associated participant. Skipping");
+            changes_to_release_.push_back(ch); // Release change so it can be reused
             return;
         }
         else if (reader_part_it->second.change()->kind != fastdds::rtps::ChangeKind_t::ALIVE)
         {
             EPROSIMA_LOG_WARNING(DISCOVERY_DATABASE,
                     "Reader " << reader_guid << " is associated to a removed participant. Skipping");
+            changes_to_release_.push_back(ch); // Release change so it can be reused
             return;
         }
 

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -494,9 +494,6 @@ void DiscoveryDataBase::process_pdp_data_queue()
     // Lock(exclusive mode) mutex locally
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 
-    // Swap DATA queues
-    pdp_data_queue_.Swap();
-
     // Process all messages in the queque
     while (!pdp_data_queue_.Empty())
     {
@@ -533,9 +530,6 @@ bool DiscoveryDataBase::process_edp_data_queue()
 
     // Lock(exclusive mode) mutex locally
     std::lock_guard<std::recursive_mutex> guard(mutex_);
-
-    // Swap DATA queues
-    edp_data_queue_.Swap();
 
     eprosima::fastdds::rtps::CacheChange_t* change;
     std::string topic_name;
@@ -1616,6 +1610,14 @@ bool DiscoveryDataBase::delete_entity_of_change(
 bool DiscoveryDataBase::data_queue_empty()
 {
     return (pdp_data_queue_.BothEmpty() && edp_data_queue_.BothEmpty());
+}
+
+void DiscoveryDataBase::swap_data_queues()
+{
+    // Swap EDP before PDP to avoid race condition in which both data P and w/r are received at the same time,
+    // just after having swapped the PDP queue
+    edp_data_queue_.Swap();
+    pdp_data_queue_.Swap();
 }
 
 bool DiscoveryDataBase::is_participant(

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.cpp
@@ -784,8 +784,9 @@ void DiscoveryDataBase::update_participant_from_change_(
 
     assert(ch->kind == eprosima::fastdds::rtps::ALIVE);
 
-    // If the change corresponds to a previously removed participant, update map with new data and behave as if it was a
-    // new participant. Remove also the old change from the disposals collection, if it was added just before
+    // If the change corresponds to a previously removed participant (which hasn't yet been removed from the map since
+    // the DATA(Up) is still unacked), update map with new data and behave as if it was a new participant.
+    // Remove also the old change from the disposals collection, if it was added just before
     if (participant_info.change()->kind != eprosima::fastdds::rtps::ALIVE)
     {
         // If it is local and server we have to create virtual endpoints, except for our own server
@@ -946,8 +947,8 @@ void DiscoveryDataBase::create_writers_from_change_(
     else
     {
         // Check if corresponding participant is known, abort otherwise
-        // NOTE: Processing a data w should always be preceded by the reception and processing of its corresponding
-        // participant. However, one may receive a data w just after the participant has been removed, case in which the
+        // NOTE: Processing a DATA(w) should always be preceded by the reception and processing of its corresponding
+        // participant. However, one may receive a DATA(w) just after the participant has been removed, case in which the
         // former should no longer be processed.
         std::map<eprosima::fastdds::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator writer_part_it =
                 participants_.find(writer_guid.guidPrefix);
@@ -1072,8 +1073,8 @@ void DiscoveryDataBase::create_readers_from_change_(
     else
     {
         // Check if corresponding participant is known, abort otherwise
-        // NOTE: Processing a data r should always be preceded by the reception and processing of its corresponding
-        // participant. However, one may receive a data r just after the participant has been removed, case in which the
+        // NOTE: Processing a DATA(r) should always be preceded by the reception and processing of its corresponding
+        // participant. However, one may receive a DATA(r) just after the participant has been removed, case in which the
         // former should no longer be processed.
         std::map<eprosima::fastdds::rtps::GuidPrefix_t, DiscoveryParticipantInfo>::iterator reader_part_it =
                 participants_.find(reader_guid.guidPrefix);
@@ -1392,7 +1393,7 @@ void DiscoveryDataBase::process_dispose_participant_(
         delete_reader_entity_(reader_guid);
     }
 
-    // All participant endpoints must be already unmatched in others endopoints relevant_ack maps
+    // All participant endpoints must be already unmatched in others endpoints relevant_ack maps
 
     // Unmatch own participant
     unmatch_participant_(participant_guid.guidPrefix);

--- a/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
+++ b/src/cpp/rtps/builtin/discovery/database/DiscoveryDataBase.hpp
@@ -294,6 +294,9 @@ public:
     // Check if the data queue is empty
     bool data_queue_empty();
 
+    // Swap both EDP and PDP data queues
+    void swap_data_queues();
+
     void to_json(
             nlohmann::json& j) const;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -1081,6 +1081,9 @@ bool PDPServer::remove_remote_participant(
 bool PDPServer::process_data_queues()
 {
     EPROSIMA_LOG_INFO(RTPS_PDP_SERVER, "process_data_queues start");
+    // Swap both as a first step in order to avoid the following race condition: reception of data w/r while processing
+    // the PDP queue, not having processed yet the corresponding data P (also received while processing the queue).
+    discovery_db_.swap_data_queues();
     discovery_db_.process_pdp_data_queue();
     return discovery_db_.process_edp_data_queue();
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR attempts to fix a couple of race conditions detected in scenarios where a large number of clients are present:
- PDP and EDP messages are stored in two queues which are not atomically swapped, which could create situations such as processing a data r/w of a data P already received but to be processed in the next server routine iteration.
- When a data UP is received (or manually inserted if a participant is dropped), it remains in the internal participants map but with its change updated. The item will be deleted only after the data UP is acked by all participants. If a new data P is received before this occurs, it will not be correctly processed. As a result, when the data UP is acked the item will be deleted from the participants map, and if a data r/w was to be processed afterwards, this would fail and print one of these errors "Reader/Writer has no associated participant. Skipping" or "Matching unexisting participant from reader/writer".
- When a reader/writer is being inserted to the database, checking if the corresponding participant is present is done after insertion, instead of as a first step. And even if the participant is present, it should be checked if it is alive to abort otherwise.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
@Mergifyio backport 3.1.x 2.14.x 2.10.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
