### PR TITLE
[23142] Add regression test checking type_information is always copied in `ProxyDatas` copies

### DIFF
--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -2131,3 +2131,245 @@ TEST(DDSDiscovery, client_server_participants_with_different_domain_ids_discover
     // All data received
     EXPECT_EQ(client_domain_3.block_for_all(std::chrono::seconds(3)), data_size);
 }
+
+/*!
+ * @test: regression test for redmine issue #23047
+ *
+ * This test checks that type_information is always copied between
+ * proxy data copies/assignments, even if the type information is not assigned.
+ *
+ */
+TEST(DDSDiscovery, proxy_data_assignment_operator_always_include_type_information)
+{
+    using namespace eprosima;
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastdds::rtps;
+    using namespace eprosima::fastdds::dds::xtypes;
+
+    /**
+     * A dummy type support class with the same type name as HelloWorldPubSubType
+     */
+    class HelloWorldDummyType : public TopicDataType
+    {
+    public:
+
+        HelloWorldDummyType()
+            : TopicDataType()
+        {
+            set_name("HelloWorld");
+            is_compute_key_provided = false;
+            max_serialized_type_size = 16;
+        }
+
+        bool serialize(
+                const void* const,
+                fastdds::rtps::SerializedPayload_t&,
+                fastdds::dds::DataRepresentationId_t) override
+        {
+            return true;
+        }
+
+        bool deserialize(
+                fastdds::rtps::SerializedPayload_t&,
+                void*) override
+        {
+            return true;
+        }
+
+        uint32_t calculate_serialized_size(
+                const void* const,
+                fastdds::dds::DataRepresentationId_t) override
+        {
+            return 0u;
+        }
+
+        void* create_data() override
+        {
+            return nullptr;
+        }
+
+        void delete_data(
+                void*) override
+        {
+        }
+
+        bool compute_key(
+                fastdds::rtps::SerializedPayload_t&,
+                fastdds::rtps::InstanceHandle_t&,
+                bool) override
+        {
+            return true;
+        }
+
+        bool compute_key(
+                const void* const,
+                fastdds::rtps::InstanceHandle_t&,
+                bool) override
+        {
+            return false;
+        }
+
+    private:
+
+        using TopicDataType::calculate_serialized_size;
+        using TopicDataType::serialize;
+    };
+
+    struct CustomParticipantReaders
+    {
+        class ReadersListener : public eprosima::fastdds::dds::DataReaderListener
+        {
+        public:
+
+            void on_subscription_matched(
+                    eprosima::fastdds::dds::DataReader* /*datareader*/,
+                    const eprosima::fastdds::dds::SubscriptionMatchedStatus& info) override
+            {
+                if (0 < info.current_count_change)
+                {
+                    std::cout << "Subscriber matched publisher " << info.last_publication_handle << std::endl;
+                    n_matches_++;
+                }
+                else
+                {
+                    std::cout << "Subscriber unmatched publisher " << info.last_publication_handle << std::endl;
+                    n_matches_--;
+                }
+            }
+
+            std::atomic<uint16_t> n_matches_{0};
+
+        }
+        readers_listener_;
+
+        CustomParticipantReaders(
+                const std::vector<std::pair<std::string, TypeSupport>>& topics_and_types,
+                uint32_t ms_delay_between_creations = 1000)
+        {
+            DomainParticipantQos pqos;
+
+            pqos.transport().use_builtin_transports = false;
+            auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+            pqos.transport().user_transports.push_back(udp_transport);
+
+            participant_ = DomainParticipantFactory::get_instance()->create_participant(
+                (uint32_t)GET_PID() % 230, pqos, nullptr);
+
+            if (participant_ == nullptr)
+            {
+                std::cerr << "Error creating participant" << std::endl;
+            }
+
+            subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+
+            if (subscriber_ == nullptr)
+            {
+                std::cerr << "Error creating subscriber" << std::endl;
+            }
+
+            for (auto& topic_and_type : topics_and_types)
+            {
+                participant_->register_type(topic_and_type.second);
+
+                Topic* topic;
+
+                // Magic to fit with the same one in PubSubWriter/Reader
+                std::ostringstream t;
+                t << topic_and_type.first << "_" << asio::ip::host_name() << "_" << GET_PID();
+
+                topic = participant_->create_topic(t.str(), topic_and_type.second->get_name(), TOPIC_QOS_DEFAULT);
+
+                if (topic == nullptr)
+                {
+                    std::cerr << "Error creating topic" << std::endl;
+                }
+
+                DataReader* reader;
+                reader = subscriber_->create_datareader(&(*topic), DATAREADER_QOS_DEFAULT, &readers_listener_);
+                if (reader == nullptr)
+                {
+                    std::cerr << "Error creating reader" << std::endl;
+                }
+
+                topics_and_readers_.push_back({topic, reader});
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(ms_delay_between_creations));
+            }
+        }
+
+        bool wait_discovery(
+                unsigned int expected_matches,
+                std::chrono::seconds timeout = std::chrono::seconds::zero())
+        {
+            std::unique_lock<std::mutex> lock(discovery_mutex_);
+
+            if (timeout == std::chrono::seconds::zero())
+            {
+                cv_.wait(lock, [&]()
+                        {
+                            return readers_listener_.n_matches_.load() == expected_matches;
+                        });
+            }
+            else
+            {
+                cv_.wait_for(lock, timeout, [&]()
+                        {
+                            return readers_listener_.n_matches_.load() == expected_matches;
+                        });
+            }
+
+            return readers_listener_.n_matches_.load() == expected_matches;
+        }
+
+        ~CustomParticipantReaders()
+        {
+            if (participant_)
+            {
+                participant_->delete_contained_entities();
+                DomainParticipantFactory::get_instance()->delete_participant(participant_);
+            }
+        }
+
+        DomainParticipant* participant_;
+        std::vector<std::pair<Topic*, DataReader*>> topics_and_readers_;
+        Subscriber* subscriber_;
+        std::mutex discovery_mutex_;
+        std::condition_variable cv_;
+    };
+
+    PubSubWriter<HelloWorldPubSubType> writer_1(TEST_TOPIC_NAME);
+    writer_1.disable_builtin_transport();
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+    writer_1.add_user_transport_to_pparams(udp_transport);
+
+    std::vector<std::pair<std::string, TypeSupport>> topics_and_types;
+    topics_and_types.reserve(2);
+    topics_and_types.push_back(std::make_pair("OtherTopic", TypeSupport(new Data64kbPubSubType())));
+    topics_and_types.push_back(std::make_pair(TEST_TOPIC_NAME, TypeSupport(new HelloWorldDummyType())));
+
+    writer_1.init();
+
+    // Create two readers in the same participant on different topics
+    // Wait one second between each creation
+    // When the second reader is registered, it will try to match with any already
+    // discovered writer, so it lookups and loads its ReaderProxyData into a temporal reader proxy pool
+    // which is not cleared before. If the assignment operation in the ReaderProxyData does not
+    // always copy the type_information, the second reader will not be able to match with the writer.
+    CustomParticipantReaders readers(
+        topics_and_types);
+
+    // Create a second writer
+    PubSubWriter<HelloWorldPubSubType> writer_2(TEST_TOPIC_NAME);
+    writer_2.disable_builtin_transport();
+    auto udp_transport_2 = std::make_shared<UDPv4TransportDescriptor>();
+    writer_2.add_user_transport_to_pparams(udp_transport_2);
+    writer_2.init();
+
+    writer_1.wait_discovery();
+    ASSERT_EQ(writer_1.get_matched(), 1u);
+    writer_2.wait_discovery();
+    ASSERT_EQ(writer_2.get_matched(), 1u);
+
+    // One discovery should happen per reader
+    ASSERT_TRUE(readers.wait_discovery(2u, std::chrono::seconds(2)));
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the regression test pending for PR #5766.
The added test checks that `type_information` is always copied between `ProxyData` copies/assignments, even if the type information is not assigned.

Thanks to @juanlofer-eprosima for detecting and iterating with the test.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- **N/A** If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
