### PR TITLE
[23153] Add matching checks to RPC entities

### DIFF
--- a/src/cpp/fastdds/rpc/ReplierImpl.cpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.cpp
@@ -16,10 +16,14 @@
 
 #include <string>
 
+#include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
+#include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/core/detail/DDSReturnCode.hpp>
 #include <fastdds/dds/core/LoanableCollection.hpp>
 #include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/core/status/PublicationMatchedStatus.hpp>
 #include <fastdds/dds/core/status/StatusMask.hpp>
+#include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/dds/domain/qos/ReplierQos.hpp>
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/dds/rpc/RequestInfo.hpp>
@@ -92,12 +96,25 @@ ReturnCode_t ReplierImpl::send_reply(
         void* data,
         const RequestInfo& info)
 {
-    FASTDDS_TODO_BEFORE(3, 3, "Implement matching algorithm");
-
     if (!enabled_)
     {
         EPROSIMA_LOG_ERROR(REPLIER, "Trying to send a reply with a disabled replier");
         return RETCODE_PRECONDITION_NOT_MET;
+    }
+
+    FASTDDS_TODO_BEFORE(3, 3, "Wait for the requester to be fully matched");
+    auto match_status = requester_match_status(info);
+    if (RequesterMatchStatus::UNMATCHED == match_status)
+    {
+        // The writer that sent the request has been unmatched.
+        EPROSIMA_LOG_WARNING(REPLIER, "Trying to send a reply to a disconnected requester");
+        return RETCODE_PRECONDITION_NOT_MET;
+    }
+    else if (RequesterMatchStatus::PARTIALLY_MATCHED == match_status)
+    {
+        // The writer that sent the request is still matched, but the reply topic is not.
+        EPROSIMA_LOG_WARNING(REPLIER, "Trying to send a reply to a partially matched requester");
+        return RETCODE_TIMEOUT;
     }
 
     rtps::WriteParams wparams;
@@ -273,6 +290,52 @@ ReturnCode_t ReplierImpl::delete_contained_entities()
     replier_reader_ = nullptr;
 
     return RETCODE_OK;
+}
+
+ReplierImpl::RequesterMatchStatus ReplierImpl::requester_match_status(
+        const RequestInfo& info) const
+{
+    // Check if the replier is still matched with the requester in the request topic
+    PublicationBuiltinTopicData pub_data;
+    if (RETCODE_OK != replier_reader_->get_matched_publication_data(pub_data, info.sample_identity.writer_guid()))
+    {
+        return RequesterMatchStatus::UNMATCHED;
+    }
+
+    FASTDDS_TODO_BEFORE(3, 3, "Get reply reader GUID from pub_data");
+
+    auto related_guid = info.related_sample_identity.writer_guid();
+    bool reply_topic_matched = false;
+    if (info.sample_identity.writer_guid() != related_guid)
+    {
+        // Custom related GUID (i.e. reply reader GUID) sent with the request.
+        // Check if the replier writer is matched with that specific reader.
+        SubscriptionBuiltinTopicData sub_data;
+        reply_topic_matched = RETCODE_OK == replier_writer_->get_matched_subscription_data(sub_data, related_guid);
+    }
+    else
+    {
+        // No custom related GUID, check if the replier is matched with all the requesters
+        // (same number of matched readers and writers)
+        reply_topic_matched = is_fully_matched();
+    }
+
+    return reply_topic_matched ?
+           RequesterMatchStatus::MATCHED :
+           RequesterMatchStatus::PARTIALLY_MATCHED;
+}
+
+bool ReplierImpl::is_fully_matched() const
+{
+    PublicationMatchedStatus pub_status;
+    SubscriptionMatchedStatus sub_status;
+
+    if ((RETCODE_OK == replier_reader_->get_subscription_matched_status(sub_status)) &&
+            (RETCODE_OK == replier_writer_->get_publication_matched_status(pub_status)))
+    {
+        return (pub_status.current_count > 0) && (pub_status.current_count == sub_status.current_count);
+    }
+    return false;
 }
 
 } // namespace rpc

--- a/src/cpp/fastdds/rpc/ReplierImpl.hpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.hpp
@@ -156,6 +156,28 @@ private:
      */
     ReturnCode_t delete_contained_entities();
 
+    /**
+     * @brief Possible states of the replier with respect to a requester
+     */
+    enum class RequesterMatchStatus
+    {
+        UNMATCHED,          // Request topic not matched
+        PARTIALLY_MATCHED,  // Request topic matched but Reply topic not matched
+        MATCHED             // Both topics matched
+    };
+
+    /**
+     * @brief Check the matched status of the replier with respect to a requester
+     *
+     * @param info Information about the request for which to check the status
+     *
+     * @return The matched status of the replier with respect to the requester that sent the request
+     */
+    RequesterMatchStatus requester_match_status(
+            const RequestInfo& info) const;
+
+    bool is_fully_matched() const;
+
     DataReader* replier_reader_;
     DataWriter* replier_writer_;
     ReplierQos qos_;

--- a/src/cpp/fastdds/rpc/RequesterImpl.hpp
+++ b/src/cpp/fastdds/rpc/RequesterImpl.hpp
@@ -156,6 +156,13 @@ private:
      */
     ReturnCode_t delete_contained_entities();
 
+    /**
+     * @brief Check if the requester is fully matched with a replier
+     *
+     * @return true if the requester is fully matched, false otherwise
+     */
+    bool is_fully_matched() const;
+
     DataReader* requester_reader_;
     DataWriter* requester_writer_;
     RequesterQos qos_;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR makes requester and replier methods to return an error if they are not fully matched.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
