### PR TITLE
[23042] Bugfix: Properly delete secure endpoints if registration fails

### DIFF
--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -975,6 +975,7 @@ bool RTPSParticipantImpl::create_writer(
         if (!m_security_manager.register_local_writer(SWriter->getGuid(),
                 param.endpoint.properties, SWriter->getAttributes().security_attributes()))
         {
+            SWriter->local_actions_on_writer_removed();
             delete(SWriter);
             return false;
         }
@@ -984,6 +985,7 @@ bool RTPSParticipantImpl::create_writer(
         if (!m_security_manager.register_local_builtin_writer(SWriter->getGuid(),
                 SWriter->getAttributes().security_attributes()))
         {
+            SWriter->local_actions_on_writer_removed();
             delete(SWriter);
             return false;
         }
@@ -1111,6 +1113,7 @@ bool RTPSParticipantImpl::create_reader(
         if (!m_security_manager.register_local_reader(SReader->getGuid(),
                 param.endpoint.properties, SReader->getAttributes().security_attributes()))
         {
+            SReader->local_actions_on_reader_removed();
             delete(SReader);
             return false;
         }
@@ -1120,6 +1123,7 @@ bool RTPSParticipantImpl::create_reader(
         if (!m_security_manager.register_local_builtin_reader(SReader->getGuid(),
                 SReader->getAttributes().security_attributes()))
         {
+            SReader->local_actions_on_reader_removed();
             delete(SReader);
             return false;
         }

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -96,6 +96,8 @@ target_include_directories(BlackboxTests_RTPS PRIVATE
     ${Asio_INCLUDE_DIR})
 target_link_libraries(BlackboxTests_RTPS fastdds fastcdr foonathan_memory GTest::gtest)
 gtest_discover_tests(BlackboxTests_RTPS
+    PROPERTIES
+            ENVIRONMENT "CERTS_PATH=${PROJECT_SOURCE_DIR}/test/certs"
     TEST_PREFIX "BlackboxTests_RTPS."
     TEST_FILTER ${BLACKBOX_HIGH_LEVEL_IGNORED_TESTS}
     NO_PRETTY_VALUES

--- a/test/blackbox/common/RTPSBlackboxTests.cpp
+++ b/test/blackbox/common/RTPSBlackboxTests.cpp
@@ -34,6 +34,7 @@ using namespace eprosima::fastdds::rtps;
 
 //#define cout "Use Log instead!"
 
+const char* certs_path = nullptr;
 uint16_t global_port = 0;
 //bool enable_datasharing;
 
@@ -119,5 +120,11 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     testing::AddGlobalTestEnvironment(new BlackboxEnvironment);
 
+    if (!::testing::GTEST_FLAG(list_tests))
+    {
+#if HAVE_SECURITY
+        blackbox_security_init();
+#endif // if HAVE_SECURITY
+    }
     return RUN_ALL_TESTS();
 }

--- a/test/blackbox/common/RTPSBlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsSecurity.cpp
@@ -1,0 +1,100 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#if HAVE_SECURITY
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.hpp>
+#include <fastdds/rtps/RTPSDomain.hpp>
+
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+
+void set_authentication_config(
+        rtps::PropertySeq& properties)
+{
+    properties.emplace_back("dds.sec.auth.plugin", "builtin.PKI-DH");
+    properties.emplace_back("dds.sec.auth.builtin.PKI-DH.identity_ca",
+            "file://" + std::string(certs_path) + "/maincacert.pem");
+    properties.emplace_back("dds.sec.auth.builtin.PKI-DH.identity_certificate",
+            "file://" + std::string(certs_path) + "/mainpubcert.pem");
+    properties.emplace_back("dds.sec.auth.builtin.PKI-DH.private_key",
+            "file://" + std::string(certs_path) + "/mainpubkey.pem");
+}
+
+void set_participant_crypto_config(
+        rtps::PropertySeq& props,
+        const std::string& governance_file = "governance_helloworld_all_enable.smime",
+        const std::string& permissions_file = "permissions_helloworld.smime")
+{
+    props.emplace_back("dds.sec.crypto.plugin", "builtin.AES-GCM-GMAC");
+    props.emplace_back(Property("dds.sec.access.plugin",
+            "builtin.Access-Permissions"));
+    props.emplace_back(Property(
+                "dds.sec.access.builtin.Access-Permissions.permissions_ca",
+                "file://" + std::string(certs_path) + "/maincacert.pem"));
+    props.emplace_back(Property("dds.sec.access.builtin.Access-Permissions.governance",
+            "file://" + std::string(certs_path) + "/" + governance_file));
+    props.emplace_back(Property("dds.sec.access.builtin.Access-Permissions.permissions",
+            "file://" + std::string(certs_path) + "/" + permissions_file));
+}
+
+/**
+ * This test checks the a StatefulWriter created with security
+ * with a wrong permissions on topic, should be properly cleaned up
+ */
+TEST(RTPSSecurityTests, statefulwriter_wrong_permissions_properly_cleaned_up)
+{
+    RTPSWithRegistrationWriter<HelloWorldPubSubType> writer("CustomTopicName");
+    RTPSWithRegistrationReader<HelloWorldPubSubType> reader("CustomTopicName");
+
+    PropertyPolicy security_properties;
+    set_authentication_config(security_properties.properties());
+    set_participant_crypto_config(security_properties.properties());
+
+    writer.add_participant_properties(security_properties);
+    reader.add_participant_properties(security_properties);
+
+    // This should fail but properly exit
+    ASSERT_NO_THROW(writer.init());
+    ASSERT_NO_THROW(reader.init());
+}
+
+void blackbox_security_init()
+{
+    certs_path = std::getenv("CERTS_PATH");
+
+    if (certs_path == nullptr)
+    {
+        std::cout << "Cannot get enviroment variable CERTS_PATH" << std::endl;
+        exit(-1);
+    }
+}
+
+#endif // if HAVE_SECURITY
+

--- a/test/blackbox/common/RTPSBlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsSecurity.cpp
@@ -65,8 +65,8 @@ void set_participant_crypto_config(
 }
 
 /**
- * This test checks the a StatefulWriter created with security
- * with a wrong permissions on topic, should be properly cleaned up
+ * This test checks that a StatefulWriter created with security,
+ * but with a wrong permissions on topic, is properly cleaned up
  */
 TEST(RTPSSecurityTests, statefulwriter_wrong_permissions_properly_cleaned_up)
 {

--- a/test/blackbox/common/RTPSWithRegistrationReader.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationReader.hpp
@@ -515,6 +515,13 @@ public:
         return *this;
     }
 
+    RTPSWithRegistrationReader& add_participant_properties(
+            const eprosima::fastdds::rtps::PropertyPolicy& props)
+    {
+        participant_attr_.properties = props;
+        return *this;
+    }
+
     RTPSWithRegistrationReader& persistence_guid_att(
             const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix,
             const eprosima::fastdds::rtps::EntityId_t& entityId)

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -462,6 +462,13 @@ public:
         return *this;
     }
 
+    RTPSWithRegistrationWriter& add_participant_properties(
+            const eprosima::fastdds::rtps::PropertyPolicy& props)
+    {
+        participant_attr_.properties = props;
+        return *this;
+    }
+
     RTPSWithRegistrationWriter& persistence_guid_att(
             const eprosima::fastdds::rtps::GuidPrefix_t& guidPrefix,
             const eprosima::fastdds::rtps::EntityId_t& entityId)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR fixes a bug in which, when secure writers or readers failed to register, cleanup is not properly performed.

No need for backport since `local_actions_on_.._removed()` was introduced in `3.2.x`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- NO Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- NO Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
