### PR TITLE
[21427] Add references to documentation in mds

### DIFF
--- a/PLATFORM_SUPPORT.md
+++ b/PLATFORM_SUPPORT.md
@@ -38,6 +38,8 @@ Community members may provide assistance with these platforms.
 |arm64       |Tier 3 [^a][^s]     |Tier 1 [^a][^s]     |                    |                   |                   |Tier 3 [^s]       |Tier 3 [^s]|Tier 3 [^s]|Tier 3 [^s]|
 |arm32       |                    |Tier 3 [^s]         |                    |                   |                   |Tier 3 [^s]       |Tier 3 [^s]|Tier 3 [^s]|           |
 
+More information about Platforms support and eProsima products compatibility can be found on [Fast DDS Documentation](https://fast-dds.docs.eprosima.com/en/latest/notes/versions.html#dependencies-and-compatibilities).
+
 [^a]: Binary releases are provided as a single archive per platform.
 [^s]: Compilation from source.
 

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -27,6 +27,8 @@ This period applies since the end of standard support date to the end of life (E
 
 [^*]: Support may be extended.
 
+A detailed view of the features of each supported version is available at [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/notes/previous_versions/supported_versions.html).
+
 ## *eProsima Fast DDS* previously supported versions.
 
 |Version|Version branch|Latest Release|Release Date|EOL Date|
@@ -48,3 +50,5 @@ This period applies since the end of standard support date to the end of life (E
 |1.9|[1.9.x](https://github.com/eProsima/Fast-DDS/tree/1.9.x)|[v1.9.5](https://github.com/eProsima/Fast-DDS/releases/tag/v1.9.5)|August 2019|February 2022|
 |1.8|[1.8.x](https://github.com/eProsima/Fast-DDS/tree/1.8.x)|[v1.8.5](https://github.com/eProsima/Fast-DDS/releases/tag/v1.8.5)|May 2019|February 2022|
 |1.7|[1.7.x](https://github.com/eProsima/Fast-DDS/tree/1.7.x)|[v1.7.3](https://github.com/eProsima/Fast-DDS/releases/tag/v1.7.3)|December 2018|February 2022|
+
+A detailed view of the features of each previously supported version is available at [Fast DDS documentation](https://fast-dds.docs.eprosima.com/en/latest/notes/previous_versions/previous_versions.html).


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds some references and links to Fast DDS Documentation in the RELEASE_SUPPORT and PLARFORM_SUPPORT sections.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
