### PR TITLE
[23169] Add `WireProtocolConfigQos` to optionals serialization and make `Monitor Service` always serialize optionals

### DIFF
--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -143,6 +143,7 @@ constexpr uint16_t DEFAULT_ROS2_SERVER_PORT = 11811;
 constexpr uint16_t DEFAULT_TCP_SERVER_PORT = 42100;
 
 //! Filtering flags when discovering participants
+FASTDDS_TODO_BEFORE(4, 0, "Change it to uint8_t (implies also changing [de]serializations)");
 enum ParticipantFilteringFlags : uint32_t
 {
     NO_FILTER = 0,

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -242,7 +242,7 @@ inline bool ParameterSerializer<ParameterLocator_t>::add_content_to_cdr_message(
         const ParameterLocator_t& parameter,
         rtps::CDRMessage_t* cdr_message)
 {
-    return rtps::CDRMessage::addLocator(cdr_message, parameter.locator);
+    return rtps::CDRMessage::add_locator(cdr_message, parameter.locator);
 }
 
 template<>
@@ -256,7 +256,7 @@ inline bool ParameterSerializer<ParameterLocator_t>::read_content_from_cdr_messa
         return false;
     }
     parameter.length = parameter_length;
-    return rtps::CDRMessage::readLocator(cdr_message, &parameter.locator);
+    return rtps::CDRMessage::read_locator(cdr_message, &parameter.locator);
 }
 
 template<>
@@ -324,7 +324,7 @@ inline bool ParameterSerializer<ParameterString_t>::read_content_from_cdr_messag
 
     parameter.length = parameter_length;
     fastcdr::string_255 aux;
-    bool valid = rtps::CDRMessage::readString(cdr_message, &aux);
+    bool valid = rtps::CDRMessage::read_string(cdr_message, &aux);
     parameter.setName(aux.c_str());
     return valid;
 }
@@ -963,7 +963,7 @@ public:
             }
             if (valid)
             {
-                valid = rtps::CDRMessage::readString(cdr_message, &parameter.filter_expression) &&
+                valid = rtps::CDRMessage::read_string(cdr_message, &parameter.filter_expression) &&
                         (0 < parameter.filter_expression.size());
             }
 

--- a/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
@@ -2086,11 +2086,12 @@ inline bool QosPoliciesSerializer<WireProtocolConfigQos>::add_to_cdr_message(
             valid &= rtps::CDRMessage::add_duration_t(cdr_message,
                             qos_policy.builtin.discovery_config.discoveryServer_client_syncperiod);
             // m_discovery_servers
-            valid &= rtps::CDRMessage::add_locator_list(cdr_message, qos_policy.builtin.discovery_config.m_DiscoveryServers);
+            valid &= rtps::CDRMessage::add_locator_list(cdr_message,
+                            qos_policy.builtin.discovery_config.m_DiscoveryServers);
             // ignore_participant_flags
             valid &=
                     rtps::CDRMessage::addUInt32(cdr_message,
-                             qos_policy.builtin.discovery_config.
+                            qos_policy.builtin.discovery_config.
                                     ignoreParticipantFlags);
 
             // static_edp_xml_config
@@ -2114,7 +2115,7 @@ inline bool QosPoliciesSerializer<WireProtocolConfigQos>::add_to_cdr_message(
         valid &= rtps::CDRMessage::add_locator_list(cdr_message, qos_policy.builtin.metatrafficMulticastLocatorList);
         // metatraffic_external_unicast_locators
         valid &= rtps::CDRMessage::add_external_locator_list(cdr_message,
-            qos_policy.builtin.metatraffic_external_unicast_locators);
+                        qos_policy.builtin.metatraffic_external_unicast_locators);
         // initial_peers_list
         valid &= rtps::CDRMessage::add_locator_list(cdr_message, qos_policy.builtin.initialPeersList);
         // reader_history_memory_policy
@@ -2264,7 +2265,8 @@ inline bool QosPoliciesSerializer<WireProtocolConfigQos>::read_content_from_cdr_
             valid &= rtps::CDRMessage::read_duration_t(cdr_message,
                             qos_policy.builtin.discovery_config.discoveryServer_client_syncperiod);
             // m_discovery_servers
-            valid &= rtps::CDRMessage::read_locator_list(cdr_message, &qos_policy.builtin.discovery_config.m_DiscoveryServers);
+            valid &= rtps::CDRMessage::read_locator_list(cdr_message,
+                            &qos_policy.builtin.discovery_config.m_DiscoveryServers);
             // ignore_participant_flags
             valid &= rtps::CDRMessage::readUInt32(cdr_message,
                             (uint32_t*)&qos_policy.builtin.discovery_config.ignoreParticipantFlags);
@@ -2286,7 +2288,8 @@ inline bool QosPoliciesSerializer<WireProtocolConfigQos>::read_content_from_cdr_
         // metatraffic_multicast_locator_list
         valid &= rtps::CDRMessage::read_locator_list(cdr_message, &qos_policy.builtin.metatrafficMulticastLocatorList);
         // metatraffic_external_unicast_locators
-        valid &= rtps::CDRMessage::read_external_locator_list(cdr_message, &qos_policy.builtin.metatraffic_external_unicast_locators);
+        valid &= rtps::CDRMessage::read_external_locator_list(cdr_message,
+                        &qos_policy.builtin.metatraffic_external_unicast_locators);
         // initial_peers_list
         valid &= rtps::CDRMessage::read_locator_list(cdr_message, &qos_policy.builtin.initialPeersList);
         // reader_history_memory_policy

--- a/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
@@ -1391,7 +1391,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::add_to_cdr_message(
             it != qos_policy.unicast_locator_list.end();
             ++it)
     {
-        valid &= rtps::CDRMessage::addLocator(cdr_message, *it);
+        valid &= rtps::CDRMessage::add_locator(cdr_message, *it);
     }
 
     // Multicast locator list
@@ -1400,7 +1400,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::add_to_cdr_message(
             it != qos_policy.multicast_locator_list.end();
             ++it)
     {
-        valid &= rtps::CDRMessage::addLocator(cdr_message, *it);
+        valid &= rtps::CDRMessage::add_locator(cdr_message, *it);
     }
 
     // Remote locator list
@@ -1409,7 +1409,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::add_to_cdr_message(
             it != qos_policy.remote_locator_list.end();
             ++it)
     {
-        valid &= rtps::CDRMessage::addLocator(cdr_message, *it);
+        valid &= rtps::CDRMessage::add_locator(cdr_message, *it);
     }
 
     // Do not serialize external_locators yet.
@@ -1456,7 +1456,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::read_content_from_cdr_messag
     for (uint32_t i = 0; i < locators_size; ++i)
     {
         rtps::Locator_t loc;
-        valid &= rtps::CDRMessage::readLocator(cdr_message, &loc);
+        valid &= rtps::CDRMessage::read_locator(cdr_message, &loc);
         qos_policy.unicast_locator_list.push_back(loc);
     }
 
@@ -1466,7 +1466,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::read_content_from_cdr_messag
     for (uint32_t i = 0; i < locators_size; ++i)
     {
         rtps::Locator_t loc;
-        valid &= rtps::CDRMessage::readLocator(cdr_message, &loc);
+        valid &= rtps::CDRMessage::read_locator(cdr_message, &loc);
         qos_policy.multicast_locator_list.push_back(loc);
     }
 
@@ -1476,7 +1476,7 @@ inline bool QosPoliciesSerializer<RTPSEndpointQos>::read_content_from_cdr_messag
     for (uint32_t i = 0; i < locators_size; ++i)
     {
         rtps::Locator_t loc;
-        valid &= rtps::CDRMessage::readLocator(cdr_message, &loc);
+        valid &= rtps::CDRMessage::read_locator(cdr_message, &loc);
         qos_policy.remote_locator_list.push_back(loc);
     }
 
@@ -1599,7 +1599,7 @@ inline bool QosPoliciesSerializer<PublishModeQosPolicy>::read_content_from_cdr_m
                     (fastdds::rtps::octet*)&qos_policy.kind);
     cdr_message->pos += 3; //padding
 
-    rtps::CDRMessage::readString(cdr_message, &qos_policy.flow_controller_name);
+    rtps::CDRMessage::read_string(cdr_message, &qos_policy.flow_controller_name);
 
     uint32_t length_diff = cdr_message->pos - pos_ref;
     valid &= (parameter_length == length_diff);

--- a/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/QosPoliciesSerializer.hpp
@@ -1942,7 +1942,8 @@ inline uint32_t QosPoliciesSerializer<WireProtocolConfigQos>::cdr_serialized_siz
             ret_val += 44;
             // m_discovery_servers
             ret_val += 4;
-            ret_val +=  qos_policy.builtin.discovery_config.m_DiscoveryServers.size() * (4 + 4 + 16); // kind + port + address
+            ret_val +=  static_cast<uint32_t>(qos_policy.builtin.discovery_config.m_DiscoveryServers.size()) *
+                    (4 + 4 + 16);                                                                                            // kind + port + address
             // ignore_participant_flags
             ret_val += 4;
             // easy_mode (str_size + str_data (including null char))
@@ -1957,22 +1958,22 @@ inline uint32_t QosPoliciesSerializer<WireProtocolConfigQos>::cdr_serialized_siz
         ret_val += 8;
         // metatraffic_unicast_locator_list
         ret_val += 4;
-        ret_val += qos_policy.builtin.metatrafficUnicastLocatorList.size() * (4 + 4 + 16); // kind + port + address
+        ret_val += static_cast<uint32_t>(qos_policy.builtin.metatrafficUnicastLocatorList.size()) * (4 + 4 + 16); // kind + port + address
         // metatraffic_multicast_locator_list
         ret_val += 4;
-        ret_val += qos_policy.builtin.metatrafficMulticastLocatorList.size() * (4 + 4 + 16); // kind + port + address
+        ret_val += static_cast<uint32_t>(qos_policy.builtin.metatrafficMulticastLocatorList.size()) * (4 + 4 + 16); // kind + port + address
         // metatraffic_external_unicast_locators
         ret_val += 4;
         for (const auto& externality__cost_locator_list : qos_policy.builtin.metatraffic_external_unicast_locators)
         {
             for (const auto& cost__locator_list : externality__cost_locator_list.second)
             {
-                ret_val += cost__locator_list.second.size() * (4 + 4 + 16 + 4); // kind + port + address + externality + cost + mask
+                ret_val += static_cast<uint32_t>(cost__locator_list.second.size()) * (4 + 4 + 16 + 4); // kind + port + address + externality + cost + mask
             }
         }
         // initial_peers_list
         ret_val += 4;
-        ret_val += qos_policy.builtin.initialPeersList.size() * (4 + 4 + 16); // kind + port + address
+        ret_val += static_cast<uint32_t>(qos_policy.builtin.initialPeersList.size()) * (4 + 4 + 16); // kind + port + address
         // up to flow_controller_name
         ret_val += 24;
         // flow_controller_name (str_size + str_data (including null char))
@@ -1984,17 +1985,17 @@ inline uint32_t QosPoliciesSerializer<WireProtocolConfigQos>::cdr_serialized_siz
     ret_val += 16;
     // default_unicast_locator_list
     ret_val += 4;
-    ret_val += qos_policy.default_unicast_locator_list.size() * (4 + 4 + 16); // kind + port + address
+    ret_val += static_cast<uint32_t>(qos_policy.default_unicast_locator_list.size()) * (4 + 4 + 16); // kind + port + address
     // default_multicast_locator_list
     ret_val += 4;
-    ret_val += qos_policy.default_multicast_locator_list.size() * (4 + 4 + 16); // kind + port + address
+    ret_val += static_cast<uint32_t>(qos_policy.default_multicast_locator_list.size()) * (4 + 4 + 16); // kind + port + address
     // default_external_unicast_locators
     ret_val += 4;
     for (const auto& externality__cost_locator_list : qos_policy.default_external_unicast_locators)
     {
         for (const auto& cost__locator_list : externality__cost_locator_list.second)
         {
-            ret_val += cost__locator_list.second.size() * (4 + 4 + 16 + 4); // kind + port + address + externality + cost + mask
+            ret_val += static_cast<uint32_t>(cost__locator_list.second.size()) * (4 + 4 + 16 + 4); // kind + port + address + externality + cost + mask
         }
     }
     // + ignore_non_matching_locators

--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.hpp
@@ -122,18 +122,24 @@ public:
     /**
      * Get the size in bytes of the CDR serialization of this object.
      * @param include_encapsulation Whether to include the size of the encapsulation info.
+     * @param force_including_optional_qos Whether to force including of the optional Qos.
      * @return size in bytes of the CDR serialization.
      */
     uint32_t get_serialized_size(
-            bool include_encapsulation) const;
+            bool include_encapsulation,
+            bool force_including_optional_qos = false) const;
 
     /**
      * Write as a parameter list on a CDRMessage_t
+     * @param msg CDRMessage_t to write to
+     * @param write_encapsulation Whether to write the encapsulation info.
+     * @param force_write_optional_qos Whether to write the optional Qos.
      * @return True on success
      */
     bool write_to_cdr_message(
             CDRMessage_t* msg,
-            bool write_encapsulation);
+            bool write_encapsulation,
+            bool force_write_optional_qos = false);
 
     /**
      * Read the parameter list from a received CDRMessage_t
@@ -209,6 +215,23 @@ public:
         return last_received_message_tm_;
     }
 
+    //! Getter for m_should_send_optional_qos.
+    bool should_send_optional_qos() const
+    {
+        return m_should_send_optional_qos;
+    }
+
+    /**
+     * Set whether optional QoS should be serialized and added to Data(p).
+     * @param should_send_optional_qos Boolean indicating whether optional QoS should be serialized
+     *                                 and added to Data(p).
+     */
+    void should_send_optional_qos(
+            bool should_send_optional_qos)
+    {
+        m_should_send_optional_qos = should_send_optional_qos;
+    }
+
 private:
 
     //! Store the last timestamp it was received a RTPS message from the remote participant.
@@ -216,6 +239,9 @@ private:
 
     //! Remote participant lease duration in microseconds.
     std::chrono::microseconds lease_duration_;
+
+    //!Whether optional QoS should be serialized and added to Data(p)
+    bool m_should_send_optional_qos{false};
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -208,7 +208,8 @@ void ReaderProxyData::init(
 }
 
 uint32_t ReaderProxyData::get_serialized_size(
-        bool include_encapsulation) const
+        bool include_encapsulation,
+        bool force_including_optional_qos) const
 {
     uint32_t ret_val = include_encapsulation ? 4 : 0;
 
@@ -370,7 +371,7 @@ uint32_t ReaderProxyData::get_serialized_size(
     }
 
     // Send the optional QoS policies if they are enabled
-    if (should_send_optional_qos())
+    if (force_including_optional_qos || should_send_optional_qos())
     {
         if (dds::QosPoliciesSerializer<dds::ResourceLimitsQosPolicy>::should_be_sent(resource_limits))
         {
@@ -408,7 +409,8 @@ uint32_t ReaderProxyData::get_serialized_size(
 
 bool ReaderProxyData::write_to_cdr_message(
         CDRMessage_t* msg,
-        bool write_encapsulation) const
+        bool write_encapsulation,
+        bool force_write_optional_qos) const
 {
     if (write_encapsulation)
     {
@@ -696,7 +698,7 @@ bool ReaderProxyData::write_to_cdr_message(
     }
 
     // Send the optional QoS policies if they are enabled
-    if (should_send_optional_qos())
+    if (force_write_optional_qos || should_send_optional_qos())
     {
         if (dds::QosPoliciesSerializer<dds::ResourceLimitsQosPolicy>::should_be_sent(resource_limits))
         {

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.hpp
@@ -304,18 +304,24 @@ public:
     /**
      * Get the size in bytes of the CDR serialization of this object.
      * @param include_encapsulation Whether to include the size of the encapsulation info.
+     * @param force_including_optional_qos Whether to force including the optional QoS in the size.
      * @return size in bytes of the CDR serialization.
      */
     uint32_t get_serialized_size(
-            bool include_encapsulation) const;
+            bool include_encapsulation,
+            bool force_including_optional_qos = false) const;
 
     /**
      * Write as a parameter list on a CDRMessage_t
+     * @param msg Pointer to the CDRmessage.
+     * @param write_encapsulation Whether to write the encapsulation info.
+     * @param force_write_optional_qos Whether to force writing the optional QoS.
      * @return True on success
      */
     bool write_to_cdr_message(
             CDRMessage_t* msg,
-            bool write_encapsulation) const;
+            bool write_encapsulation,
+            bool force_write_optional_qos = false) const;
 
     /**
      * Read the information from a CDRMessage_t. The position of the message must be in the beginning on the
@@ -442,7 +448,7 @@ private:
     dds::TypeObjectV1* m_type;
 
     //!Whether optional QoS should be serialized and added to Data(r)
-    bool m_should_send_optional_qos;
+    bool m_should_send_optional_qos{false};
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -200,7 +200,8 @@ void WriterProxyData::init(
 }
 
 uint32_t WriterProxyData::get_serialized_size(
-        bool include_encapsulation) const
+        bool include_encapsulation,
+        bool force_including_optional_qos) const
 {
     uint32_t ret_val = include_encapsulation ? 4 : 0;
 
@@ -357,7 +358,7 @@ uint32_t WriterProxyData::get_serialized_size(
     }
 
     // Send the optional QoS policies if they are enabled
-    if (should_send_optional_qos())
+    if (force_including_optional_qos || should_send_optional_qos() )
     {
         if (dds::QosPoliciesSerializer<dds::ResourceLimitsQosPolicy>::should_be_sent(resource_limits))
         {
@@ -407,7 +408,8 @@ uint32_t WriterProxyData::get_serialized_size(
 
 bool WriterProxyData::write_to_cdr_message(
         CDRMessage_t* msg,
-        bool write_encapsulation) const
+        bool write_encapsulation,
+        bool force_write_optional_qos) const
 {
     if (write_encapsulation)
     {
@@ -677,8 +679,9 @@ bool WriterProxyData::write_to_cdr_message(
         }
     }
 
-    // Send the optional QoS policies if they are enabled
-    if (should_send_optional_qos())
+    // Send the optional QoS policies if required
+    // Should_send_optional_qos() is true if `fastdds.serialize_optional_qos` property is set to true
+    if (force_write_optional_qos || should_send_optional_qos())
     {
         if (dds::QosPoliciesSerializer<dds::ResourceLimitsQosPolicy>::should_be_sent(resource_limits))
         {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -358,7 +358,7 @@ uint32_t WriterProxyData::get_serialized_size(
     }
 
     // Send the optional QoS policies if they are enabled
-    if (force_including_optional_qos || should_send_optional_qos() )
+    if (force_including_optional_qos || should_send_optional_qos())
     {
         if (dds::QosPoliciesSerializer<dds::ResourceLimitsQosPolicy>::should_be_sent(resource_limits))
         {

--- a/src/cpp/rtps/builtin/data/WriterProxyData.hpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.hpp
@@ -329,15 +329,24 @@ public:
     /**
      * Get the size in bytes of the CDR serialization of this object.
      * @param include_encapsulation Whether to include the size of the encapsulation info.
+     * @param force_including_optional_qos Whether to force including the optional QoS in the size.
      * @return size in bytes of the CDR serialization.
      */
     uint32_t get_serialized_size(
-            bool include_encapsulation) const;
+            bool include_encapsulation,
+            bool force_including_optional_qos = false) const;
 
-    //!Write as a parameter list on a CDRMessage_t
+    /**
+     * Write as a parameter list on a CDRMessage_t
+     * @param msg Pointer to the CDRmessage.
+     * @param write_encapsulation Whether to write the encapsulation info.
+     * @param force_write_optional_qos Whether to write the optional QoS.
+     * @return True on success
+     */
     bool write_to_cdr_message(
             CDRMessage_t* msg,
-            bool write_encapsulation) const;
+            bool write_encapsulation,
+            bool force_write_optional_qos = false) const;
 
     /**
      * Read the information from a CDRMessage_t. The position of the message must be in the beginning on the
@@ -438,7 +447,7 @@ private:
     dds::TypeObjectV1* m_type;
 
     //!Whether optional QoS should be serialized and added to Data(r)
-    bool m_should_send_optional_qos;
+    bool m_should_send_optional_qos{false};
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -464,6 +464,20 @@ void PDP::initializeParticipantProxyData(
 
     // Set properties that will be sent to Proxy Data
     set_external_participant_properties_(participant_data);
+
+    // Fill wire_protocol qos
+    participant_data->wire_protocol = dds::WireProtocolConfigQos();
+    participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
+    participant_data->wire_protocol->participant_id = attributes.participantID;
+    participant_data->wire_protocol->builtin = attributes.builtin;
+    participant_data->wire_protocol->port = attributes.port;
+    participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
+    participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
+    participant_data->wire_protocol->default_external_unicast_locators = attributes.default_external_unicast_locators;
+    participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
+
+    // Mark whether this participant should send optional QoS
+    participant_data->should_send_optional_qos(mp_RTPSParticipant->should_send_optional_qos());
 }
 
 bool PDP::initPDP(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -465,19 +465,23 @@ void PDP::initializeParticipantProxyData(
     // Set properties that will be sent to Proxy Data
     set_external_participant_properties_(participant_data);
 
-    // Fill wire_protocol qos
-    participant_data->wire_protocol = dds::WireProtocolConfigQos();
-    participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
-    participant_data->wire_protocol->participant_id = attributes.participantID;
-    participant_data->wire_protocol->builtin = attributes.builtin;
-    participant_data->wire_protocol->port = attributes.port;
-    participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
-    participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
-    participant_data->wire_protocol->default_external_unicast_locators = attributes.default_external_unicast_locators;
-    participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
+    if (mp_RTPSParticipant->should_send_optional_qos())
+    {
+        // Fill wire_protocol qos
+        participant_data->wire_protocol = dds::WireProtocolConfigQos();
+        participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
+        participant_data->wire_protocol->participant_id = attributes.participantID;
+        participant_data->wire_protocol->builtin = attributes.builtin;
+        participant_data->wire_protocol->port = attributes.port;
+        participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
+        participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
+        participant_data->wire_protocol->default_external_unicast_locators =
+                attributes.default_external_unicast_locators;
+        participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
 
-    // Mark whether this participant should send optional QoS
-    participant_data->should_send_optional_qos(mp_RTPSParticipant->should_send_optional_qos());
+        // Mark this participant should send optional QoS
+        participant_data->should_send_optional_qos(true);
+    }
 }
 
 bool PDP::initPDP(

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1186,8 +1186,8 @@ bool PDP::get_serialized_proxy(
             if ((*part_proxy)->guid == guid)
             {
                 msg->msg_endian = LITTLEEND;
-                msg->max_size = msg->reserved_size = (*part_proxy)->get_serialized_size(true);
-                ret = (*part_proxy)->write_to_cdr_message(msg, true);
+                msg->max_size = msg->reserved_size = (*part_proxy)->get_serialized_size(true, true);
+                ret = (*part_proxy)->write_to_cdr_message(msg, true, true);
                 found = true;
                 break;
             }
@@ -1209,8 +1209,8 @@ bool PDP::get_serialized_proxy(
                 {
                     if (reader.second->guid == guid)
                     {
-                        msg->max_size = msg->reserved_size = reader.second->get_serialized_size(true);
-                        ret = reader.second->write_to_cdr_message(msg, true);
+                        msg->max_size = msg->reserved_size = reader.second->get_serialized_size(true, true);
+                        ret = reader.second->write_to_cdr_message(msg, true, true);
                         found = true;
                         break;
                     }
@@ -1235,8 +1235,8 @@ bool PDP::get_serialized_proxy(
                 {
                     if (writer.second->guid == guid)
                     {
-                        msg->max_size = msg->reserved_size = writer.second->get_serialized_size(true);
-                        ret = writer.second->write_to_cdr_message(msg, true);
+                        msg->max_size = msg->reserved_size = writer.second->get_serialized_size(true, true);
+                        ret = writer.second->write_to_cdr_message(msg, true, true);
                         found = true;
                         break;
                     }

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -465,23 +465,18 @@ void PDP::initializeParticipantProxyData(
     // Set properties that will be sent to Proxy Data
     set_external_participant_properties_(participant_data);
 
-    if (mp_RTPSParticipant->should_send_optional_qos())
-    {
-        // Fill wire_protocol qos
-        participant_data->wire_protocol = dds::WireProtocolConfigQos();
-        participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
-        participant_data->wire_protocol->participant_id = attributes.participantID;
-        participant_data->wire_protocol->builtin = attributes.builtin;
-        participant_data->wire_protocol->port = attributes.port;
-        participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
-        participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
-        participant_data->wire_protocol->default_external_unicast_locators =
-                attributes.default_external_unicast_locators;
-        participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
+    // Fill wire_protocol qos
+    participant_data->wire_protocol = dds::WireProtocolConfigQos();
+    participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
+    participant_data->wire_protocol->participant_id = attributes.participantID;
+    participant_data->wire_protocol->builtin = attributes.builtin;
+    participant_data->wire_protocol->port = attributes.port;
+    participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
+    participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
+    participant_data->wire_protocol->default_external_unicast_locators = attributes.default_external_unicast_locators;
+    participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
 
-        // Mark this participant should send optional QoS
-        participant_data->should_send_optional_qos(true);
-    }
+    participant_data->should_send_optional_qos(mp_RTPSParticipant->should_send_optional_qos());
 }
 
 bool PDP::initPDP(

--- a/src/cpp/rtps/messages/CDRMessage.cpp
+++ b/src/cpp/rtps/messages/CDRMessage.cpp
@@ -363,8 +363,8 @@ bool CDRMessage::read_locator(
 }
 
 bool CDRMessage::read_locator_list(
-    CDRMessage_t* msg,
-    LocatorList* locator_list)
+        CDRMessage_t* msg,
+        LocatorList* locator_list)
 {
     assert(locator_list != nullptr);
 
@@ -382,10 +382,10 @@ bool CDRMessage::read_locator_list(
 }
 
 bool CDRMessage::read_external_locator(
-    CDRMessage_t* msg,
-    LocatorWithMask* loc,
-    uint8_t* externality,
-    uint8_t* cost)
+        CDRMessage_t* msg,
+        LocatorWithMask* loc,
+        uint8_t* externality,
+        uint8_t* cost)
 {
     bool ret = false;
 
@@ -404,8 +404,8 @@ bool CDRMessage::read_external_locator(
 }
 
 bool CDRMessage::read_external_locator_list(
-    CDRMessage_t* msg,
-    ExternalLocators* external_locators)
+        CDRMessage_t* msg,
+        ExternalLocators* external_locators)
 {
     assert(external_locators != nullptr);
 
@@ -793,8 +793,8 @@ bool CDRMessage::add_locator(
 }
 
 bool CDRMessage::add_locator_list(
-    CDRMessage_t* msg,
-    const LocatorList& locator_list)
+        CDRMessage_t* msg,
+        const LocatorList& locator_list)
 {
     bool valid = rtps::CDRMessage::addUInt32(msg, (uint32_t)locator_list.size());
     for (const auto& locator : locator_list)
@@ -805,10 +805,10 @@ bool CDRMessage::add_locator_list(
 }
 
 bool CDRMessage::add_external_locator(
-        CDRMessage_t *msg,
-        const LocatorWithMask &loc,
-        const uint8_t &externality,
-        const uint8_t &cost)
+        CDRMessage_t* msg,
+        const LocatorWithMask& loc,
+        const uint8_t& externality,
+        const uint8_t& cost)
 {
     bool ret = false;
 
@@ -825,8 +825,8 @@ bool CDRMessage::add_external_locator(
 }
 
 bool CDRMessage::add_external_locator_list(
-    CDRMessage_t* msg,
-    const ExternalLocators& external_locators)
+        CDRMessage_t* msg,
+        const ExternalLocators& external_locators)
 {
     uint32_t external_locator_list_size = 0;
     for (const auto& externality__cost_locator_list : external_locators)

--- a/src/cpp/rtps/messages/CDRMessage.cpp
+++ b/src/cpp/rtps/messages/CDRMessage.cpp
@@ -833,7 +833,7 @@ bool CDRMessage::add_external_locator_list(
     {
         for (const auto& cost__locator_list : externality__cost_locator_list.second)
         {
-            external_locator_list_size += cost__locator_list.second.size();
+            external_locator_list_size += static_cast<uint32_t>(cost__locator_list.second.size());
         }
     }
     bool valid =

--- a/src/cpp/rtps/messages/CDRMessage.cpp
+++ b/src/cpp/rtps/messages/CDRMessage.cpp
@@ -346,7 +346,7 @@ bool CDRMessage::readTimestamp(
     return valid;
 }
 
-bool CDRMessage::readLocator(
+bool CDRMessage::read_locator(
         CDRMessage_t* msg,
         Locator_t* loc)
 {
@@ -358,6 +358,67 @@ bool CDRMessage::readLocator(
     bool valid = readInt32(msg, &loc->kind);
     valid &= readUInt32(msg, &loc->port);
     valid &= readData(msg, loc->address, 16);
+
+    return valid;
+}
+
+bool CDRMessage::read_locator_list(
+    CDRMessage_t* msg,
+    LocatorList* locator_list)
+{
+    assert(locator_list != nullptr);
+
+    uint32_t locator_list_size = 0;
+    bool valid = rtps::CDRMessage::readUInt32(msg, &locator_list_size);
+    locator_list->reserve(locator_list_size);
+    for (uint32_t i = 0; i < locator_list_size; ++i)
+    {
+        rtps::Locator_t locator;
+        valid &= rtps::CDRMessage::read_locator(msg, &locator);
+        locator_list->push_back(locator);
+    }
+
+    return valid;
+}
+
+bool CDRMessage::read_external_locator(
+    CDRMessage_t* msg,
+    LocatorWithMask* loc,
+    uint8_t* externality,
+    uint8_t* cost)
+{
+    bool ret = false;
+
+    if (msg->pos + 28 <= msg->length)
+    {
+        ret = read_locator(msg, loc);
+        ret &= readOctet(msg, externality);
+        ret &= readOctet(msg, cost);
+        uint8_t mask = 0;
+        ret &= readOctet(msg, &mask);
+        loc->mask(mask);
+        msg->pos += 1; // padding
+    }
+
+    return ret;
+}
+
+bool CDRMessage::read_external_locator_list(
+    CDRMessage_t* msg,
+    ExternalLocators* external_locators)
+{
+    assert(external_locators != nullptr);
+
+    uint32_t external_locators_size = 0;
+    bool valid = rtps::CDRMessage::readUInt32(msg, &external_locators_size);
+    for (uint32_t i = 0; i < external_locators_size; ++i)
+    {
+        rtps::Locator_t locator;
+        rtps::LocatorWithMask locator_with_mask;
+        uint8_t externality = 0, cost = 0;
+        valid &= rtps::CDRMessage::read_external_locator(msg, &locator_with_mask, &externality, &cost);
+        (*external_locators)[externality][cost].push_back(locator_with_mask);
+    }
 
     return valid;
 }
@@ -437,7 +498,7 @@ bool CDRMessage::readOctetVector(
     return valid;
 }
 
-bool CDRMessage::readString(
+bool CDRMessage::read_string(
         CDRMessage_t* msg,
         std::string* stri)
 {
@@ -464,7 +525,7 @@ bool CDRMessage::readString(
     return valid;
 }
 
-bool CDRMessage::readString(
+bool CDRMessage::read_string(
         CDRMessage_t* msg,
         fastcdr::string_255* stri)
 {
@@ -721,7 +782,7 @@ bool CDRMessage::addFragmentNumberSet(
     return true;
 }
 
-bool CDRMessage::addLocator(
+bool CDRMessage::add_locator(
         CDRMessage_t* msg,
         const Locator_t& loc)
 {
@@ -729,6 +790,68 @@ bool CDRMessage::addLocator(
     addUInt32(msg, loc.port);
     addData(msg, loc.address, 16);
     return true;
+}
+
+bool CDRMessage::add_locator_list(
+    CDRMessage_t* msg,
+    const LocatorList& locator_list)
+{
+    bool valid = rtps::CDRMessage::addUInt32(msg, (uint32_t)locator_list.size());
+    for (const auto& locator : locator_list)
+    {
+        valid &= rtps::CDRMessage::add_locator(msg, locator);
+    }
+    return valid;
+}
+
+bool CDRMessage::add_external_locator(
+        CDRMessage_t *msg,
+        const LocatorWithMask &loc,
+        const uint8_t &externality,
+        const uint8_t &cost)
+{
+    bool ret = false;
+
+    if (msg->pos + 28 <= msg->max_size)
+    {
+        ret = add_locator(msg, loc);
+        ret &= addOctet(msg, externality);
+        ret &= addOctet(msg, cost);
+        ret &= addOctet(msg, loc.mask());
+        ret &= addOctet(msg, 0); // Padding
+    }
+
+    return ret;
+}
+
+bool CDRMessage::add_external_locator_list(
+    CDRMessage_t* msg,
+    const ExternalLocators& external_locators)
+{
+    uint32_t external_locator_list_size = 0;
+    for (const auto& externality__cost_locator_list : external_locators)
+    {
+        for (const auto& cost__locator_list : externality__cost_locator_list.second)
+        {
+            external_locator_list_size += cost__locator_list.second.size();
+        }
+    }
+    bool valid =
+            rtps::CDRMessage::addUInt32(msg, external_locator_list_size);
+    for (const auto& externality__cost_locator_list : external_locators)
+    {
+        for (const auto& cost__locator_list : externality__cost_locator_list.second)
+        {
+            for (const auto& locator : cost__locator_list.second)
+            {
+                valid &= rtps::CDRMessage::add_external_locator(msg, locator,
+                                externality__cost_locator_list.first,
+                                cost__locator_list.first);
+            }
+        }
+    }
+
+    return valid;
 }
 
 bool CDRMessage::add_string(
@@ -787,11 +910,11 @@ bool CDRMessage::readProperty(
 {
     assert(msg);
 
-    if (!CDRMessage::readString(msg, &property.name()))
+    if (!CDRMessage::read_string(msg, &property.name()))
     {
         return false;
     }
-    if (!CDRMessage::readString(msg, &property.value()))
+    if (!CDRMessage::read_string(msg, &property.value()))
     {
         return false;
     }
@@ -827,7 +950,7 @@ bool CDRMessage::readBinaryProperty(
 {
     assert(msg);
 
-    if (!CDRMessage::readString(msg, &binary_property.name()))
+    if (!CDRMessage::read_string(msg, &binary_property.name()))
     {
         return false;
     }
@@ -1045,7 +1168,7 @@ bool CDRMessage::readDataHolder(
 {
     assert(msg);
 
-    if (!CDRMessage::readString(msg, &data_holder.class_id()))
+    if (!CDRMessage::read_string(msg, &data_holder.class_id()))
     {
         return false;
     }
@@ -1250,7 +1373,7 @@ bool CDRMessage::readParticipantGenericMessage(
     {
         return false;
     }
-    if (!CDRMessage::readString(msg, &message.message_class_id()))
+    if (!CDRMessage::read_string(msg, &message.message_class_id()))
     {
         return false;
     }

--- a/src/cpp/rtps/messages/CDRMessage.hpp
+++ b/src/cpp/rtps/messages/CDRMessage.hpp
@@ -22,6 +22,7 @@
 
 #include <fastcdr/cdr/fixed_size_string.hpp>
 
+#include <fastdds/rtps/attributes/ExternalLocators.hpp>
 #include <fastdds/rtps/common/CDRMessage_t.hpp>
 #include <fastdds/rtps/common/Property.hpp>
 #include <fastdds/rtps/common/BinaryProperty.hpp>
@@ -30,6 +31,8 @@
 #include <fastdds/rtps/common/SampleIdentity.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 #include <fastdds/rtps/common/Locator.hpp>
+#include <fastdds/rtps/common/LocatorList.hpp>
+#include <fastdds/rtps/common/LocatorWithMask.hpp>
 #include <fastdds/utils/collections/ResourceLimitedContainerConfig.hpp>
 
 #include <rtps/security/common/ParticipantGenericMessage.h>
@@ -104,9 +107,23 @@ bool readUInt16(
         CDRMessage_t* msg,
         uint16_t* i16);
 
-bool readLocator(
+bool read_locator(
         CDRMessage_t* msg,
         Locator_t* loc);
+
+bool read_locator_list(
+        CDRMessage_t* msg,
+        LocatorList_t* loc_list);
+
+bool read_external_locator(
+        CDRMessage_t* msg,
+        LocatorWithMask* loc,
+        uint8_t* externality,
+        uint8_t* cost);
+
+bool read_external_locator_list(
+        CDRMessage_t* msg,
+        ExternalLocators* external_locators);
 
 bool readOctet(
         CDRMessage_t* msg,
@@ -123,11 +140,11 @@ bool readTimestamp(
         CDRMessage_t* msg,
         Time_t* ts);
 
-bool readString(
+bool read_string(
         CDRMessage_t* msg,
         std::string* p_str);
 
-bool readString(
+bool read_string(
         CDRMessage_t* msg,
         fastcdr::string_255* stri);
 
@@ -281,9 +298,23 @@ bool addFragmentNumberSet(
         CDRMessage_t* msg,
         FragmentNumberSet_t* fns);
 
-bool addLocator(
+bool add_locator(
         CDRMessage_t* msg,
         const Locator_t& loc);
+
+bool add_locator_list(
+        CDRMessage_t* msg,
+        const LocatorList& loc_list);
+
+bool add_external_locator(
+        CDRMessage_t* msg,
+        const LocatorWithMask& loc,
+        const uint8_t &externality,
+        const uint8_t &cost);
+
+bool add_external_locator_list(
+        CDRMessage_t* msg,
+        const ExternalLocators& external_locators);
 
 bool add_string(
         CDRMessage_t* msg,

--- a/src/cpp/rtps/messages/CDRMessage.hpp
+++ b/src/cpp/rtps/messages/CDRMessage.hpp
@@ -309,8 +309,8 @@ bool add_locator_list(
 bool add_external_locator(
         CDRMessage_t* msg,
         const LocatorWithMask& loc,
-        const uint8_t &externality,
-        const uint8_t &cost);
+        const uint8_t& externality,
+        const uint8_t& cost);
 
 bool add_external_locator_list(
         CDRMessage_t* msg,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1453,18 +1453,22 @@ dds::ReturnCode_t RTPSParticipantImpl::register_reader(
 
 bool RTPSParticipantImpl::should_send_optional_qos() const
 {
-    bool should_send_opt_qos = false;
-    if (m_att.properties.properties().size() > 0)
+    if (should_send_optional_qos_ < 0) // not evaluated yet
     {
-        const Property* const serialize_optional_qos_property =
-                PropertyPolicyHelper::get_property(m_att.properties, fastdds::dds::parameter_serialize_optional_qos);
-
-        if (serialize_optional_qos_property != nullptr)
+        should_send_optional_qos_ = false;
+        if (m_att.properties.properties().size() > 0)
         {
-            should_send_opt_qos = PropertyParser::as_bool(*serialize_optional_qos_property);
+            const Property* const serialize_optional_qos_property =
+                    PropertyPolicyHelper::get_property(m_att.properties, fastdds::dds::parameter_serialize_optional_qos);
+
+            if (serialize_optional_qos_property != nullptr)
+            {
+                should_send_optional_qos_ = PropertyParser::as_bool(*serialize_optional_qos_property);
+            }
         }
     }
-    return should_send_opt_qos;
+
+    return should_send_optional_qos_ > 0;
 }
 
 void RTPSParticipantImpl::update_attributes(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1459,7 +1459,8 @@ bool RTPSParticipantImpl::should_send_optional_qos() const
         if (m_att.properties.properties().size() > 0)
         {
             const Property* const serialize_optional_qos_property =
-                    PropertyPolicyHelper::get_property(m_att.properties, fastdds::dds::parameter_serialize_optional_qos);
+                    PropertyPolicyHelper::get_property(m_att.properties,
+                            fastdds::dds::parameter_serialize_optional_qos);
 
             if (serialize_optional_qos_property != nullptr)
             {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -620,6 +620,10 @@ private:
     //! Determine if the RTPSParticipantImpl was initialized successfully.
     bool initialized_ = false;
 
+    //! Whether the participant should send optional QoS in the discovery
+    //! This is regulated by the `fastdds.send_optional_qos` property
+    mutable signed char should_send_optional_qos_ = -1;
+
     //! Ignored entities collections
     std::set<GuidPrefix_t> ignored_participants_;
     std::set<GUID_t> ignored_writers_;

--- a/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
+++ b/src/cpp/statistics/rtps/messages/RTPSStatisticsMessages.hpp
@@ -131,7 +131,7 @@ inline void read_statistics_submessage(
 
     // Read all fields
     using namespace eprosima::fastdds::rtps;
-    CDRMessage::readLocator(msg, &data.destination);
+    CDRMessage::read_locator(msg, &data.destination);
     CDRMessage::readInt32(msg, &data.ts.seconds);
     CDRMessage::readUInt32(msg, &data.ts.fraction);
     CDRMessage::readUInt64(msg, &data.seq.sequence);

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -531,19 +531,19 @@ struct SampleValidator
     }
 
     void register_remote_participant_builtin_topic_data(
-        const ParticipantBuiltinTopicData& data)
+            const ParticipantBuiltinTopicData& data)
     {
         remote_participants_data_[data.guid] = data;
     }
 
     void register_remote_publication_builtin_topic_data(
-        const PublicationBuiltinTopicData& data)
+            const PublicationBuiltinTopicData& data)
     {
         remote_pulications_data_[data.guid] = data;
     }
 
     void register_remote_subscription_builtin_topic_data(
-        const SubscriptionBuiltinTopicData& data)
+            const SubscriptionBuiltinTopicData& data)
     {
         remote_subscriptions_data_[data.guid] = data;
     }
@@ -855,6 +855,7 @@ struct ProxySampleValidator : public SampleValidator
             update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
+
 };
 
 struct ConnectionListSampleValidator : public SampleValidator
@@ -2938,7 +2939,8 @@ TEST(DDSMonitorServiceTest, monitor_service_proxy_optional_qos)
 
     expected_participant_builtin_topic_data.guid = statistics::to_fastdds_type(MSP.get_participant_guid());
     expected_participant_builtin_topic_data.wire_protocol = participant_qos.wire_protocol();
-    expected_participant_builtin_topic_data.wire_protocol->prefix = expected_participant_builtin_topic_data.guid.guidPrefix;
+    expected_participant_builtin_topic_data.wire_protocol->prefix =
+            expected_participant_builtin_topic_data.guid.guidPrefix;
     expected_participant_builtin_topic_data.wire_protocol->participant_id = 0;
     expected_participant_builtin_topic_data.wire_protocol->builtin.network_configuration = LOCATOR_KIND_SHM;
 

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -787,9 +787,9 @@ struct ProxySampleValidator : public SampleValidator
 
                     if (assert_optional_remote_data_)
                     {
-                        auto it = remote_participants_data_.find(guid);
-                        ASSERT_TRUE(it != remote_participants_data_.end());
-                        ASSERT_EQ(it->second.wire_protocol.value(), pdata.wire_protocol.value());
+                        auto it_rpartd = remote_participants_data_.find(guid);
+                        ASSERT_TRUE(it_rpartd != remote_participants_data_.end());
+                        ASSERT_EQ(it_rpartd->second.wire_protocol.value(), pdata.wire_protocol.value());
                     }
                 }
                 else if (guid.entityId.is_reader())
@@ -802,11 +802,12 @@ struct ProxySampleValidator : public SampleValidator
 
                     if (assert_optional_remote_data_)
                     {
-                        auto it = remote_subscriptions_data_.find(guid);
-                        ASSERT_TRUE(it != remote_subscriptions_data_.end());
-                        ASSERT_EQ(it->second.reader_data_lifecycle.value(), sub_data.reader_data_lifecycle.value());
-                        ASSERT_EQ(it->second.rtps_reliable_reader.value(), sub_data.rtps_reliable_reader.value());
-                        ASSERT_EQ(it->second.reader_resource_limits.value(), sub_data.reader_resource_limits.value());
+                        auto it_rsd = remote_subscriptions_data_.find(guid);
+                        ASSERT_TRUE(it_rsd != remote_subscriptions_data_.end());
+                        ASSERT_EQ(it_rsd->second.reader_data_lifecycle.value(), sub_data.reader_data_lifecycle.value());
+                        ASSERT_EQ(it_rsd->second.rtps_reliable_reader.value(), sub_data.rtps_reliable_reader.value());
+                        ASSERT_EQ(it_rsd->second.reader_resource_limits.value(),
+                                sub_data.reader_resource_limits.value());
                     }
 
                 }
@@ -820,12 +821,13 @@ struct ProxySampleValidator : public SampleValidator
 
                     if (assert_optional_remote_data_)
                     {
-                        auto it = remote_pulications_data_.find(guid);
-                        ASSERT_TRUE(it != remote_pulications_data_.end());
-                        ASSERT_EQ(it->second.writer_data_lifecycle.value(), pub_data.writer_data_lifecycle.value());
-                        ASSERT_EQ(it->second.publish_mode.value(), pub_data.publish_mode.value());
-                        ASSERT_EQ(it->second.rtps_reliable_writer.value(), pub_data.rtps_reliable_writer.value());
-                        ASSERT_EQ(it->second.writer_resource_limits.value(), pub_data.writer_resource_limits.value());
+                        auto it_rpd = remote_pulications_data_.find(guid);
+                        ASSERT_TRUE(it_rpd != remote_pulications_data_.end());
+                        ASSERT_EQ(it_rpd->second.writer_data_lifecycle.value(), pub_data.writer_data_lifecycle.value());
+                        ASSERT_EQ(it_rpd->second.publish_mode.value(), pub_data.publish_mode.value());
+                        ASSERT_EQ(it_rpd->second.rtps_reliable_writer.value(), pub_data.rtps_reliable_writer.value());
+                        ASSERT_EQ(it_rpd->second.writer_resource_limits.value(),
+                                pub_data.writer_resource_limits.value());
                     }
                 }
                 else

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -530,8 +530,38 @@ struct SampleValidator
         }
     }
 
+    void register_remote_participant_builtin_topic_data(
+        const ParticipantBuiltinTopicData& data)
+    {
+        remote_participants_data_[data.guid] = data;
+    }
+
+    void register_remote_publication_builtin_topic_data(
+        const PublicationBuiltinTopicData& data)
+    {
+        remote_pulications_data_[data.guid] = data;
+    }
+
+    void register_remote_subscription_builtin_topic_data(
+        const SubscriptionBuiltinTopicData& data)
+    {
+        remote_subscriptions_data_[data.guid] = data;
+    }
+
+    void set_assert_optional_remote_data()
+    {
+        assert_optional_remote_data_ = true;
+    }
+
+protected:
+
     std::bitset<statistics::StatusKind::STATUSES_SIZE> validation_mask;
     bool assert_on_non_expected_msgs_;
+    bool assert_optional_remote_data_{false};
+
+    std::map<GUID_t, ParticipantBuiltinTopicData> remote_participants_data_;
+    std::map<GUID_t, PublicationBuiltinTopicData> remote_pulications_data_;
+    std::map<GUID_t, SubscriptionBuiltinTopicData> remote_subscriptions_data_;
 
 };
 
@@ -656,6 +686,11 @@ public:
         return participant_matched_;
     }
 
+    SampleValidator* get_sample_validator()
+    {
+        return sample_validator_;
+    }
+
 protected:
 
     void receive_one(
@@ -749,23 +784,49 @@ struct ProxySampleValidator : public SampleValidator
                     auto it_names =
                             std::find(part_names.begin(), part_names.end(), pdata.participant_name.to_string());
                     ASSERT_TRUE(it_names != part_names.end());
+
+                    if (assert_optional_remote_data_)
+                    {
+                        auto it = remote_participants_data_.find(guid);
+                        ASSERT_TRUE(it != remote_participants_data_.end());
+                        ASSERT_EQ(it->second.wire_protocol.value(), pdata.wire_protocol.value());
+                    }
                 }
                 else if (guid.entityId.is_reader())
                 {
-                    SubscriptionBuiltinTopicData rdata;
+                    SubscriptionBuiltinTopicData sub_data;
 
-                    ASSERT_EQ(participant->fill_discovery_data_from_cdr_message(rdata,
+                    ASSERT_EQ(participant->fill_discovery_data_from_cdr_message(sub_data,
                             data),
                             eprosima::fastdds::dds::RETCODE_OK);
+
+                    if (assert_optional_remote_data_)
+                    {
+                        auto it = remote_subscriptions_data_.find(guid);
+                        ASSERT_TRUE(it != remote_subscriptions_data_.end());
+                        ASSERT_EQ(it->second.reader_data_lifecycle.value(), sub_data.reader_data_lifecycle.value());
+                        ASSERT_EQ(it->second.rtps_reliable_reader.value(), sub_data.rtps_reliable_reader.value());
+                        ASSERT_EQ(it->second.reader_resource_limits.value(), sub_data.reader_resource_limits.value());
+                    }
 
                 }
                 else if (guid.entityId.is_writer())
                 {
-                    PublicationBuiltinTopicData wdata;
+                    PublicationBuiltinTopicData pub_data;
 
-                    ASSERT_EQ(participant->fill_discovery_data_from_cdr_message(wdata,
+                    ASSERT_EQ(participant->fill_discovery_data_from_cdr_message(pub_data,
                             data),
                             eprosima::fastdds::dds::RETCODE_OK);
+
+                    if (assert_optional_remote_data_)
+                    {
+                        auto it = remote_pulications_data_.find(guid);
+                        ASSERT_TRUE(it != remote_pulications_data_.end());
+                        ASSERT_EQ(it->second.writer_data_lifecycle.value(), pub_data.writer_data_lifecycle.value());
+                        ASSERT_EQ(it->second.publish_mode.value(), pub_data.publish_mode.value());
+                        ASSERT_EQ(it->second.rtps_reliable_writer.value(), pub_data.rtps_reliable_writer.value());
+                        ASSERT_EQ(it->second.writer_resource_limits.value(), pub_data.writer_resource_limits.value());
+                    }
                 }
                 else
                 {
@@ -794,7 +855,6 @@ struct ProxySampleValidator : public SampleValidator
             update_processed_msgs(it, total_msgs, processed_count, cv, msg_was_expected);
         }
     }
-
 };
 
 struct ConnectionListSampleValidator : public SampleValidator
@@ -2804,3 +2864,155 @@ TEST(DDSMonitorServiceTest,  monitor_service_late_joiner_consumer_receives_only_
 #endif //FASTDDS_STATISTICS
 }
 
+/**
+ * Test checking that the monitor service properly serializes the optional qos
+ * for the participant/reader/writer.
+ */
+TEST(DDSMonitorServiceTest, monitor_service_proxy_optional_qos)
+{
+#ifdef FASTDDS_STATISTICS
+    //! Validate PROXY samples only
+    std::bitset<statistics::StatusKind::STATUSES_SIZE> validation_mask;
+    validation_mask[statistics::StatusKind::PROXY] = true;
+
+    //! Setup
+    MonitorServiceParticipant MSP;
+    MonitorServiceConsumer MSC(validation_mask);
+
+    DomainParticipantQos participant_qos;
+
+    auto test_flow_controller = std::make_shared<eprosima::fastdds::rtps::FlowControllerDescriptor>();
+    test_flow_controller->name = "test_flow_controller";
+    test_flow_controller->scheduler = FlowControllerSchedulerPolicy::FIFO;
+    test_flow_controller->max_bytes_per_period = 0;
+    test_flow_controller->period_ms = static_cast<uint64_t>(50);
+    participant_qos.flow_controllers().push_back(test_flow_controller);
+    participant_qos.wire_protocol().builtin.flow_controller_name = "test_flow_controller";
+    participant_qos.wire_protocol().builtin.mutation_tries = 5;
+    participant_qos.wire_protocol().builtin.discovery_config.initial_announcements.count = 6;
+    participant_qos.wire_protocol().builtin.discovery_config.initial_announcements.period = {3, 0};
+    participant_qos.wire_protocol().builtin.discovery_config.leaseDuration = {100, 0};
+    participant_qos.wire_protocol().builtin.readerPayloadSize = 700;
+    participant_qos.wire_protocol().builtin.writerPayloadSize = 800;
+
+    Locator_t locator;
+    locator.kind = LOCATOR_KIND_UDPv4;
+    locator.port = participant_qos.wire_protocol().port.getUnicastPort((uint32_t)GET_PID() % 230, 1);
+    IPLocator::setIPv4(locator, "127.0.0.1");
+    participant_qos.wire_protocol().builtin.metatrafficUnicastLocatorList.push_back(locator);
+
+    LocatorWithMask locator_with_mask;
+    IPLocator::setIPv4(locator_with_mask, "127.0.0.1");
+    locator_with_mask.port = locator.port;
+    locator_with_mask.mask(8);
+    ExternalLocators external_locators;
+    external_locators[0][1].push_back(locator_with_mask);
+    participant_qos.wire_protocol().builtin.metatraffic_external_unicast_locators = external_locators;
+
+    locator.port += 1;
+    participant_qos.wire_protocol().default_unicast_locator_list.push_back(locator);
+
+    locator_with_mask.port = locator.port;
+    external_locators[0][1].clear();
+    external_locators[0][1].push_back(locator_with_mask);
+    participant_qos.wire_protocol().default_external_unicast_locators = external_locators;
+
+    IPLocator::setIPv4(locator, "239.255.0.1");
+    locator.port = participant_qos.wire_protocol().port.getMulticastPort((uint32_t)GET_PID() % 230);
+    participant_qos.wire_protocol().builtin.metatrafficMulticastLocatorList.push_back(locator);
+    participant_qos.wire_protocol().builtin.initialPeersList.push_back(locator);
+
+    MSP.setup(participant_qos);
+
+    SampleValidator* validator = MSC.get_sample_validator();
+
+    //! Assert optional qos when received the proxy datas
+    validator->set_assert_optional_remote_data();
+
+    //! Prepare the expected builtin data
+    //! To be received by the MSC
+
+    ParticipantBuiltinTopicData expected_participant_builtin_topic_data;
+    PublicationBuiltinTopicData expected_publication_builtin_topic_data;
+    SubscriptionBuiltinTopicData expected_subscription_builtin_topic_data;
+
+    expected_participant_builtin_topic_data.guid = statistics::to_fastdds_type(MSP.get_participant_guid());
+    expected_participant_builtin_topic_data.wire_protocol = participant_qos.wire_protocol();
+    expected_participant_builtin_topic_data.wire_protocol->prefix = expected_participant_builtin_topic_data.guid.guidPrefix;
+    expected_participant_builtin_topic_data.wire_protocol->participant_id = 0;
+    expected_participant_builtin_topic_data.wire_protocol->builtin.network_configuration = LOCATOR_KIND_SHM;
+
+    validator->register_remote_participant_builtin_topic_data(expected_participant_builtin_topic_data);
+
+    //! Procedure
+    MSC.init_monitor_service_reader();
+    MSP.enable_monitor_service();
+
+    std::list<MonitorServiceType::type> expected_msgs;
+
+    MonitorServiceType::type participant_proxy_msg, writer_proxy_msg, reader_proxy_msg;
+
+    participant_proxy_msg.status_kind(eprosima::fastdds::statistics::StatusKind::PROXY);
+    participant_proxy_msg.local_entity(MSP.get_participant_guid());
+
+    expected_msgs.push_back(participant_proxy_msg);
+
+    DataWriterQos writer_qos;
+    writer_qos.writer_data_lifecycle().autodispose_unregistered_instances = false;
+    writer_qos.publish_mode().kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+    writer_qos.publish_mode().flow_controller_name = "test_flow_controller";
+    writer_qos.reliable_writer_qos().disable_positive_acks.enabled = true;
+    writer_qos.reliable_writer_qos().disable_positive_acks.duration = {1, 0};
+    writer_qos.writer_resource_limits().matched_subscriber_allocation = 1000;
+
+    MSP.create_and_add_writer(writer_qos);
+
+    writer_proxy_msg.status_kind(eprosima::fastdds::statistics::StatusKind::PROXY);
+    StatisticsGUIDList guids = MSP.get_writer_guids();
+
+    ASSERT_EQ(guids.size(), 1u);
+    writer_proxy_msg.local_entity(guids.back());
+
+    expected_msgs.push_back(writer_proxy_msg);
+
+    expected_publication_builtin_topic_data.guid = statistics::to_fastdds_type(guids.back());
+    expected_publication_builtin_topic_data.writer_data_lifecycle = writer_qos.writer_data_lifecycle();
+    expected_publication_builtin_topic_data.publish_mode = writer_qos.publish_mode();
+    expected_publication_builtin_topic_data.rtps_reliable_writer = writer_qos.reliable_writer_qos();
+    expected_publication_builtin_topic_data.writer_resource_limits = writer_qos.writer_resource_limits();
+
+    validator->register_remote_publication_builtin_topic_data(expected_publication_builtin_topic_data);
+
+    DataReaderQos reader_qos;
+    reader_qos.reader_data_lifecycle().autopurge_disposed_samples_delay = {10, 0};
+    reader_qos.reader_data_lifecycle().autopurge_no_writer_samples_delay = {5, 0};
+    reader_qos.reliable_reader_qos().disable_positive_acks.enabled = true;
+    reader_qos.reliable_reader_qos().disable_positive_acks.duration = {1, 0};
+    reader_qos.reader_resource_limits().matched_publisher_allocation = 500;
+    reader_qos.reader_resource_limits().outstanding_reads_allocation = 1000;
+    reader_qos.reader_resource_limits().sample_infos_allocation = 1500;
+    reader_qos.reader_resource_limits().max_samples_per_read = 200;
+
+    MSP.create_and_add_reader(reader_qos);
+
+    reader_proxy_msg.status_kind(eprosima::fastdds::statistics::StatusKind::PROXY);
+    guids = MSP.get_reader_guids();
+
+    ASSERT_EQ(guids.size(), 1u);
+    reader_proxy_msg.local_entity(guids.back());
+
+    expected_msgs.push_back(reader_proxy_msg);
+
+    expected_subscription_builtin_topic_data.guid = statistics::to_fastdds_type(guids.back());
+    expected_subscription_builtin_topic_data.reader_data_lifecycle = reader_qos.reader_data_lifecycle();
+    expected_subscription_builtin_topic_data.rtps_reliable_reader = reader_qos.reliable_reader_qos();
+    expected_subscription_builtin_topic_data.reader_resource_limits = reader_qos.reader_resource_limits();
+
+    validator->register_remote_subscription_builtin_topic_data(expected_subscription_builtin_topic_data);
+
+    MSC.start_reception(expected_msgs);
+
+    //! Assertions
+    ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(5)), expected_msgs.size());
+#endif //FASTDDS_STATISTICS
+}

--- a/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
@@ -1,0 +1,151 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/domain/DomainParticipantListener.hpp>
+#include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
+#include <fastdds/rtps/builtin/data/ParticipantBuiltinTopicData.hpp>
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <fastdds/rtps/common/Locator.hpp>
+#include <fastdds/rtps/participant/ParticipantDiscoveryInfo.hpp>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
+#include <gtest/gtest.h>
+
+#include "../utils/filter_helpers.hpp"
+#include "BlackboxTests.hpp"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+
+auto check_qos_in_data_p =
+        [](eprosima::fastdds::rtps::CDRMessage_t& msg, std::atomic<uint8_t>& qos_found, std::vector<uint16_t>& expected_qos_pids)
+        {
+            uint32_t qos_size = 0;
+            uint32_t original_pos = msg.pos;
+            bool is_sentinel = false;
+
+            while (!is_sentinel)
+            {
+                msg.pos = original_pos + qos_size;
+
+                uint16_t pid = eprosima::fastdds::helpers::cdr_parse_u16(
+                    (char*)&msg.buffer[msg.pos]);
+                msg.pos += 2;
+                uint16_t plength = eprosima::fastdds::helpers::cdr_parse_u16(
+                    (char*)&msg.buffer[msg.pos]);
+                msg.pos += 2;
+                bool valid = true;
+
+                // If inline_qos submessage is found we will have an additional Sentinel
+                if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+                {
+                    // PID_SENTINEL is always considered of length 0
+                    plength = 0;
+                    // If the PID is not inline qos, then we need to set the sentinel
+                    // to true, as it is the last PID
+                    is_sentinel = true;
+                }
+
+                qos_size += (4 + plength);
+
+                // Align to 4 byte boundary and prepare for next iteration
+                qos_size = (qos_size + 3) & ~3;
+
+                if (!valid || ((msg.pos + plength) > msg.length))
+                {
+                    return false;
+                }
+                else if (!is_sentinel)
+                {
+                    //std::cout << std::hex << "PID: " << pid << std::endl;
+                    if (pid == eprosima::fastdds::dds::PID_WIREPROTOCOL_CONFIG)
+                    {
+                        std::cout << "WireProtocolConfig found" << std::endl;
+                        qos_found.fetch_add(1u, std::memory_order_seq_cst);
+                    }
+                    // Delete the PID from the expected list if present
+                    expected_qos_pids.erase(
+                        std::remove(expected_qos_pids.begin(), expected_qos_pids.end(), pid),
+                        expected_qos_pids.end());
+                }
+            }
+
+            // Do not drop the packet in any case
+            return false;
+        };
+
+// This tests checks that non-default optional QoS are correctly sent in the Data(p)
+// QoS that should be sent:
+// - WireProtocolConfigQos
+// a) The test is run with the property set to false, so the optional QoS are not serialized.
+// b) The test is run with the property set to true, so the optional QoS are serialized.
+// Note: In a Participant, if the property 'fastdds.serialize_optional_qos' is set to true,
+// the optional QoS are always serialized.
+TEST(DDSParticipant, participant_sends_non_default_qos_optional)
+{
+
+    std::atomic<uint8_t> qos_found { 0 };
+    std::vector<uint16_t> expected_qos_pids = {
+        eprosima::fastdds::dds::PID_WIREPROTOCOL_CONFIG
+    };
+    const uint8_t expected_qos_size = static_cast<uint8_t>(expected_qos_pids.size());
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    test_transport->drop_builtin_data_messages_filter_ = [&](eprosima::fastdds::rtps::CDRMessage_t& msg)
+            {
+                return check_qos_in_data_p(msg, qos_found, expected_qos_pids);
+            };
+
+    // Default participant QoS
+    writer.disable_builtin_transport()
+          .add_user_transport_to_pparams(test_transport);
+
+    // a) Init both entities without setting the property
+    writer.init();
+    reader.init();
+    ASSERT_TRUE(writer.isInitialized());
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // No optional QoS should be sent.
+    EXPECT_EQ(qos_found.load(), 0u);
+    EXPECT_EQ(expected_qos_pids.size(), expected_qos_size);
+
+    // b) Now set the property to serialize optional QoS and re-init the reader
+    writer.destroy();
+    reader.wait_writer_undiscovery();
+    qos_found.store(0);
+
+    eprosima::fastdds::dds::PropertyPolicyQos properties;
+    properties.properties().emplace_back("fastdds.serialize_optional_qos", "true");
+    writer.property_policy(properties);
+
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Check that the optional QoS are serialized
+    // It may be found more than one time due to initial announcements
+    EXPECT_GE(qos_found.load(), expected_qos_size);
+    EXPECT_EQ(expected_qos_pids.size(), 0u);
+}

--- a/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
@@ -71,7 +71,6 @@ auto check_qos_in_data_p =
                 }
                 else if (!is_sentinel)
                 {
-                    //std::cout << std::hex << "PID: " << pid << std::endl;
                     if (pid == eprosima::fastdds::dds::PID_WIREPROTOCOL_CONFIG)
                     {
                         std::cout << "WireProtocolConfig found" << std::endl;
@@ -130,7 +129,7 @@ TEST(DDSParticipant, participant_sends_non_default_qos_optional)
     EXPECT_EQ(qos_found.load(), 0u);
     EXPECT_EQ(expected_qos_pids.size(), expected_qos_size);
 
-    // b) Now set the property to serialize optional QoS and re-init the reader
+    // b) Now set the property to serialize optional QoS and re-init the writer
     writer.destroy();
     reader.wait_writer_undiscovery();
     qos_found.store(0);

--- a/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsParticipant.cpp
@@ -31,7 +31,8 @@
 #include "PubSubWriter.hpp"
 
 auto check_qos_in_data_p =
-        [](eprosima::fastdds::rtps::CDRMessage_t& msg, std::atomic<uint8_t>& qos_found, std::vector<uint16_t>& expected_qos_pids)
+        [](eprosima::fastdds::rtps::CDRMessage_t& msg, std::atomic<uint8_t>& qos_found,
+                std::vector<uint16_t>& expected_qos_pids)
         {
             uint32_t qos_size = 0;
             uint32_t original_pos = msg.pos;
@@ -114,7 +115,7 @@ TEST(DDSParticipant, participant_sends_non_default_qos_optional)
 
     // Default participant QoS
     writer.disable_builtin_transport()
-          .add_user_transport_to_pparams(test_transport);
+            .add_user_transport_to_pparams(test_transport);
 
     // a) Init both entities without setting the property
     writer.init();

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -143,6 +143,8 @@ public:
 
     MOCK_METHOD0(get_persistence_guid_prefix, GuidPrefix_t());
 
+    MOCK_METHOD0(should_send_optional_qos, bool());
+
 #if HAVE_SECURITY
     MOCK_CONST_METHOD0(security_attributes, const security::ParticipantSecurityAttributes& ());
 

--- a/test/unittest/rtps/discovery/PDPTests.cpp
+++ b/test/unittest/rtps/discovery/PDPTests.cpp
@@ -149,6 +149,7 @@ public:
         RTPSParticipantAllocationAttributes attrs;
         ParticipantProxyData* pdata = new ParticipantProxyData(attrs);
         pdata->guid = part_guid;
+        pdata->wire_protocol = dds::WireProtocolConfigQos();
 
         add_participant_proxy_data(part_guid, false, pdata);
         pdatas_.push_back(pdata);

--- a/versions.md
+++ b/versions.md
@@ -4,6 +4,8 @@ Forthcoming
 * QoS Policies are now only added to EDP messages if they do not have the default value.
 * HistoryQosPolicy has been included to EDP messages (when non-default value is used).
 * New property to extend EDP messages with eProsima Extensions QoS.
+  * Added optional serialization of `WireProtocolConfigQos` to the `ParticipantDiscoveryData`.
+* Monitor service now serializes all optional QoS in the ProxyDatas.
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the optional `WireProtocolConfigQos` serialization to Data(p)s based on the property `fastdds.serialize_optional_qos`. 
It also makes monitor service to always serialize the optional qos for Data(p), Data(w) and Data(r).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- NO Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    - Related documentation PR: eProsima/Fast-DDS-docs#1068
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
