### PR TITLE
[21670] Avoid Data Race in Reader Locator

### DIFF
--- a/src/cpp/rtps/RTPSDomain.cpp
+++ b/src/cpp/rtps/RTPSDomain.cpp
@@ -856,21 +856,27 @@ RTPSParticipantImpl* RTPSDomainImpl::find_local_participant(
     return nullptr;
 }
 
-std::shared_ptr<LocalReaderPointer> RTPSDomainImpl::find_local_reader(
+void RTPSDomainImpl::find_local_reader(
+        std::shared_ptr<LocalReaderPointer>& local_reader,
         const GUID_t& reader_guid)
 {
     auto instance = get_instance();
     std::lock_guard<std::mutex> guard(instance->m_mutex);
-    for (const t_p_RTPSParticipant& participant : instance->m_RTPSParticipants)
+    if (!local_reader)
     {
-        if (participant.second->getGuid().guidPrefix == reader_guid.guidPrefix)
+        for (const t_p_RTPSParticipant& participant : instance->m_RTPSParticipants)
         {
-            // Participant found, forward the query
-            return participant.second->find_local_reader(reader_guid);
+            if (participant.second->getGuid().guidPrefix == reader_guid.guidPrefix)
+            {
+                // Participant found, forward the query
+                local_reader = participant.second->find_local_reader(reader_guid);
+                break;
+            }
         }
+        // If the reader was not found, local_reader will remain nullptr
     }
 
-    return std::shared_ptr<LocalReaderPointer>(nullptr);
+    return;
 }
 
 BaseWriter* RTPSDomainImpl::find_local_writer(

--- a/src/cpp/rtps/RTPSDomainImpl.hpp
+++ b/src/cpp/rtps/RTPSDomainImpl.hpp
@@ -213,11 +213,13 @@ public:
     /**
      * Find a local-process reader.
      *
-     * @param reader_guid GUID of the local reader to search.
+     * @param [in, out] local_reader Reference to the shared pointer to be set.
+     * @param           reader_guid GUID of the local reader to search.
      *
-     * @returns A pointer to a local reader given its endpoint guid, or nullptr if not found.
+     * @returns A shared pointer to a local reader given its endpoint guid, or nullptr if not found.
      */
-    static std::shared_ptr<LocalReaderPointer> find_local_reader(
+    static void find_local_reader(
+            std::shared_ptr<LocalReaderPointer>& local_reader,
             const GUID_t& reader_guid);
 
     /**

--- a/src/cpp/rtps/writer/ReaderLocator.cpp
+++ b/src/cpp/rtps/writer/ReaderLocator.cpp
@@ -208,10 +208,7 @@ bool ReaderLocator::send(
 
 LocalReaderPointer::Instance ReaderLocator::local_reader()
 {
-    if (!local_reader_)
-    {
-        local_reader_ = RTPSDomainImpl::find_local_reader(general_locator_info_.remote_guid);
-    }
+    RTPSDomainImpl::find_local_reader(local_reader_, general_locator_info_.remote_guid);
     return LocalReaderPointer::Instance(local_reader_);
 }
 

--- a/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
+++ b/test/mock/rtps/RTPSDomainImpl/rtps/RTPSDomainImpl.hpp
@@ -134,8 +134,10 @@ public:
     }
 
     static RTPSReader* find_local_reader(
+            RTPSReader* local_reader,
             const GUID_t& reader_guid)
     {
+        static_cast<void>(local_reader);
         static_cast<void>(reader_guid);
         return nullptr;
     }

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -422,6 +422,7 @@ public:
     }
 
     RTPSReader* find_local_reader(
+            RTPSReader*,
             const GUID_t&)
     {
         return nullptr;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR modifies `find_local_reader` method to assign the `local_reader` shared pointer within the function, instead of returning the value. In this way, all operations are protected by the `RTPSDomain` mutex and no data race can occur.

This Data Race is reported by DDS Router CI.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x 2.10.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
