### PR TITLE
[23264] Feature: `DataWriter` sample prefilter

### DIFF
--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -613,6 +613,7 @@ public:
      */
     FASTDDS_EXPORTED_API ReturnCode_t set_sample_prefilter(
             std::shared_ptr<IContentFilter> prefilter);
+
 protected:
 
     DataWriterImpl* impl_;

--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -55,6 +55,8 @@ class DataWriterListener;
 class DataWriterQos;
 class Topic;
 
+struct IContentFilter;
+
 /**
  * Class DataWriter, contains the actual implementation of the behaviour of the DataWriter.
  *
@@ -596,6 +598,21 @@ public:
     FASTDDS_EXPORTED_API ReturnCode_t get_publication_builtin_topic_data(
             PublicationBuiltinTopicData& publication_data) const;
 
+    /**
+     *  @brief Set a sample prefilter to be used. This filter is always
+     *  evaluated before sending the sample to any DataReader and prior to
+     *  any content filtering.
+     *  Reader filters should be enabled in the DataWriter.
+     *
+     * @param prefilter The prefilter to be set.
+     *
+     * @return RETCODE_OK if the prefilter is set correctly,
+     * @return RETCODE_PRECONDITION_NOT_MET if the reader filters are not enabled.
+     *
+     * @note The prefilter is currently incompatible with DataSharing.
+     */
+    FASTDDS_EXPORTED_API ReturnCode_t set_sample_prefilter(
+            std::shared_ptr<IContentFilter> prefilter);
 protected:
 
     DataWriterImpl* impl_;

--- a/include/fastdds/dds/topic/IContentFilter.hpp
+++ b/include/fastdds/dds/topic/IContentFilter.hpp
@@ -48,7 +48,8 @@ struct IContentFilter
 
         FilterSampleInfo() = default;
 
-        FilterSampleInfo(const rtps::WriteParams &wparams)
+        FilterSampleInfo(
+                const rtps::WriteParams& wparams)
             : sample_identity(wparams.sample_identity())
             , related_sample_identity(wparams.related_sample_identity())
             , user_write_data(wparams.user_write_data())

--- a/include/fastdds/dds/topic/IContentFilter.hpp
+++ b/include/fastdds/dds/topic/IContentFilter.hpp
@@ -24,6 +24,7 @@
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/SampleIdentity.hpp>
 #include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
 
 namespace eprosima {
 namespace fastdds {
@@ -45,10 +46,21 @@ struct IContentFilter
     {
         using SampleIdentity = eprosima::fastdds::rtps::SampleIdentity;
 
+        FilterSampleInfo() = default;
+
+        FilterSampleInfo(const rtps::WriteParams &wparams)
+            : sample_identity(wparams.sample_identity())
+            , related_sample_identity(wparams.related_sample_identity())
+            , user_write_data(wparams.user_write_data())
+        {
+        }
+
         /// Identity of the sample being filtered.
         SampleIdentity sample_identity;
         /// Identity of a sample related to the one being filtered.
         SampleIdentity related_sample_identity;
+        /// Extra write information that can be used by the prefilter.
+        std::shared_ptr<fastdds::rtps::WriteParams::UserWriteData> user_write_data;
     };
 
     /**

--- a/include/fastdds/rtps/common/WriteParams.hpp
+++ b/include/fastdds/rtps/common/WriteParams.hpp
@@ -18,6 +18,8 @@
 #ifndef FASTDDS_RTPS_COMMON__WRITEPARAMS_HPP
 #define FASTDDS_RTPS_COMMON__WRITEPARAMS_HPP
 
+#include <memory>
+
 #include <fastdds/rtps/common/SampleIdentity.hpp>
 #include <fastdds/rtps/common/Time_t.hpp>
 
@@ -33,6 +35,19 @@ namespace rtps {
 class FASTDDS_EXPORTED_API WriteParams
 {
 public:
+
+    /**
+     * @brief Base class storing custom information in the
+     * WriteParams structure for later filtering.
+     *
+     * This struct serves as a base class that allows derived
+     * classes to be deleted safely through a pointer to this base type.
+     * It is intended to be user-extensible.
+     */
+    struct UserWriteData
+    {
+        virtual ~UserWriteData() = default;
+    };
 
     /**
      * Set the value of the sample_identity member.
@@ -178,6 +193,30 @@ public:
         return *this;
     }
 
+    /**
+     * @brief Retrieves the user write data.
+     *
+     * @return Shared pointer to the user write data.
+     */
+    std::shared_ptr<UserWriteData> user_write_data() const
+    {
+        return user_write_data_;
+    }
+
+    /**
+     * Set the user write data.
+     *
+     * @param write_data  New value for the user_write_data member.
+     *
+     * @return Reference to the modified object in order to allow daisy chaining.
+     */
+    WriteParams& user_write_data(
+            std::shared_ptr<UserWriteData> write_data)
+    {
+        user_write_data_ = write_data;
+        return *this;
+    }
+
     static WriteParams WRITE_PARAM_DEFAULT;
 
     /**
@@ -204,6 +243,8 @@ private:
     SampleIdentity related_sample_identity_;
     /// Attribute that holds source_timestamp member value
     Time_t source_timestamp_{ -1, TIME_T_INFINITE_NANOSECONDS };
+    /// User write data
+    std::shared_ptr<UserWriteData> user_write_data_ = nullptr;
 };
 
 }  // namespace rtps

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -305,6 +305,12 @@ ReturnCode_t DataWriter::get_publication_builtin_topic_data(
     return impl_->get_publication_builtin_topic_data(publication_data);
 }
 
+ReturnCode_t DataWriter::set_sample_prefilter(
+            std::shared_ptr<IContentFilter> prefilter)
+{
+    return impl_->set_sample_prefilter(prefilter);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima

--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -306,7 +306,7 @@ ReturnCode_t DataWriter::get_publication_builtin_topic_data(
 }
 
 ReturnCode_t DataWriter::set_sample_prefilter(
-            std::shared_ptr<IContentFilter> prefilter)
+        std::shared_ptr<IContentFilter> prefilter)
 {
     return impl_->set_sample_prefilter(prefilter);
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1500,6 +1500,13 @@ ReturnCode_t DataWriterImpl::get_publication_matched_status(
     return RETCODE_OK;
 }
 
+ReturnCode_t DataWriterImpl::set_sample_prefilter(
+        std::shared_ptr<IContentFilter> prefilter)
+{
+    ReturnCode_t ret_code = RETCODE_OK;
+    return ret_code;
+}
+
 bool DataWriterImpl::deadline_timer_reschedule()
 {
     assert(qos_.deadline().period != dds::c_TimeInfinite);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1504,6 +1504,17 @@ ReturnCode_t DataWriterImpl::set_sample_prefilter(
         std::shared_ptr<IContentFilter> prefilter)
 {
     ReturnCode_t ret_code = RETCODE_OK;
+    if (!reader_filters_)
+    {
+        EPROSIMA_LOG_ERROR(DATA_WRITER, "Filtering is not enabled for this DataWriter");
+        ret_code = RETCODE_PRECONDITION_NOT_MET;
+    }
+    else
+    {
+        std::lock_guard<std::mutex> lock(sample_prefilter_mutex_);
+        sample_prefilter_ = prefilter;
+    }
+
     return ret_code;
 }
 
@@ -2379,9 +2390,27 @@ bool DataWriterImpl::is_relevant(
         const fastdds::rtps::CacheChange_t& change,
         const fastdds::rtps::GUID_t& reader_guid) const
 {
-    assert(reader_filters_);
+    assert(reader_filters_ || sample_prefilter_);
+    bool is_relevant_for_reader = true;
     const DataWriterFilteredChange& writer_change = static_cast<const DataWriterFilteredChange&>(change);
-    return writer_change.is_relevant_for(reader_guid);
+
+    {
+        std::lock_guard<std::mutex> lock(sample_prefilter_mutex_);
+        if (sample_prefilter_)
+        {
+            IContentFilter::FilterSampleInfo filter_sample_info(writer_change.write_params);
+            is_relevant_for_reader = sample_prefilter_->evaluate(writer_change.serializedPayload,
+                            filter_sample_info,
+                            reader_guid);
+        }
+    }
+
+    if (is_relevant_for_reader && reader_filters_)
+    {
+        is_relevant_for_reader = writer_change.is_relevant_for(reader_guid);
+    }
+
+    return is_relevant_for_reader;
 }
 
 } // namespace dds

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -417,6 +417,20 @@ public:
     ReturnCode_t get_publication_builtin_topic_data(
             PublicationBuiltinTopicData& publication_data) const;
 
+    /**
+     *  @brief Set a sample prefilter to be used. This filter is always
+     *  evaluated before sending the sample to any DataReader and prior to
+     *  any content filtering.
+     *  Reader filters should be enabled in the DataWriter.
+     *
+     * @param prefilter The prefilter to be set.
+     *
+     * @return RETCODE_OK if the prefilter is set correctly,
+     * @return RETCODE_PRECONDITION_NOT_MET if the reader filters are not enabled.
+     */
+    ReturnCode_t set_sample_prefilter(
+            std::shared_ptr<IContentFilter> prefilter);
+
 protected:
 
     using IChangePool = eprosima::fastdds::rtps::IChangePool;
@@ -536,6 +550,9 @@ protected:
     std::unique_ptr<ReaderFilterCollection> reader_filters_;
 
     DataRepresentationId_t data_representation_ {DEFAULT_DATA_REPRESENTATION};
+
+    mutable std::mutex sample_prefilter_mutex_;
+    std::shared_ptr<IContentFilter> sample_prefilter_;
 
     ReturnCode_t check_write_preconditions(
             const void* const data,

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -282,7 +282,8 @@ protected:
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     reader->get_subscription_matched_status(status);
-                } while (status.current_count < 1);
+                }
+                while (status.current_count < 1);
             }
 
             return reader;
@@ -706,6 +707,98 @@ TEST(DDSContentFilter, OnlyFilterAliveChanges)
     ASSERT_EQ(reader.valid_samples.load(), 10u);
     ASSERT_EQ(reader.invalid_samples.load(), 10u);
     ASSERT_EQ(reader.get_sample_lost_status().total_count, 0);
+}
+
+/**
+ * @test DataWriter Sample prefilter feature
+ *
+ * This test asserts that prefiltering with an active content filter works correctly.
+ * It creates a ContentFilteredTopic an expression that only accepts samples with index <= 6.
+ * On its side, the prefilter is set to only accept samples with 4 < index < 8
+ */
+TEST_P(DDSContentFilter, filter_with_prefilter)
+{
+    // TODO(Mario-DL): Remove when multiple filtering readers case is fixed for data-sharing
+    if (enable_datasharing)
+    {
+        GTEST_SKIP() << "Several filtering readers not correctly working on data sharing";
+    }
+
+    struct CustomUserWriteData : public rtps::WriteParams::UserWriteData
+    {
+        CustomUserWriteData(
+                const uint16_t& upper_bound_idx,
+                const uint16_t& lower_bound_idx )
+            : upper_bound_idx_(upper_bound_idx)
+            , lower_bound_idx_(lower_bound_idx)
+        {
+        }
+
+        uint16_t upper_bound_idx_;
+        uint16_t lower_bound_idx_;
+    };
+
+    struct CustomPreFilter : public eprosima::fastdds::dds::IContentFilter
+    {
+        //! Custom filter for the HelloWorld example
+        bool evaluate(
+                const SerializedPayload& payload,
+                const FilterSampleInfo& filter_sample_info,
+                const rtps::GUID_t&) const override
+        {
+            HelloWorldPubSubType hello_world_type_support;
+            HelloWorld hello_world_sample;
+            hello_world_type_support.deserialize(*const_cast<SerializedPayload*>(&payload), &hello_world_sample);
+
+            bool sample_should_be_sent = true;
+
+            auto custom_write_data =
+                    std::static_pointer_cast<CustomUserWriteData>(filter_sample_info.user_write_data);
+
+            // Filter out samples
+            if (hello_world_sample.index() > custom_write_data->upper_bound_idx_ ||
+                    hello_world_sample.index() < custom_write_data->lower_bound_idx_)
+            {
+                sample_should_be_sent = false;
+            }
+            return sample_should_be_sent;
+        }
+
+    };
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME, "index <= %0", {"6"}, true, false, false);
+
+    // Initialize writer and the filtered reader
+    TestState state;
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // wait for discovery between writer and filtered reader
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Set a prefilter on the filtered reader
+    ASSERT_EQ(writer.set_sample_prefilter(
+                std::make_shared<CustomPreFilter>()),
+            eprosima::fastdds::dds::RETCODE_OK);
+
+    // Set a user write data on the writer to filter out samples 4 < index < 8
+    rtps::WriteParams write_params;
+    write_params.user_write_data(std::make_shared<CustomUserWriteData>(
+                8u, 4u));
+    writer.write_params(write_params);
+
+    auto data = default_helloworld_data_generator();
+
+    reader.startReception(data);
+
+    writer.send(data, 50, true);
+
+    // Reader should have received 3 samples
+    ASSERT_EQ(reader.block_for_all(std::chrono::seconds(1)), 3u);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -442,6 +442,12 @@ public:
         return RETCODE_ERROR;
     }
 
+    ReturnCode_t set_sample_prefilter(
+            std::shared_ptr<IContentFilter>)
+    {
+        return RETCODE_OK;
+    }
+
     //! Pointer to the associated Data Writer.
     fastdds::rtps::RTPSWriter* writer_ = nullptr;
     Topic* topic_ = nullptr;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR brings the `prefiltering` feature in the `DataWriter`. This operation lets user to filter out destination readers fro a particular sample based on the `SerializedPayload` and/or `WriteParams` by implementing a `IContentFilter` interface. 

It also extends the `FilteredSampleInfo` and the `WriteParams` structures to include a new member `UserWriteData` meant to be extended by the user.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.1.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [X] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [X] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- NO Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- NO Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
