### PR TITLE
Update RPC example types

### DIFF
--- a/examples/cpp/rpc/types/calculatorClient.cxx
+++ b/examples/cpp/rpc/types/calculatorClient.cxx
@@ -205,6 +205,7 @@ private:
             std::shared_ptr<T> result,
             std::promise<TResult>& promise)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);
@@ -224,6 +225,7 @@ private:
             const RequestType& request,
             std::shared_ptr<T> result)
     {
+        result->info.related_sample_identity.writer_guid(requester_->get_requester_reader()->guid());
         if (fdds::RETCODE_OK == requester_->send_request((void*)&request, result->info))
         {
             std::lock_guard<std::mutex> _ (mtx_);

--- a/examples/cpp/rpc/types/calculatorServer.cxx
+++ b/examples/cpp/rpc/types/calculatorServer.cxx
@@ -64,6 +64,7 @@ namespace frtps = eprosima::fastdds::rtps;
 
 class CalculatorServerLogic
     : public CalculatorServer
+    , public std::enable_shared_from_this<CalculatorServerLogic>
 {
     using RequestType = Calculator_Request;
     using ReplyType = Calculator_Reply;
@@ -71,14 +72,29 @@ class CalculatorServerLogic
 public:
 
     CalculatorServerLogic(
-            eprosima::fastdds::dds::DomainParticipant& part,
+            fdds::DomainParticipant& part,
             const char* service_name,
-            const eprosima::fastdds::dds::ReplierQos& qos,
+            const fdds::ReplierQos& qos,
             size_t thread_pool_size,
+            std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
+        : CalculatorServerLogic(
+                part,
+                service_name,
+                qos,
+                std::make_shared<ThreadPool>(*this, thread_pool_size),
+                std::move(implementation))
+    {
+    }
+
+    CalculatorServerLogic(
+            fdds::DomainParticipant& part,
+            const char* service_name,
+            const fdds::ReplierQos& qos,
+            std::shared_ptr<CalculatorServerSchedulingStrategy> scheduler,
             std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
         : CalculatorServer()
         , participant_(part)
-        , thread_pool_(*this, thread_pool_size)
+        , request_scheduler_(scheduler)
         , implementation_(std::move(implementation))
     {
         // Register the service type support
@@ -106,8 +122,6 @@ public:
 
     ~CalculatorServerLogic() override
     {
-        stop();
-
         if (nullptr != replier_)
         {
             participant_.delete_service_replier(service_->get_service_name(), replier_);
@@ -174,7 +188,21 @@ public:
         }
 
         // Wait for all threads to finish
-        thread_pool_.stop();
+        request_scheduler_->server_stopped(shared_from_this());
+    }
+
+    void execute_request(
+            const std::shared_ptr<CalculatorServer_ClientContext>& request) override
+    {
+        auto ctx = std::dynamic_pointer_cast<RequestContext>(request);
+        if (ctx)
+        {
+            execute_request(ctx);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid request context type");
+        }
     }
 
 private:
@@ -999,6 +1027,7 @@ private:
     };
 
     struct ThreadPool
+        : public CalculatorServerSchedulingStrategy
     {
         ThreadPool(
                 CalculatorServerLogic& server,
@@ -1015,7 +1044,7 @@ private:
                     {
                         while (!finished_)
                         {
-                            std::shared_ptr<RequestContext> req;
+                            std::shared_ptr<CalculatorServer_ClientContext> req;
                             {
                                 std::unique_lock<std::mutex> lock(mtx_);
                                 cv_.wait(lock, [this]()
@@ -1041,9 +1070,12 @@ private:
             }
         }
 
-        void new_request(
-                const std::shared_ptr<RequestContext>& req)
+        void schedule_request(
+                const std::shared_ptr<CalculatorServer_ClientContext>& req,
+                const std::shared_ptr<CalculatorServer>& server) override
         {
+            static_cast<void>(server);
+
             std::lock_guard<std::mutex> lock(mtx_);
             if (!finished_)
             {
@@ -1052,8 +1084,11 @@ private:
             }
         }
 
-        void stop()
+        void server_stopped(
+                const std::shared_ptr<CalculatorServer>& server) override
         {
+            static_cast<void>(server);
+
             // Notify all threads in the pool to stop
             {
                 std::lock_guard<std::mutex> lock(mtx_);
@@ -1075,7 +1110,7 @@ private:
         CalculatorServerLogic& server_;
         std::mutex mtx_;
         std::condition_variable cv_;
-        std::queue<std::shared_ptr<RequestContext>> requests_;
+        std::queue<std::shared_ptr<CalculatorServer_ClientContext>> requests_;
         bool finished_{ false };
         std::vector<std::thread> threads_;
     };
@@ -1107,7 +1142,7 @@ private:
             processing_requests_[id] = ctx;
         }
 
-        thread_pool_.new_request(ctx);
+        request_scheduler_->schedule_request(ctx, shared_from_this());
     }
 
     void execute_request(
@@ -1312,9 +1347,47 @@ private:
     fdds::GuardCondition finish_condition_;
     std::mutex mtx_;
     std::map<frtps::SampleIdentity, std::shared_ptr<RequestContext>> processing_requests_;
-    ThreadPool thread_pool_;
+    std::shared_ptr<CalculatorServerSchedulingStrategy> request_scheduler_;
     std::shared_ptr<CalculatorServer_IServerImplementation> implementation_;
 
+};
+
+struct CalculatorServerProxy
+    : public CalculatorServer
+{
+    CalculatorServerProxy(
+            std::shared_ptr<CalculatorServer> impl)
+        : impl_(std::move(impl))
+    {
+    }
+
+    ~CalculatorServerProxy() override
+    {
+        if (impl_)
+        {
+            impl_->stop();
+        }
+    }
+
+    void run() override
+    {
+        impl_->run();
+    }
+
+    void stop() override
+    {
+        impl_->stop();
+    }
+
+    void execute_request(
+            const std::shared_ptr<CalculatorServer_ClientContext>& request) override
+    {
+        impl_->execute_request(request);
+    }
+
+private:
+
+   std::shared_ptr<CalculatorServer> impl_;
 };
 
 }  // namespace detail
@@ -1326,8 +1399,21 @@ std::shared_ptr<CalculatorServer> create_CalculatorServer(
         size_t thread_pool_size,
         std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
 {
-    return std::make_shared<detail::CalculatorServerLogic>(
+    auto ptr = std::make_shared<detail::CalculatorServerLogic>(
         part, service_name, qos, thread_pool_size, implementation);
+    return std::make_shared<detail::CalculatorServerProxy>(ptr);
+}
+
+std::shared_ptr<CalculatorServer> create_CalculatorServer(
+        eprosima::fastdds::dds::DomainParticipant& part,
+        const char* service_name,
+        const eprosima::fastdds::dds::ReplierQos& qos,
+        std::shared_ptr<CalculatorServerSchedulingStrategy> scheduler,
+        std::shared_ptr<CalculatorServer_IServerImplementation> implementation)
+{
+    auto ptr = std::make_shared<detail::CalculatorServerLogic>(
+        part, service_name, qos, scheduler, implementation);
+    return std::make_shared<detail::CalculatorServerProxy>(ptr);
 }
 
 //} interface Calculator


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This updates the RPC example autogenerated types after the following PR was merged.

- https://github.com/eProsima/Fast-DDS-Gen/pull/482

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- ❌ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- ❌ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
