### PR TITLE
[23207] clip min_low_mark to handle the acked changes properly.

### DIFF
--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -932,8 +932,10 @@ bool StatefulReader::process_gap_msg(
         // TODO (Miguel C): Refactor this inside WriterProxy
         SequenceNumber_t auxSN;
         SequenceNumber_t finalSN = gapList.base();
+        // Avoids iterating over sequence numbers already known irrelevant or processed
+        SequenceNumber_t startSN = std::max(gapStart, pWP->available_changes_max());
         History::const_iterator history_iterator = history_->changesBegin();
-        for (auxSN = gapStart; auxSN < finalSN; auxSN++)
+        for (auxSN = startSN; auxSN < finalSN; auxSN++)
         {
             if (pWP->irrelevant_change_set(auxSN))
             {

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1460,7 +1460,7 @@ void StatefulWriter::check_acked_status()
     // To prevent this condition, clip min_low_mark to handle the acked changes.
     if (all_acked)
     {
-      min_low_mark = mp_history->next_sequence_number() - 1;
+        min_low_mark = history_->next_sequence_number() - 1;
     }
 
     bool something_changed = all_acked;

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1453,6 +1453,16 @@ void StatefulWriter::check_acked_status()
             }
             );
 
+    // In situation that there are recently matched readers to the writer has not yet
+    // sent changes, both 'min_low_mark = zero' and 'all_acked == true' will be met.
+    // In this scenario, onWriterChangeReceivedByAll() will be skipped for the acked
+    // changes, that causes the changes to remain in history indefinitely.
+    // To prevent this condition, clip min_low_mark to handle the acked changes.
+    if (all_acked)
+    {
+      min_low_mark = mp_history->next_sequence_number() - 1;
+    }
+
     bool something_changed = all_acked;
     SequenceNumber_t min_seq = get_seq_num_min();
     if (min_seq != SequenceNumber_t::unknown())


### PR DESCRIPTION
## Description

Closes https://github.com/ros2/rmw_fastrtps/issues/789

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
