### PR TITLE
[23265] Allow creation of built-in content filters with different type name

### DIFF
--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterFactory.cpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterFactory.cpp
@@ -473,15 +473,15 @@ static std::shared_ptr<xtypes::TypeObject> get_complete_type_object(
 
     // If not found, try to get the complete TypeObject from the type identifier
     xtypes::TypeObject complete_type_object;
-    if (xtypes::EK_MINIMAL == data_type->type_identifiers().type_identifier1()._d())
-    {
-        ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_object(
-            data_type->type_identifiers().type_identifier2(), complete_type_object);
-    }
-    else
+    if (xtypes::EK_COMPLETE == data_type->type_identifiers().type_identifier1()._d())
     {
         ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_object(
             data_type->type_identifiers().type_identifier1(), complete_type_object);
+    }
+    else if (xtypes::EK_COMPLETE == data_type->type_identifiers().type_identifier2()._d())
+    {
+        ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_object(
+            data_type->type_identifiers().type_identifier2(), complete_type_object);
     }
 
     if (RETCODE_OK == ret)

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -802,6 +802,36 @@ TEST_P(DDSContentFilter, filter_with_prefilter)
     ASSERT_EQ(reader.block_for_all(std::chrono::seconds(1)), 3u);
 }
 
+/*
+ * Regression test for https://eprosima.easyredmine.com/issues/23265
+ *
+ * This test checks that a DDSSQL content filter can be created with a type name that is different from the one
+ * in the generated type support.
+ */
+TEST(DDSContentFilter, filter_other_type_name)
+{
+    using namespace eprosima::fastdds;
+
+    // Create a DomainParticipant
+    DomainParticipant* participant =
+            dds::DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    // Create a ContentFilteredTopic with a different type name
+    dds::TypeSupport type_support(new HelloWorldPubSubType());
+    ASSERT_EQ(type_support.register_type(participant, "CustomType"), RETCODE_OK);
+    dds::Topic* topic = participant->create_topic(
+        "TestTopic", "CustomType", TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+    dds::ContentFilteredTopic* filtered_topic = participant->create_contentfilteredtopic(
+        "FilteredTopic", topic, "index <= %0", { "6" });
+    ASSERT_NE(filtered_topic, nullptr);
+
+    // Delete all entities
+    ASSERT_EQ(participant->delete_contained_entities(), RETCODE_OK);
+    ASSERT_EQ(dds::DomainParticipantFactory::get_instance()->delete_participant(participant), RETCODE_OK);
+}
+
 #ifdef INSTANTIATE_TEST_SUITE_P
 #define GTEST_INSTANTIATE_TEST_MACRO(x, y, z, w) INSTANTIATE_TEST_SUITE_P(x, y, z, w)
 #else

--- a/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
@@ -559,6 +559,28 @@ TEST_F(DDSSQLFilterTests, type_compatibility_compare_operand_op_operand)
     }
 }
 
+/*
+ * Regression test for https://eprosima.easyredmine.com/issues/23265
+ *
+ * This test checks that a DDSSQL content filter can be created with a type name that is different from the one
+ * used to register the type object representation.
+ */
+TEST_F(DDSSQLFilterTests, different_type_name)
+{
+    ContentFilterTestTypePubSubType type;
+    type.register_type_object_representation();
+
+    IContentFilter* filter_instance = nullptr;
+    DDSFilterFactory factory;
+    StackAllocatedSequence<const char*, 10> params;
+
+    EXPECT_EQ(factory.create_content_filter("DDSSQL", "MyCustomType", &type,
+            "uint16_field = 3", params, filter_instance), RETCODE_OK);
+
+    EXPECT_EQ(RETCODE_OK,
+            factory.delete_content_filter("DDSSQL", filter_instance));
+}
+
 /**
  * Singleton that holds the serialized payloads to be evaluated
  */


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This fixes a bug that disallows the creation of built-in content filters when the type support is registered with a custom type name.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
This PR is on top of the following one, and should be merged after it:
- https://github.com/eProsima/Fast-DDS/pull/5861

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
