### PR TITLE
[23325] Add generic interfaces for RPC servers

### DIFF
--- a/include/fastdds/dds/rpc/interfaces.hpp
+++ b/include/fastdds/dds/rpc/interfaces.hpp
@@ -22,6 +22,7 @@
 #include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcRequest.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServer.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerReader.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerWriter.hpp>

--- a/include/fastdds/dds/rpc/interfaces.hpp
+++ b/include/fastdds/dds/rpc/interfaces.hpp
@@ -25,6 +25,7 @@
 #include <fastdds/dds/rpc/interfaces/RpcRequest.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServer.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerReader.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcServerSchedulingStrategy.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerWriter.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>
 

--- a/include/fastdds/dds/rpc/interfaces.hpp
+++ b/include/fastdds/dds/rpc/interfaces.hpp
@@ -22,6 +22,7 @@
 #include <fastdds/dds/rpc/interfaces/RpcClientReader.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcClientWriter.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcFuture.hpp>
+#include <fastdds/dds/rpc/interfaces/RpcServer.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerReader.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcServerWriter.hpp>
 #include <fastdds/dds/rpc/interfaces/RpcStatusCode.hpp>

--- a/include/fastdds/dds/rpc/interfaces/RpcRequest.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcRequest.hpp
@@ -1,0 +1,63 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcRequest.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCREQUEST_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCREQUEST_HPP
+
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/RemoteLocators.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * An interface with generic RPC requests functionality.
+ */
+class RpcRequest
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcRequest() noexcept = default;
+
+    /**
+     * @brief Get the GUID of the client that made the request.
+     *
+     * @return The GUID of the client that made the request.
+     */
+    virtual const eprosima::fastdds::rtps::GUID_t& get_client_id() const = 0;
+
+    /**
+     * @brief Get the locators of the client that made the request.
+     *
+     * @return The locators of the client that made the request.
+     */
+    virtual const eprosima::fastdds::rtps::RemoteLocatorList& get_client_locators() const = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCREQUEST_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcServer.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServer.hpp
@@ -1,0 +1,75 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcServer.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCSERVER_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCSERVER_HPP
+
+#include <memory>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+// Forward declaration of RpcRequest class.
+class RpcRequest;
+
+/**
+ * An interface with generic RPC server functionality.
+ */
+class RpcServer
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcServer() noexcept = default;
+
+    /**
+     * @brief Run the server.
+     *
+     * This method starts the server and begins processing requests.
+     * The method will block until the server is stopped.
+     */
+    virtual void run() = 0;
+
+    /**
+     * @brief Stop the server.
+     *
+     * This method stops the server and releases all resources.
+     * It will cancel all pending requests, and wait for all processing threads to finish before returning.
+     */
+    virtual void stop() = 0;
+
+    /**
+     * @brief Perform execution of a client request.
+     *
+     * @param request The client request to execute.
+     */
+    virtual void execute_request(
+            const std::shared_ptr<RpcRequest>& request) = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCSERVER_HPP

--- a/include/fastdds/dds/rpc/interfaces/RpcServerSchedulingStrategy.hpp
+++ b/include/fastdds/dds/rpc/interfaces/RpcServerSchedulingStrategy.hpp
@@ -1,0 +1,69 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RpcServerSchedulingStrategy.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC_INTERFACES__RPCSERVERSCHEDULINGSTRATEGY_HPP
+#define FASTDDS_DDS_RPC_INTERFACES__RPCSERVERSCHEDULINGSTRATEGY_HPP
+
+#include <memory>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+class RpcRequest;
+class RpcServer;
+
+/**
+ * An interface with generic RPC requests functionality.
+ */
+class RpcServerSchedulingStrategy
+{
+public:
+
+    /**
+     * Destructor.
+     */
+    virtual ~RpcServerSchedulingStrategy() noexcept = default;
+
+    /**
+     * @brief Schedule a request for processing.
+     *
+     * @param request  The request to schedule.
+     * @param server   The server instance that should process the request.
+     */
+    virtual void schedule_request(
+            const std::shared_ptr<RpcRequest>& request,
+            const std::shared_ptr<RpcServer>& server) = 0;
+
+    /**
+     * @brief Informs that a server has been stopped and all its requests have been cancelled.
+     *
+     * @param server  The server instance that has been stopped.
+     */
+    virtual void server_stopped(
+            const std::shared_ptr<RpcServer>& server) = 0;
+
+};
+
+}  // namespace rpc
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+#endif  // FASTDDS_DDS_RPC_INTERFACES__RPCSERVERSCHEDULINGSTRATEGY_HPP


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Adding generic interfaces for RPC server, so the generated code can be cleaner.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __NO__: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
