### PR TITLE
[23253] Split windows workflow (3.2.x backport)

### DIFF
--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -33,13 +33,18 @@ on:
         required: false
         type: string
         default: 'RelWithDebInfo'
+      run-tests:
+        description: 'Run test suite of Fast DDS'
+        required: false
+        type: boolean
+        default: true
 
 defaults:
   run:
     shell: pwsh
 
 jobs:
-  reusable-windows-ci:
+  fastdds_build:
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -98,34 +103,6 @@ jobs:
         with:
           packages: vcstool xmlschema psutil
 
-      - name: Update known hosts file for DNS resolver testing
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
-        run: |
-          $hostfile = "$Env:SystemRoot\system32\drivers" -replace "\\", "/"
-          $hostfile += "/etc/hosts"
-
-          # DNS entries to add
-          $new_entries = @{
-            "localhost.test" = "127.0.0.1", "::1"
-            "www.eprosima.com.test" = "154.56.134.194"
-            "www.acme.com.test" = "216.58.215.164", "2a00:1450:400e:803::2004"
-            "www.foo.com.test" = "140.82.121.4", "140.82.121.3"
-            "acme.org.test" = "ff1e::ffff:efff:1"
-          }
-
-          # Modify the file
-          $mod = { Param([string]$FilePath, [Hashtable]$Entries )
-            $entries.GetEnumerator() |
-              % { $hostname = $_.key; $_.value |
-              % { "{0,-25} {1}" -f $_, $hostname }} |
-              Out-File $filepath -Append
-          }
-
-          & $mod -FilePath $hostfile -Entries $new_entries
-
-          # Show the result
-          gc $hostfile
-
       - name: Get Fast CDR branch
         id: get_fastcdr_branch
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
@@ -163,26 +140,152 @@ jobs:
           colcon_build_args: ${{ inputs.colcon-args }}
           # The following Fast DDS CMake options need to be specified here instead of in the meta files
           # because they vary from platform to platform
+          cmake_args_default: ${{ inputs.cmake-args }} -T ${{ matrix.vs-toolset }} -DTHIRDPARTY_Asio=FORCE -DTHIRDPARTY_TinyXML2=FORCE -DTHIRDPARTY_fastcdr=OFF -DTHIRDPARTY_UPDATE=ON -DCOMPILE_EXAMPLES=ON -DEPROSIMA_EXTRA_CMAKE_CXX_FLAGS="/MP /WX"
+          cmake_build_type: ${{ inputs.cmake-config }}
+          workspace: ${{ github.workspace }}
+
+      - name: Upload build artifacts
+        uses: eProsima/eProsima-CI/external/upload-artifact@v0
+        with:
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+  fastdds_test:
+    needs: fastdds_build
+    if: ${{ inputs.run-tests == true }}
+    name: fastdds_test (${{ matrix.cmake_build_type }}, ${{ matrix.test_filter }})
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        vs-toolset:
+          - 'v142'
+        cmake_build_type:
+          - ${{ inputs.cmake-config }}
+        test_filter:
+          - 'blackbox'
+          - 'unittest-I'
+          - 'unittest-II'
+          - 'examples'
+        filter_expression_blackbox:
+          - 'BlackboxTests|ParticipantTests|SecureDiscoverServer|SimpleCommunication|system.'
+        filter_expression_examples:
+          - 'example_tests'
+        filter_expression_unittests_I:
+          - 'DDSSQLFilterValue'
+
+    steps:
+      - name: Download build artifacts
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: fastdds_build_${{ inputs.label }}
+          path: ${{ github.workspace }}
+
+      - name: Update known hosts file for DNS resolver testing
+        run: |
+          $hostfile = "$Env:SystemRoot\system32\drivers" -replace "\\", "/"
+          $hostfile += "/etc/hosts"
+
+          # DNS entries to add
+          $new_entries = @{
+            "localhost.test" = "127.0.0.1", "::1"
+            "www.eprosima.com.test" = "154.56.134.194"
+            "www.acme.com.test" = "216.58.215.164", "2a00:1450:400e:803::2004"
+            "www.foo.com.test" = "140.82.121.4", "140.82.121.3"
+            "acme.org.test" = "ff1e::ffff:efff:1"
+          }
+
+          # Modify the file
+          $mod = { Param([string]$FilePath, [Hashtable]$Entries )
+            $entries.GetEnumerator() |
+              % { $hostname = $_.key; $_.value |
+              % { "{0,-25} {1}" -f $_, $hostname }} |
+              Out-File $filepath -Append
+          }
+
+          & $mod -FilePath $hostfile -Entries $new_entries
+
+          # Show the result
+          gc $hostfile
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.22.6'
+
+      - name: Install OpenSSL
+        uses: eProsima/eprosima-CI/windows/install_openssl@v0
+        with:
+          version: '3.1.1'
+
+      - name: Update OpenSSL environment variables
+        run: |
+          # Update the environment
+          if (Test-Path -Path $Env:ProgramW6432\OpenSSL)
+          {
+            "OPENSSL64_ROOT=$Env:ProgramW6432\OpenSSL" | Out-File $Env:GITHUB_ENV -Append -Encoding OEM
+          }
+          elseif (Test-Path -Path $Env:ProgramW6432\OpenSSL-Win)
+          {
+            "OPENSSL64_ROOT=$Env:ProgramW6432\OpenSSL-Win" | Out-File $Env:GITHUB_ENV -Append -Encoding OEM
+          }
+          elseif (Test-Path -Path $Env:ProgramW6432\OpenSSL-Win64)
+          {
+            "OPENSSL64_ROOT=$Env:ProgramW6432\OpenSSL-Win64" | Out-File $Env:GITHUB_ENV -Append -Encoding OEM
+          }
+          else
+          {
+            Write-Error -Message "Cannot find OpenSSL installation."
+            exit 1
+          }
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/windows/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/windows/install_python_packages@v0
+        with:
+          packages: vcstool xmlschema psutil
+
+      #Build Windows examples testing docker image
+      - name: Build with example testing
+        if: ${{ matrix.test_filter == 'examples' }}
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/windows/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build.meta ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta
+          colcon_build_args: ${{ inputs.colcon-args }}
+          # The following Fast DDS CMake options need to be specified here instead of in the meta files
+          # because they vary from platform to platform
           cmake_args_default: ${{ inputs.cmake-args }} -T ${{ matrix.vs-toolset }} -DTHIRDPARTY_Asio=FORCE -DTHIRDPARTY_TinyXML2=FORCE -DTHIRDPARTY_fastcdr=OFF -DTHIRDPARTY_UPDATE=ON -DFASTDDS_EXAMPLE_TESTS=ON -DEPROSIMA_EXTRA_CMAKE_CXX_FLAGS="/MP /WX"
           cmake_build_type: ${{ inputs.cmake-config }}
           workspace: ${{ github.workspace }}
 
       - name: Test
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-test') }}
         id: test
         uses: eProsima/eProsima-CI/windows/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta
           colcon_test_args: ${{ inputs.colcon-args }}
           colcon_test_args_default: --event-handlers=console_direct+
-          ctest_args: ${{ inputs.ctest-args }}
+          ctest_args: >
+            ${{ inputs.ctest-args }}
+            ${{ matrix.test_filter == 'blackbox' && format('-R "{0}"', matrix.filter_expression_blackbox) ||
+                matrix.test_filter == 'examples' && format('-R "{0}"', matrix.filter_expression_examples) ||
+                matrix.test_filter == 'unittest-I' && format('-R "{0}" -j 4', matrix.filter_expression_unittests_I) ||
+                format('-E "{0}|{1}|{2}"', matrix.filter_expression_blackbox, matrix.filter_expression_examples, matrix.filter_expression_unittests_I) }}
           packages_names: fastdds
           workspace: ${{ github.workspace }}
           test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
 
       - name: Test summary
         uses: eProsima/eProsima-CI/windows/junit_summary@v0
-        if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'no-test') }}
+        if: ${{ !cancelled() }}
         with:
           junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
           print_summary: 'True'

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -49,3 +49,4 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds_branch: ${{ inputs.fastdds_branch || github.ref || '3.2.x' }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Backprot from #5849 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- **N/A** Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- **N/A** Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- **N/A** Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **N/A** Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- **N/A** Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- **N/A** New feature has been added to the `versions.md` file (if applicable).
- **N/A** New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
