### PR TITLE
[23346] Add get_complete_type_object to `ITypeObjectRegistry`

### DIFF
--- a/include/fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp
@@ -172,6 +172,19 @@ public:
             TypeObject& type_object) = 0;
 
     /**
+     * @brief Get the CompleteTypeObject related to the given type identifiers.
+     *
+     * @param [in] type_identifiers Identifiers of the type being queried.
+     * @param [out] type_object CompleteTypeObject related with the given identifiers.
+     * @return ReturnCode_t RETCODE_OK if the CompleteTypeObject are found in the registry.
+     *                      RETCODE_NO_DATA if the given type_identifiers has not been registered.
+     *                      RETCODE_BAD_PARAMETER if the type_identifiers correspond to an indirect hash.
+     */
+    virtual FASTDDS_EXPORTED_API ReturnCode_t get_complete_type_object(
+            const TypeIdentifierPair& type_identifiers,
+            CompleteTypeObject& type_object) = 0;
+
+    /**
      * @brief Get the TypeInformation related to a specific type_name.
      *
      * @pre type_ids must not be empty.

--- a/include/fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp
+++ b/include/fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp
@@ -88,7 +88,7 @@ public:
      *                      RETCODE_PRECONDITION_NOT_MET if the TypeIdentifier is not consistent with the given
      *                      TypeObject.
      */
-    virtual ReturnCode_t register_type_object(
+    virtual FASTDDS_EXPORTED_API ReturnCode_t register_type_object(
             const TypeObject& type_object,
             TypeIdentifierPair& type_ids) = 0;
 
@@ -184,7 +184,7 @@ public:
      *                      RETCODE_BAD_PARAMETER if the given @ref TypeIdentifier corresponds to a indirect hash TypeIdentifier.
      *                      RETCODE_PRECONDITION_NOT_MET if any type_ids is empty.
      */
-    virtual ReturnCode_t get_type_information(
+    virtual FASTDDS_EXPORTED_API ReturnCode_t get_type_information(
             const TypeIdentifierPair& type_ids,
             TypeInformation& type_information,
             bool with_dependencies = false) = 0;

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterFactory.cpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterFactory.cpp
@@ -461,32 +461,25 @@ static std::shared_ptr<xtypes::TypeObject> get_complete_type_object(
         const TopicDataType* data_type)
 {
     ReturnCode_t ret;
+    auto& registry = DomainParticipantFactory::get_instance()->type_object_registry();
 
     // Try to get the complete TypeObject from the type name
     std::shared_ptr<xtypes::TypeObjectPair> type_objects = std::make_shared<xtypes::TypeObjectPair>();
-    ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_objects(
-        type_name, *type_objects);
+    ret = registry.get_type_objects(type_name, *type_objects);
     if (RETCODE_OK == ret)
     {
         return std::make_shared<xtypes::TypeObject>(type_objects->complete_type_object);
     }
 
     // If not found, try to get the complete TypeObject from the type identifier
-    xtypes::TypeObject complete_type_object;
-    if (xtypes::EK_COMPLETE == data_type->type_identifiers().type_identifier1()._d())
-    {
-        ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_object(
-            data_type->type_identifiers().type_identifier1(), complete_type_object);
-    }
-    else if (xtypes::EK_COMPLETE == data_type->type_identifiers().type_identifier2()._d())
-    {
-        ret = DomainParticipantFactory::get_instance()->type_object_registry().get_type_object(
-            data_type->type_identifiers().type_identifier2(), complete_type_object);
-    }
+    xtypes::CompleteTypeObject complete_type_object;
+    ret = registry.get_complete_type_object(data_type->type_identifiers(), complete_type_object);
 
     if (RETCODE_OK == ret)
     {
-        return std::make_shared<xtypes::TypeObject>(complete_type_object);
+        auto value = std::make_shared<xtypes::TypeObject>();
+        value->complete(complete_type_object);
+        return value;
     }
 
     return nullptr;

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
@@ -340,10 +340,31 @@ ReturnCode_t TypeObjectRegistry::get_complete_type_object(
         const TypeIdentifierPair& type_identifiers,
         CompleteTypeObject& type_object)
 {
-    static_cast<void>(type_identifiers);
-    static_cast<void>(type_object);
+    TypeIdentifier complete_type_identifier;
+    if (xtypes::EK_COMPLETE == type_identifiers.type_identifier1()._d())
+    {
+        complete_type_identifier = type_identifiers.type_identifier1();
+    }
+    else if (xtypes::EK_COMPLETE == type_identifiers.type_identifier2()._d())
+    {
+        complete_type_identifier = type_identifiers.type_identifier2();
+    }
+    else
+    {
+        return eprosima::fastdds::dds::RETCODE_BAD_PARAMETER;
+    }
 
-    return RETCODE_UNSUPPORTED;
+    try
+    {
+        std::lock_guard<std::mutex> data_guard(type_object_registry_mutex_);
+        type_object = type_registry_entries_.at(complete_type_identifier).type_object.complete();
+    }
+    catch (std::exception&)
+    {
+        return eprosima::fastdds::dds::RETCODE_NO_DATA;
+    }
+
+    return eprosima::fastdds::dds::RETCODE_OK;
 }
 
 ReturnCode_t TypeObjectRegistry::get_type_information(

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
@@ -336,6 +336,16 @@ ReturnCode_t TypeObjectRegistry::get_type_object(
     return eprosima::fastdds::dds::RETCODE_OK;
 }
 
+ReturnCode_t TypeObjectRegistry::get_complete_type_object(
+        const TypeIdentifierPair& type_identifiers,
+        CompleteTypeObject& type_object)
+{
+    static_cast<void>(type_identifiers);
+    static_cast<void>(type_object);
+
+    return RETCODE_UNSUPPORTED;
+}
+
 ReturnCode_t TypeObjectRegistry::get_type_information(
         const TypeIdentifierPair& type_ids,
         TypeInformation& type_information,

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -232,6 +232,19 @@ public:
             TypeObject& type_object) override;
 
     /**
+     * @brief Get the CompleteTypeObject related to the given type identifiers.
+     *
+     * @param [in] type_identifiers Identifiers of the type being queried.
+     * @param [out] type_object CompleteTypeObject related with the given identifiers.
+     * @return ReturnCode_t RETCODE_OK if the CompleteTypeObject are found in the registry.
+     *                      RETCODE_NO_DATA if the given type_identifiers has not been registered.
+     *                      RETCODE_BAD_PARAMETER if the type_identifiers correspond to an indirect hash.
+     */
+    ReturnCode_t get_complete_type_object(
+            const TypeIdentifierPair& type_identifiers,
+            CompleteTypeObject& type_object) override;
+
+    /**
      * @brief Build the TypeInformation related to the provided @ref TypeIdentifierPair.
      *
      * @pre type_ids must not be empty. At least @ref TypeIdentifierPair::type_identifier1 must be filled.

--- a/test/mock/xtypes/TypeObjectRegistry/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/test/mock/xtypes/TypeObjectRegistry/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -69,6 +69,10 @@ public:
                 const TypeIdentifier& /*type_identifier*/,
                 TypeObject & /*type_object*/), (override));
 
+    MOCK_METHOD(ReturnCode_t, get_complete_type_object, (
+                const TypeIdentifierPair& /*type_identifier*/,
+                CompleteTypeObject & /*type_object*/), (override));
+
     MOCK_METHOD(ReturnCode_t, get_type_objects, (
                 const std::string& /*type_name*/,
                 TypeObjectPair & /*type_objects*/), (override));

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
@@ -134,6 +134,34 @@ TEST(TypeObjectRegistryTests, get_type_objects)
     EXPECT_EQ(type_objects.complete_type_object, type_object);
 }
 
+// Test TypeObjectRegistry::get_complete_type_object
+TEST(TypeObjectRegistryTests, get_complete_type_object)
+{
+    CompleteTypeObject type_object;
+    TypeIdentifierPair type_ids;
+    auto& registry = DomainParticipantFactory::get_instance()->type_object_registry();
+
+    EXPECT_EQ(RETCODE_BAD_PARAMETER, registry.get_complete_type_object(type_ids, type_object));
+
+    EXPECT_EQ(RETCODE_OK, registry.get_type_identifiers(boolean_type_name, type_ids));
+    EXPECT_EQ(RETCODE_BAD_PARAMETER, registry.get_complete_type_object(type_ids, type_object));
+
+    TypeIdentifier alias_type_id;
+    alias_type_id._d(TK_BYTE);
+    CompleteAliasType complete_alias_type;
+    complete_alias_type.header().detail().type_name("alias_name");
+    complete_alias_type.body().common().related_type(alias_type_id);
+    CompleteTypeObject input_type_object;
+    input_type_object.alias_type(complete_alias_type);
+    TypeObject reg_type_object;
+    reg_type_object.complete(input_type_object);
+
+    TypeIdentifierPair reg_type_object_ids;
+    EXPECT_EQ(RETCODE_OK, registry.register_type_object(reg_type_object, reg_type_object_ids));
+    EXPECT_EQ(RETCODE_OK, registry.get_complete_type_object(reg_type_object_ids, type_object));
+    EXPECT_EQ(type_object, input_type_object);
+}
+
 // Test TypeObjectRegistry::get_type_identifiers
 TEST(TypeObjectRegistryTests, get_type_identifiers)
 {

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
@@ -60,6 +60,25 @@ TEST(TypeObjectRegistryTests, register_type_object)
             type_object, type_ids));
 }
 
+// Test TypeObjectRegistry::register_type_object
+TEST(TypeObjectRegistryTests, register_type_object_no_name)
+{
+    TypeIdentifier type_id;
+    type_id._d(TK_BYTE);
+    CompleteAliasType complete_alias_type;
+    complete_alias_type.header().detail().type_name("alias_name");
+    CompleteTypeObject type_object;
+    type_object.alias_type(complete_alias_type);
+    complete_alias_type.body().common().related_type(type_id);
+    type_object.alias_type(complete_alias_type);
+
+    TypeIdentifierPair type_ids;
+    TypeObject t;
+    t.complete(type_object);
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+            DomainParticipantFactory::get_instance()->type_object_registry().register_type_object(t, type_ids));
+}
+
 // Test TypeObjectRegistry::register_type_identifier
 TEST(TypeObjectRegistryTests, register_type_identifier)
 {
@@ -257,6 +276,30 @@ TEST(TypeObjectRegistryTests, get_type_identifiers_primitive_types)
     type_id._d(TK_CHAR16);
     EXPECT_EQ(type_ids.type_identifier1(), type_id);
     EXPECT_EQ(type_ids.type_identifier2(), none_type_id);
+}
+
+// Test TypeObjectRegistry::get_type_information
+TEST(TypeObjectRegistryTests, get_type_information)
+{
+    auto& registry = DomainParticipantFactory::get_instance()->type_object_registry();
+
+    TypeIdentifier type_id;
+    type_id._d(TK_BYTE);
+    CompleteAliasType complete_alias_type;
+    complete_alias_type.header().detail().type_name("alias_name");
+    CompleteTypeObject type_object;
+    type_object.alias_type(complete_alias_type);
+    complete_alias_type.body().common().related_type(type_id);
+    type_object.alias_type(complete_alias_type);
+
+    TypeIdentifierPair type_ids;
+    TypeObject t;
+    t.complete(type_object);
+    EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
+        DomainParticipantFactory::get_instance()->type_object_registry().register_type_object(t, type_ids));
+
+    TypeInformation type_info;
+    EXPECT_EQ(RETCODE_OK, registry.get_type_information(type_ids, type_info, false));
 }
 
 } // xtypes

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
@@ -324,7 +324,7 @@ TEST(TypeObjectRegistryTests, get_type_information)
     TypeObject t;
     t.complete(type_object);
     EXPECT_EQ(eprosima::fastdds::dds::RETCODE_OK,
-        DomainParticipantFactory::get_instance()->type_object_registry().register_type_object(t, type_ids));
+            DomainParticipantFactory::get_instance()->type_object_registry().register_type_object(t, type_ids));
 
     TypeInformation type_info;
     EXPECT_EQ(RETCODE_OK, registry.get_type_information(type_ids, type_info, false));

--- a/versions.md
+++ b/versions.md
@@ -10,6 +10,7 @@ Forthcoming
 * Add DataWriter Sample Prefilter feature:
   * New `DataWriter::set_sample_prefilter` method.
   * New `WriteParams::UserWriteData` extensible struct.
+* Add `get_complete_type_object` to `ITypeObjectRegistry`
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds a new getter to `ITypeObjectRegistry` that allows getting a `CompleteTypeObject` from a registered `TypeIdentifierPair`.

This is the follow-up that we decided to do in https://github.com/eProsima/Fast-DDS/pull/5867#discussion_r2144500362, so the related code in `DDSFilterFactory` has also been updated.

It also exports two methods and adds unit tests for them.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
