### PR TITLE
[23268] Add methods for TypeObject registration of RPC types

### DIFF
--- a/include/fastdds/dds/rpc/RPCTypeObjectSupport.hpp
+++ b/include/fastdds/dds/rpc/RPCTypeObjectSupport.hpp
@@ -33,7 +33,7 @@ namespace rpc {
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -46,7 +46,7 @@ FASTDDS_EXPORTED_API void register_RpcException_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -59,7 +59,7 @@ FASTDDS_EXPORTED_API void register_RpcBrokenPipeException_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -72,7 +72,7 @@ FASTDDS_EXPORTED_API void register_RpcStatusCode_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -85,7 +85,7 @@ FASTDDS_EXPORTED_API void register_RpcFeedCancelledException_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -98,7 +98,7 @@ FASTDDS_EXPORTED_API void register_RpcOperationError_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -111,7 +111,7 @@ FASTDDS_EXPORTED_API void register_RemoteExceptionCode_t_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */
@@ -124,7 +124,7 @@ FASTDDS_EXPORTED_API void register_RpcRemoteException_type_identifier(
  *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
  *        indirectly registered as well.
  *
- * @param[out] TypeIdentifier of the registered type.
+ * @param[out] type_ids TypeIdentifier of the registered type.
  *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
  *             Invalid TypeIdentifier is returned in case of error.
  */

--- a/include/fastdds/dds/rpc/RPCTypeObjectSupport.hpp
+++ b/include/fastdds/dds/rpc/RPCTypeObjectSupport.hpp
@@ -1,0 +1,139 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file RPCTypeObjectSupport.hpp
+ */
+
+#ifndef FASTDDS_DDS_RPC__RPCTYPEOBJECTSUPPORT_HPP
+#define FASTDDS_DDS_RPC__RPCTYPEOBJECTSUPPORT_HPP
+
+#include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
+#include <fastdds/fastdds_dll.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+/**
+ * @brief Register RpcException related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcException_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcBrokenPipeException related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcBrokenPipeException_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcStatusCode related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcStatusCode_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcFeedCancelledException related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcFeedCancelledException_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcOperationError related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcOperationError_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RemoteExceptionCode_t related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RemoteExceptionCode_t_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcRemoteException related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcRemoteException_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+/**
+ * @brief Register RpcTimeoutException related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+FASTDDS_EXPORTED_API void register_RpcTimeoutException_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+
+} // namespace rpc
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima
+
+#endif // FASTDDS_DDS_RPC__RPCTYPEOBJECTSUPPORT_HPP

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -76,6 +76,7 @@ set(${PROJECT_NAME}_source_files
     fastdds/rpc/ServiceImpl.cpp
     fastdds/rpc/ReplierImpl.cpp
     fastdds/rpc/RequesterImpl.cpp
+    fastdds/rpc/RPCTypeObjectSupport.cpp
     fastdds/rpc/ServiceTypeSupport.cpp
     fastdds/subscriber/DataReader.cpp
     fastdds/subscriber/DataReaderImpl.cpp

--- a/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
+++ b/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
@@ -43,16 +43,20 @@ void register_RpcException_type_identifier(
 {
     ReturnCode_t return_code_RpcException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcException =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcException);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcException)
     {
-        StructTypeFlag struct_flags_RpcException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcException = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_RpcException = "eprosima::fastdds::dds::rpc::RpcException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcException;
-        CompleteTypeDetail detail_RpcException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcException, ann_custom_RpcException, type_name_RpcException.to_string());
+        CompleteTypeDetail detail_RpcException = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcException, ann_custom_RpcException,
+            type_name_RpcException.to_string());
         CompleteStructHeader header_RpcException;
         header_RpcException = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_RpcException);
         CompleteStructMemberSeq member_seq_RpcException;
@@ -60,7 +64,8 @@ void register_RpcException_type_identifier(
             TypeIdentifierPair type_ids_message;
             ReturnCode_t return_code_message {eprosima::fastdds::dds::RETCODE_OK};
             return_code_message =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_message);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_message)
@@ -73,15 +78,19 @@ void register_RpcException_type_identifier(
                             "anonymous_string_unbounded", type_ids_message))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_message = 0x00000000;
             bool common_message_ec {false};
-            CommonStructMember common_message {TypeObjectUtils::build_common_struct_member(member_id_message, member_flags_message, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_message, common_message_ec))};
+            CommonStructMember common_message {TypeObjectUtils::build_common_struct_member(member_id_message,
+                                                       member_flags_message, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_message,
+                                                           common_message_ec))};
             if (!common_message_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure message member TypeIdentifier inconsistent.");
@@ -90,13 +99,18 @@ void register_RpcException_type_identifier(
             MemberName name_message = "message";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_message;
             ann_custom_RpcException.reset();
-            CompleteMemberDetail detail_message = TypeObjectUtils::build_complete_member_detail(name_message, member_ann_builtin_message, ann_custom_RpcException);
-            CompleteStructMember member_message = TypeObjectUtils::build_complete_struct_member(common_message, detail_message);
+            CompleteMemberDetail detail_message = TypeObjectUtils::build_complete_member_detail(name_message,
+                            member_ann_builtin_message,
+                            ann_custom_RpcException);
+            CompleteStructMember member_message = TypeObjectUtils::build_complete_struct_member(common_message,
+                            detail_message);
             TypeObjectUtils::add_complete_struct_member(member_seq_RpcException, member_message);
         }
-        CompleteStructType struct_type_RpcException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcException, header_RpcException, member_seq_RpcException);
+        CompleteStructType struct_type_RpcException = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcException, header_RpcException, member_seq_RpcException);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcException, type_name_RpcException.to_string(), type_ids_RpcException))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcException,
+                type_name_RpcException.to_string(), type_ids_RpcException))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcException already registered in TypeObjectRegistry for a different type.");
@@ -111,14 +125,17 @@ void register_RpcBrokenPipeException_type_identifier(
 
     ReturnCode_t return_code_RpcBrokenPipeException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcBrokenPipeException =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcBrokenPipeException", type_ids_RpcBrokenPipeException);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcBrokenPipeException)
     {
-        StructTypeFlag struct_flags_RpcBrokenPipeException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcBrokenPipeException = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         return_code_RpcBrokenPipeException =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcBrokenPipeException);
 
         if (return_code_RpcBrokenPipeException != eprosima::fastdds::dds::RETCODE_OK)
@@ -128,15 +145,19 @@ void register_RpcBrokenPipeException_type_identifier(
         QualifiedTypeName type_name_RpcBrokenPipeException = "eprosima::fastdds::dds::rpc::RpcBrokenPipeException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcBrokenPipeException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcBrokenPipeException;
-        CompleteTypeDetail detail_RpcBrokenPipeException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcBrokenPipeException, ann_custom_RpcBrokenPipeException, type_name_RpcBrokenPipeException.to_string());
+        CompleteTypeDetail detail_RpcBrokenPipeException = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcBrokenPipeException, ann_custom_RpcBrokenPipeException,
+            type_name_RpcBrokenPipeException.to_string());
         CompleteStructHeader header_RpcBrokenPipeException;
         if (EK_COMPLETE == type_ids_RpcBrokenPipeException.type_identifier1()._d())
         {
-            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcBrokenPipeException.type_identifier1(), detail_RpcBrokenPipeException);
+            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcBrokenPipeException.type_identifier1(), detail_RpcBrokenPipeException);
         }
         else if (EK_COMPLETE == type_ids_RpcBrokenPipeException.type_identifier2()._d())
         {
-            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcBrokenPipeException.type_identifier2(), detail_RpcBrokenPipeException);
+            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcBrokenPipeException.type_identifier2(), detail_RpcBrokenPipeException);
         }
         else
         {
@@ -145,9 +166,12 @@ void register_RpcBrokenPipeException_type_identifier(
             return;
         }
         CompleteStructMemberSeq member_seq_RpcBrokenPipeException;
-        CompleteStructType struct_type_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcBrokenPipeException, header_RpcBrokenPipeException, member_seq_RpcBrokenPipeException);
+        CompleteStructType struct_type_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcBrokenPipeException, header_RpcBrokenPipeException,
+            member_seq_RpcBrokenPipeException);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcBrokenPipeException, type_name_RpcBrokenPipeException.to_string(), type_ids_RpcBrokenPipeException))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcBrokenPipeException,
+                type_name_RpcBrokenPipeException.to_string(), type_ids_RpcBrokenPipeException))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcBrokenPipeException already registered in TypeObjectRegistry for a different type.");
@@ -160,7 +184,8 @@ void register_RpcStatusCode_type_identifier(
 {
     ReturnCode_t return_code_RpcStatusCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcStatusCode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcStatusCode", type_ids_RpcStatusCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcStatusCode)
     {
@@ -168,11 +193,14 @@ void register_RpcStatusCode_type_identifier(
         QualifiedTypeName type_name_RpcStatusCode = "eprosima::fastdds::dds::rpc::RpcStatusCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcStatusCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcStatusCode;
-        CompleteTypeDetail detail_RpcStatusCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode, type_name_RpcStatusCode.to_string());
+        CompleteTypeDetail detail_RpcStatusCode = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode,
+            type_name_RpcStatusCode.to_string());
         CompleteAliasHeader header_RpcStatusCode = TypeObjectUtils::build_complete_alias_header(detail_RpcStatusCode);
         AliasMemberFlag related_flags_RpcStatusCode = 0;
         return_code_RpcStatusCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "_uint32_t", type_ids_RpcStatusCode);
 
         if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcStatusCode)
@@ -183,24 +211,27 @@ void register_RpcStatusCode_type_identifier(
         }
         bool common_RpcStatusCode_ec {false};
         CommonAliasBody common_RpcStatusCode {TypeObjectUtils::build_common_alias_body(related_flags_RpcStatusCode,
-                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_RpcStatusCode, common_RpcStatusCode_ec))};
+                                                      TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_RpcStatusCode, common_RpcStatusCode_ec))};
         if (!common_RpcStatusCode_ec)
         {
-            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::dds::rpc::RpcStatusCode related TypeIdentifier inconsistent.");
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcStatusCode related TypeIdentifier inconsistent.");
             return;
         }
         eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RpcStatusCode;
         ann_custom_RpcStatusCode.reset();
         CompleteAliasBody body_RpcStatusCode = TypeObjectUtils::build_complete_alias_body(common_RpcStatusCode,
-                member_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode);
-        CompleteAliasType alias_type_RpcStatusCode = TypeObjectUtils::build_complete_alias_type(alias_flags_RpcStatusCode,
-                header_RpcStatusCode, body_RpcStatusCode);
+                        member_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode);
+        CompleteAliasType alias_type_RpcStatusCode = TypeObjectUtils::build_complete_alias_type(
+            alias_flags_RpcStatusCode,
+            header_RpcStatusCode, body_RpcStatusCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
                 TypeObjectUtils::build_and_register_alias_type_object(alias_type_RpcStatusCode,
-                    type_name_RpcStatusCode.to_string(), type_ids_RpcStatusCode))
+                type_name_RpcStatusCode.to_string(), type_ids_RpcStatusCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "eprosima::fastdds::dds::rpc::RpcStatusCode already registered in TypeObjectRegistry for a different type.");
+                    "eprosima::fastdds::dds::rpc::RpcStatusCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
@@ -211,32 +242,42 @@ void register_RpcFeedCancelledException_type_identifier(
 {
     ReturnCode_t return_code_RpcFeedCancelledException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcFeedCancelledException =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcFeedCancelledException", type_ids_RpcFeedCancelledException);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcFeedCancelledException)
     {
-        StructTypeFlag struct_flags_RpcFeedCancelledException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcFeedCancelledException = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         return_code_RpcFeedCancelledException =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcFeedCancelledException);
 
         if (return_code_RpcFeedCancelledException != eprosima::fastdds::dds::RETCODE_OK)
         {
             eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcFeedCancelledException);
         }
-        QualifiedTypeName type_name_RpcFeedCancelledException = "eprosima::fastdds::dds::rpc::RpcFeedCancelledException";
+        QualifiedTypeName type_name_RpcFeedCancelledException =
+                "eprosima::fastdds::dds::rpc::RpcFeedCancelledException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcFeedCancelledException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcFeedCancelledException;
-        CompleteTypeDetail detail_RpcFeedCancelledException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcFeedCancelledException, ann_custom_RpcFeedCancelledException, type_name_RpcFeedCancelledException.to_string());
+        CompleteTypeDetail detail_RpcFeedCancelledException = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcFeedCancelledException, ann_custom_RpcFeedCancelledException,
+            type_name_RpcFeedCancelledException.to_string());
         CompleteStructHeader header_RpcFeedCancelledException;
         if (EK_COMPLETE == type_ids_RpcFeedCancelledException.type_identifier1()._d())
         {
-            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcFeedCancelledException.type_identifier1(), detail_RpcFeedCancelledException);
+            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcFeedCancelledException.type_identifier1(),
+                detail_RpcFeedCancelledException);
         }
         else if (EK_COMPLETE == type_ids_RpcFeedCancelledException.type_identifier2()._d())
         {
-            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcFeedCancelledException.type_identifier2(), detail_RpcFeedCancelledException);
+            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcFeedCancelledException.type_identifier2(),
+                detail_RpcFeedCancelledException);
         }
         else
         {
@@ -249,18 +290,23 @@ void register_RpcFeedCancelledException_type_identifier(
             TypeIdentifierPair type_ids_reason;
             ReturnCode_t return_code_reason {eprosima::fastdds::dds::RETCODE_OK};
             return_code_reason =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "eprosima::fastdds::dds::rpc::RpcStatusCode", type_ids_reason);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_reason)
             {
                 eprosima::fastdds::dds::rpc::register_RpcStatusCode_type_identifier(type_ids_reason);
             }
-            StructMemberFlag member_flags_reason = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_reason = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_reason = 0x00000001;
             bool common_reason_ec {false};
-            CommonStructMember common_reason {TypeObjectUtils::build_common_struct_member(member_id_reason, member_flags_reason, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_reason, common_reason_ec))};
+            CommonStructMember common_reason {TypeObjectUtils::build_common_struct_member(member_id_reason,
+                                                      member_flags_reason, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_reason,
+                                                          common_reason_ec))};
             if (!common_reason_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure reason member TypeIdentifier inconsistent.");
@@ -269,13 +315,19 @@ void register_RpcFeedCancelledException_type_identifier(
             MemberName name_reason = "reason";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_reason;
             ann_custom_RpcFeedCancelledException.reset();
-            CompleteMemberDetail detail_reason = TypeObjectUtils::build_complete_member_detail(name_reason, member_ann_builtin_reason, ann_custom_RpcFeedCancelledException);
-            CompleteStructMember member_reason = TypeObjectUtils::build_complete_struct_member(common_reason, detail_reason);
+            CompleteMemberDetail detail_reason = TypeObjectUtils::build_complete_member_detail(name_reason,
+                            member_ann_builtin_reason,
+                            ann_custom_RpcFeedCancelledException);
+            CompleteStructMember member_reason = TypeObjectUtils::build_complete_struct_member(common_reason,
+                            detail_reason);
             TypeObjectUtils::add_complete_struct_member(member_seq_RpcFeedCancelledException, member_reason);
         }
-        CompleteStructType struct_type_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcFeedCancelledException, header_RpcFeedCancelledException, member_seq_RpcFeedCancelledException);
+        CompleteStructType struct_type_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcFeedCancelledException, header_RpcFeedCancelledException,
+            member_seq_RpcFeedCancelledException);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcFeedCancelledException, type_name_RpcFeedCancelledException.to_string(), type_ids_RpcFeedCancelledException))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcFeedCancelledException,
+                type_name_RpcFeedCancelledException.to_string(), type_ids_RpcFeedCancelledException))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcFeedCancelledException already registered in TypeObjectRegistry for a different type.");
@@ -289,14 +341,17 @@ void register_RpcOperationError_type_identifier(
 {
     ReturnCode_t return_code_RpcOperationError {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcOperationError =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcOperationError", type_ids_RpcOperationError);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcOperationError)
     {
-        StructTypeFlag struct_flags_RpcOperationError = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcOperationError = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         return_code_RpcOperationError =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcOperationError);
 
         if (return_code_RpcOperationError != eprosima::fastdds::dds::RETCODE_OK)
@@ -306,15 +361,19 @@ void register_RpcOperationError_type_identifier(
         QualifiedTypeName type_name_RpcOperationError = "eprosima::fastdds::dds::rpc::RpcOperationError";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcOperationError;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcOperationError;
-        CompleteTypeDetail detail_RpcOperationError = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcOperationError, ann_custom_RpcOperationError, type_name_RpcOperationError.to_string());
+        CompleteTypeDetail detail_RpcOperationError = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcOperationError, ann_custom_RpcOperationError,
+            type_name_RpcOperationError.to_string());
         CompleteStructHeader header_RpcOperationError;
         if (EK_COMPLETE == type_ids_RpcOperationError.type_identifier1()._d())
         {
-            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(type_ids_RpcOperationError.type_identifier1(), detail_RpcOperationError);
+            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcOperationError.type_identifier1(), detail_RpcOperationError);
         }
         else if (EK_COMPLETE == type_ids_RpcOperationError.type_identifier2()._d())
         {
-            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(type_ids_RpcOperationError.type_identifier2(), detail_RpcOperationError);
+            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcOperationError.type_identifier2(), detail_RpcOperationError);
         }
         else
         {
@@ -323,9 +382,11 @@ void register_RpcOperationError_type_identifier(
             return;
         }
         CompleteStructMemberSeq member_seq_RpcOperationError;
-        CompleteStructType struct_type_RpcOperationError = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcOperationError, header_RpcOperationError, member_seq_RpcOperationError);
+        CompleteStructType struct_type_RpcOperationError = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcOperationError, header_RpcOperationError, member_seq_RpcOperationError);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcOperationError, type_name_RpcOperationError.to_string(), type_ids_RpcOperationError))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcOperationError,
+                type_name_RpcOperationError.to_string(), type_ids_RpcOperationError))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcOperationError already registered in TypeObjectRegistry for a different type.");
@@ -338,86 +399,135 @@ void register_RemoteExceptionCode_t_type_identifier(
 {
     ReturnCode_t return_code_RemoteExceptionCode_t {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RemoteExceptionCode_t =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t", type_ids_RemoteExceptionCode_t);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RemoteExceptionCode_t)
     {
         EnumTypeFlag enum_flags_RemoteExceptionCode_t = 0;
         BitBound bit_bound_RemoteExceptionCode_t = 32;
-        CommonEnumeratedHeader common_RemoteExceptionCode_t = TypeObjectUtils::build_common_enumerated_header(bit_bound_RemoteExceptionCode_t);
+        CommonEnumeratedHeader common_RemoteExceptionCode_t = TypeObjectUtils::build_common_enumerated_header(
+            bit_bound_RemoteExceptionCode_t);
         QualifiedTypeName type_name_RemoteExceptionCode_t = "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RemoteExceptionCode_t;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RemoteExceptionCode_t;
-        CompleteTypeDetail detail_RemoteExceptionCode_t = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RemoteExceptionCode_t, ann_custom_RemoteExceptionCode_t, type_name_RemoteExceptionCode_t.to_string());
-        CompleteEnumeratedHeader header_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_header(common_RemoteExceptionCode_t, detail_RemoteExceptionCode_t);
+        CompleteTypeDetail detail_RemoteExceptionCode_t = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RemoteExceptionCode_t, ann_custom_RemoteExceptionCode_t,
+            type_name_RemoteExceptionCode_t.to_string());
+        CompleteEnumeratedHeader header_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_header(
+            common_RemoteExceptionCode_t, detail_RemoteExceptionCode_t);
         CompleteEnumeratedLiteralSeq literal_seq_RemoteExceptionCode_t;
         {
             EnumeratedLiteralFlag flags_REMOTE_EX_OK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_OK = TypeObjectUtils::build_common_enumerated_literal(0, flags_REMOTE_EX_OK);
+            CommonEnumeratedLiteral common_REMOTE_EX_OK = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_REMOTE_EX_OK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_OK;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_OK = "REMOTE_EX_OK";
-            CompleteMemberDetail detail_REMOTE_EX_OK = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_OK, member_ann_builtin_REMOTE_EX_OK, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_OK = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_OK, detail_REMOTE_EX_OK);
+            CompleteMemberDetail detail_REMOTE_EX_OK = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_OK,
+                            member_ann_builtin_REMOTE_EX_OK,
+                            ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_OK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_REMOTE_EX_OK, detail_REMOTE_EX_OK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_OK);
         }
         {
             EnumeratedLiteralFlag flags_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_common_enumerated_literal(1, flags_REMOTE_EX_UNSUPPORTED);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_REMOTE_EX_UNSUPPORTED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNSUPPORTED;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_UNSUPPORTED = "REMOTE_EX_UNSUPPORTED";
-            CompleteMemberDetail detail_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNSUPPORTED, member_ann_builtin_REMOTE_EX_UNSUPPORTED, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNSUPPORTED, detail_REMOTE_EX_UNSUPPORTED);
-            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNSUPPORTED);
+            CompleteMemberDetail detail_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_complete_member_detail(
+                name_REMOTE_EX_UNSUPPORTED, member_ann_builtin_REMOTE_EX_UNSUPPORTED,
+                ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNSUPPORTED =
+                    TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNSUPPORTED,
+                            detail_REMOTE_EX_UNSUPPORTED);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t,
+                    literal_REMOTE_EX_UNSUPPORTED);
         }
         {
-            EnumeratedLiteralFlag flags_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_common_enumerated_literal(2, flags_REMOTE_EX_INVALID_ARGUMENT);
+            EnumeratedLiteralFlag flags_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_enumerated_literal_flag(
+                false);
+            CommonEnumeratedLiteral common_REMOTE_EX_INVALID_ARGUMENT =
+                    TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_REMOTE_EX_INVALID_ARGUMENT);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_INVALID_ARGUMENT;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_INVALID_ARGUMENT = "REMOTE_EX_INVALID_ARGUMENT";
-            CompleteMemberDetail detail_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_INVALID_ARGUMENT, member_ann_builtin_REMOTE_EX_INVALID_ARGUMENT, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_INVALID_ARGUMENT, detail_REMOTE_EX_INVALID_ARGUMENT);
-            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_INVALID_ARGUMENT);
+            CompleteMemberDetail detail_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_complete_member_detail(
+                name_REMOTE_EX_INVALID_ARGUMENT, member_ann_builtin_REMOTE_EX_INVALID_ARGUMENT,
+                ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_INVALID_ARGUMENT =
+                    TypeObjectUtils::build_complete_enumerated_literal(
+                common_REMOTE_EX_INVALID_ARGUMENT, detail_REMOTE_EX_INVALID_ARGUMENT);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t,
+                    literal_REMOTE_EX_INVALID_ARGUMENT);
         }
         {
-            EnumeratedLiteralFlag flags_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_common_enumerated_literal(3, flags_REMOTE_EX_OUT_OF_RESOURCES);
+            EnumeratedLiteralFlag flags_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_enumerated_literal_flag(
+                false);
+            CommonEnumeratedLiteral common_REMOTE_EX_OUT_OF_RESOURCES =
+                    TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_REMOTE_EX_OUT_OF_RESOURCES);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_OUT_OF_RESOURCES;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_OUT_OF_RESOURCES = "REMOTE_EX_OUT_OF_RESOURCES";
-            CompleteMemberDetail detail_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_OUT_OF_RESOURCES, member_ann_builtin_REMOTE_EX_OUT_OF_RESOURCES, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_OUT_OF_RESOURCES, detail_REMOTE_EX_OUT_OF_RESOURCES);
-            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_OUT_OF_RESOURCES);
+            CompleteMemberDetail detail_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_complete_member_detail(
+                name_REMOTE_EX_OUT_OF_RESOURCES, member_ann_builtin_REMOTE_EX_OUT_OF_RESOURCES,
+                ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_OUT_OF_RESOURCES =
+                    TypeObjectUtils::build_complete_enumerated_literal(
+                common_REMOTE_EX_OUT_OF_RESOURCES, detail_REMOTE_EX_OUT_OF_RESOURCES);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t,
+                    literal_REMOTE_EX_OUT_OF_RESOURCES);
         }
         {
-            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_common_enumerated_literal(4, flags_REMOTE_EX_UNKNOWN_OPERATION);
+            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_enumerated_literal_flag(
+                false);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_OPERATION =
+                    TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_REMOTE_EX_UNKNOWN_OPERATION);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNKNOWN_OPERATION;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_UNKNOWN_OPERATION = "REMOTE_EX_UNKNOWN_OPERATION";
-            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNKNOWN_OPERATION, member_ann_builtin_REMOTE_EX_UNKNOWN_OPERATION, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNKNOWN_OPERATION, detail_REMOTE_EX_UNKNOWN_OPERATION);
-            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNKNOWN_OPERATION);
+            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_complete_member_detail(
+                name_REMOTE_EX_UNKNOWN_OPERATION, member_ann_builtin_REMOTE_EX_UNKNOWN_OPERATION,
+                ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_OPERATION =
+                    TypeObjectUtils::build_complete_enumerated_literal(
+                common_REMOTE_EX_UNKNOWN_OPERATION, detail_REMOTE_EX_UNKNOWN_OPERATION);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t,
+                    literal_REMOTE_EX_UNKNOWN_OPERATION);
         }
         {
-            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_common_enumerated_literal(5, flags_REMOTE_EX_UNKNOWN_EXCEPTION);
+            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_enumerated_literal_flag(
+                false);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_EXCEPTION =
+                    TypeObjectUtils::build_common_enumerated_literal(5,
+                            flags_REMOTE_EX_UNKNOWN_EXCEPTION);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNKNOWN_EXCEPTION;
             ann_custom_RemoteExceptionCode_t.reset();
             MemberName name_REMOTE_EX_UNKNOWN_EXCEPTION = "REMOTE_EX_UNKNOWN_EXCEPTION";
-            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNKNOWN_EXCEPTION, member_ann_builtin_REMOTE_EX_UNKNOWN_EXCEPTION, ann_custom_RemoteExceptionCode_t);
-            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNKNOWN_EXCEPTION, detail_REMOTE_EX_UNKNOWN_EXCEPTION);
-            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNKNOWN_EXCEPTION);
+            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_complete_member_detail(
+                name_REMOTE_EX_UNKNOWN_EXCEPTION, member_ann_builtin_REMOTE_EX_UNKNOWN_EXCEPTION,
+                ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_EXCEPTION =
+                    TypeObjectUtils::build_complete_enumerated_literal(
+                common_REMOTE_EX_UNKNOWN_EXCEPTION, detail_REMOTE_EX_UNKNOWN_EXCEPTION);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t,
+                    literal_REMOTE_EX_UNKNOWN_EXCEPTION);
         }
-        CompleteEnumeratedType enumerated_type_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_type(enum_flags_RemoteExceptionCode_t, header_RemoteExceptionCode_t,
-                literal_seq_RemoteExceptionCode_t);
+        CompleteEnumeratedType enumerated_type_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_RemoteExceptionCode_t, header_RemoteExceptionCode_t,
+            literal_seq_RemoteExceptionCode_t);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_RemoteExceptionCode_t, type_name_RemoteExceptionCode_t.to_string(), type_ids_RemoteExceptionCode_t))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_RemoteExceptionCode_t,
+                type_name_RemoteExceptionCode_t.to_string(), type_ids_RemoteExceptionCode_t))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t already registered in TypeObjectRegistry for a different type.");
+                    "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
@@ -428,14 +538,17 @@ void register_RpcRemoteException_type_identifier(
 {
     ReturnCode_t return_code_RpcRemoteException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcRemoteException =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcRemoteException", type_ids_RpcRemoteException);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcRemoteException)
     {
-        StructTypeFlag struct_flags_RpcRemoteException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcRemoteException = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         return_code_RpcRemoteException =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcRemoteException);
 
         if (return_code_RpcRemoteException != eprosima::fastdds::dds::RETCODE_OK)
@@ -445,15 +558,19 @@ void register_RpcRemoteException_type_identifier(
         QualifiedTypeName type_name_RpcRemoteException = "eprosima::fastdds::dds::rpc::RpcRemoteException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcRemoteException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcRemoteException;
-        CompleteTypeDetail detail_RpcRemoteException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcRemoteException, ann_custom_RpcRemoteException, type_name_RpcRemoteException.to_string());
+        CompleteTypeDetail detail_RpcRemoteException = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcRemoteException, ann_custom_RpcRemoteException,
+            type_name_RpcRemoteException.to_string());
         CompleteStructHeader header_RpcRemoteException;
         if (EK_COMPLETE == type_ids_RpcRemoteException.type_identifier1()._d())
         {
-            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcRemoteException.type_identifier1(), detail_RpcRemoteException);
+            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcRemoteException.type_identifier1(), detail_RpcRemoteException);
         }
         else if (EK_COMPLETE == type_ids_RpcRemoteException.type_identifier2()._d())
         {
-            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcRemoteException.type_identifier2(), detail_RpcRemoteException);
+            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcRemoteException.type_identifier2(), detail_RpcRemoteException);
         }
         else
         {
@@ -466,18 +583,23 @@ void register_RpcRemoteException_type_identifier(
             TypeIdentifierPair type_ids_code;
             ReturnCode_t return_code_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_code =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t", type_ids_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_code)
             {
                 eprosima::fastdds::dds::rpc::register_RemoteExceptionCode_t_type_identifier(type_ids_code);
             }
-            StructMemberFlag member_flags_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_code = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_code = 0x00000001;
             bool common_code_ec {false};
-            CommonStructMember common_code {TypeObjectUtils::build_common_struct_member(member_id_code, member_flags_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_code, common_code_ec))};
+            CommonStructMember common_code {TypeObjectUtils::build_common_struct_member(member_id_code,
+                                                    member_flags_code, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                        type_ids_code,
+                                                        common_code_ec))};
             if (!common_code_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure code member TypeIdentifier inconsistent.");
@@ -486,13 +608,18 @@ void register_RpcRemoteException_type_identifier(
             MemberName name_code = "code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_code;
             ann_custom_RpcRemoteException.reset();
-            CompleteMemberDetail detail_code = TypeObjectUtils::build_complete_member_detail(name_code, member_ann_builtin_code, ann_custom_RpcRemoteException);
+            CompleteMemberDetail detail_code = TypeObjectUtils::build_complete_member_detail(name_code,
+                            member_ann_builtin_code,
+                            ann_custom_RpcRemoteException);
             CompleteStructMember member_code = TypeObjectUtils::build_complete_struct_member(common_code, detail_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_RpcRemoteException, member_code);
         }
-        CompleteStructType struct_type_RpcRemoteException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcRemoteException, header_RpcRemoteException, member_seq_RpcRemoteException);
+        CompleteStructType struct_type_RpcRemoteException = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcRemoteException, header_RpcRemoteException,
+            member_seq_RpcRemoteException);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcRemoteException, type_name_RpcRemoteException.to_string(), type_ids_RpcRemoteException))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcRemoteException,
+                type_name_RpcRemoteException.to_string(), type_ids_RpcRemoteException))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcRemoteException already registered in TypeObjectRegistry for a different type.");
@@ -506,14 +633,17 @@ void register_RpcTimeoutException_type_identifier(
 {
     ReturnCode_t return_code_RpcTimeoutException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcTimeoutException =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "eprosima::fastdds::dds::rpc::RpcTimeoutException", type_ids_RpcTimeoutException);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcTimeoutException)
     {
-        StructTypeFlag struct_flags_RpcTimeoutException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_RpcTimeoutException = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         return_code_RpcTimeoutException =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                        get_type_identifiers(
             "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcTimeoutException);
 
         if (return_code_RpcTimeoutException != eprosima::fastdds::dds::RETCODE_OK)
@@ -523,15 +653,19 @@ void register_RpcTimeoutException_type_identifier(
         QualifiedTypeName type_name_RpcTimeoutException = "eprosima::fastdds::dds::rpc::RpcTimeoutException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcTimeoutException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcTimeoutException;
-        CompleteTypeDetail detail_RpcTimeoutException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcTimeoutException, ann_custom_RpcTimeoutException, type_name_RpcTimeoutException.to_string());
+        CompleteTypeDetail detail_RpcTimeoutException = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_RpcTimeoutException, ann_custom_RpcTimeoutException,
+            type_name_RpcTimeoutException.to_string());
         CompleteStructHeader header_RpcTimeoutException;
         if (EK_COMPLETE == type_ids_RpcTimeoutException.type_identifier1()._d())
         {
-            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcTimeoutException.type_identifier1(), detail_RpcTimeoutException);
+            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcTimeoutException.type_identifier1(), detail_RpcTimeoutException);
         }
         else if (EK_COMPLETE == type_ids_RpcTimeoutException.type_identifier2()._d())
         {
-            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcTimeoutException.type_identifier2(), detail_RpcTimeoutException);
+            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(
+                type_ids_RpcTimeoutException.type_identifier2(), detail_RpcTimeoutException);
         }
         else
         {
@@ -540,9 +674,12 @@ void register_RpcTimeoutException_type_identifier(
             return;
         }
         CompleteStructMemberSeq member_seq_RpcTimeoutException;
-        CompleteStructType struct_type_RpcTimeoutException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcTimeoutException, header_RpcTimeoutException, member_seq_RpcTimeoutException);
+        CompleteStructType struct_type_RpcTimeoutException = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_RpcTimeoutException, header_RpcTimeoutException,
+            member_seq_RpcTimeoutException);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcTimeoutException, type_name_RpcTimeoutException.to_string(), type_ids_RpcTimeoutException))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcTimeoutException,
+                type_name_RpcTimeoutException.to_string(), type_ids_RpcTimeoutException))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "eprosima::fastdds::dds::rpc::RpcTimeoutException already registered in TypeObjectRegistry for a different type.");

--- a/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
+++ b/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*!
- * @file RPCTypeObjectSupport.cxx
+ * @file RPCTypeObjectSupport.cpp
  */
 
 #include <fastdds/dds/rpc/RPCTypeObjectSupport.hpp>
@@ -49,11 +49,18 @@ void register_RpcException_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcException)
     {
         StructTypeFlag struct_flags_RpcException = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         QualifiedTypeName type_name_RpcException = "eprosima::fastdds::dds::rpc::RpcException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcException;
+        AppliedAnnotationSeq tmp_ann_custom_RpcException;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcException;
+        if (!tmp_ann_custom_RpcException.empty())
+        {
+            ann_custom_RpcException = tmp_ann_custom_RpcException;
+        }
+
         CompleteTypeDetail detail_RpcException = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcException, ann_custom_RpcException,
             type_name_RpcException.to_string());
@@ -122,7 +129,6 @@ void register_RpcException_type_identifier(
 void register_RpcBrokenPipeException_type_identifier(
         TypeIdentifierPair& type_ids_RpcBrokenPipeException)
 {
-
     ReturnCode_t return_code_RpcBrokenPipeException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcBrokenPipeException =
             eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
@@ -131,8 +137,8 @@ void register_RpcBrokenPipeException_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcBrokenPipeException)
     {
         StructTypeFlag struct_flags_RpcBrokenPipeException = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         return_code_RpcBrokenPipeException =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
                         get_type_identifiers(
@@ -145,6 +151,13 @@ void register_RpcBrokenPipeException_type_identifier(
         QualifiedTypeName type_name_RpcBrokenPipeException = "eprosima::fastdds::dds::rpc::RpcBrokenPipeException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcBrokenPipeException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcBrokenPipeException;
+        AppliedAnnotationSeq tmp_ann_custom_RpcBrokenPipeException;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcBrokenPipeException;
+        if (!tmp_ann_custom_RpcBrokenPipeException.empty())
+        {
+            ann_custom_RpcBrokenPipeException = tmp_ann_custom_RpcBrokenPipeException;
+        }
+
         CompleteTypeDetail detail_RpcBrokenPipeException = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcBrokenPipeException, ann_custom_RpcBrokenPipeException,
             type_name_RpcBrokenPipeException.to_string());
@@ -248,8 +261,8 @@ void register_RpcFeedCancelledException_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcFeedCancelledException)
     {
         StructTypeFlag struct_flags_RpcFeedCancelledException = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         return_code_RpcFeedCancelledException =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
                         get_type_identifiers(
@@ -263,6 +276,13 @@ void register_RpcFeedCancelledException_type_identifier(
                 "eprosima::fastdds::dds::rpc::RpcFeedCancelledException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcFeedCancelledException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcFeedCancelledException;
+        AppliedAnnotationSeq tmp_ann_custom_RpcFeedCancelledException;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcFeedCancelledException;
+        if (!tmp_ann_custom_RpcFeedCancelledException.empty())
+        {
+            ann_custom_RpcFeedCancelledException = tmp_ann_custom_RpcFeedCancelledException;
+        }
+
         CompleteTypeDetail detail_RpcFeedCancelledException = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcFeedCancelledException, ann_custom_RpcFeedCancelledException,
             type_name_RpcFeedCancelledException.to_string());
@@ -347,8 +367,8 @@ void register_RpcOperationError_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcOperationError)
     {
         StructTypeFlag struct_flags_RpcOperationError = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         return_code_RpcOperationError =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
                         get_type_identifiers(
@@ -361,6 +381,13 @@ void register_RpcOperationError_type_identifier(
         QualifiedTypeName type_name_RpcOperationError = "eprosima::fastdds::dds::rpc::RpcOperationError";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcOperationError;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcOperationError;
+        AppliedAnnotationSeq tmp_ann_custom_RpcOperationError;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcOperationError;
+        if (!tmp_ann_custom_RpcOperationError.empty())
+        {
+            ann_custom_RpcOperationError = tmp_ann_custom_RpcOperationError;
+        }
+
         CompleteTypeDetail detail_RpcOperationError = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcOperationError, ann_custom_RpcOperationError,
             type_name_RpcOperationError.to_string());
@@ -411,6 +438,13 @@ void register_RemoteExceptionCode_t_type_identifier(
         QualifiedTypeName type_name_RemoteExceptionCode_t = "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RemoteExceptionCode_t;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RemoteExceptionCode_t;
+        AppliedAnnotationSeq tmp_ann_custom_RemoteExceptionCode_t;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RemoteExceptionCode_t;
+        if (!tmp_ann_custom_RemoteExceptionCode_t.empty())
+        {
+            ann_custom_RemoteExceptionCode_t = tmp_ann_custom_RemoteExceptionCode_t;
+        }
+
         CompleteTypeDetail detail_RemoteExceptionCode_t = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RemoteExceptionCode_t, ann_custom_RemoteExceptionCode_t,
             type_name_RemoteExceptionCode_t.to_string());
@@ -544,8 +578,8 @@ void register_RpcRemoteException_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcRemoteException)
     {
         StructTypeFlag struct_flags_RpcRemoteException = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         return_code_RpcRemoteException =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
                         get_type_identifiers(
@@ -558,6 +592,13 @@ void register_RpcRemoteException_type_identifier(
         QualifiedTypeName type_name_RpcRemoteException = "eprosima::fastdds::dds::rpc::RpcRemoteException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcRemoteException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcRemoteException;
+        AppliedAnnotationSeq tmp_ann_custom_RpcRemoteException;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcRemoteException;
+        if (!tmp_ann_custom_RpcRemoteException.empty())
+        {
+            ann_custom_RpcRemoteException = tmp_ann_custom_RpcRemoteException;
+        }
+
         CompleteTypeDetail detail_RpcRemoteException = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcRemoteException, ann_custom_RpcRemoteException,
             type_name_RpcRemoteException.to_string());
@@ -631,6 +672,7 @@ void register_RpcRemoteException_type_identifier(
 void register_RpcTimeoutException_type_identifier(
         TypeIdentifierPair& type_ids_RpcTimeoutException)
 {
+
     ReturnCode_t return_code_RpcTimeoutException {eprosima::fastdds::dds::RETCODE_OK};
     return_code_RpcTimeoutException =
             eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
@@ -639,8 +681,8 @@ void register_RpcTimeoutException_type_identifier(
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcTimeoutException)
     {
         StructTypeFlag struct_flags_RpcTimeoutException = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::FINAL,
+            true, false);
         return_code_RpcTimeoutException =
                 eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
                         get_type_identifiers(
@@ -653,6 +695,13 @@ void register_RpcTimeoutException_type_identifier(
         QualifiedTypeName type_name_RpcTimeoutException = "eprosima::fastdds::dds::rpc::RpcTimeoutException";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcTimeoutException;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcTimeoutException;
+        AppliedAnnotationSeq tmp_ann_custom_RpcTimeoutException;
+        eprosima::fastcdr::optional<AppliedVerbatimAnnotation> verbatim_RpcTimeoutException;
+        if (!tmp_ann_custom_RpcTimeoutException.empty())
+        {
+            ann_custom_RpcTimeoutException = tmp_ann_custom_RpcTimeoutException;
+        }
+
         CompleteTypeDetail detail_RpcTimeoutException = TypeObjectUtils::build_complete_type_detail(
             type_ann_builtin_RpcTimeoutException, ann_custom_RpcTimeoutException,
             type_name_RpcTimeoutException.to_string());

--- a/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
+++ b/src/cpp/fastdds/rpc/RPCTypeObjectSupport.cpp
@@ -1,0 +1,556 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file RPCTypeObjectSupport.cxx
+ */
+
+#include <fastdds/dds/rpc/RPCTypeObjectSupport.hpp>
+
+#include <mutex>
+#include <string>
+
+#include <fastcdr/xcdr/external.hpp>
+#include <fastcdr/xcdr/optional.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+#include <fastdds/dds/log/Log.hpp>
+#include <fastdds/dds/xtypes/common.hpp>
+#include <fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp>
+#include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
+#include <fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp>
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace rpc {
+
+using namespace eprosima::fastdds::dds::xtypes;
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcException_type_identifier(
+        TypeIdentifierPair& type_ids_RpcException)
+{
+    ReturnCode_t return_code_RpcException {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcException =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcException);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcException)
+    {
+        StructTypeFlag struct_flags_RpcException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_RpcException = "eprosima::fastdds::dds::rpc::RpcException";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcException;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcException;
+        CompleteTypeDetail detail_RpcException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcException, ann_custom_RpcException, type_name_RpcException.to_string());
+        CompleteStructHeader header_RpcException;
+        header_RpcException = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_RpcException);
+        CompleteStructMemberSeq member_seq_RpcException;
+        {
+            TypeIdentifierPair type_ids_message;
+            ReturnCode_t return_code_message {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_message =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_message);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_message)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_message))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_message = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_message = 0x00000000;
+            bool common_message_ec {false};
+            CommonStructMember common_message {TypeObjectUtils::build_common_struct_member(member_id_message, member_flags_message, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_message, common_message_ec))};
+            if (!common_message_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure message member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_message = "message";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_message;
+            ann_custom_RpcException.reset();
+            CompleteMemberDetail detail_message = TypeObjectUtils::build_complete_member_detail(name_message, member_ann_builtin_message, ann_custom_RpcException);
+            CompleteStructMember member_message = TypeObjectUtils::build_complete_struct_member(common_message, detail_message);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RpcException, member_message);
+        }
+        CompleteStructType struct_type_RpcException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcException, header_RpcException, member_seq_RpcException);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcException, type_name_RpcException.to_string(), type_ids_RpcException))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcException already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcBrokenPipeException_type_identifier(
+        TypeIdentifierPair& type_ids_RpcBrokenPipeException)
+{
+
+    ReturnCode_t return_code_RpcBrokenPipeException {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcBrokenPipeException =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcBrokenPipeException", type_ids_RpcBrokenPipeException);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcBrokenPipeException)
+    {
+        StructTypeFlag struct_flags_RpcBrokenPipeException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        return_code_RpcBrokenPipeException =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcBrokenPipeException);
+
+        if (return_code_RpcBrokenPipeException != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcBrokenPipeException);
+        }
+        QualifiedTypeName type_name_RpcBrokenPipeException = "eprosima::fastdds::dds::rpc::RpcBrokenPipeException";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcBrokenPipeException;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcBrokenPipeException;
+        CompleteTypeDetail detail_RpcBrokenPipeException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcBrokenPipeException, ann_custom_RpcBrokenPipeException, type_name_RpcBrokenPipeException.to_string());
+        CompleteStructHeader header_RpcBrokenPipeException;
+        if (EK_COMPLETE == type_ids_RpcBrokenPipeException.type_identifier1()._d())
+        {
+            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcBrokenPipeException.type_identifier1(), detail_RpcBrokenPipeException);
+        }
+        else if (EK_COMPLETE == type_ids_RpcBrokenPipeException.type_identifier2()._d())
+        {
+            header_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcBrokenPipeException.type_identifier2(), detail_RpcBrokenPipeException);
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcBrokenPipeException Structure: base_type TypeIdentifier registered in TypeObjectRegistry is inconsistent.");
+            return;
+        }
+        CompleteStructMemberSeq member_seq_RpcBrokenPipeException;
+        CompleteStructType struct_type_RpcBrokenPipeException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcBrokenPipeException, header_RpcBrokenPipeException, member_seq_RpcBrokenPipeException);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcBrokenPipeException, type_name_RpcBrokenPipeException.to_string(), type_ids_RpcBrokenPipeException))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcBrokenPipeException already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+void register_RpcStatusCode_type_identifier(
+        TypeIdentifierPair& type_ids_RpcStatusCode)
+{
+    ReturnCode_t return_code_RpcStatusCode {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcStatusCode =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcStatusCode", type_ids_RpcStatusCode);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcStatusCode)
+    {
+        AliasTypeFlag alias_flags_RpcStatusCode = 0;
+        QualifiedTypeName type_name_RpcStatusCode = "eprosima::fastdds::dds::rpc::RpcStatusCode";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcStatusCode;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcStatusCode;
+        CompleteTypeDetail detail_RpcStatusCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode, type_name_RpcStatusCode.to_string());
+        CompleteAliasHeader header_RpcStatusCode = TypeObjectUtils::build_complete_alias_header(detail_RpcStatusCode);
+        AliasMemberFlag related_flags_RpcStatusCode = 0;
+        return_code_RpcStatusCode =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "_uint32_t", type_ids_RpcStatusCode);
+
+        if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcStatusCode)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcStatusCode related TypeIdentifier unknown to TypeObjectRegistry.");
+            return;
+        }
+        bool common_RpcStatusCode_ec {false};
+        CommonAliasBody common_RpcStatusCode {TypeObjectUtils::build_common_alias_body(related_flags_RpcStatusCode,
+                TypeObjectUtils::retrieve_complete_type_identifier(type_ids_RpcStatusCode, common_RpcStatusCode_ec))};
+        if (!common_RpcStatusCode_ec)
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "eprosima::fastdds::dds::rpc::RpcStatusCode related TypeIdentifier inconsistent.");
+            return;
+        }
+        eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RpcStatusCode;
+        ann_custom_RpcStatusCode.reset();
+        CompleteAliasBody body_RpcStatusCode = TypeObjectUtils::build_complete_alias_body(common_RpcStatusCode,
+                member_ann_builtin_RpcStatusCode, ann_custom_RpcStatusCode);
+        CompleteAliasType alias_type_RpcStatusCode = TypeObjectUtils::build_complete_alias_type(alias_flags_RpcStatusCode,
+                header_RpcStatusCode, body_RpcStatusCode);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_alias_type_object(alias_type_RpcStatusCode,
+                    type_name_RpcStatusCode.to_string(), type_ids_RpcStatusCode))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::dds::rpc::RpcStatusCode already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcFeedCancelledException_type_identifier(
+        TypeIdentifierPair& type_ids_RpcFeedCancelledException)
+{
+    ReturnCode_t return_code_RpcFeedCancelledException {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcFeedCancelledException =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcFeedCancelledException", type_ids_RpcFeedCancelledException);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcFeedCancelledException)
+    {
+        StructTypeFlag struct_flags_RpcFeedCancelledException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        return_code_RpcFeedCancelledException =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcFeedCancelledException);
+
+        if (return_code_RpcFeedCancelledException != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcFeedCancelledException);
+        }
+        QualifiedTypeName type_name_RpcFeedCancelledException = "eprosima::fastdds::dds::rpc::RpcFeedCancelledException";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcFeedCancelledException;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcFeedCancelledException;
+        CompleteTypeDetail detail_RpcFeedCancelledException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcFeedCancelledException, ann_custom_RpcFeedCancelledException, type_name_RpcFeedCancelledException.to_string());
+        CompleteStructHeader header_RpcFeedCancelledException;
+        if (EK_COMPLETE == type_ids_RpcFeedCancelledException.type_identifier1()._d())
+        {
+            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcFeedCancelledException.type_identifier1(), detail_RpcFeedCancelledException);
+        }
+        else if (EK_COMPLETE == type_ids_RpcFeedCancelledException.type_identifier2()._d())
+        {
+            header_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcFeedCancelledException.type_identifier2(), detail_RpcFeedCancelledException);
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcFeedCancelledException Structure: base_type TypeIdentifier registered in TypeObjectRegistry is inconsistent.");
+            return;
+        }
+        CompleteStructMemberSeq member_seq_RpcFeedCancelledException;
+        {
+            TypeIdentifierPair type_ids_reason;
+            ReturnCode_t return_code_reason {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_reason =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::dds::rpc::RpcStatusCode", type_ids_reason);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_reason)
+            {
+                eprosima::fastdds::dds::rpc::register_RpcStatusCode_type_identifier(type_ids_reason);
+            }
+            StructMemberFlag member_flags_reason = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_reason = 0x00000001;
+            bool common_reason_ec {false};
+            CommonStructMember common_reason {TypeObjectUtils::build_common_struct_member(member_id_reason, member_flags_reason, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_reason, common_reason_ec))};
+            if (!common_reason_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure reason member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_reason = "reason";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_reason;
+            ann_custom_RpcFeedCancelledException.reset();
+            CompleteMemberDetail detail_reason = TypeObjectUtils::build_complete_member_detail(name_reason, member_ann_builtin_reason, ann_custom_RpcFeedCancelledException);
+            CompleteStructMember member_reason = TypeObjectUtils::build_complete_struct_member(common_reason, detail_reason);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RpcFeedCancelledException, member_reason);
+        }
+        CompleteStructType struct_type_RpcFeedCancelledException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcFeedCancelledException, header_RpcFeedCancelledException, member_seq_RpcFeedCancelledException);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcFeedCancelledException, type_name_RpcFeedCancelledException.to_string(), type_ids_RpcFeedCancelledException))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcFeedCancelledException already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcOperationError_type_identifier(
+        TypeIdentifierPair& type_ids_RpcOperationError)
+{
+    ReturnCode_t return_code_RpcOperationError {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcOperationError =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcOperationError", type_ids_RpcOperationError);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcOperationError)
+    {
+        StructTypeFlag struct_flags_RpcOperationError = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        return_code_RpcOperationError =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcOperationError);
+
+        if (return_code_RpcOperationError != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcOperationError);
+        }
+        QualifiedTypeName type_name_RpcOperationError = "eprosima::fastdds::dds::rpc::RpcOperationError";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcOperationError;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcOperationError;
+        CompleteTypeDetail detail_RpcOperationError = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcOperationError, ann_custom_RpcOperationError, type_name_RpcOperationError.to_string());
+        CompleteStructHeader header_RpcOperationError;
+        if (EK_COMPLETE == type_ids_RpcOperationError.type_identifier1()._d())
+        {
+            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(type_ids_RpcOperationError.type_identifier1(), detail_RpcOperationError);
+        }
+        else if (EK_COMPLETE == type_ids_RpcOperationError.type_identifier2()._d())
+        {
+            header_RpcOperationError = TypeObjectUtils::build_complete_struct_header(type_ids_RpcOperationError.type_identifier2(), detail_RpcOperationError);
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcOperationError Structure: base_type TypeIdentifier registered in TypeObjectRegistry is inconsistent.");
+            return;
+        }
+        CompleteStructMemberSeq member_seq_RpcOperationError;
+        CompleteStructType struct_type_RpcOperationError = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcOperationError, header_RpcOperationError, member_seq_RpcOperationError);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcOperationError, type_name_RpcOperationError.to_string(), type_ids_RpcOperationError))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcOperationError already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+void register_RemoteExceptionCode_t_type_identifier(
+        TypeIdentifierPair& type_ids_RemoteExceptionCode_t)
+{
+    ReturnCode_t return_code_RemoteExceptionCode_t {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RemoteExceptionCode_t =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t", type_ids_RemoteExceptionCode_t);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RemoteExceptionCode_t)
+    {
+        EnumTypeFlag enum_flags_RemoteExceptionCode_t = 0;
+        BitBound bit_bound_RemoteExceptionCode_t = 32;
+        CommonEnumeratedHeader common_RemoteExceptionCode_t = TypeObjectUtils::build_common_enumerated_header(bit_bound_RemoteExceptionCode_t);
+        QualifiedTypeName type_name_RemoteExceptionCode_t = "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RemoteExceptionCode_t;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RemoteExceptionCode_t;
+        CompleteTypeDetail detail_RemoteExceptionCode_t = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RemoteExceptionCode_t, ann_custom_RemoteExceptionCode_t, type_name_RemoteExceptionCode_t.to_string());
+        CompleteEnumeratedHeader header_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_header(common_RemoteExceptionCode_t, detail_RemoteExceptionCode_t);
+        CompleteEnumeratedLiteralSeq literal_seq_RemoteExceptionCode_t;
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_OK = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_OK = TypeObjectUtils::build_common_enumerated_literal(0, flags_REMOTE_EX_OK);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_OK;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_OK = "REMOTE_EX_OK";
+            CompleteMemberDetail detail_REMOTE_EX_OK = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_OK, member_ann_builtin_REMOTE_EX_OK, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_OK = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_OK, detail_REMOTE_EX_OK);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_OK);
+        }
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_common_enumerated_literal(1, flags_REMOTE_EX_UNSUPPORTED);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNSUPPORTED;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_UNSUPPORTED = "REMOTE_EX_UNSUPPORTED";
+            CompleteMemberDetail detail_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNSUPPORTED, member_ann_builtin_REMOTE_EX_UNSUPPORTED, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNSUPPORTED = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNSUPPORTED, detail_REMOTE_EX_UNSUPPORTED);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNSUPPORTED);
+        }
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_common_enumerated_literal(2, flags_REMOTE_EX_INVALID_ARGUMENT);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_INVALID_ARGUMENT;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_INVALID_ARGUMENT = "REMOTE_EX_INVALID_ARGUMENT";
+            CompleteMemberDetail detail_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_INVALID_ARGUMENT, member_ann_builtin_REMOTE_EX_INVALID_ARGUMENT, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_INVALID_ARGUMENT = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_INVALID_ARGUMENT, detail_REMOTE_EX_INVALID_ARGUMENT);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_INVALID_ARGUMENT);
+        }
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_common_enumerated_literal(3, flags_REMOTE_EX_OUT_OF_RESOURCES);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_OUT_OF_RESOURCES;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_OUT_OF_RESOURCES = "REMOTE_EX_OUT_OF_RESOURCES";
+            CompleteMemberDetail detail_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_OUT_OF_RESOURCES, member_ann_builtin_REMOTE_EX_OUT_OF_RESOURCES, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_OUT_OF_RESOURCES = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_OUT_OF_RESOURCES, detail_REMOTE_EX_OUT_OF_RESOURCES);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_OUT_OF_RESOURCES);
+        }
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_common_enumerated_literal(4, flags_REMOTE_EX_UNKNOWN_OPERATION);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNKNOWN_OPERATION;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_UNKNOWN_OPERATION = "REMOTE_EX_UNKNOWN_OPERATION";
+            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNKNOWN_OPERATION, member_ann_builtin_REMOTE_EX_UNKNOWN_OPERATION, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_OPERATION = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNKNOWN_OPERATION, detail_REMOTE_EX_UNKNOWN_OPERATION);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNKNOWN_OPERATION);
+        }
+        {
+            EnumeratedLiteralFlag flags_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_enumerated_literal_flag(false);
+            CommonEnumeratedLiteral common_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_common_enumerated_literal(5, flags_REMOTE_EX_UNKNOWN_EXCEPTION);
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_REMOTE_EX_UNKNOWN_EXCEPTION;
+            ann_custom_RemoteExceptionCode_t.reset();
+            MemberName name_REMOTE_EX_UNKNOWN_EXCEPTION = "REMOTE_EX_UNKNOWN_EXCEPTION";
+            CompleteMemberDetail detail_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_complete_member_detail(name_REMOTE_EX_UNKNOWN_EXCEPTION, member_ann_builtin_REMOTE_EX_UNKNOWN_EXCEPTION, ann_custom_RemoteExceptionCode_t);
+            CompleteEnumeratedLiteral literal_REMOTE_EX_UNKNOWN_EXCEPTION = TypeObjectUtils::build_complete_enumerated_literal(common_REMOTE_EX_UNKNOWN_EXCEPTION, detail_REMOTE_EX_UNKNOWN_EXCEPTION);
+            TypeObjectUtils::add_complete_enumerated_literal(literal_seq_RemoteExceptionCode_t, literal_REMOTE_EX_UNKNOWN_EXCEPTION);
+        }
+        CompleteEnumeratedType enumerated_type_RemoteExceptionCode_t = TypeObjectUtils::build_complete_enumerated_type(enum_flags_RemoteExceptionCode_t, header_RemoteExceptionCode_t,
+                literal_seq_RemoteExceptionCode_t);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_RemoteExceptionCode_t, type_name_RemoteExceptionCode_t.to_string(), type_ids_RemoteExceptionCode_t))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcRemoteException_type_identifier(
+        TypeIdentifierPair& type_ids_RpcRemoteException)
+{
+    ReturnCode_t return_code_RpcRemoteException {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcRemoteException =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcRemoteException", type_ids_RpcRemoteException);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcRemoteException)
+    {
+        StructTypeFlag struct_flags_RpcRemoteException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        return_code_RpcRemoteException =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcRemoteException);
+
+        if (return_code_RpcRemoteException != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcRemoteException);
+        }
+        QualifiedTypeName type_name_RpcRemoteException = "eprosima::fastdds::dds::rpc::RpcRemoteException";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcRemoteException;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcRemoteException;
+        CompleteTypeDetail detail_RpcRemoteException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcRemoteException, ann_custom_RpcRemoteException, type_name_RpcRemoteException.to_string());
+        CompleteStructHeader header_RpcRemoteException;
+        if (EK_COMPLETE == type_ids_RpcRemoteException.type_identifier1()._d())
+        {
+            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcRemoteException.type_identifier1(), detail_RpcRemoteException);
+        }
+        else if (EK_COMPLETE == type_ids_RpcRemoteException.type_identifier2()._d())
+        {
+            header_RpcRemoteException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcRemoteException.type_identifier2(), detail_RpcRemoteException);
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcRemoteException Structure: base_type TypeIdentifier registered in TypeObjectRegistry is inconsistent.");
+            return;
+        }
+        CompleteStructMemberSeq member_seq_RpcRemoteException;
+        {
+            TypeIdentifierPair type_ids_code;
+            ReturnCode_t return_code_code {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_code =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "eprosima::fastdds::dds::rpc::RemoteExceptionCode_t", type_ids_code);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_code)
+            {
+                eprosima::fastdds::dds::rpc::register_RemoteExceptionCode_t_type_identifier(type_ids_code);
+            }
+            StructMemberFlag member_flags_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_code = 0x00000001;
+            bool common_code_ec {false};
+            CommonStructMember common_code {TypeObjectUtils::build_common_struct_member(member_id_code, member_flags_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_code, common_code_ec))};
+            if (!common_code_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure code member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_code = "code";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_code;
+            ann_custom_RpcRemoteException.reset();
+            CompleteMemberDetail detail_code = TypeObjectUtils::build_complete_member_detail(name_code, member_ann_builtin_code, ann_custom_RpcRemoteException);
+            CompleteStructMember member_code = TypeObjectUtils::build_complete_struct_member(common_code, detail_code);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RpcRemoteException, member_code);
+        }
+        CompleteStructType struct_type_RpcRemoteException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcRemoteException, header_RpcRemoteException, member_seq_RpcRemoteException);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcRemoteException, type_name_RpcRemoteException.to_string(), type_ids_RpcRemoteException))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcRemoteException already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RpcTimeoutException_type_identifier(
+        TypeIdentifierPair& type_ids_RpcTimeoutException)
+{
+    ReturnCode_t return_code_RpcTimeoutException {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RpcTimeoutException =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "eprosima::fastdds::dds::rpc::RpcTimeoutException", type_ids_RpcTimeoutException);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RpcTimeoutException)
+    {
+        StructTypeFlag struct_flags_RpcTimeoutException = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        return_code_RpcTimeoutException =
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            "eprosima::fastdds::dds::rpc::RpcException", type_ids_RpcTimeoutException);
+
+        if (return_code_RpcTimeoutException != eprosima::fastdds::dds::RETCODE_OK)
+        {
+            eprosima::fastdds::dds::rpc::register_RpcException_type_identifier(type_ids_RpcTimeoutException);
+        }
+        QualifiedTypeName type_name_RpcTimeoutException = "eprosima::fastdds::dds::rpc::RpcTimeoutException";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RpcTimeoutException;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RpcTimeoutException;
+        CompleteTypeDetail detail_RpcTimeoutException = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RpcTimeoutException, ann_custom_RpcTimeoutException, type_name_RpcTimeoutException.to_string());
+        CompleteStructHeader header_RpcTimeoutException;
+        if (EK_COMPLETE == type_ids_RpcTimeoutException.type_identifier1()._d())
+        {
+            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcTimeoutException.type_identifier1(), detail_RpcTimeoutException);
+        }
+        else if (EK_COMPLETE == type_ids_RpcTimeoutException.type_identifier2()._d())
+        {
+            header_RpcTimeoutException = TypeObjectUtils::build_complete_struct_header(type_ids_RpcTimeoutException.type_identifier2(), detail_RpcTimeoutException);
+        }
+        else
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcTimeoutException Structure: base_type TypeIdentifier registered in TypeObjectRegistry is inconsistent.");
+            return;
+        }
+        CompleteStructMemberSeq member_seq_RpcTimeoutException;
+        CompleteStructType struct_type_RpcTimeoutException = TypeObjectUtils::build_complete_struct_type(struct_flags_RpcTimeoutException, header_RpcTimeoutException, member_seq_RpcTimeoutException);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RpcTimeoutException, type_name_RpcTimeoutException.to_string(), type_ids_RpcTimeoutException))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "eprosima::fastdds::dds::rpc::RpcTimeoutException already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+
+} // namespace rpc
+} // namespace dds
+} // namespace fastdds
+} // namespace eprosima

--- a/src/cpp/fastdds/rpc/RPC_idl.md
+++ b/src/cpp/fastdds/rpc/RPC_idl.md
@@ -22,14 +22,14 @@ module dds {
 module rpc {
 
 // Base class for RPC exceptions.
-@nested
+@nested @final
 struct RpcException
 {
     string message;
 };
 
 // Exception thrown by the RPC API when the communication with the remote endpoint breaks.
-@nested
+@nested @final
 struct RpcBrokenPipeException : RpcException
 {
 };
@@ -38,14 +38,14 @@ struct RpcBrokenPipeException : RpcException
 typedef unsigned long RpcStatusCode;
 
 // Exception thrown by the RPC API when the client cancels an input feed.
-@nested
+@nested @final
 struct RpcFeedCancelledException : RpcException
 {
     RpcStatusCode reason;
 };
 
 // Base class for user defined exceptions.
-@nested
+@nested @final
 struct RpcOperationError : RpcException
 {
 };
@@ -54,6 +54,7 @@ struct RpcOperationError : RpcException
  * Enumeration of possible error codes that can be returned by a remote service.
  * Extracted from DDS-RPC v1.0 - 7.5.2 Mapping of Error Codes.
  */
+@final
 enum RemoteExceptionCode_t
 {
     REMOTE_EX_OK,                 // The request was executed successfully.
@@ -65,8 +66,15 @@ enum RemoteExceptionCode_t
 };
 
 // Class for exceptions that map to a RpcExceptionCode_t
-@nested
+@nested @final
 struct RpcRemoteException : RpcException
+{
+    RemoteExceptionCode_t code;
+};
+
+// Exception thrown by the RPC API when an operation times out.
+@nested @final
+struct RpcTimeoutException : RpcException
 {
 };
 

--- a/src/cpp/fastdds/rpc/RPC_idl.md
+++ b/src/cpp/fastdds/rpc/RPC_idl.md
@@ -1,0 +1,78 @@
+# TypeObject support for RPC types
+
+The code for registering the TypeObject of RPC exception classes has been developed by updating
+auto-generated code from the IDL below.
+
+This IDL has not been included in the automatic regeneration script for the following reasons:
+
+* The generated header needs to be a public header, and that requires updating the DLL export
+  annotation, as well as adding the corresponding `#include <fastdds/fastdds_dll.hpp>`.
+  These changes could be automated, but changes in the generated code might also require changes
+  in the automated patch.
+* Only the TypeObject support code is necessary.
+  The generated classes, type support, and (de)serialization code would need to be removed.
+* Changes in the model would be not be frequent.
+
+## IDL model of RPC exception classes
+
+```
+module eprosima {
+module fastdds {
+module dds {
+module rpc {
+
+// Base class for RPC exceptions.
+@nested
+struct RpcException
+{
+    string message;
+};
+
+// Exception thrown by the RPC API when the communication with the remote endpoint breaks.
+@nested
+struct RpcBrokenPipeException : RpcException
+{
+};
+
+// Code used in RpcFeedCancelledException
+typedef unsigned long RpcStatusCode;
+
+// Exception thrown by the RPC API when the client cancels an input feed.
+@nested
+struct RpcFeedCancelledException : RpcException
+{
+    RpcStatusCode reason;
+};
+
+// Base class for user defined exceptions.
+@nested
+struct RpcOperationError : RpcException
+{
+};
+
+/**
+ * Enumeration of possible error codes that can be returned by a remote service.
+ * Extracted from DDS-RPC v1.0 - 7.5.2 Mapping of Error Codes.
+ */
+enum RemoteExceptionCode_t
+{
+    REMOTE_EX_OK,                 // The request was executed successfully.
+    REMOTE_EX_UNSUPPORTED,        // Operation is valid but it is unsupported (a.k.a. not implemented).
+    REMOTE_EX_INVALID_ARGUMENT,   // The value of a parameter passed has an illegal value.
+    REMOTE_EX_OUT_OF_RESOURCES,   // The remote service ran out of resources while processing the request.
+    REMOTE_EX_UNKNOWN_OPERATION,  // The operation called is unknown.
+    REMOTE_EX_UNKNOWN_EXCEPTION   // A generic, unspecified exception was raised by the service implementation.
+};
+
+// Class for exceptions that map to a RpcExceptionCode_t
+@nested
+struct RpcRemoteException : RpcException
+{
+};
+
+};  // module rpc
+};  // module dds
+};  // module fastdds
+};  // module eprosima
+
+```

--- a/versions.md
+++ b/versions.md
@@ -14,6 +14,7 @@ Forthcoming
 * Support modules in `IdlParser`
 * New version of EDP static discovery which reduces greatly the Data(p) messages size.
 * Bump to asio 1.34.2 release.
+* Add methods for TypeObject registration of RPC types.
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds methods to register the TypeObject of RPC exceptions and related types.
It is necessary in order to generate TypeObject registration of generated RPC request and reply types in Fast DDS Gen.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
