### PR TITLE
[22973] Support modules in IDL Parser

### DIFF
--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
@@ -310,7 +310,7 @@ struct case_label : sor<seq<kw_case, const_expr, colon>, seq<kw_default, colon>>
 struct switch_case : seq<plus<case_label>, element_spec, semicolon> {};
 struct switch_body : plus<switch_case> {};
 struct switch_type_spec : sor<integer_type, char_type, boolean_type, wide_char_type, octet_type, scoped_name> {};
-struct union_def : seq<kw_union, identifier, kw_switch, open_parentheses, switch_type_spec, close_parentheses, open_brace, switch_body, close_brace> {};
+struct union_def : seq<kw_union, identifier, kw_switch, open_parentheses, star<annotation_appl>, switch_type_spec, close_parentheses, open_brace, switch_body, close_brace> {};
 struct union_dcl : sor<union_def, union_forward_dcl> {};
 struct struct_forward_dcl : seq<kw_struct, identifier, not_at<open_brace>> {};
 struct member : seq<star<annotation_appl>, type_spec, declarators, semicolon> {};

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
@@ -510,6 +510,14 @@ public:
         return builder;
     }
 
+    std::string create_scoped_name(
+            const std::string& plain_name) const
+    {
+        assert(plain_name.find("::") == std::string::npos);
+        const std::string& name_space = scope();
+        return name_space.empty() ? plain_name : name_space + "::" + plain_name;
+    }
+
 protected:
 
     // NOTE: Builders are stored using the scoped name as key

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
@@ -135,9 +135,6 @@ public:
             const std::string& ident,
             bool extend = true) const
     {
-        // __FLAG__
-        std::cout << "[DEBUG] Checking for symbol: " << ident << " in module: " << scope() << "\n";
-        /////////////////
         bool has_it = structs_.count(ident) > 0
                 || unions_.count(ident) > 0
                 || aliases_.count(ident) > 0
@@ -147,9 +144,6 @@ public:
 
         if (has_it)
         {
-            // __FLAG__
-            std::cout << "[DEBUG] Found symbol: " << ident << " in module: " << scope() << "\n";
-            /////////////////
             return true;
         }
         if (extend && outer_ != nullptr)
@@ -164,10 +158,6 @@ public:
             const std::string& name) const
     {
         // Solve scope
-        // Solve scope
-        // __FLAG__
-        std::cout << "[HAS_STRUCTURE]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -267,10 +257,6 @@ public:
             const std::string& name) const
     {
         // Solve scope
-        // Solve scope
-        // __FLAG__
-        std::cout << "[HAS_UNION]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -364,10 +350,6 @@ public:
         DynamicData::_ref_type xdata;
 
         // Solve scope
-        // Solve scope
-        // __FLAG__
-        std::cout << "[CONSTANT]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -387,10 +369,6 @@ public:
             const std::string& name) const
     {
         // Solve scope
-        // Solve scope
-        // __FLAG__
-        std::cout << "[HAS_CONSTANT]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -453,10 +431,6 @@ public:
             const std::string& name) const
     {
         // Solve scope
-        // Solve scope
-        // __FLAG__
-        std::cout << "[HAS_ALIAS]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -497,17 +471,7 @@ public:
         }
 
         // Solve scope
-        // __FLAG__
-        std::cout << "[GET_BUILDER]Resolving scope for: " << name << std::endl;
-        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
-        // __FLAG__
-        if (name == "NoCommon_Module::My_SequenceString" || name == "My_SequenceString")
-        {
-            std::cout << "module.second: " << module.second << std::endl;
-            std::cout << "module.first: " << (module.first ? module.first->name() : "nullptr") << std::endl;
-        }
-        //////////////
         if (module.first == nullptr)
         {
             return builder;
@@ -516,36 +480,24 @@ public:
         // Check enums
         if (module.first->has_enum_32(module.second))
         {
-            // __FLAG__
-            std::cout << "[GET_BUILDER] Found enum: " << module.second << " in module: " << module.first->scope() << std::endl;
-            ///////////////////
             builder = module.first->enumerations_32_.at(module.second);
         }
 
         // Check structs
         if (module.first->has_structure(module.second))
         {
-            // __FLAG__
-            std::cout << "[GET_BUILDER] Found structure: " << module.second << " in module: " << module.first->scope() << std::endl;
-            ///////////////////
             builder = module.first->structs_.at(module.second);
         }
 
         // Check unions
         if (module.first->has_union(module.second))
         {
-            // __FLAG__
-            std::cout << "[GET_BUILDER] Found union: " << module.second << " in module: " << module.first->scope() << std::endl;
-            ///////////////////
             builder = module.first->unions_.at(module.second);
         }
 
         // Check aliases
         if (module.first->has_alias(module.second))
         {
-            // __FLAG__
-            std::cout << "[GET_BUILDER] Found alias: " << module.second << " in module: " << module.first->scope() << std::endl;
-            ///////////////////
             builder = module.first->aliases_.at(module.second);
         }
 
@@ -554,12 +506,6 @@ public:
 
         // Check bitmasks
         // TODO
-        // __FLAG__
-        if (!builder)
-        {
-            std::cout << "Builder is nullptr" << std::endl;
-        }
-        /////////////////
         return builder;
     }
 
@@ -609,11 +555,6 @@ protected:
             return pair;
         }
 
-        // __FLAG__
-        std::cout << "resolve_scope--> symbol_name: " << symbol_name << std::endl;
-        std::cout << "resolve_scope--> original_name: " << original_name << std::endl;
-        std::cout << "resolve_scope--> scope: " << scope() << std::endl;
-        ////////////////
         std::string name = symbol_name;
         std::string name_space = scope();
         // Solve scope

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
@@ -68,7 +68,7 @@ public:
         return inner_.size();
     }
 
-    using ModuleVisitor = std::function<void(const Module& mod)>;
+    using ModuleVisitor = std::function<void (const Module& mod)>;
 
     void for_each_submodule(
             ModuleVisitor visitor,

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
@@ -44,78 +44,83 @@ public:
     Module(
             const Module& other) = delete;
 
-    // Module& create_submodule(
-    //         const std::string& submodule)
-    // {
-    //     std::shared_ptr<Module> new_submodule(new Module(this, submodule));
-    //     auto result = inner_.emplace(submodule, new_submodule);
-    //     return *result.first->second.get();
-    // }
+    Module& create_submodule(
+            const std::string& submodule)
+    {
+        std::shared_ptr<Module> new_submodule(new Module(this, submodule));
+        auto result = inner_.emplace(submodule, new_submodule);
+        return *result.first->second.get();
+    }
 
-    // std::shared_ptr<Module> submodule(
-    //         const std::string& submodule)
-    // {
-    //     return inner_[submodule];
-    // }
+    const Module* outer() const
+    {
+        return outer_;
+    }
 
-    // size_t submodule_size()
-    // {
-    //     return inner_.size();
-    // }
+    std::shared_ptr<Module> submodule(
+            const std::string& submodule)
+    {
+        return inner_[submodule];
+    }
 
-    // using ModuleVisitor = std::function<void(const Module& mod)>;
+    size_t submodule_size()
+    {
+        return inner_.size();
+    }
 
-    // void for_each_submodule(
-    //         ModuleVisitor visitor,
-    //         const Module* module,
-    //         bool recursive = true) const
-    // {
-    //     for (const auto& inner : module->inner_)
-    //     {
-    //         visitor(*inner.second.get());
-    //         if (recursive)
-    //         {
-    //             for_each_submodule(visitor, inner.second.get());
-    //         }
-    //     }
-    // }
+    using ModuleVisitor = std::function<void(const Module& mod)>;
 
-    // void for_each_submodule(
-    //         ModuleVisitor visitor,
-    //         bool recursive = true) const
-    // {
-    //     for_each_submodule(visitor, this, recursive);
-    // }
+    void for_each_submodule(
+            ModuleVisitor visitor,
+            const Module* module,
+            bool recursive = true) const
+    {
+        for (const auto& inner : module->inner_)
+        {
+            visitor(*inner.second.get());
+            if (recursive)
+            {
+                for_each_submodule(visitor, inner.second.get());
+            }
+        }
+    }
 
-    // void for_each(
-    //         ModuleVisitor visitor) const
-    // {
-    //     visitor(*this);
-    //     for_each_submodule(visitor, this);
-    // }
+    void for_each_submodule(
+            ModuleVisitor visitor,
+            bool recursive = true) const
+    {
+        for_each_submodule(visitor, this, recursive);
+    }
 
-    // bool has_submodule(
-    //         const std::string& submodule) const
-    // {
-    //     return inner_.count(submodule) > 0;
-    // }
+    void for_each(
+            ModuleVisitor visitor) const
+    {
+        visitor(*this);
+        for_each_submodule(visitor, this);
+    }
 
-    // Module& operator [] (
-    //         const std::string& submodule)
-    // {
-    //     return *inner_[submodule];
-    // }
+    bool has_submodule(
+            const std::string& submodule) const
+    {
+        return inner_.count(submodule) > 0;
+    }
 
-    // const Module& operator [] (
-    //         const std::string& submodule) const
-    // {
-    //     return *inner_.at(submodule);
-    // }
+    Module& operator [] (
+            const std::string& submodule)
+    {
+        return *inner_[submodule];
+    }
 
-    // const std::string& name() const
-    // {
-    //     return name_;
-    // }
+    const Module& operator [] (
+            const std::string& submodule) const
+    {
+        return *inner_.at(submodule);
+    }
+
+    const std::string& name() const
+    {
+        return name_;
+    }
 
     std::string scope() const
     {
@@ -130,6 +135,9 @@ public:
             const std::string& ident,
             bool extend = true) const
     {
+        // __FLAG__
+        std::cout << "[DEBUG] Checking for symbol: " << ident << " in module: " << scope() << "\n";
+        /////////////////
         bool has_it = structs_.count(ident) > 0
                 || unions_.count(ident) > 0
                 || aliases_.count(ident) > 0
@@ -139,6 +147,9 @@ public:
 
         if (has_it)
         {
+            // __FLAG__
+            std::cout << "[DEBUG] Found symbol: " << ident << " in module: " << scope() << "\n";
+            /////////////////
             return true;
         }
         if (extend && outer_ != nullptr)
@@ -153,6 +164,10 @@ public:
             const std::string& name) const
     {
         // Solve scope
+        // Solve scope
+        // __FLAG__
+        std::cout << "[HAS_STRUCTURE]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -234,11 +249,6 @@ public:
             bool replace = false)
     {
         std::string name(builder->get_name());
-        if (name.find("::") != std::string::npos)
-        {
-            return false; // Cannot add a symbol with scoped name.
-        }
-
         if (replace)
         {
             auto it = structs_.find(name);
@@ -248,10 +258,6 @@ public:
             }
         }
 
-        std::string name_space = scope();
-        TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
-        builder->get_descriptor(type_descriptor);
-        type_descriptor->name(name_space + (name_space.empty() ? "" : "::") + name);
         auto result = structs_.emplace(name, builder);
 
         return result.second;
@@ -261,6 +267,10 @@ public:
             const std::string& name) const
     {
         // Solve scope
+        // Solve scope
+        // __FLAG__
+        std::cout << "[HAS_UNION]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -315,15 +325,6 @@ public:
             DynamicTypeBuilder::_ref_type builder)
     {
         std::string name(builder->get_name());
-        if (name.find("::") != std::string::npos)
-        {
-            return false; // Cannot add a symbol with scoped name.
-        }
-
-        std::string name_space = scope();
-        TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
-        builder->get_descriptor(type_descriptor);
-        type_descriptor->name(name_space + (name_space.empty() ? "" : "::") + name);
         auto result = unions_.emplace(name, builder);
 
         return result.second;
@@ -363,6 +364,10 @@ public:
         DynamicData::_ref_type xdata;
 
         // Solve scope
+        // Solve scope
+        // __FLAG__
+        std::cout << "[CONSTANT]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -382,6 +387,10 @@ public:
             const std::string& name) const
     {
         // Solve scope
+        // Solve scope
+        // __FLAG__
+        std::cout << "[HAS_CONSTANT]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -398,11 +407,6 @@ public:
             bool replace = false,
             bool from_enumeration = false)
     {
-        if (name.find("::") != std::string::npos)
-        {
-            return false; // Cannot add a symbol with scoped name.
-        }
-
         if (replace)
         {
             auto it = constants_.find(name);
@@ -431,11 +435,6 @@ public:
             DynamicTypeBuilder::_ref_type builder,
             bool replace = false)
     {
-        if (name.find("::") != std::string::npos)
-        {
-            return false; // Cannot add a symbol with scoped name.
-        }
-
         if (replace)
         {
             auto it = enumerations_32_.find(name);
@@ -445,10 +444,6 @@ public:
             }
         }
 
-        std::string name_space = scope();
-        TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
-        builder->get_descriptor(type_descriptor);
-        type_descriptor->name(name_space + (name_space.empty() ? "" : "::") + name);
         auto result = enumerations_32_.emplace(name, builder);
 
         return result.second;
@@ -458,6 +453,10 @@ public:
             const std::string& name) const
     {
         // Solve scope
+        // Solve scope
+        // __FLAG__
+        std::cout << "[HAS_ALIAS]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
         if (module.first == nullptr)
         {
@@ -472,11 +471,6 @@ public:
             const std::string& name,
             DynamicTypeBuilder::_ref_type builder)
     {
-        if (name.find("::") != std::string::npos || has_alias(name))
-        {
-            return false; // Cannot define alias with scoped name (or already defined).
-        }
-
         std::string name_space = scope();
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         builder->get_descriptor(type_descriptor);
@@ -503,7 +497,17 @@ public:
         }
 
         // Solve scope
+        // __FLAG__
+        std::cout << "[GET_BUILDER]Resolving scope for: " << name << std::endl;
+        ///////////////////
         PairModuleSymbol module = resolve_scope(name);
+        // __FLAG__
+        if (name == "NoCommon_Module::My_SequenceString" || name == "My_SequenceString")
+        {
+            std::cout << "module.second: " << module.second << std::endl;
+            std::cout << "module.first: " << (module.first ? module.first->name() : "nullptr") << std::endl;
+        }
+        //////////////
         if (module.first == nullptr)
         {
             return builder;
@@ -512,33 +516,37 @@ public:
         // Check enums
         if (module.first->has_enum_32(module.second))
         {
+            // __FLAG__
+            std::cout << "[GET_BUILDER] Found enum: " << module.second << " in module: " << module.first->scope() << std::endl;
+            ///////////////////
             builder = module.first->enumerations_32_.at(module.second);
         }
 
         // Check structs
         if (module.first->has_structure(module.second))
         {
+            // __FLAG__
+            std::cout << "[GET_BUILDER] Found structure: " << module.second << " in module: " << module.first->scope() << std::endl;
+            ///////////////////
             builder = module.first->structs_.at(module.second);
         }
 
         // Check unions
         if (module.first->has_union(module.second))
         {
+            // __FLAG__
+            std::cout << "[GET_BUILDER] Found union: " << module.second << " in module: " << module.first->scope() << std::endl;
+            ///////////////////
             builder = module.first->unions_.at(module.second);
         }
 
         // Check aliases
         if (module.first->has_alias(module.second))
         {
+            // __FLAG__
+            std::cout << "[GET_BUILDER] Found alias: " << module.second << " in module: " << module.first->scope() << std::endl;
+            ///////////////////
             builder = module.first->aliases_.at(module.second);
-        }
-
-        if (name.find("::") == 0)
-        {
-            // Scope ambiguity solver was originally used, add it to the retrieved DynamicTypeBuilder
-            TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
-            builder->get_descriptor(type_descriptor);
-            type_descriptor->name(name);
         }
 
         // Check bitsets
@@ -546,12 +554,18 @@ public:
 
         // Check bitmasks
         // TODO
-
+        // __FLAG__
+        if (!builder)
+        {
+            std::cout << "Builder is nullptr" << std::endl;
+        }
+        /////////////////
         return builder;
     }
 
 protected:
 
+    // NOTE: Builders are stored using the scoped name as key
     std::map<std::string, DynamicTypeBuilder::_ref_type> aliases_;
     // std::map<std::string, Type> constants_types_;
     std::map<std::string, DynamicData::_ref_type> constants_;
@@ -595,7 +609,13 @@ protected:
             return pair;
         }
 
+        // __FLAG__
+        std::cout << "resolve_scope--> symbol_name: " << symbol_name << std::endl;
+        std::cout << "resolve_scope--> original_name: " << original_name << std::endl;
+        std::cout << "resolve_scope--> scope: " << scope() << std::endl;
+        ////////////////
         std::string name = symbol_name;
+        std::string name_space = scope();
         // Solve scope
         if (symbol_name.find("::") != std::string::npos) // It is an scoped name
         {
@@ -616,16 +636,50 @@ protected:
                 // Maybe the current scope its me?
                 if (inner_scope == name_)
                 {
-                    std::string innest_scope = inner_scope.substr(0, inner_scope.find("::"));
-                    if (inner_.count(innest_scope) > 0)
+                    // std::string innest_scope = inner_scope.substr(0, inner_scope.find("::"));
+                    // if (inner_.count(innest_scope) > 0)
+                    // {
+                    //     std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
+                    //     const auto& it = inner_.find(innest_scope);
+                    //     PairModuleSymbol result = it->second->resolve_scope(inner_name, original_name);
+                    //     if (result.first != nullptr)
+                    //     {
+                    //         return result;
+                    //     }
+                    // }
+
+                    std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
+                    // inner_name is a scoped name (i.e: is this in the scope of one my submodules)?
+                    if (inner_name.find("::") != std::string::npos)
                     {
-                        std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
-                        const auto& it = inner_.find(innest_scope);
-                        PairModuleSymbol result = it->second->resolve_scope(inner_name, original_name);
-                        if (result.first != nullptr)
+                        // We should be in the scope of one of my submodules, go down.
+                        const auto& it = inner_.find(inner_name.substr(0, inner_name.find("::")));
+                        if (it == inner_.end())
                         {
-                            return result;
+                            EPROSIMA_LOG_ERROR(IDLPARSER, "Cannot find inner scope '" << inner_name << "'.");
+                            // Unknown scope
+                            PairModuleSymbol pair;
+                            pair.first = nullptr;
+                            pair.second = original_name;
+                            return pair;
                         }
+                        // Resolve from the inner submodule
+                        return it->second->resolve_scope(inner_name, original_name);
+                    }
+                    else
+                    {
+                        // Symbol should be stored in the current module
+                        std::string scoped_name = name_space.empty() ? inner_name : name_space + "::" + inner_name;
+                        if (has_symbol(scoped_name, false))
+                        {
+                            return std::make_pair<const Module*, std::string>(this, std::move(scoped_name));
+                        }
+
+                        // Failed, not found
+                        PairModuleSymbol pair;
+                        pair.first = nullptr;
+                        pair.second = original_name;
+                        return pair;
                     }
                 }
                 // Do we have a inner scope that matches?
@@ -648,9 +702,10 @@ protected:
             }
         }
 
-        if (has_symbol(name, false))
+        std::string scoped_name = name_space.empty() ? name : name_space + "::" + name;
+        if (has_symbol(scoped_name, false))
         {
-            return std::make_pair<const Module*, std::string>(this, std::move(name));
+            return std::make_pair<const Module*, std::string>(this, std::move(scoped_name));
         }
 
         if (outer_ != nullptr)

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlModule.hpp
@@ -506,6 +506,7 @@ public:
 
         // Check bitmasks
         // TODO
+
         return builder;
     }
 
@@ -577,18 +578,6 @@ protected:
                 // Maybe the current scope its me?
                 if (inner_scope == name_)
                 {
-                    // std::string innest_scope = inner_scope.substr(0, inner_scope.find("::"));
-                    // if (inner_.count(innest_scope) > 0)
-                    // {
-                    //     std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
-                    //     const auto& it = inner_.find(innest_scope);
-                    //     PairModuleSymbol result = it->second->resolve_scope(inner_name, original_name);
-                    //     if (result.first != nullptr)
-                    //     {
-                    //         return result;
-                    //     }
-                    // }
-
                     std::string inner_name = symbol_name.substr(symbol_name.find("::") + 2);
                     // inner_name is a scoped name (i.e: is this in the scope of one my submodules)?
                     if (inner_name.find("::") != std::string::npos)

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
@@ -394,9 +394,6 @@ struct action<scoped_name>
     {
         auto module = ctx->modules().current();
         std::string identifier_name = in.string();
-        // const std::string& name_space = module->scope();
-        // const std::string& scoped_identifier_name = name_space.empty() ?
-        //     identifier_name : name_space + "::" + identifier_name;
 
         if (state.count("arithmetic_expr"))
         {
@@ -2276,7 +2273,7 @@ struct action<typedef_dcl>
 
         if (!alias_type)
         {
-            // EPROSIMA_LOG_WARNING(IDLPARSER, "[TODO] alias type not supported: " << state["type"]);
+            EPROSIMA_LOG_WARNING(IDLPARSER, "[TODO] alias type not supported: " << state["type"]);
             return;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
@@ -63,6 +63,67 @@ using namespace tao::TAO_PEGTL_NAMESPACE;
 
 class Parser;
 
+/**
+ * @brief Class representing a hierarchy of nested modules, allowing to manage the current module context during parsing.
+ * @note This class is used to keep track of the current module scope when parsing IDL attributes, types, and other elements.
+ *       It is intended to be always non-empty, starting with a root module representing the global scope.
+ *       The current module can be pushed and popped to navigate through nested modules.
+ *       The root module is created upon instantiation and cannot be popped.
+ */
+class ModuleStack
+{
+public:
+
+    ModuleStack()
+    {
+        // Initialize the stack with a global scope module (root)
+        stack_.push(std::make_shared<Module>());
+    }
+
+    std::shared_ptr<Module> current() const
+    {
+        return stack_.top();
+    }
+
+    std::shared_ptr<Module> push(
+            const std::string& submodule)
+    {
+        auto current = stack_.top();
+
+        if (!current->has_submodule(submodule))
+        {
+            current->create_submodule(submodule);
+        }
+
+        auto new_module = current->submodule(submodule);
+        stack_.push(new_module);
+
+        return new_module;
+    }
+
+    void pop()
+    {
+        if (stack_.size() == 1)
+        {
+            EPROSIMA_LOG_ERROR(IDLPARSER, "Cannot pop the root module.");
+            return;
+        }
+
+        stack_.pop();
+    }
+
+    void reset()
+    {
+        while (stack_.size() > 1)
+        {
+            stack_.pop();
+        }
+    }
+
+private:
+    std::stack<std::shared_ptr<Module>, std::vector<std::shared_ptr<Module>>> stack_;
+};
+
 class Context
     : public PreprocessorContext
 {
@@ -113,13 +174,9 @@ public:
 
     DynamicTypeBuilder::_ref_type builder;
 
-    Module& module()
+    ModuleStack& modules()
     {
-        if (!module_)
-        {
-            module_ = std::make_shared<Module>();
-        }
-        return *module_;
+        return modules_;
     }
 
     void clear_context()
@@ -127,7 +184,7 @@ public:
         if (clear)
         {
             parser_.reset();
-            module_.reset();
+            modules_.reset();
         }
     }
 
@@ -140,10 +197,31 @@ private:
 
     friend class Parser;
     std::shared_ptr<Parser> parser_;
-    std::shared_ptr<Module> module_;
+    ModuleStack modules_;
 
 }; // class Context
 
+
+
+// __FLAG__
+template<typename Input>
+void debug_action(
+        const std::string& rule_name,
+        const Input& in,
+        const std::map<std::string, std::string>& state)
+{
+    std::cout << "[DEBUG] Rule: " << rule_name << "\n";
+    std::cout << "        Input: \"" << in.string() << "\"\n";
+    std::cout << "        State:\n";
+    for (std::map<std::string, std::string>::const_iterator it = state.begin(); it != state.end(); ++it)
+    {
+        std::cout << "          - " << it->first << ": " << it->second << "\n";
+    }
+
+    std::cout << "-----------------------------------\n";
+}
+
+/////////////////
 
 // Actions
 template<typename Rule>
@@ -167,7 +245,7 @@ struct action<identifier>
     template<typename Input>
     static void apply(
             const Input& in,
-            Context* /*ctx*/,
+            Context* ctx,
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
     {
@@ -305,6 +383,12 @@ struct action<identifier>
                 return;
             }
         }
+        else if (state.count("parsing_module") && state["parsing_module"] == "true")
+        {
+            // Update the scope adding a the new module
+            ctx->modules().push(identifier_name);
+            state.erase("parsing_module");
+        }
         else
         {
             // Keep the identifier for super-expression use
@@ -324,14 +408,17 @@ struct action<scoped_name>
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& operands)
     {
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
         std::string identifier_name = in.string();
+        // const std::string& name_space = module->scope();
+        // const std::string& scoped_identifier_name = name_space.empty() ?
+        //     identifier_name : name_space + "::" + identifier_name;
 
         if (state.count("arithmetic_expr"))
         {
-            if (module.has_constant(identifier_name))
+            if (module->has_constant(identifier_name))
             {
-                DynamicData::_ref_type xdata = module.constant(identifier_name);
+                DynamicData::_ref_type xdata = module->constant(identifier_name);
                 operands.push_back(xdata);
             }
             else
@@ -1382,24 +1469,33 @@ struct action<struct_forward_dcl>
         }
         cleanup_guard{state};
 
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
         const std::string& struct_name = state["struct_name"];
-        if (module.has_symbol(struct_name, false))
+
+        if (struct_name.find("::") != std::string::npos)
         {
-            EPROSIMA_LOG_ERROR(IDLPARSER, "Struct " << struct_name << " was already declared.");
-            throw std::runtime_error("Struct " + struct_name + " was already declared.");
+            return; // Cannot add a symbol with scoped name.
+        }
+
+        const std::string& name_space = module->scope();
+        const std::string scoped_struct_name = name_space.empty() ? struct_name : name_space + "::" + struct_name;
+
+        if (module->has_symbol(scoped_struct_name, false))
+        {
+            EPROSIMA_LOG_ERROR(IDLPARSER, "Struct " << scoped_struct_name << " was already declared.");
+            throw std::runtime_error("Struct " + scoped_struct_name + " was already declared.");
         }
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         type_descriptor->kind(TK_STRUCTURE);
-        type_descriptor->name(struct_name);
+        type_descriptor->name(scoped_struct_name);
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found forward struct declaration: " << struct_name);
-        module.structure(builder);
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found forward struct declaration: " << scoped_struct_name);
+        module->structure(builder);
 
-        if (struct_name == ctx->target_type_name)
+        if (scoped_struct_name == ctx->target_type_name)
         {
             ctx->builder = builder;
         }
@@ -1444,25 +1540,34 @@ struct action<union_forward_dcl>
         }
         cleanup_guard{state};
 
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
         const std::string& union_name = state["union_name"];
-        if (module.has_symbol(union_name, false))
+
+        if (union_name.find("::") != std::string::npos)
         {
-            EPROSIMA_LOG_ERROR(IDLPARSER, "Union " << union_name << " was already declared.");
-            throw std::runtime_error("Union " + union_name + " was already declared.");
+            return; // Cannot add a symbol with scoped name.
+        }
+
+        const std::string& name_space = module->scope();
+        const std::string scoped_union_name = name_space.empty() ? union_name : name_space + "::" + union_name;
+
+        if (module->has_symbol(scoped_union_name, false))
+        {
+            EPROSIMA_LOG_ERROR(IDLPARSER, "Union " << scoped_union_name << " was already declared.");
+            throw std::runtime_error("Union " + scoped_union_name + " was already declared.");
         }
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         type_descriptor->kind(TK_UNION);
-        type_descriptor->name(union_name);
+        type_descriptor->name(scoped_union_name);
         type_descriptor->discriminator_type(factory->get_primitive_type(TK_INT32));
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found forward union declaration: " << union_name);
-        module.union_switch(builder);
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found forward union declaration: " << scoped_union_name);
+        module->union_switch(builder);
 
-        if (union_name == ctx->target_type_name)
+        if (scoped_union_name == ctx->target_type_name)
         {
             ctx->builder = builder;
         }
@@ -1496,12 +1601,19 @@ struct action<const_dcl>
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& operands)
     {
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
         const std::string& const_name = state["identifier"];
+        const std::string& name_space = module->scope();
+        const std::string scoped_const_name = name_space.empty() ? const_name : name_space + "::" + const_name;
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found const: " << const_name);
+        if (const_name.find("::") != std::string::npos)
+        {
+            return; // Cannot add a symbol with scoped name.
+        }
 
-        module.create_constant(const_name, operands.back());
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found const: " << scoped_const_name);
+
+        module->create_constant(scoped_const_name, operands.back());
         operands.pop_back();
         if (!operands.empty())
         {
@@ -1540,13 +1652,21 @@ struct action<enum_dcl>
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
     {
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
         const std::string& enum_name = state["enum_name"];
+
+        if (enum_name.find("::") != std::string::npos)
+        {
+            return; // Cannot add a symbol with scoped name.
+        }
+
+        const std::string& name_space = module->scope();
+        const std::string scoped_enum_name = name_space.empty() ? enum_name : name_space + "::" + enum_name;
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         type_descriptor->kind(TK_ENUM);
-        type_descriptor->name(enum_name);
+        type_descriptor->name(scoped_enum_name);
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
         std::vector<std::string> tokens = ctx->split_string(state["enum_member_names"], ';');
@@ -1562,13 +1682,13 @@ struct action<enum_dcl>
             DynamicData::_ref_type member_data {DynamicDataFactory::get_instance()->create_data(member_type)};
             member_data->set_int32_value(MEMBER_ID_INVALID, (int32_t)i);
 
-            module.create_constant(tokens[i], member_data, false, true); // Mark it as "from_enum"
+            module->create_constant(tokens[i], member_data, false, true); // Mark it as "from_enum"
         }
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found enum: " << enum_name);
-        module.enum_32(enum_name, builder);
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found enum: " << scoped_enum_name);
+        module->enum_32(scoped_enum_name, builder);
 
-        if (enum_name == ctx->target_type_name)
+        if (scoped_enum_name == ctx->target_type_name)
         {
             ctx->builder = builder;
         }
@@ -1621,7 +1741,7 @@ struct action<struct_def>
 
     template<typename Input>
     static void apply(
-            const Input& /*in*/,
+            const Input& in,
             Context* ctx,
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
@@ -1638,13 +1758,28 @@ struct action<struct_def>
         }
         cleanup_guard{state};
 
-        Module& module = ctx->module();
+        // __FLAG__
+        // static_cast<void>(in);
+        if (state["struct_name"] == "My_Structure")
+        {
+            debug_action("struct_def", in, state);
+        }
+        ///////////////
+
+        auto module = ctx->modules().current();
         const std::string& struct_name = state["struct_name"];
+        const std::string& name_space = module->scope();
+        const std::string scoped_struct_name = name_space.empty() ? struct_name : name_space + "::" + struct_name;
+
+        if (struct_name.find("::") != std::string::npos)
+        {
+            return; // Cannot add a symbol with scoped name.
+        }
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         type_descriptor->kind(TK_STRUCTURE);
-        type_descriptor->name(struct_name);
+        type_descriptor->name(scoped_struct_name);
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
         std::vector<std::string> types = ctx->split_string(state["struct_member_types"], ';');
@@ -1669,9 +1804,9 @@ struct action<struct_def>
                 std::vector<uint32_t> sizes;
                 for (const auto& size : array_sizes)
                 {
-                    if (module.has_constant(size))
+                    if (module->has_constant(size))
                     {
-                        DynamicData::_ref_type xdata = module.constant(size);
+                        DynamicData::_ref_type xdata = module->constant(size);
                         int64_t size_val = 0;
                         xdata->get_int64_value(size_val, MEMBER_ID_INVALID);
                         sizes.push_back(static_cast<uint32_t>(size_val));
@@ -1700,9 +1835,9 @@ struct action<struct_def>
             {
                 uint32_t size;
 
-                if (module.has_constant(sequence_sizes[i]))
+                if (module->has_constant(sequence_sizes[i]))
                 {
-                    DynamicData::_ref_type xdata = module.constant(sequence_sizes[i]);
+                    DynamicData::_ref_type xdata = module->constant(sequence_sizes[i]);
                     int64_t size_val = 0;
                     xdata->get_int64_value(size_val, MEMBER_ID_INVALID);
                     size = static_cast<uint32_t>(size_val);
@@ -1731,10 +1866,21 @@ struct action<struct_def>
         }
 
         EPROSIMA_LOG_INFO(IDLPARSER, "Found struct: " << struct_name);
-        module.structure(builder);
+        // __FLAG__
+        
+        ////////////////
+        module->structure(builder);
 
-        if (struct_name == ctx->target_type_name)
+        // Check if the scoped name matches the target type name
+        if (scoped_struct_name == ctx->target_type_name)
         {
+            // __FLAG__
+            if (!builder)
+            {
+                EPROSIMA_LOG_ERROR(IDLPARSER, "Builder is null for struct: " << scoped_struct_name);
+                throw std::runtime_error("Builder is null for struct: " + scoped_struct_name);
+            }
+            /////////////////
             ctx->builder = builder;
         }
     }
@@ -1762,6 +1908,20 @@ struct action<kw_union>
         state["type"] = "";
     }
 
+};
+
+template<>
+struct action<kw_module>
+{
+    template<typename Input>
+    static void apply(
+            const Input& /*in*/,
+            Context* /*ctx*/,
+            std::map<std::string, std::string>& state,
+            std::vector<traits<DynamicData>::ref_type>& /*operands*/)
+    {
+        state["parsing_module"] = "true";
+    }
 };
 
 template<>
@@ -1905,7 +2065,7 @@ struct action<union_def>
 
     template<typename Input>
     static void apply(
-            const Input& /*in*/,
+            const Input& in,
             Context* ctx,
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
@@ -1922,8 +2082,20 @@ struct action<union_def>
         }
         cleanup_guard{state};
 
-        Module& module = ctx->module();
+        // __FLAG__
+        static_cast<void>(in);
+        // debug_action("union_def", in, state);
+        ///////////////
+
+        auto module = ctx->modules().current();
         const std::string& union_name = state["union_name"];
+        const std::string& name_space = module->scope();
+        const std::string scoped_union_name = name_space.empty() ? union_name : name_space + "::" + union_name;
+
+        if (union_name.find("::") != std::string::npos)
+        {
+            return; // Cannot add a symbol with scoped name.
+        }
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
@@ -1934,7 +2106,7 @@ struct action<union_def>
             return;
         }
         type_descriptor->kind(TK_UNION);
-        type_descriptor->name(union_name);
+        type_descriptor->name(scoped_union_name);
         type_descriptor->discriminator_type(discriminant_type);
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
@@ -1989,9 +2161,9 @@ struct action<union_def>
             {
                 uint32_t size;
 
-                if (module.has_constant(sequence_sizes[i]))
+                if (module->has_constant(sequence_sizes[i]))
                 {
-                    DynamicData::_ref_type xdata = module.constant(sequence_sizes[i]);
+                    DynamicData::_ref_type xdata = module->constant(sequence_sizes[i]);
                     int64_t size_val = 0;
                     xdata->get_int64_value(size_val, MEMBER_ID_INVALID);
                     size = static_cast<uint32_t>(size_val);
@@ -2034,10 +2206,10 @@ struct action<union_def>
             builder->add_member(member_descriptor);
         }
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found union: " << union_name);
-        module.union_switch(builder);
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found union: " << scoped_union_name);
+        module->union_switch(builder);
 
-        if (union_name == ctx->target_type_name)
+        if (scoped_union_name == ctx->target_type_name)
         {
             ctx->builder = builder;
         }
@@ -2100,7 +2272,7 @@ struct action<typedef_dcl>
         }
         cleanup_guard{state};
 
-        Module& module = ctx->module();
+        auto module = ctx->modules().current();
 
         std::string alias_name;
         std::vector<std::string> array_sizes = ctx->split_string(state["current_array_sizes"], ',');
@@ -2125,20 +2297,28 @@ struct action<typedef_dcl>
             alias_name = state["alias"];
         }
 
+        const std::string& name_space = module->scope();
+        const std::string scoped_alias_name = name_space.empty() ? alias_name : name_space + "::" + alias_name;
+
+        if (alias_name.find("::") != std::string::npos || module->has_alias(scoped_alias_name))
+        {
+            return; // Cannot define alias with scoped name (or already defined).
+        }
+
         // For sequence types, ctx->get_type() should return the type of the elements
         DynamicType::_ref_type alias_type = (state["type"] == "sequence") ? ctx->get_type(state, state["element_type"])
                 : ctx->get_type(state, state["type"]);
 
         if (!alias_type)
         {
-            EPROSIMA_LOG_WARNING(IDLPARSER, "[TODO] alias type not supported: " << state["type"]);
+            // EPROSIMA_LOG_WARNING(IDLPARSER, "[TODO] alias type not supported: " << state["type"]);
             return;
         }
 
         DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
         TypeDescriptor::_ref_type type_descriptor {traits<TypeDescriptor>::make_shared()};
         type_descriptor->kind(TK_ALIAS);
-        type_descriptor->name(alias_name);
+        type_descriptor->name(scoped_alias_name);
 
         if (state["type"] == "sequence")
         {
@@ -2170,10 +2350,10 @@ struct action<typedef_dcl>
 
         DynamicTypeBuilder::_ref_type builder {factory->create_type(type_descriptor)};
 
-        EPROSIMA_LOG_INFO(IDLPARSER, "Found alias: " << alias_name);
-        module.create_alias(alias_name, builder);
+        EPROSIMA_LOG_INFO(IDLPARSER, "Found alias: " << scoped_alias_name);
+        module->create_alias(scoped_alias_name, builder);
 
-        if (alias_name == ctx->target_type_name)
+        if (scoped_alias_name == ctx->target_type_name)
         {
             ctx->builder = builder;
         }
@@ -2234,15 +2414,14 @@ struct action<module_dcl>
 {
     template<typename Input>
     static void apply(
-            const Input& in,
-            Context* /*ctx*/,
-            std::map<std::string, std::string>& state,
+            const Input& /*in*/,
+            Context* ctx,
+            std::map<std::string, std::string>& /*state*/,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
     {
-        state["type"] = in.string();
-        EPROSIMA_LOG_INFO(IDLPARSER, "[TODO] module_dcl parsing not supported: " << state["type"]);
+        // Move scope to the parent module
+        ctx->modules().pop();
     }
-
 };
 
 class Parser
@@ -2495,7 +2674,7 @@ private:
         }
         else
         {
-            builder = context_->module().get_builder(type);
+            builder = context_->modules().current()->get_builder(type);
             if (builder)
             {
                 xtype = builder->build();

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
@@ -121,6 +121,7 @@ public:
     }
 
 private:
+
     std::stack<std::shared_ptr<Module>, std::vector<std::shared_ptr<Module>>> stack_;
 };
 
@@ -232,7 +233,7 @@ struct action<identifier>
         std::string identifier_name = in.string();
         const std::string& name_space = module->scope();
         const std::string& scoped_identifier_name = name_space.empty() ?
-            identifier_name : name_space + "::" + identifier_name;
+                identifier_name : name_space + "::" + identifier_name;
 
         if (state.count("enum_name"))
         {
@@ -456,7 +457,8 @@ struct action<semicolon>
                 state["struct_member_names"] += state["current_struct_member_name"] + ";";
 
                 // Add the array dimensions for this member to `all_array_sizes`
-                std::string current_array_sizes = state["current_array_sizes"].empty() ? "0" : state["current_array_sizes"];
+                std::string current_array_sizes =
+                        state["current_array_sizes"].empty() ? "0" : state["current_array_sizes"];
                 if (!state["all_array_sizes"].empty())
                 {
                     state["all_array_sizes"] += ";" + current_array_sizes;
@@ -553,7 +555,8 @@ struct action<semicolon>
             std::map<std::string, std::string>& state, \
             std::vector<traits<DynamicData>::ref_type>& /*operands*/) \
         { \
-            std::string type{#id}; \
+            std::string type{#id \
+            }; \
             if (type == "sequence") \
             { \
                 state["type"] = type; \
@@ -914,6 +917,7 @@ struct action<kw_sequence>
             state.erase("arithmetic_expr");
         }
     }
+
 };
 
 template<>
@@ -1889,6 +1893,7 @@ struct action<kw_module>
     {
         state["parsing_module"] = "true";
     }
+
 };
 
 template<>
@@ -2384,6 +2389,7 @@ struct action<module_dcl>
         // Move scope to the parent module
         ctx->modules().pop();
     }
+
 };
 
 class Parser

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <mutex>
 #include <regex>
+#include <stack>
 #include <string>
 #include <thread>
 #include <type_traits>

--- a/test/feature/idl_parser/CMakeLists.txt
+++ b/test/feature/idl_parser/CMakeLists.txt
@@ -67,4 +67,6 @@ add_custom_command(
     TARGET IdlParserTests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/thirdparty/dds-types-test/IDL ${CMAKE_CURRENT_BINARY_DIR}/IDL
     COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/no_path_included.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_structures.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_unions.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
 )

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -374,7 +374,8 @@ TEST_F(IdlParserTests, structures)
     DynamicType::_ref_type type21 = builder21->build();
     ASSERT_TRUE(type21);
 
-    DynamicTypeBuilder::_ref_type builder22 = factory->create_type_w_uri("IDL/structures.idl", "StructSequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder22 = factory->create_type_w_uri("IDL/structures.idl", "StructSequence",
+                    include_paths);
     EXPECT_TRUE(builder22);
     DynamicType::_ref_type type22 = builder22->build();
     ASSERT_TRUE(type22);
@@ -453,25 +454,25 @@ TEST_F(IdlParserTests, structures)
 
     /* Additional cases */
     DynamicTypeBuilder::_ref_type builder35 = factory->create_type_w_uri(
-                "IDL/extra_structures.idl",
-                "Module_1::Module_2::NestedModuleStruct",
-                include_paths);
+        "IDL/extra_structures.idl",
+        "Module_1::Module_2::NestedModuleStruct",
+        include_paths);
     EXPECT_TRUE(builder35);
     DynamicType::_ref_type type35 = builder35->build();
     ASSERT_TRUE(type35);
 
     DynamicTypeBuilder::_ref_type builder36 = factory->create_type_w_uri(
-                "IDL/extra_structures.idl",
-                "Outer::StructWithInnerAlias",
-                include_paths);
+        "IDL/extra_structures.idl",
+        "Outer::StructWithInnerAlias",
+        include_paths);
     EXPECT_TRUE(builder36);
     DynamicType::_ref_type type36 = builder36->build();
     ASSERT_TRUE(type36);
 
     DynamicTypeBuilder::_ref_type builder37 = factory->create_type_w_uri(
-                "IDL/extra_structures.idl",
-                "Module::ScopedNamesStruct",
-                include_paths);
+        "IDL/extra_structures.idl",
+        "Module::ScopedNamesStruct",
+        include_paths);
     EXPECT_TRUE(builder37);
     DynamicType::_ref_type type37 = builder37->build();
     ASSERT_TRUE(type37);
@@ -604,7 +605,8 @@ TEST_F(IdlParserTests, aliases)
     DynamicType::_ref_type type20 = builder20->build();
     ASSERT_TRUE(type20);
 
-    DynamicTypeBuilder::_ref_type builder21 = factory->create_type_w_uri("IDL/aliases.idl", "AliasSequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder21 = factory->create_type_w_uri("IDL/aliases.idl", "AliasSequence",
+                    include_paths);
     EXPECT_TRUE(builder21);
     DynamicType::_ref_type type21 = builder21->build();
     ASSERT_TRUE(type21);
@@ -767,7 +769,8 @@ TEST_F(IdlParserTests, arrays)
     DynamicType::_ref_type type22 = builder22->build();
     ASSERT_TRUE(type22);
 
-    DynamicTypeBuilder::_ref_type builder23 = factory->create_type_w_uri("IDL/arrays.idl", "ArraySequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder23 = factory->create_type_w_uri("IDL/arrays.idl", "ArraySequence",
+                    include_paths);
     EXPECT_TRUE(builder23);
     DynamicType::_ref_type type23 = builder23->build();
     ASSERT_TRUE(type23);
@@ -918,7 +921,8 @@ TEST_F(IdlParserTests, arrays)
     DynamicType::_ref_type type47 = builder47->build();
     ASSERT_TRUE(type47);
 
-    DynamicTypeBuilder::_ref_type builder48 = factory->create_type_w_uri("IDL/arrays.idl", "ArrayMultiDimensionSequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder48 = factory->create_type_w_uri("IDL/arrays.idl",
+                    "ArrayMultiDimensionSequence", include_paths);
     EXPECT_TRUE(builder48);
     DynamicType::_ref_type type48 = builder48->build();
     ASSERT_TRUE(type48);
@@ -1093,7 +1097,9 @@ TEST_F(IdlParserTests, arrays)
     DynamicType::_ref_type type73 = builder73->build();
     ASSERT_TRUE(type73);
 
-    DynamicTypeBuilder::_ref_type builder74 = factory->create_type_w_uri("IDL/arrays.idl", "ArraySingleDimensionLiteralsSequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder74 = factory->create_type_w_uri("IDL/arrays.idl",
+                    "ArraySingleDimensionLiteralsSequence",
+                    include_paths);
     EXPECT_TRUE(builder74);
     DynamicType::_ref_type type74 = builder74->build();
     ASSERT_TRUE(type74);
@@ -1263,7 +1269,9 @@ TEST_F(IdlParserTests, arrays)
     DynamicType::_ref_type type98 = builder98->build();
     ASSERT_TRUE(type98);
 
-    DynamicTypeBuilder::_ref_type builder99 = factory->create_type_w_uri("IDL/arrays.idl", "ArrayMultiDimensionLiteralsSequence", include_paths);
+    DynamicTypeBuilder::_ref_type builder99 = factory->create_type_w_uri("IDL/arrays.idl",
+                    "ArrayMultiDimensionLiteralsSequence",
+                    include_paths);
     EXPECT_TRUE(builder99);
     DynamicType::_ref_type type99 = builder99->build();
     ASSERT_TRUE(type99);
@@ -1460,7 +1468,7 @@ TEST_F(IdlParserTests, unions)
     data = DynamicDataFactory::get_instance()->create_data(type);
     ASSERT_TRUE(data);
 
-     builder = factory->create_type_w_uri("IDL/unions.idl", "Union_BoundedString", include_paths);
+    builder = factory->create_type_w_uri("IDL/unions.idl", "Union_BoundedString", include_paths);
     EXPECT_TRUE(builder);
     type = builder->build();
     ASSERT_TRUE(type);
@@ -1987,7 +1995,8 @@ TEST_F(IdlParserTests, sequences)
     include_paths.push_back("IDL/helpers/basic_inner_types.idl");
 
     /* sequence<short> */
-    DynamicTypeBuilder::_ref_type builder = factory->create_type_w_uri("IDL/sequences.idl", "SequenceShort", include_paths);
+    DynamicTypeBuilder::_ref_type builder = factory->create_type_w_uri("IDL/sequences.idl", "SequenceShort",
+                    include_paths);
     EXPECT_TRUE(builder);
     DynamicType::_ref_type type = builder->build();
     ASSERT_TRUE(type);

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -17,7 +17,6 @@
 #include <fastdds/dds/xtypes/dynamic_types/DynamicDataFactory.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
-#include <fastdds/dds/xtypes/utils.hpp>
 #include <ScopedLogs.hpp>
 #include "IdlParserTests.hpp"
 
@@ -357,11 +356,11 @@ TEST_F(IdlParserTests, structures)
     DynamicType::_ref_type type18 = builder18->build();
     ASSERT_TRUE(type18);
 
-//     // TODO StructBitMask is skipped since bitmask parsing is not supported.
-//     // DynamicTypeBuilder::_ref_type builder19 = factory->create_type_w_uri("IDL/structures.idl", "StructBitMask", include_paths);
-//     // EXPECT_TRUE(builder19);
-//     // DynamicType::_ref_type type19 = builder19->build();
-//     // ASSERT_TRUE(type19);
+    // TODO StructBitMask is skipped since bitmask parsing is not supported.
+    // DynamicTypeBuilder::_ref_type builder19 = factory->create_type_w_uri("IDL/structures.idl", "StructBitMask", include_paths);
+    // EXPECT_TRUE(builder19);
+    // DynamicType::_ref_type type19 = builder19->build();
+    // ASSERT_TRUE(type19);
 
     DynamicTypeBuilder::_ref_type builder20 = factory->create_type_w_uri("IDL/structures.idl", "StructAlias",
                     include_paths);
@@ -410,11 +409,11 @@ TEST_F(IdlParserTests, structures)
     DynamicType::_ref_type type27 = builder27->build();
     ASSERT_TRUE(type27);
 
-//     TODO Structures is skipped since some members parsing is not supported.
-//     DynamicTypeBuilder::_ref_type builder28 = factory->create_type_w_uri("IDL/structures.idl", "Structures", include_paths);
-//     EXPECT_TRUE(builder28);
-//     DynamicType::_ref_type type28 = builder28->build();
-//     ASSERT_TRUE(type28);
+    // TODO Structures is skipped since some members parsing is not supported.
+    // DynamicTypeBuilder::_ref_type builder28 = factory->create_type_w_uri("IDL/structures.idl", "Structures", include_paths);
+    // EXPECT_TRUE(builder28);
+    // DynamicType::_ref_type type28 = builder28->build();
+    // ASSERT_TRUE(type28);
 
     DynamicTypeBuilder::_ref_type builder29 = factory->create_type_w_uri("IDL/structures.idl", "testing_1::foo",
                     include_paths);

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -17,6 +17,7 @@
 #include <fastdds/dds/xtypes/dynamic_types/DynamicDataFactory.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
+#include <fastdds/dds/xtypes/utils.hpp>
 #include <ScopedLogs.hpp>
 #include "IdlParserTests.hpp"
 
@@ -356,11 +357,11 @@ TEST_F(IdlParserTests, structures)
     DynamicType::_ref_type type18 = builder18->build();
     ASSERT_TRUE(type18);
 
-    // TODO StructBitMask is skipped since bitmask parsing is not supported.
-    // DynamicTypeBuilder::_ref_type builder19 = factory->create_type_w_uri("IDL/structures.idl", "StructBitMask", include_paths);
-    // EXPECT_TRUE(builder19);
-    // DynamicType::_ref_type type19 = builder19->build();
-    // ASSERT_TRUE(type19);
+//     // TODO StructBitMask is skipped since bitmask parsing is not supported.
+//     // DynamicTypeBuilder::_ref_type builder19 = factory->create_type_w_uri("IDL/structures.idl", "StructBitMask", include_paths);
+//     // EXPECT_TRUE(builder19);
+//     // DynamicType::_ref_type type19 = builder19->build();
+//     // ASSERT_TRUE(type19);
 
     DynamicTypeBuilder::_ref_type builder20 = factory->create_type_w_uri("IDL/structures.idl", "StructAlias",
                     include_paths);
@@ -409,13 +410,47 @@ TEST_F(IdlParserTests, structures)
     DynamicType::_ref_type type27 = builder27->build();
     ASSERT_TRUE(type27);
 
-    // TODO Structures is skipped since some members parsing is not supported.
-    // DynamicTypeBuilder::_ref_type builder28 = factory->create_type_w_uri("IDL/structures.idl", "Structures", include_paths);
-    // EXPECT_TRUE(builder28);
-    // DynamicType::_ref_type type28 = builder28->build();
-    // ASSERT_TRUE(type28);
+//     TODO Structures is skipped since some members parsing is not supported.
+//     DynamicTypeBuilder::_ref_type builder28 = factory->create_type_w_uri("IDL/structures.idl", "Structures", include_paths);
+//     EXPECT_TRUE(builder28);
+//     DynamicType::_ref_type type28 = builder28->build();
+//     ASSERT_TRUE(type28);
 
-    // TODO The rest types are skipped since module parsing is not supported.
+    DynamicTypeBuilder::_ref_type builder29 = factory->create_type_w_uri("IDL/structures.idl", "testing_1::foo",
+                    include_paths);
+    EXPECT_TRUE(builder29);
+    DynamicType::_ref_type type29 = builder29->build();
+    ASSERT_TRUE(type29);
+
+    DynamicTypeBuilder::_ref_type builder30 = factory->create_type_w_uri("IDL/structures.idl", "testing_2::foo",
+                    include_paths);
+    EXPECT_TRUE(builder30);
+    DynamicType::_ref_type type30 = builder30->build();
+    ASSERT_TRUE(type30);
+
+    DynamicTypeBuilder::_ref_type builder31 = factory->create_type_w_uri("IDL/structures.idl", "bar",
+                    include_paths);
+    EXPECT_TRUE(builder31);
+    DynamicType::_ref_type type31 = builder31->build();
+    ASSERT_TRUE(type31);
+
+    DynamicTypeBuilder::_ref_type builder32 = factory->create_type_w_uri("IDL/structures.idl", "root1",
+                    include_paths);
+    EXPECT_TRUE(builder32);
+    DynamicType::_ref_type type32 = builder32->build();
+    ASSERT_TRUE(type32);
+
+    DynamicTypeBuilder::_ref_type builder33 = factory->create_type_w_uri("IDL/structures.idl", "root2",
+                    include_paths);
+    EXPECT_TRUE(builder33);
+    DynamicType::_ref_type type33 = builder33->build();
+    ASSERT_TRUE(type33);
+
+    DynamicTypeBuilder::_ref_type builder34 = factory->create_type_w_uri("IDL/structures.idl", "root",
+                    include_paths);
+    EXPECT_TRUE(builder34);
+    DynamicType::_ref_type type34 = builder34->build();
+    ASSERT_TRUE(type34);
 }
 
 TEST_F(IdlParserTests, aliases)
@@ -1586,13 +1621,12 @@ TEST_F(IdlParserTests, unions)
     data = DynamicDataFactory::get_instance()->create_data(type);
     ASSERT_TRUE(data);
 
-    // TODO Union_Fixed_String_In_Module_Alias is skipped since module parsing is not supported.
-    // builder = factory->create_type_w_uri("IDL/unions.idl", "Union_Fixed_String_In_Module_Alias", include_paths);
-    // EXPECT_TRUE(builder);
-    // type = builder->build();
-    // ASSERT_TRUE(type);
-    // data = DynamicDataFactory::get_instance()->create_data(type);
-    // ASSERT_TRUE(data);
+    builder = factory->create_type_w_uri("IDL/unions.idl", "Union_Fixed_String_In_Module_Alias", include_paths);
+    EXPECT_TRUE(builder);
+    type = builder->build();
+    ASSERT_TRUE(type);
+    data = DynamicDataFactory::get_instance()->create_data(type);
+    ASSERT_TRUE(data);
 
     builder = factory->create_type_w_uri("IDL/unions.idl", "UnionShort", include_paths);
     EXPECT_TRUE(builder);
@@ -1884,7 +1918,34 @@ TEST_F(IdlParserTests, unions)
     data = DynamicDataFactory::get_instance()->create_data(type);
     ASSERT_TRUE(data);
 
-    // TODO The rest types are skipped since annotation/module parsing are not supported.
+    // TODO The following types are skipped since annotation parsing is not supported.
+    // builder = factory->create_type_w_uri("IDL/unions.idl", "DefaultAnnotation", include_paths);
+    // EXPECT_TRUE(builder);
+    // type = builder->build();
+    // ASSERT_TRUE(type);
+    // data = DynamicDataFactory::get_instance()->create_data(type);
+    // ASSERT_TRUE(data);
+
+    // builder = factory->create_type_w_uri("IDL/unions.idl", "DefaultAnnotationExternalValue", include_paths);
+    // EXPECT_TRUE(builder);
+    // type = builder->build();
+    // ASSERT_TRUE(type);
+    // data = DynamicDataFactory::get_instance()->create_data(type);
+    // ASSERT_TRUE(data);
+
+    builder = factory->create_type_w_uri("IDL/unions.idl", "UnionShortExtraMember", include_paths);
+    EXPECT_TRUE(builder);
+    type = builder->build();
+    ASSERT_TRUE(type);
+    data = DynamicDataFactory::get_instance()->create_data(type);
+    ASSERT_TRUE(data);
+
+    builder = factory->create_type_w_uri("IDL/unions.idl", "UnionFixedStringAlias", include_paths);
+    EXPECT_TRUE(builder);
+    type = builder->build();
+    ASSERT_TRUE(type);
+    data = DynamicDataFactory::get_instance()->create_data(type);
+    ASSERT_TRUE(data);
 }
 
 TEST_F(IdlParserTests, sequences)
@@ -2126,20 +2187,12 @@ TEST_F(IdlParserTests, sequences)
     data = DynamicDataFactory::get_instance()->create_data(type);
     ASSERT_TRUE(data);
 
-    // TODO: The rest types are skipped since module parsing is not supported.
-    // builder = factory->create_type_w_uri("IDL/sequences.idl", "Common_Module", include_paths);
-    // EXPECT_TRUE(builder);
-    // type = builder->build();
-    // ASSERT_TRUE(type);
-    // data = DynamicDataFactory::get_instance()->create_data(type);
-    // ASSERT_TRUE(data);
-
-    // builder = factory->create_type_w_uri("IDL/sequences.idl", "NoCommon_Module", include_paths);
-    // EXPECT_TRUE(builder);
-    // type = builder->build();
-    // ASSERT_TRUE(type);
-    // data = DynamicDataFactory::get_instance()->create_data(type);
-    // ASSERT_TRUE(data);
+    builder = factory->create_type_w_uri("IDL/sequences.idl", "NoCommon_Module::My_Structure", include_paths);
+    EXPECT_TRUE(builder);
+    type = builder->build();
+    ASSERT_TRUE(type);
+    data = DynamicDataFactory::get_instance()->create_data(type);
+    ASSERT_TRUE(data);
 }
 
 int main(

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -451,6 +451,31 @@ TEST_F(IdlParserTests, structures)
     EXPECT_TRUE(builder34);
     DynamicType::_ref_type type34 = builder34->build();
     ASSERT_TRUE(type34);
+
+    /* Additional cases */
+    DynamicTypeBuilder::_ref_type builder35 = factory->create_type_w_uri(
+                "IDL/extra_structures.idl",
+                "Module_1::Module_2::NestedModuleStruct",
+                include_paths);
+    EXPECT_TRUE(builder35);
+    DynamicType::_ref_type type35 = builder35->build();
+    ASSERT_TRUE(type35);
+
+    DynamicTypeBuilder::_ref_type builder36 = factory->create_type_w_uri(
+                "IDL/extra_structures.idl",
+                "Outer::StructWithInnerAlias",
+                include_paths);
+    EXPECT_TRUE(builder36);
+    DynamicType::_ref_type type36 = builder36->build();
+    ASSERT_TRUE(type36);
+
+    DynamicTypeBuilder::_ref_type builder37 = factory->create_type_w_uri(
+                "IDL/extra_structures.idl",
+                "Module::ScopedNamesStruct",
+                include_paths);
+    EXPECT_TRUE(builder37);
+    DynamicType::_ref_type type37 = builder37->build();
+    ASSERT_TRUE(type37);
 }
 
 TEST_F(IdlParserTests, aliases)
@@ -1941,6 +1966,14 @@ TEST_F(IdlParserTests, unions)
     ASSERT_TRUE(data);
 
     builder = factory->create_type_w_uri("IDL/unions.idl", "UnionFixedStringAlias", include_paths);
+    EXPECT_TRUE(builder);
+    type = builder->build();
+    ASSERT_TRUE(type);
+    data = DynamicDataFactory::get_instance()->create_data(type);
+    ASSERT_TRUE(data);
+
+    /* Additional cases */
+    builder = factory->create_type_w_uri("IDL/extra_unions.idl", "UnionScopedDiscriminator", include_paths);
     EXPECT_TRUE(builder);
     type = builder->build();
     ASSERT_TRUE(type);

--- a/test/feature/idl_parser/idl_extra_cases/extra_structures.idl
+++ b/test/feature/idl_parser/idl_extra_cases/extra_structures.idl
@@ -1,0 +1,41 @@
+
+
+// Check nested modules
+module Module_1
+{
+    module Module_2
+    {
+        struct NestedModuleStruct
+        {
+            long var_int32;
+            string<10> var_string;
+        };
+    };
+};
+
+// Check scope resolution from an inner module
+module Outer
+{
+    module Inner
+    {
+        typedef long IntAlias;
+    };
+
+    struct StructWithInnerAlias
+    {
+        Inner::IntAlias int_alias;
+    };
+};
+
+// Check resolution of relative and absolute scoped names
+module Module
+{
+    typedef float FloatAlias;
+
+    struct ScopedNamesStruct
+    {
+        Module::FloatAlias absolute_scoped_float;
+        ::Module::FloatAlias absolute_scoped_w_root_float;
+        FloatAlias relative_scoped_float;
+    };
+};

--- a/test/feature/idl_parser/idl_extra_cases/extra_structures.idl
+++ b/test/feature/idl_parser/idl_extra_cases/extra_structures.idl
@@ -1,5 +1,3 @@
-
-
 // Check nested modules
 module Module_1
 {

--- a/test/feature/idl_parser/idl_extra_cases/extra_unions.idl
+++ b/test/feature/idl_parser/idl_extra_cases/extra_unions.idl
@@ -1,0 +1,20 @@
+// Union with scoped discriminator
+module Module
+{
+    enum ScopedEnumHelper
+    {
+        ENUM_VALUE_1,
+        ENUM_VALUE_2,
+        ENUM_VALUE_3
+    };
+};
+
+union UnionScopedDiscriminator switch (Module::ScopedEnumHelper)
+{
+    case Module::ENUM_VALUE_1:
+        long first;
+    case Module::ENUM_VALUE_2:
+        long long second;
+    default:
+        octet third;
+};

--- a/versions.md
+++ b/versions.md
@@ -11,6 +11,7 @@ Forthcoming
   * New `DataWriter::set_sample_prefilter` method.
   * New `WriteParams::UserWriteData` extensible struct.
 * Add `get_complete_type_object` to `ITypeObjectRegistry`
+* Support modules in `IdlParser`
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds support for scoped types in the IDL Parser. The main changes are as follows:

1. Introduced the `ModuleStack` class to manage hierarchies of nested modules.

2. Updated usage of `DynamicTypeBuilder::get_descriptor`. Since it returns a copy of the Type Descriptor instead of a `shared_ptr` to the original, the previous logic for updating the descriptor after builder instantiation was incorrect. This logic has been moved before the builder instantiation.

3. Internal builder maps now store types using fully qualified names, enabling support for types with the same name in different scopes.

4. Enabled previously commented API functions related to module tree management.

5. Fixed `resolve_scope` method.

6. Added new test cases not covered in `dds-types-test`:
   - Nested modules  
   - Scope resolution  
   - Scoped union discriminators

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
Related documentation PR:
- https://github.com/eProsima/Fast-DDS-docs/pull/1090
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
