### PR TITLE
[23362] Apply changes of uncrustify to all IPP files

### DIFF
--- a/src/cpp/utils/thread_impl/thread_impl_win32.ipp
+++ b/src/cpp/utils/thread_impl/thread_impl_win32.ipp
@@ -24,28 +24,28 @@ thread::native_handle_type thread::start_thread_impl(
         thread::start_routine_type start,
         void* arg)
 {
-        // Set the requested stack size, if given.
-        unsigned stack_attr = 0;
-        if (stack_size > 0)
+    // Set the requested stack size, if given.
+    unsigned stack_attr = 0;
+    if (stack_size > 0)
+    {
+        if (sizeof(unsigned) <= sizeof(int32_t) &&
+                stack_size > static_cast<int32_t>(std::numeric_limits<unsigned>::max() / 2))
         {
-            if (sizeof(unsigned) <= sizeof(int32_t) &&
-                    stack_size > static_cast<int32_t>(std::numeric_limits<unsigned>::max() / 2))
-            {
-                throw std::invalid_argument("Cannot cast stack_size into unsigned");
-            }
-
-            stack_attr = static_cast<unsigned>(stack_size);
+            throw std::invalid_argument("Cannot cast stack_size into unsigned");
         }
 
-        // Construct and execute the thread.
-        HANDLE hnd = (HANDLE) ::_beginthreadex(NULL, stack_attr, start, arg, 0, NULL);
-        if(!hnd)
-        {
-            throw std::system_error(std::make_error_code(std::errc::resource_unavailable_try_again));
-        }
-
-        return hnd;
+        stack_attr = static_cast<unsigned>(stack_size);
     }
+
+    // Construct and execute the thread.
+    HANDLE hnd = (HANDLE) ::_beginthreadex(NULL, stack_attr, start, arg, 0, NULL);
+    if (!hnd)
+    {
+        throw std::system_error(std::make_error_code(std::errc::resource_unavailable_try_again));
+    }
+
+    return hnd;
+}
 
 thread::id thread::get_thread_id_impl(
         thread::native_handle_type hnd)

--- a/src/cpp/utils/threading/threading_pthread.ipp
+++ b/src/cpp/utils/threading/threading_pthread.ipp
@@ -33,9 +33,9 @@
 #include <sys/syscall.h>
 #ifndef SYS_gettid
     #error "SYS_gettid unavailable on this system"
-#endif
+#endif // ifndef SYS_gettid
 #define gettid() ((pid_t)syscall(SYS_gettid))
-#endif
+#endif // if defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ <= 30)))
 
 namespace eprosima {
 
@@ -100,10 +100,10 @@ static void configure_current_thread_scheduler(
 
     if ((sched_class == SCHED_OTHER)
 #if !defined(__QNX__)
-        || (sched_class == SCHED_BATCH)
-        || (sched_class == SCHED_IDLE)
+            || (sched_class == SCHED_BATCH)
+            || (sched_class == SCHED_IDLE)
 #endif  // !defined(__QNX__)
-        )
+            )
     {
         //
         // BATCH and IDLE do not have explicit priority values.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR apply all the changes requested by uncrustify in all the .ipp files on fasdds.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- __N/A__ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
-  __N/A__ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
-  __N/A__ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
-  __N/A__ New feature has been added to the `versions.md` file (if applicable).
-  __N/A__ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
-  __N/A__ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
