### PR TITLE
[22970] Bump to asio 1.34.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 eprosima_find_package(fastcdr 2 REQUIRED)
-eprosima_find_thirdparty(Asio asio VERSION 1.10.8)
+eprosima_find_thirdparty(Asio asio VERSION 1.13.0)
 eprosima_find_thirdparty(TinyXML2 tinyxml2)
 
 find_package(foonathan_memory REQUIRED)

--- a/src/cpp/rtps/transport/TCPAcceptor.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptor.cpp
@@ -24,28 +24,28 @@ namespace rtps {
 using IPLocator = fastdds::rtps::IPLocator;
 
 TCPAcceptor::TCPAcceptor(
-        asio::io_service& io_service,
+        asio::io_context& io_context,
         TCPTransportInterface* parent,
         const Locator& locator)
-    : acceptor_(io_service, parent->generate_endpoint(IPLocator::getPhysicalPort(locator)))
+    : acceptor_(io_context, parent->generate_endpoint(IPLocator::getPhysicalPort(locator)))
     , locator_(locator)
-    , io_service_(&io_service)
+    , io_context_(&io_context)
 {
     locator_.port = acceptor_.local_endpoint().port();
     endpoint_ = asio::ip::tcp::endpoint(parent->generate_protocol(), IPLocator::getPhysicalPort(locator_));
 }
 
 TCPAcceptor::TCPAcceptor(
-        asio::io_service& io_service,
+        asio::io_context& io_context,
         const std::string& iface,
         const Locator& locator)
-    : acceptor_(io_service, asio::ip::tcp::endpoint(asio::ip::address::from_string(iface),
+    : acceptor_(io_context, asio::ip::tcp::endpoint(asio::ip::make_address(iface),
             IPLocator::getPhysicalPort(locator)))
     , locator_(locator)
-    , io_service_(&io_service)
+    , io_context_(&io_context)
 {
     locator_.port = acceptor_.local_endpoint().port();
-    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address::from_string(iface),
+    endpoint_ = asio::ip::tcp::endpoint(asio::ip::make_address(iface),
                     IPLocator::getPhysicalPort(locator_));
 }
 

--- a/src/cpp/rtps/transport/TCPAcceptor.h
+++ b/src/cpp/rtps/transport/TCPAcceptor.h
@@ -35,17 +35,17 @@ protected:
     Locator locator_;
     asio::ip::tcp::endpoint endpoint_;
     std::vector<Locator> pending_out_locators_;
-    asio::io_service* io_service_;
+    asio::io_context* io_context_;
 
 public:
 
     TCPAcceptor(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             TCPTransportInterface* parent,
             const Locator& locator);
 
     TCPAcceptor(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             const std::string& iface,
             const Locator& locator);
 

--- a/src/cpp/rtps/transport/TCPAcceptorBasic.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptorBasic.cpp
@@ -24,23 +24,23 @@ namespace rtps {
 using IPLocator = fastdds::rtps::IPLocator;
 
 TCPAcceptorBasic::TCPAcceptorBasic(
-        asio::io_service& io_service,
+        asio::io_context& io_context,
         TCPTransportInterface* parent,
         const Locator& locator)
-    : TCPAcceptor(io_service, parent, locator)
-    , socket_(*io_service_)
+    : TCPAcceptor(io_context, parent, locator)
+    , socket_(*io_context_)
 {
     endpoint_ = asio::ip::tcp::endpoint(parent->generate_protocol(), IPLocator::getPhysicalPort(locator_));
 }
 
 TCPAcceptorBasic::TCPAcceptorBasic(
-        asio::io_service& io_service,
+        asio::io_context& io_context,
         const std::string& iface,
         const Locator& locator)
-    : TCPAcceptor(io_service, iface, locator)
-    , socket_(*io_service_)
+    : TCPAcceptor(io_context, iface, locator)
+    , socket_(*io_context_)
 {
-    endpoint_ = asio::ip::tcp::endpoint(asio::ip::address::from_string(iface),
+    endpoint_ = asio::ip::tcp::endpoint(asio::ip::make_address(iface),
                     IPLocator::getPhysicalPort(locator_));
 }
 

--- a/src/cpp/rtps/transport/TCPAcceptorBasic.h
+++ b/src/cpp/rtps/transport/TCPAcceptorBasic.h
@@ -31,23 +31,23 @@ public:
 
     /**
      * Constructor
-     * @param io_service Reference to the ASIO service.
+     * @param io_context Reference to the ASIO context.
      * @param parent Pointer to the transport that is going to manage the acceptor.
      * @param locator Locator with the information about where to accept connections.
      */
     TCPAcceptorBasic(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             TCPTransportInterface* parent,
             const Locator& locator);
 
     /**
      * Constructor
-     * @param io_service Reference to the ASIO service.
+     * @param io_context Reference to the ASIO context.
      * @param iface Network interface to bind the socket
      * @param locator Locator with the information about where to accept connections.
      */
     TCPAcceptorBasic(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             const std::string& iface,
             const Locator& locator);
 

--- a/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
@@ -27,18 +27,18 @@ using Log = fastdds::dds::Log;
 using namespace asio;
 
 TCPAcceptorSecure::TCPAcceptorSecure(
-        io_service& io_service,
+        io_context& io_context,
         TCPTransportInterface* parent,
         const Locator_t& locator)
-    : TCPAcceptor(io_service, parent, locator)
+    : TCPAcceptor(io_context, parent, locator)
 {
 }
 
 TCPAcceptorSecure::TCPAcceptorSecure(
-        io_service& io_service,
+        io_context& io_context,
         const std::string& iface,
         const Locator_t& locator)
-    : TCPAcceptor(io_service, iface, locator)
+    : TCPAcceptor(io_context, iface, locator)
 {
 }
 
@@ -83,7 +83,7 @@ void TCPAcceptorSecure::accept(
                 }
             });
 #else
-        auto secure_socket = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(*io_service_, ssl_context);
+        auto secure_socket = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(*io_context_, ssl_context);
 
         acceptor_.async_accept(secure_socket->lowest_layer(),
                 [locator, parent, secure_socket](const std::error_code& error)

--- a/src/cpp/rtps/transport/TCPAcceptorSecure.h
+++ b/src/cpp/rtps/transport/TCPAcceptorSecure.h
@@ -37,23 +37,23 @@ public:
 
     /**
      * Constructor
-     * @param io_service Reference to the ASIO service.
+     * @param io_context Reference to the ASIO context.
      * @param parent Pointer to the transport that is going to manage the acceptor.
      * @param locator Locator with the information about where to accept connections.
      */
     TCPAcceptorSecure(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             TCPTransportInterface* parent,
             const Locator& locator);
 
     /**
      * Constructor
-     * @param io_service Reference to the ASIO service.
+     * @param io_context Reference to the ASIO context.
      * @param iface Network interface to bind the socket
      * @param locator Locator with the information about where to accept connections.
      */
     TCPAcceptorSecure(
-            asio::io_service& io_service,
+            asio::io_context& io_context,
             const std::string& iface,
             const Locator& locator);
 

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -67,9 +67,9 @@ void TCPChannelResourceBasic::connect(
             ip::tcp::resolver resolver(context_);
 
             auto endpoints = resolver.resolve(
-                            IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
-                                locator_),
-                            std::to_string(IPLocator::getPhysicalPort(locator_)));
+                IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
+                    locator_),
+                std::to_string(IPLocator::getPhysicalPort(locator_)));
 
             socket_ = std::make_shared<asio::ip::tcp::socket>(context_);
             std::weak_ptr<TCPChannelResource> channel_weak_ptr = myself;

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -31,21 +31,21 @@ using Log = fastdds::dds::Log;
 
 TCPChannelResourceBasic::TCPChannelResourceBasic(
         TCPTransportInterface* parent,
-        asio::io_service& service,
+        asio::io_context& context,
         const Locator& locator,
         uint32_t maxMsgSize)
     : TCPChannelResource(parent, locator, maxMsgSize)
-    , service_(service)
+    , context_(context)
 {
 }
 
 TCPChannelResourceBasic::TCPChannelResourceBasic(
         TCPTransportInterface* parent,
-        asio::io_service& service,
+        asio::io_context& context,
         std::shared_ptr<asio::ip::tcp::socket> socket,
         uint32_t maxMsgSize)
     : TCPChannelResource(parent, maxMsgSize)
-    , service_(service)
+    , context_(context)
     , socket_(socket)
 {
 }
@@ -64,14 +64,14 @@ void TCPChannelResourceBasic::connect(
     {
         try
         {
-            ip::tcp::resolver resolver(service_);
+            ip::tcp::resolver resolver(context_);
 
-            auto endpoints = resolver.resolve({
+            auto endpoints = resolver.resolve(
                             IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
                                 locator_),
-                            std::to_string(IPLocator::getPhysicalPort(locator_))});
+                            std::to_string(IPLocator::getPhysicalPort(locator_)));
 
-            socket_ = std::make_shared<asio::ip::tcp::socket>(service_);
+            socket_ = std::make_shared<asio::ip::tcp::socket>(context_);
             std::weak_ptr<TCPChannelResource> channel_weak_ptr = myself;
 
             asio::async_connect(
@@ -109,7 +109,7 @@ void TCPChannelResourceBasic::disconnect()
         std::error_code ec;
         socket->shutdown(asio::ip::tcp::socket::shutdown_both, ec);
 
-        service_.post([&, socket]()
+        asio::post(context_, [&, socket]()
                 {
                     try
                     {

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -25,7 +25,7 @@ namespace rtps {
 
 class TCPChannelResourceBasic : public TCPChannelResource
 {
-    asio::io_service& service_;
+    asio::io_context& context_;
 
     std::mutex send_mutex_;
     std::shared_ptr<asio::ip::tcp::socket> socket_;
@@ -35,14 +35,14 @@ public:
     // Constructor called when trying to connect to a remote server
     TCPChannelResourceBasic(
             TCPTransportInterface* parent,
-            asio::io_service& service,
+            asio::io_context& context,
             const Locator& locator,
             uint32_t maxMsgSize);
 
     // Constructor called when local server accepted connection
     TCPChannelResourceBasic(
             TCPTransportInterface* parent,
-            asio::io_service& service,
+            asio::io_context& context,
             std::shared_ptr<asio::ip::tcp::socket> socket,
             uint32_t maxMsgSize);
 

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -31,29 +31,29 @@ using namespace asio;
 
 TCPChannelResourceSecure::TCPChannelResourceSecure(
         TCPTransportInterface* parent,
-        asio::io_service& service,
+        asio::io_context& context,
         asio::ssl::context& ssl_context,
         const Locator_t& locator,
         uint32_t maxMsgSize)
     : TCPChannelResource(parent, locator, maxMsgSize)
-    , service_(service)
+    , context_(context)
     , ssl_context_(ssl_context)
-    , strand_read_(service)
-    , strand_write_(service)
+    , strand_read_(make_strand(context))
+    , strand_write_(make_strand(context))
 {
 }
 
 TCPChannelResourceSecure::TCPChannelResourceSecure(
         TCPTransportInterface* parent,
-        asio::io_service& service,
+        asio::io_context& context,
         asio::ssl::context& ssl_context,
         std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> socket,
         uint32_t maxMsgSize)
     : TCPChannelResource(parent, maxMsgSize)
-    , service_(service)
+    , context_(context)
     , ssl_context_(ssl_context)
-    , strand_read_(service)
-    , strand_write_(service)
+    , strand_read_(make_strand(context))
+    , strand_write_(make_strand(context))
     , secure_socket_(socket)
 {
     set_tls_verify_mode(parent->configuration());
@@ -76,15 +76,15 @@ void TCPChannelResourceSecure::connect(
     {
         try
         {
-            ip::tcp::resolver resolver(service_);
+            ip::tcp::resolver resolver(context_);
 
-            auto endpoints = resolver.resolve({
+            auto endpoints = resolver.resolve(
                             IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
                                 locator_),
-                            std::to_string(IPLocator::getPhysicalPort(locator_))});
+                            std::to_string(IPLocator::getPhysicalPort(locator_)));
 
             TCPTransportInterface* parent = parent_;
-            secure_socket_ = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(service_, ssl_context_);
+            secure_socket_ = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(context_, ssl_context_);
             set_tls_verify_mode(parent->configuration());
             set_tls_sni(parent->configuration());
             std::weak_ptr<TCPChannelResource> channel_weak_ptr = myself;
@@ -142,7 +142,7 @@ void TCPChannelResourceSecure::disconnect()
     {
         auto socket = secure_socket_;
 
-        service_.post([&, socket]()
+        post(context_, [&, socket]()
                 {
                     std::error_code ec;
                     socket->lowest_layer().close(ec);
@@ -166,7 +166,7 @@ uint32_t TCPChannelResourceSecure::read(
         auto bytes_future = read_bytes_promise.get_future();
         auto socket = secure_socket_;
 
-        strand_read_.post([&, socket]()
+        asio::post(strand_read_, [&, socket]()
                 {
                     if (socket->lowest_layer().is_open())
                     {
@@ -227,7 +227,7 @@ size_t TCPChannelResourceSecure::send(
         auto bytes_future = write_bytes_promise.get_future();
         auto socket = secure_socket_;
 
-        strand_write_.post([&, socket]()
+        asio::post(strand_write_, [&, socket]()
                 {
                     if (socket->lowest_layer().is_open())
                     {

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -79,9 +79,9 @@ void TCPChannelResourceSecure::connect(
             ip::tcp::resolver resolver(context_);
 
             auto endpoints = resolver.resolve(
-                            IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
-                                locator_),
-                            std::to_string(IPLocator::getPhysicalPort(locator_)));
+                IPLocator::hasWan(locator_) ? IPLocator::toWanstring(locator_) : IPLocator::ip_to_string(
+                    locator_),
+                std::to_string(IPLocator::getPhysicalPort(locator_)));
 
             TCPTransportInterface* parent = parent_;
             secure_socket_ = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(context_, ssl_context_);

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -36,7 +36,7 @@ public:
     // Constructor called when trying to connect to a remote server (secure version)
     TCPChannelResourceSecure(
             TCPTransportInterface* parent,
-            asio::io_service& service,
+            asio::io_context& context,
             asio::ssl::context& ssl_context,
             const Locator& locator,
             uint32_t maxMsgSize);
@@ -44,7 +44,7 @@ public:
     // Constructor called when local server accepted connection (secure version)
     TCPChannelResourceSecure(
             TCPTransportInterface* parent,
-            asio::io_service& service,
+            asio::io_context& context,
             asio::ssl::context& ssl_context,
             std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> socket,
             uint32_t maxMsgSize);
@@ -104,10 +104,10 @@ private:
     TCPChannelResourceSecure& operator =(
             const TCPChannelResource&) = delete;
 
-    asio::io_service& service_;
+    asio::io_context& context_;
     asio::ssl::context& ssl_context_;
-    asio::io_service::strand strand_read_;
-    asio::io_service::strand strand_write_;
+    asio::strand<asio::io_context::executor_type> strand_read_;
+    asio::strand<asio::io_context::executor_type> strand_write_;
     std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> secure_socket_;
 };
 

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -586,7 +586,7 @@ bool TCPTransportInterface::init(
         auto ioContextTimersFunction = [&]()
                 {
                     asio::executor_work_guard<asio::io_context::executor_type> work = make_work_guard(io_context_timers_.
-                                    get_executor());
+                                            get_executor());
                     io_context_timers_.run();
                 };
         io_context_timers_thread_ = create_thread(ioContextTimersFunction,

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -168,7 +168,7 @@ TCPTransportInterface::TCPTransportInterface(
 #if TLS_FOUND
     , ssl_context_(asio::ssl::context::sslv23)
 #endif // if TLS_FOUND
-    , keep_alive_event_(io_service_timers_)
+    , keep_alive_event_(io_context_timers_)
 {
 }
 
@@ -182,10 +182,10 @@ void TCPTransportInterface::clean()
     alive_.store(false);
 
     keep_alive_event_.cancel();
-    if (io_service_timers_thread_.joinable())
+    if (io_context_timers_thread_.joinable())
     {
-        io_service_timers_.stop();
-        io_service_timers_thread_.join();
+        io_context_timers_.stop();
+        io_context_timers_thread_.join();
     }
 
     {
@@ -250,10 +250,10 @@ void TCPTransportInterface::clean()
         initial_peer_local_locator_socket_.reset();
     }
 
-    if (io_service_thread_.joinable())
+    if (io_context_thread_.joinable())
     {
-        io_service_.stop();
-        io_service_thread_.join();
+        io_context_.stop();
+        io_context_thread_.join();
     }
 }
 
@@ -383,7 +383,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
             if (configuration()->apply_security)
             {
                 std::shared_ptr<TCPAcceptorSecure> acceptor =
-                        std::make_shared<TCPAcceptorSecure>(io_service_, this, locator);
+                        std::make_shared<TCPAcceptorSecure>(io_context_, this, locator);
                 acceptors_[acceptor->locator()] = acceptor;
                 acceptor->accept(this, ssl_context_);
                 final_port = static_cast<uint16_t>(acceptor->locator().port);
@@ -392,7 +392,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
 #endif // if TLS_FOUND
             {
                 std::shared_ptr<TCPAcceptorBasic> acceptor =
-                        std::make_shared<TCPAcceptorBasic>(io_service_, this, locator);
+                        std::make_shared<TCPAcceptorBasic>(io_context_, this, locator);
                 acceptors_[acceptor->locator()] = acceptor;
                 acceptor->accept(this);
                 final_port = static_cast<uint16_t>(acceptor->locator().port);
@@ -421,7 +421,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
                 if (configuration()->apply_security)
                 {
                     std::shared_ptr<TCPAcceptorSecure> acceptor =
-                            std::make_shared<TCPAcceptorSecure>(io_service_, sInterface, loc);
+                            std::make_shared<TCPAcceptorSecure>(io_context_, sInterface, loc);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this, ssl_context_);
                     final_port = static_cast<uint16_t>(acceptor->locator().port);
@@ -430,7 +430,7 @@ uint16_t TCPTransportInterface::create_acceptor_socket(
 #endif // if TLS_FOUND
                 {
                     std::shared_ptr<TCPAcceptorBasic> acceptor =
-                            std::make_shared<TCPAcceptorBasic>(io_service_, sInterface, loc);
+                            std::make_shared<TCPAcceptorBasic>(io_context_, sInterface, loc);
                     acceptors_[acceptor->locator()] = acceptor;
                     acceptor->accept(this);
                     final_port = static_cast<uint16_t>(acceptor->locator().port);
@@ -535,7 +535,7 @@ bool TCPTransportInterface::init(
        This process ensures uniqueness in the server's channel resources mapping, which uses client locators as keys.
        Although differing from the real client socket local port, provides a reliable mapping mechanism.
      */
-    initial_peer_local_locator_socket_ = std::unique_ptr<asio::ip::tcp::socket>(new asio::ip::tcp::socket(io_service_));
+    initial_peer_local_locator_socket_ = std::unique_ptr<asio::ip::tcp::socket>(new asio::ip::tcp::socket(io_context_));
     initial_peer_local_locator_socket_->open(generate_protocol());
 
     // Binding to port 0 delegates the port selection to the system.
@@ -574,30 +574,22 @@ bool TCPTransportInterface::init(
         rtcp_message_manager_ = std::make_shared<RTCPMessageManager>(this);
     }
 
-    auto ioServiceFunction = [&]()
+    auto ioContextFunction = [&]()
             {
-#if ASIO_VERSION >= 101200
-                asio::executor_work_guard<asio::io_service::executor_type> work(io_service_.get_executor());
-#else
-                io_service::work work(io_service_);
-#endif // if ASIO_VERSION >= 101200
-                io_service_.run();
+                asio::executor_work_guard<asio::io_context::executor_type> work = make_work_guard(io_context_);
+                io_context_.run();
             };
-    io_service_thread_ = create_thread(ioServiceFunction, configuration()->accept_thread, "dds.tcp_accept");
+    io_context_thread_ = create_thread(ioContextFunction, configuration()->accept_thread, "dds.tcp_accept");
 
     if (0 < configuration()->keep_alive_frequency_ms)
     {
-        auto ioServiceTimersFunction = [&]()
+        auto ioContextTimersFunction = [&]()
                 {
-#if ASIO_VERSION >= 101200
-                    asio::executor_work_guard<asio::io_service::executor_type> work(io_service_timers_.
+                    asio::executor_work_guard<asio::io_context::executor_type> work = make_work_guard(io_context_timers_.
                                     get_executor());
-#else
-                    io_service::work work(io_service_timers_);
-#endif // if ASIO_VERSION >= 101200
-                    io_service_timers_.run();
+                    io_context_timers_.run();
                 };
-        io_service_timers_thread_ = create_thread(ioServiceTimersFunction,
+        io_context_timers_thread_ = create_thread(ioContextTimersFunction,
                         configuration()->keep_alive_thread, "dds.tcp_keep");
     }
 
@@ -898,11 +890,11 @@ bool TCPTransportInterface::OpenOutputChannel(
 #if TLS_FOUND
                 (configuration()->apply_security) ?
                 static_cast<TCPChannelResource*>(
-                    new TCPChannelResourceSecure(this, io_service_, ssl_context_,
+                    new TCPChannelResourceSecure(this, io_context_, ssl_context_,
                     physical_locator, configuration()->maxMessageSize)) :
 #endif // if TLS_FOUND
                 static_cast<TCPChannelResource*>(
-                    new TCPChannelResourceBasic(this, io_service_, physical_locator,
+                    new TCPChannelResourceBasic(this, io_context_, physical_locator,
                     configuration()->maxMessageSize))
                 );
 
@@ -1020,11 +1012,11 @@ bool TCPTransportInterface::CreateInitialConnect(
 #if TLS_FOUND
         (configuration()->apply_security) ?
         static_cast<TCPChannelResource*>(
-            new TCPChannelResourceSecure(this, io_service_, ssl_context_,
+            new TCPChannelResourceSecure(this, io_context_, ssl_context_,
             physical_locator, configuration()->maxMessageSize)) :
 #endif // if TLS_FOUND
         static_cast<TCPChannelResource*>(
-            new TCPChannelResourceBasic(this, io_service_, physical_locator,
+            new TCPChannelResourceBasic(this, io_context_, physical_locator,
             configuration()->maxMessageSize))
         );
 
@@ -1665,7 +1657,7 @@ void TCPTransportInterface::SocketAccepted(
         {
             // Always create a new channel, it might be replaced later in bind_socket()
             std::shared_ptr<TCPChannelResource> channel(new TCPChannelResourceBasic(this,
-                    io_service_, socket, configuration()->maxMessageSize));
+                    io_context_, socket, configuration()->maxMessageSize));
 
             {
                 std::unique_lock<std::mutex> unbound_lock(unbound_map_mutex_);
@@ -1708,7 +1700,7 @@ void TCPTransportInterface::SecureSocketAccepted(
         {
             // Always create a new secure_channel, it might be replaced later in bind_socket()
             std::shared_ptr<TCPChannelResource> secure_channel(new TCPChannelResourceSecure(this,
-                    io_service_, ssl_context_, socket, configuration()->maxMessageSize));
+                    io_context_, ssl_context_, socket, configuration()->maxMessageSize));
 
             {
                 std::unique_lock<std::mutex> unbound_lock(unbound_map_mutex_);

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -87,16 +87,16 @@ class TCPTransportInterface : public TransportInterface
 
 protected:
 
-    asio::io_service io_service_;
-    asio::io_service io_service_timers_;
+    asio::io_context io_context_;
+    asio::io_context io_context_timers_;
     std::unique_ptr<asio::ip::tcp::socket> initial_peer_local_locator_socket_;
     uint16_t initial_peer_local_locator_port_;
 
 #if TLS_FOUND
     asio::ssl::context ssl_context_;
 #endif // if TLS_FOUND
-    eprosima::thread io_service_thread_;
-    eprosima::thread io_service_timers_thread_;
+    eprosima::thread io_context_thread_;
+    eprosima::thread io_context_timers_thread_;
     std::shared_ptr<RTCPMessageManager> rtcp_message_manager_;
     std::mutex rtcp_message_manager_mutex_;
     std::condition_variable rtcp_message_manager_cv_;

--- a/src/cpp/rtps/transport/TCPv4Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv4Transport.cpp
@@ -135,7 +135,7 @@ TCPv4Transport::TCPv4Transport(
             }
             else if (descriptor.interfaceWhiteList.empty() && descriptor.interface_allowlist.empty())
             {
-                interface_whitelist_.emplace_back(ip::address_v4::from_string(infoIP.name));
+                interface_whitelist_.emplace_back(ip::make_address_v4(infoIP.name));
                 allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                         descriptor.netmask_filter);
             }
@@ -154,7 +154,7 @@ TCPv4Transport::TCPv4Transport(
                     if (network::netmask_filter::validate_and_transform(netmask_filter,
                             descriptor.netmask_filter))
                     {
-                        interface_whitelist_.emplace_back(ip::address_v4::from_string(infoIP.name));
+                        interface_whitelist_.emplace_back(ip::make_address_v4(infoIP.name));
                         allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                                 netmask_filter);
                     }
@@ -175,7 +175,7 @@ TCPv4Transport::TCPv4Transport(
                             return whitelist_element == infoIP.dev || whitelist_element == infoIP.name;
                         }) != white_end )
                 {
-                    interface_whitelist_.emplace_back(ip::address_v4::from_string(infoIP.name));
+                    interface_whitelist_.emplace_back(ip::make_address_v4(infoIP.name));
                     allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                             descriptor.netmask_filter);
                 }
@@ -185,7 +185,7 @@ TCPv4Transport::TCPv4Transport(
         if (interface_whitelist_.empty())
         {
             EPROSIMA_LOG_ERROR(TRANSPORT_TCPV4, "All whitelist interfaces were filtered out");
-            interface_whitelist_.emplace_back(ip::address_v4::from_string("192.0.2.0"));
+            interface_whitelist_.emplace_back(ip::make_address_v4("192.0.2.0"));
         }
     }
 
@@ -321,7 +321,7 @@ bool TCPv4Transport::is_interface_whitelist_empty() const
 bool TCPv4Transport::is_interface_allowed(
         const std::string& iface) const
 {
-    return is_interface_allowed(asio::ip::address_v4::from_string(iface));
+    return is_interface_allowed(asio::ip::make_address_v4(iface));
 }
 
 bool TCPv4Transport::is_interface_allowed(
@@ -351,7 +351,7 @@ LocatorList TCPv4Transport::NormalizeLocator(
         get_ipv4s(locNames, false, false);
         for (const auto& infoIP : locNames)
         {
-            auto ip = asio::ip::address_v4::from_string(infoIP.name);
+            auto ip = asio::ip::make_address_v4(infoIP.name);
             if (is_interface_allowed(ip))
             {
                 Locator newloc(locator);
@@ -491,7 +491,7 @@ asio::ip::tcp TCPv4Transport::generate_protocol() const
 bool TCPv4Transport::is_interface_allowed(
         const Locator& loc) const
 {
-    asio::ip::address_v4 ip = asio::ip::address_v4::from_string(IPLocator::toIPv4string(loc));
+    asio::ip::address_v4 ip = asio::ip::make_address_v4(IPLocator::toIPv4string(loc));
     return is_interface_allowed(ip);
 }
 

--- a/src/cpp/rtps/transport/TCPv6Transport.cpp
+++ b/src/cpp/rtps/transport/TCPv6Transport.cpp
@@ -139,7 +139,7 @@ TCPv6Transport::TCPv6Transport(
             }
             else if (descriptor.interfaceWhiteList.empty() && descriptor.interface_allowlist.empty())
             {
-                interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                 allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                         descriptor.netmask_filter);
             }
@@ -159,7 +159,7 @@ TCPv6Transport::TCPv6Transport(
                     if (network::netmask_filter::validate_and_transform(netmask_filter,
                             descriptor.netmask_filter))
                     {
-                        interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                        interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                         allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                                 netmask_filter);
                     }
@@ -180,7 +180,7 @@ TCPv6Transport::TCPv6Transport(
                             return whitelist_element == infoIP.dev || compare_ips(whitelist_element, infoIP.name);
                         }) != white_end )
                 {
-                    interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                    interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                     allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                             descriptor.netmask_filter);
                 }
@@ -190,7 +190,7 @@ TCPv6Transport::TCPv6Transport(
         if (interface_whitelist_.empty())
         {
             EPROSIMA_LOG_ERROR(TRANSPORT_TCPV6, "All whitelist interfaces were filtered out");
-            interface_whitelist_.emplace_back(ip::address_v6::from_string("2001:db8::"));
+            interface_whitelist_.emplace_back(ip::make_address_v6("2001:db8::"));
         }
     }
 
@@ -331,7 +331,7 @@ bool TCPv6Transport::is_interface_whitelist_empty() const
 bool TCPv6Transport::is_interface_allowed(
         const std::string& iface) const
 {
-    return is_interface_allowed(asio::ip::address_v6::from_string(iface));
+    return is_interface_allowed(asio::ip::make_address_v6(iface));
 }
 
 bool TCPv6Transport::is_interface_allowed(
@@ -470,7 +470,7 @@ asio::ip::tcp TCPv6Transport::generate_protocol() const
 bool TCPv6Transport::is_interface_allowed(
         const Locator& loc) const
 {
-    asio::ip::address_v6 ip = asio::ip::address_v6::from_string(IPLocator::toIPv6string(loc));
+    asio::ip::address_v6 ip = asio::ip::make_address_v6(IPLocator::toIPv6string(loc));
     return is_interface_allowed(ip);
 }
 

--- a/src/cpp/rtps/transport/UDPChannelResource.h
+++ b/src/cpp/rtps/transport/UDPChannelResource.h
@@ -38,8 +38,8 @@ class eProsimaUDPSocket : public asio::ip::udp::socket
 public:
 
     explicit eProsimaUDPSocket(
-            asio::io_service& io_service)
-        : asio::ip::udp::socket(io_service)
+            asio::io_context& io_context)
+        : asio::ip::udp::socket(io_context)
     {
     }
 
@@ -74,9 +74,9 @@ inline eProsimaUDPSocket moveSocket(
 }
 
 inline eProsimaUDPSocket createUDPSocket(
-        asio::io_service& io_service)
+        asio::io_context& io_context)
 {
-    return eProsimaUDPSocket(io_service);
+    return eProsimaUDPSocket(io_context);
 }
 
 inline eProsimaUDPSocket& getRefFromPtr(
@@ -92,8 +92,8 @@ class eProsimaUDPSocket : public std::shared_ptr<asio::ip::udp::socket>
 public:
 
     explicit eProsimaUDPSocket(
-            asio::io_service& io_service)
-        : shared_ptr<asio::ip::udp::socket>(io_service)
+            asio::io_context& io_context)
+        : shared_ptr<asio::ip::udp::socket>(io_context)
     {
     }
 
@@ -128,9 +128,9 @@ inline eProsimaUDPSocket moveSocket(
 }
 
 inline eProsimaUDPSocket createUDPSocket(
-        asio::io_service& io_service)
+        asio::io_context& io_context)
 {
-    return eProsimaUDPSocket(io_service);
+    return eProsimaUDPSocket(io_context);
 }
 
 inline eProsimaUDPSocket getRefFromPtr(

--- a/src/cpp/rtps/transport/UDPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/UDPTransportInterface.cpp
@@ -153,7 +153,7 @@ bool UDPTransportInterface::init(
     }
 
     asio::error_code ec;
-    ip::udp::socket socket(io_service_);
+    ip::udp::socket socket(io_context_);
     socket.open(generate_protocol(), ec);
     if (!!ec)
     {
@@ -249,7 +249,7 @@ eProsimaUDPSocket UDPTransportInterface::OpenAndBindUnicastOutputSocket(
         const ip::udp::endpoint& endpoint,
         uint16_t& port)
 {
-    eProsimaUDPSocket socket = createUDPSocket(io_service_);
+    eProsimaUDPSocket socket = createUDPSocket(io_context_);
     getSocketPtr(socket)->open(generate_protocol());
     if (mSendBufferSize != 0)
     {

--- a/src/cpp/rtps/transport/UDPTransportInterface.h
+++ b/src/cpp/rtps/transport/UDPTransportInterface.h
@@ -197,7 +197,7 @@ protected:
     friend class UDPChannelResource;
 
     // For UDPv6, the notion of channel corresponds to a port + direction tuple.
-    asio::io_service io_service_;
+    asio::io_context io_context_;
 
     mutable std::recursive_mutex mInputMapMutex;
     std::map<uint16_t, std::vector<UDPChannelResource*>> mInputSockets;

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -167,7 +167,7 @@ UDPv6Transport::UDPv6Transport(
             }
             else if (descriptor.interfaceWhiteList.empty() && descriptor.interface_allowlist.empty())
             {
-                interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                 allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                         descriptor.netmask_filter);
             }
@@ -187,7 +187,7 @@ UDPv6Transport::UDPv6Transport(
                     if (network::netmask_filter::validate_and_transform(netmask_filter,
                             descriptor.netmask_filter))
                     {
-                        interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                        interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                         allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                                 netmask_filter);
                     }
@@ -208,7 +208,7 @@ UDPv6Transport::UDPv6Transport(
                             return whitelist_element == infoIP.dev || compare_ips(whitelist_element, infoIP.name);
                         }) != white_end )
                 {
-                    interface_whitelist_.emplace_back(ip::address_v6::from_string(infoIP.name));
+                    interface_whitelist_.emplace_back(ip::make_address_v6(infoIP.name));
                     allowed_interfaces_.emplace_back(infoIP.dev, infoIP.name, infoIP.masked_locator,
                             descriptor.netmask_filter);
                 }
@@ -218,7 +218,7 @@ UDPv6Transport::UDPv6Transport(
         if (interface_whitelist_.empty())
         {
             EPROSIMA_LOG_ERROR(TRANSPORT_UDPV6, "All whitelist interfaces were filtered out");
-            interface_whitelist_.emplace_back(ip::address_v6::from_string("2001:db8::"));
+            interface_whitelist_.emplace_back(ip::make_address_v6("2001:db8::"));
         }
     }
 }
@@ -351,7 +351,7 @@ ip::udp::endpoint UDPv6Transport::generate_endpoint(
         const std::string& sIp,
         uint16_t port)
 {
-    return asio::ip::udp::endpoint(ip::address_v6::from_string(sIp), port);
+    return asio::ip::udp::endpoint(ip::make_address_v6(sIp), port);
 }
 
 ip::udp::endpoint UDPv6Transport::generate_endpoint(
@@ -391,7 +391,7 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
         uint16_t port,
         bool is_multicast)
 {
-    eProsimaUDPSocket socket = createUDPSocket(io_service_);
+    eProsimaUDPSocket socket = createUDPSocket(io_context_);
     getSocketPtr(socket)->open(generate_protocol());
     if (mReceiveBufferSize != 0)
     {
@@ -453,7 +453,7 @@ bool UDPv6Transport::OpenInputChannel(
     if (IPLocator::isMulticast(locator) && IsInputChannelOpen(locator))
     {
         std::string locatorAddressStr = IPLocator::toIPv6string(locator);
-        ip::address_v6 locatorAddress = ip::address_v6::from_string(locatorAddressStr);
+        ip::address_v6 locatorAddress = ip::make_address_v6(locatorAddressStr);
 
 #ifndef _WIN32
         if (!is_interface_whitelist_empty())
@@ -513,7 +513,7 @@ bool UDPv6Transport::OpenInputChannel(
                     get_ipv6s_unique_interfaces(locNames, true, false);
                     for (const auto& infoIP : locNames)
                     {
-                        auto ip = asio::ip::address_v6::from_string(infoIP.name);
+                        auto ip = asio::ip::make_address_v6(infoIP.name);
                         try
                         {
                             channelResource->socket()->set_option(ip::multicast::join_group(locatorAddress,
@@ -529,7 +529,7 @@ bool UDPv6Transport::OpenInputChannel(
                 }
                 else
                 {
-                    auto ip = asio::ip::address_v6::from_string(channelResource->iface());
+                    auto ip = asio::ip::make_address_v6(channelResource->iface());
                     try
                     {
                         channelResource->socket()->set_option(ip::multicast::join_group(locatorAddress, ip.scope_id()));
@@ -573,7 +573,7 @@ bool UDPv6Transport::is_interface_allowed(
         return true;
     }
 
-    if (asio::ip::address_v6::from_string(iface) == ip::address_v6::any())
+    if (asio::ip::make_address_v6(iface) == ip::address_v6::any())
     {
         return true;
     }
@@ -700,7 +700,7 @@ void UDPv6Transport::SetSocketOutboundInterface(
     }
 #endif // ifdef __APPLE__
     getSocketPtr(socket)->set_option(ip::multicast::outbound_interface(
-                asio::ip::address_v6::from_string(sIp).scope_id()));
+                asio::ip::make_address_v6(sIp).scope_id()));
 }
 
 bool UDPv6Transport::compare_ips(

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -63,7 +63,7 @@ test_UDPv4Transport::test_UDPv4Transport(
     UDPv4Transport::mReceiveBufferSize = descriptor.receiveBufferSize;
     for (auto interf : descriptor.interfaceWhiteList)
     {
-        UDPv4Transport::interface_whitelist_.emplace_back(asio::ip::address_v4::from_string(interf));
+        UDPv4Transport::interface_whitelist_.emplace_back(asio::ip::make_address_v4(interf));
     }
     test_transport_options->test_UDPv4Transport_DropLog.clear();
     test_transport_options->test_UDPv4Transport_DropLogLength = descriptor.dropLogLength;

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -1188,21 +1188,21 @@ std::pair<std::set<std::string>, std::set<std::string>> IPLocator::resolveNameDN
     std::set<std::string> ipv4_results;
     std::set<std::string> ipv6_results;
 
-    // Create an instance of io service
-    asio::io_service ios;
-
-    //Create a query to make the DNS petition
-    asio::ip::tcp::resolver::query resolver_query(address_name, "", asio::ip::tcp::resolver::query::numeric_service);
-
+    // Create an instance of io context
+    asio::io_context ioc;
+    
     // Create a resolver instance
-    asio::ip::tcp::resolver resolver(ios);
+    asio::ip::tcp::resolver resolver(ioc);
 
     // Used to store information about error that happens during the resolution process.
     asio::error_code ec;
 
     // Make the DNS petition
-    asio::ip::tcp::resolver::iterator it =
-            resolver.resolve(resolver_query, ec);
+    auto results = resolver.resolve(
+        address_name,
+        "",
+        asio::ip::resolver_base::numeric_service,
+        ec);
 
     // Handling errors if any.
     if (ec)
@@ -1212,20 +1212,20 @@ std::pair<std::set<std::string>, std::set<std::string>> IPLocator::resolveNameDN
         return std::make_pair(ipv4_results, ipv6_results);
     }
 
-    asio::ip::tcp::resolver::iterator end_it;
-    for (; it != end_it; ++it)
+    for (const auto& entry : results)
     {
+        const auto& addr = entry.endpoint().address();
         EPROSIMA_LOG_INFO(IP_LOCATOR,
-                "IP " << it->endpoint().address() << " found by DNS request to address " << address_name);
+                "IP " << addr << " found by DNS request to address " << address_name);
 
         // Check whether the ip get is v4 or v6
-        if (it->endpoint().address().is_v4())
+        if (addr.is_v4())
         {
-            ipv4_results.insert(it->endpoint().address().to_string());
+            ipv4_results.insert(addr.to_string());
         }
         else
         {
-            ipv6_results.insert(it->endpoint().address().to_string());
+            ipv6_results.insert(addr.to_string());
         }
     }
 

--- a/src/cpp/utils/IPLocator.cpp
+++ b/src/cpp/utils/IPLocator.cpp
@@ -1190,7 +1190,7 @@ std::pair<std::set<std::string>, std::set<std::string>> IPLocator::resolveNameDN
 
     // Create an instance of io context
     asio::io_context ioc;
-    
+
     // Create a resolver instance
     asio::ip::tcp::resolver resolver(ioc);
 

--- a/test/blackbox/common/UDPMessageSender.hpp
+++ b/test/blackbox/common/UDPMessageSender.hpp
@@ -1,4 +1,4 @@
-#include <asio/io_service.hpp>
+#include <asio/io_context.hpp>
 #include <asio/ip/udp.hpp>
 
 #include <fastdds/rtps/common/CDRMessage_t.hpp>
@@ -9,12 +9,12 @@ using namespace eprosima::fastdds::rtps;
 
 struct UDPMessageSender
 {
-    asio::io_service service;
+    asio::io_context context;
     asio::ip::udp::socket socket;
 
     UDPMessageSender()
-        : service()
-        , socket(service)
+        : context()
+        , socket(context)
     {
         socket.open(asio::ip::udp::v4());
     }
@@ -25,7 +25,7 @@ struct UDPMessageSender
     {
         std::string addr = IPLocator::toIPv4string(destination);
         unsigned short port = static_cast<unsigned short>(destination.port);
-        auto remote = asio::ip::udp::endpoint(asio::ip::address::from_string(addr), port);
+        auto remote = asio::ip::udp::endpoint(asio::ip::make_address(addr), port);
         asio::error_code ec;
 
         socket.send_to(asio::buffer(msg.buffer, msg.length), remote, 0, ec);

--- a/test/unittest/transport/AsioHelpersTests.cpp
+++ b/test/unittest/transport/AsioHelpersTests.cpp
@@ -40,8 +40,8 @@ void test_buffer_setting(
         int initial_buffer_value,
         int minimum_buffer_value)
 {
-    asio::io_service io_service;
-    auto socket = std::make_unique<SocketType>(io_service);
+    asio::io_context io_context;
+    auto socket = std::make_unique<SocketType>(io_context);
 
     // Open the socket with the provided protocol
     socket->open(Protocol::v4());

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -696,7 +696,7 @@ TEST_F(TCPv4Tests, check_TCPv4_interface_whitelist_initialization)
     auto check_whitelist = transportUnderTest.get_interface_whitelist();
     for (auto& ip : mock_interfaces)
     {
-        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v4::from_string(
+        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::make_address_v4(
                     ip)), check_whitelist.end());
     }
 
@@ -1516,25 +1516,21 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     options |= asio::ssl::context::no_compression;
     ssl_context.set_options(options);
 
-    asio::io_service io_service;
-    auto ioServiceFunction = [&]()
+    asio::io_context io_context;
+    auto ioContextFunction = [&]()
             {
-#if ASIO_VERSION >= 101200
-                asio::executor_work_guard<asio::io_service::executor_type> work(io_service.get_executor());
-#else
-                io_service::work work(io_service_);
-#endif // if ASIO_VERSION >= 101200
-                io_service.run();
+                asio::executor_work_guard<asio::io_context::executor_type> work = make_work_guard(io_context);
+                io_context.run();
             };
-    std::thread ioServiceThread(ioServiceFunction);
+    std::thread ioContextThread(ioContextFunction);
 
     // TCPChannelResourceSecure::connect() like connection
-    asio::ip::tcp::resolver resolver(io_service);
+    asio::ip::tcp::resolver resolver(io_context);
     auto endpoints = resolver.resolve(
         IPLocator::ip_to_string(serverLoc),
         std::to_string(IPLocator::getPhysicalPort(serverLoc)));
 
-    auto secure_socket = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(io_service, ssl_context);
+    auto secure_socket = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(io_context, ssl_context);
     asio::ssl::verify_mode vm = 0x00;
     vm |= asio::ssl::verify_peer;
     secure_socket->set_verify_mode(vm);
@@ -1603,8 +1599,8 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     ASSERT_EQ(bytes_sent, 0u);
 
     secure_socket->lowest_layer().close(ec);
-    io_service.stop();
-    ioServiceThread.join();
+    io_context.stop();
+    ioContextThread.join();
 }
 #endif // ifndef _WIN32
 
@@ -1868,7 +1864,7 @@ TEST_F(TCPv4Tests, receive_unordered_data)
     asio::ip::tcp::socket sender(ctx);
     asio::ip::tcp::endpoint destination;
     destination.port(g_default_port);
-    destination.address(asio::ip::address::from_string("127.0.0.1"));
+    destination.address(asio::ip::make_address("127.0.0.1"));
     sender.connect(destination, ec);
     ASSERT_TRUE(!ec) << ec;
 
@@ -2074,13 +2070,13 @@ TEST_F(TCPv4Tests, non_blocking_send)
     IPLocator::setLogicalPort(serverLoc, 7410);
 
     // TCPChannelResourceBasic::connect() like connection
-    asio::io_service io_service;
-    asio::ip::tcp::resolver resolver(io_service);
+    asio::io_context io_context;
+    asio::ip::tcp::resolver resolver(io_context);
     auto endpoints = resolver.resolve(
         IPLocator::ip_to_string(serverLoc),
         std::to_string(IPLocator::getPhysicalPort(serverLoc)));
 
-    asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_service);
+    asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_context);
     asio::async_connect(
         socket,
         endpoints,

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -322,7 +322,7 @@ TEST_F(TCPv6Tests, check_TCPv6_interface_whitelist_initialization)
     auto check_whitelist = transportUnderTest.get_interface_whitelist();
     for (auto& ip : asio_interfaces)
     {
-        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::address_v6::from_string(
+        ASSERT_NE(std::find(check_whitelist.begin(), check_whitelist.end(), asio::ip::make_address_v6(
                     ip)), check_whitelist.end());
     }
 
@@ -401,13 +401,13 @@ TEST_F(TCPv6Tests, non_blocking_send)
     IPLocator::setLogicalPort(serverLoc, 7610);
 
     // TCPChannelResourceBasic::connect() like connection
-    asio::io_service io_service;
-    asio::ip::tcp::resolver resolver(io_service);
+    asio::io_context io_context;
+    asio::ip::tcp::resolver resolver(io_context);
     auto endpoints = resolver.resolve(
         IPLocator::ip_to_string(serverLoc),
         std::to_string(IPLocator::getPhysicalPort(serverLoc)));
 
-    asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_service);
+    asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_context);
     asio::async_connect(
         socket,
         endpoints,

--- a/versions.md
+++ b/versions.md
@@ -13,6 +13,7 @@ Forthcoming
 * Add `get_complete_type_object` to `ITypeObjectRegistry`
 * Support modules in `IdlParser`
 * New version of EDP static discovery which reduces greatly the Data(p) messages size.
+* Bump to asio 1.34.2 release.
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR bumps thirdparty asio module to 1.34.2 release and fixes deprecated API related to `io_service`, `address_v4`, `address_v6` and `tcp::resolver`, avoiding build failures. Fixes:
- https://github.com/eProsima/Fast-DDS/issues/5726

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
