### PR TITLE
[23372] Process key-only payloads

### DIFF
--- a/include/fastdds/rtps/common/CacheChange.hpp
+++ b/include/fastdds/rtps/common/CacheChange.hpp
@@ -176,6 +176,7 @@ struct FASTDDS_EXPORTED_API CacheChange_t
 
         // Copy certain values from serializedPayload
         serializedPayload.encapsulation = ch_ptr->serializedPayload.encapsulation;
+        serializedPayload.is_serialized_key = ch_ptr->serializedPayload.is_serialized_key;
 
         // Copy fragment size and calculate fragment count
         setFragmentSize(ch_ptr->fragment_size_, false);
@@ -286,6 +287,12 @@ struct FASTDDS_EXPORTED_API CacheChange_t
         uint32_t original_offset = (fragment_starting_num - 1) * fragment_size_;
         uint32_t incoming_length = fragment_size_ * fragments_in_submessage;
         uint32_t last_fragment_index = fragment_starting_num + fragments_in_submessage - 1;
+
+        // Validate payload types
+        if (serializedPayload.is_serialized_key != incoming_data.is_serialized_key)
+        {
+            return false;
+        }
 
         // Validate fragment indexes
         if (last_fragment_index > fragment_count_)

--- a/include/fastdds/rtps/common/SerializedPayload.hpp
+++ b/include/fastdds/rtps/common/SerializedPayload.hpp
@@ -72,6 +72,8 @@ struct FASTDDS_EXPORTED_API SerializedPayload_t
     uint32_t pos;
     //!Pool that created the payload
     IPayloadPool* payload_owner = nullptr;
+    //!Whether the payload contains a serialized key, or the whole data
+    bool is_serialized_key = false;
 
     //!Default constructor
     SerializedPayload_t()

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -215,8 +215,14 @@ bool DataReaderHistory::received_change_keep_all(
 {
     if (!compute_key_for_change_fn_(a_change))
     {
-        // Store the sample temporally only in ReaderHistory. When completed it will be stored in DataReaderHistory too.
-        return add_to_reader_history_if_not_full(a_change, rejection_reason);
+        if (!a_change->is_fully_assembled())
+        {
+            // Store the sample temporally only in ReaderHistory. When completed it will be stored in SubscriberHistory too.
+            return add_to_reader_history_if_not_full(a_change, rejection_reason);
+        }
+
+        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
+        return false;
     }
 
     bool ret_value = false;
@@ -251,8 +257,14 @@ bool DataReaderHistory::received_change_keep_last(
 {
     if (!compute_key_for_change_fn_(a_change))
     {
-        // Store the sample temporally only in ReaderHistory. When completed it will be stored in SubscriberHistory too.
-        return add_to_reader_history_if_not_full(a_change, rejection_reason);
+        if (!a_change->is_fully_assembled())
+        {
+            // Store the sample temporally only in ReaderHistory. When completed it will be stored in SubscriberHistory too.
+            return add_to_reader_history_if_not_full(a_change, rejection_reason);
+        }
+
+        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
+        return false;
     }
 
     bool ret_value = false;

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpression.cpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterExpression.cpp
@@ -50,6 +50,12 @@ bool DDSFilterExpression::evaluate(
     using namespace eprosima::fastdds::dds::xtypes;
     using namespace eprosima::fastcdr;
 
+    // Always pass filter for key-only payloads
+    if (payload.is_serialized_key)
+    {
+        return true;
+    }
+
     dyn_data_->clear_all_values();
     try
     {

--- a/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingPayloadPool.cpp
@@ -34,6 +34,7 @@ bool DataSharingPayloadPool::release_payload(
     payload.pos = 0;
     payload.max_size = 0;
     payload.data = nullptr;
+    payload.is_serialized_key = false;
     payload.payload_owner = nullptr;
     return true;
 }

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -59,6 +59,7 @@ public:
             payload.data = data.data;
             payload.length = data.length;
             payload.max_size = data.length;
+            payload.is_serialized_key = data.is_serialized_key;
             payload.payload_owner = this;
             return true;
         }

--- a/src/cpp/rtps/DataSharing/WriterPool.hpp
+++ b/src/cpp/rtps/DataSharing/WriterPool.hpp
@@ -88,6 +88,7 @@ public:
             payload.data = data.data;
             payload.length = data.length;
             payload.max_size = data.length;
+            payload.is_serialized_key = data.is_serialized_key;
             payload.payload_owner = this;
             return true;
         }

--- a/src/cpp/rtps/common/SerializedPayload.cpp
+++ b/src/cpp/rtps/common/SerializedPayload.cpp
@@ -36,6 +36,7 @@ SerializedPayload_t& SerializedPayload_t::operator = (
     max_size = other.max_size;
     pos = other.pos;
     payload_owner = other.payload_owner;
+    is_serialized_key = other.is_serialized_key;
 
     other.encapsulation = CDR_BE;
     other.length = 0;
@@ -43,6 +44,7 @@ SerializedPayload_t& SerializedPayload_t::operator = (
     other.max_size = 0;
     other.pos = 0;
     other.payload_owner = nullptr;
+    other.is_serialized_key = false;
 
     return *this;
 }
@@ -60,6 +62,7 @@ bool SerializedPayload_t::operator == (
         const SerializedPayload_t& other) const
 {
     return ((encapsulation == other.encapsulation) &&
+           (is_serialized_key == other.is_serialized_key) &&
            (length == other.length) &&
            (0 == memcmp(data, other.data, length)));
 }
@@ -82,6 +85,7 @@ bool SerializedPayload_t::copy(
         }
     }
     encapsulation = serData->encapsulation;
+    is_serialized_key = serData->is_serialized_key;
     if (length == 0)
     {
         return true;
@@ -96,6 +100,7 @@ bool SerializedPayload_t::reserve_fragmented(
     length = serData->length;
     max_size = serData->length;
     encapsulation = serData->encapsulation;
+    is_serialized_key = serData->is_serialized_key;
     data = (octet*)calloc(length, sizeof(octet));
     return true;
 }
@@ -112,6 +117,7 @@ void SerializedPayload_t::empty()
         free(data);
     }
     data = nullptr;
+    is_serialized_key = false;
 }
 
 void SerializedPayload_t::reserve(

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -100,6 +100,7 @@ bool TopicPayloadPool::get_payload(
         payload.data = data.data;
         payload.length = data.length;
         payload.max_size = PayloadNode::data_size(data.data);
+        payload.is_serialized_key = data.is_serialized_key;
         payload.payload_owner = this;
         return true;
     }
@@ -136,6 +137,7 @@ bool TopicPayloadPool::release_payload(
     payload.pos = 0;
     payload.max_size = 0;
     payload.data = nullptr;
+    payload.is_serialized_key = false;
     payload.payload_owner = nullptr;
     return true;
 }

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -959,6 +959,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(
     //FOUND THE READER.
     //We ask the reader for a cachechange to store the information.
     CacheChange_t ch;
+    ch.kind = ALIVE;
     ch.writerGUID.guidPrefix = source_guid_prefix_;
     valid &= CDRMessage::readEntityId(msg, &ch.writerGUID.entityId);
 
@@ -1031,7 +1032,6 @@ bool MessageReceiver::proc_Submsg_DataFrag(
     uint32_t next_pos = msg->pos + payload_size;
     if (msg->length >= next_pos && payload_size > 0)
     {
-        ch.kind = ALIVE;
         ch.serializedPayload.data = &msg->buffer[msg->pos];
         ch.serializedPayload.length = payload_size;
         ch.serializedPayload.max_size = payload_size;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -867,7 +867,6 @@ bool MessageReceiver::proc_Submsg_Data(
         uint32_t next_pos = msg->pos + payload_size;
         if (msg->length >= next_pos && payload_size > 0)
         {
-            FASTDDS_TODO_BEFORE(3, 3, "Pass keyFlag in serializedPayload, and always pass input data upwards");
             ch.serializedPayload.data = &msg->buffer[msg->pos];
             ch.serializedPayload.length = payload_size;
             ch.serializedPayload.max_size = payload_size;

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -868,27 +868,10 @@ bool MessageReceiver::proc_Submsg_Data(
         if (msg->length >= next_pos && payload_size > 0)
         {
             FASTDDS_TODO_BEFORE(3, 3, "Pass keyFlag in serializedPayload, and always pass input data upwards");
-            if (dataFlag)
-            {
-                ch.serializedPayload.data = &msg->buffer[msg->pos];
-                ch.serializedPayload.length = payload_size;
-                ch.serializedPayload.max_size = payload_size;
-            }
-            else // keyFlag would be true since we are inside an if (dataFlag || keyFlag)
-            {
-                if (payload_size <= PARAMETER_KEY_HASH_LENGTH)
-                {
-                    if (!ch.instanceHandle.isDefined())
-                    {
-                        memcpy(ch.instanceHandle.value, &msg->buffer[msg->pos], payload_size);
-                    }
-                }
-                else
-                {
-                    EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Ignoring Serialized Payload for too large key-only data (" <<
-                            payload_size << ")");
-                }
-            }
+            ch.serializedPayload.data = &msg->buffer[msg->pos];
+            ch.serializedPayload.length = payload_size;
+            ch.serializedPayload.max_size = payload_size;
+            ch.serializedPayload.is_serialized_key = keyFlag;
             msg->pos = next_pos;
         }
         else
@@ -1046,49 +1029,25 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 
     // Validations??? XXX TODO
 
-    if (!keyFlag)
+    uint32_t next_pos = msg->pos + payload_size;
+    if (msg->length >= next_pos && payload_size > 0)
     {
-        uint32_t next_pos = msg->pos + payload_size;
-        if (msg->length >= next_pos && payload_size > 0)
-        {
-            ch.kind = ALIVE;
-            ch.serializedPayload.data = &msg->buffer[msg->pos];
-            ch.serializedPayload.length = payload_size;
-            ch.serializedPayload.max_size = payload_size;
-            ch.setFragmentSize(fragmentSize);
+        ch.kind = ALIVE;
+        ch.serializedPayload.data = &msg->buffer[msg->pos];
+        ch.serializedPayload.length = payload_size;
+        ch.serializedPayload.max_size = payload_size;
+        ch.serializedPayload.is_serialized_key = keyFlag;
+        ch.setFragmentSize(fragmentSize);
 
-            msg->pos = next_pos;
-        }
-        else
-        {
-            EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Serialized Payload value invalid or larger than maximum allowed size "
-                    "(" << payload_size << "/" << (msg->length - msg->pos) << ")");
-            ch.serializedPayload.data = nullptr;
-            ch.inline_qos.data = nullptr;
-            return false;
-        }
+        msg->pos = next_pos;
     }
-    else if (keyFlag)
+    else
     {
-        /* XXX TODO
-           Endianness_t previous_endian = msg->msg_endian;
-           if (ch->serializedPayload.encapsulation == PL_CDR_BE)
-           msg->msg_endian = BIGEND;
-           else if (ch->serializedPayload.encapsulation == PL_CDR_LE)
-           msg->msg_endian = LITTLEEND;
-           else
-           {
-           EPROSIMA_LOG_ERROR(RTPS_MSG_IN, IDSTRING"Bad encapsulation for KeyHash and status parameter list");
-           return false;
-           }
-           //uint32_t param_size;
-           if (ParameterList::readParameterListfromCDRMsg(msg, &m_ParamList, ch, false) <= 0)
-           {
-           EPROSIMA_LOG_INFO(RTPS_MSG_IN, IDSTRING"SubMessage Data ERROR, keyFlag ParameterList");
-           return false;
-           }
-           msg->msg_endian = previous_endian;
-         */
+        EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Serialized Payload value invalid or larger than maximum allowed size "
+                "(" << payload_size << "/" << (msg->length - msg->pos) << ")");
+        ch.serializedPayload.data = nullptr;
+        ch.inline_qos.data = nullptr;
+        return false;
     }
 
     // Set sourcetimestamp

--- a/src/cpp/rtps/reader/reader_utils.cpp
+++ b/src/cpp/rtps/reader/reader_utils.cpp
@@ -31,6 +31,12 @@ bool change_is_relevant_for_filter(
 {
     bool ret = true;
 
+    // If the change contains only a serialized key, it is always relevant
+    if (change.serializedPayload.is_serialized_key)
+    {
+        return true;
+    }
+
     // If the change has no payload, it should have an instanceHandle.
     // This is only allowed for UNREGISTERED and DISPOSED changes, where the instanceHandle is used to identify the
     // instance to unregister or dispose.

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -365,7 +365,7 @@ TEST(KeyedTopic, key_only_payload)
     EXPECT_TRUE(data.empty());
     reader.block_for_all();
 
-    // Check that compute_key was not called with a key-only payload
+    // Check that compute_key was not called with a key-only payload when KEY_HASH is present
     auto ts = std::dynamic_pointer_cast<TestTypeSupport>(reader.get_type_support());
     ASSERT_TRUE(ts != nullptr);
     EXPECT_EQ(ts->key_only_payload_count.load(), 0u);

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -14,12 +14,22 @@
 
 #include "BlackboxTests.hpp"
 
+#include <atomic>
+#include <memory>
+
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
 #include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <fastdds/rtps/common/InstanceHandle.hpp>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
 #include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
 
+#include "../types/HelloWorldPubSubTypes.hpp"
+#include "../types/KeyedHelloWorldPubSubTypes.hpp"
 #include "../utils/filter_helpers.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
+#include "UDPMessageSender.hpp"
 
 TEST(KeyedTopic, RegistrationNonKeyedFail)
 {
@@ -285,6 +295,144 @@ TEST(KeyedTopic, DataWriterAlwaysSendTheSerializedKeyViaInlineQoS)
 
     EXPECT_TRUE(writer_sends_inline_qos);
     EXPECT_TRUE(writer_sends_pid_key_hash);
+}
+
+// Check that compute_key is called with a key-only payload when KEY_HASH is not present
+TEST(KeyedTopic, key_only_payload)
+{
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastdds::rtps;
+
+    struct TestTypeSupport : public KeyedHelloWorldPubSubType
+    {
+        typedef KeyedHelloWorldPubSubType::type type;
+
+        bool compute_key(
+                eprosima::fastdds::rtps::SerializedPayload_t& payload,
+                eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                bool force_md5 = false) override
+        {
+            if (payload.is_serialized_key)
+            {
+                // Count the number of times compute_key is called with a key-only payload
+                key_only_payload_count++;
+            }
+
+            return KeyedHelloWorldPubSubType::compute_key(payload, ihandle, force_md5);
+        }
+
+        bool compute_key(
+                const void* const data,
+                eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+                bool force_md5 = false) override
+        {
+            return KeyedHelloWorldPubSubType::compute_key(data, ihandle, force_md5);
+        }
+
+        std::atomic<uint32_t> key_only_payload_count{ 0 };
+    };
+
+    // Force using UDP transport
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    PubSubWriter<TestTypeSupport> writer(TEST_TOPIC_NAME);
+    PubSubReader<TestTypeSupport> reader(TEST_TOPIC_NAME);
+
+    // Set custom reader locator so we can send hand-crafted data to a known location
+    Locator_t reader_locator;
+    ASSERT_TRUE(IPLocator::setIPv4(reader_locator, "127.0.0.1"));
+    reader_locator.port = 7000;
+    reader.add_to_unicast_locator_list("127.0.0.1", 7000);
+
+    reader.disable_builtin_transport().
+            add_user_transport_to_pparams(udp_transport).
+            init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.disable_builtin_transport().
+            add_user_transport_to_pparams(udp_transport).
+            init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    auto data = default_keyedhelloworld_data_generator(2);
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    EXPECT_TRUE(data.empty());
+    reader.block_for_all();
+
+    // Check that compute_key was not called with a key-only payload
+    auto ts = std::dynamic_pointer_cast<TestTypeSupport>(reader.get_type_support());
+    ASSERT_TRUE(ts != nullptr);
+    EXPECT_EQ(ts->key_only_payload_count.load(), 0u);
+
+    struct KeyOnlyPayloadPacket
+    {
+        std::array<char, 4> rtps_id{ {'R', 'T', 'P', 'S'} };
+        std::array<uint8_t, 2> protocol_version{ {2, 3} };
+        std::array<uint8_t, 2> vendor_id{ {0x01, 0x0F} };
+        GuidPrefix_t sender_prefix{};
+
+        struct DataSubMsg
+        {
+            struct Header
+            {
+                uint8_t submessage_id = 0x15;
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint8_t flags = 0x08;
+#else
+                uint8_t flags = 0x09;
+#endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint16_t octets_to_next_header = 28;
+                uint16_t extra_flags = 0;
+                uint16_t octets_to_inline_qos = 16;
+                EntityId_t reader_id{};
+                EntityId_t writer_id{};
+                SequenceNumber_t sn{ 3 };
+            };
+
+            struct SerializedData
+            {
+                uint16_t encapsulation;
+                uint16_t encapsulation_opts;
+                uint8_t data[4] = {0x01, 0x00, 0x00, 0x00};
+            };
+
+            Header header;
+            SerializedData payload;
+        }
+        data;
+    };
+
+    UDPMessageSender fake_msg_sender;
+
+    // Send hand-crafted data
+    {
+        auto writer_guid = writer.datawriter_guid();
+
+        KeyOnlyPayloadPacket key_only_packet{};
+        key_only_packet.sender_prefix = writer_guid.guidPrefix;
+        key_only_packet.data.header.writer_id = writer_guid.entityId;
+        key_only_packet.data.header.reader_id = reader.datareader_guid().entityId;
+        key_only_packet.data.payload.encapsulation = CDR_LE;
+
+        CDRMessage_t msg(0);
+        uint32_t msg_len = static_cast<uint32_t>(sizeof(key_only_packet));
+        msg.init(reinterpret_cast<octet*>(&key_only_packet), msg_len);
+        msg.length = msg_len;
+        msg.pos = msg_len;
+        fake_msg_sender.send(msg, reader_locator);
+    }
+
+    // Wait for key-only compute key to be called
+    while (ts->key_only_payload_count.load() <= 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 }
 
 /* Uncomment when DDS API supports NO_WRITERS_ALIVE

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -397,8 +397,8 @@ TEST(KeyedTopic, key_only_payload)
 
             struct SerializedData
             {
-                uint16_t encapsulation;
-                uint16_t encapsulation_opts;
+                uint8_t encapsulation[2] = {0x00, CDR_LE};
+                uint8_t encapsulation_opts[2] = {0x00, 0x00};
                 uint8_t data[4] = {0x01, 0x00, 0x00, 0x00};
             };
 
@@ -418,7 +418,6 @@ TEST(KeyedTopic, key_only_payload)
         key_only_packet.sender_prefix = writer_guid.guidPrefix;
         key_only_packet.data.header.writer_id = writer_guid.entityId;
         key_only_packet.data.header.reader_id = reader.datareader_guid().entityId;
-        key_only_packet.data.payload.encapsulation = CDR_LE;
 
         CDRMessage_t msg(0);
         uint32_t msg_len = static_cast<uint32_t>(sizeof(key_only_packet));

--- a/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
+++ b/test/unittest/dds/topic/DDSSQLFilter/DDSSQLFilterTests.cpp
@@ -1288,6 +1288,9 @@ TEST_F(DDSSQLFilterValueTests, key_only_payload)
 
     ASSERT_EQ(results.size(), values.size());
     perform_basic_check(filter, results, values);
+
+    ret = uut.delete_content_filter("DDSSQL", filter);
+    EXPECT_EQ(RETCODE_OK, ret);
 }
 
 static void add_test_filtered_value_inputs(

--- a/test/unittest/rtps/common/CacheChangeTests.cpp
+++ b/test/unittest/rtps/common/CacheChangeTests.cpp
@@ -27,6 +27,7 @@ struct FragmentTestStep
 
     struct __Input
     {
+        bool is_key_only;
         uint32_t initial_fragment;
         uint16_t num_fragments;
     }
@@ -44,6 +45,7 @@ struct FragmentTestStep
         if (input.num_fragments > 0)
         {
             SerializedPayload_t payload(100);
+            payload.is_serialized_key = input.is_key_only;
             payload.length = 100;
             uut.add_fragments(payload, input.initial_fragment, input.num_fragments);
         }
@@ -70,57 +72,62 @@ TEST(CacheChange, FragmentManagement)
     {
         {
             "initial state",
-            {0, 0},
+            {false, 0, 0},
             {true, true, true, true, true, true, true, true, true, true}
         },
         {
             "received out-of-bounds (11)",
-            {11, 1},
+            {false, 11, 1},
             {true, true, true, true, true, true, true, true, true, true}
         },
         {
             "received (2)",
-            {2, 1},
+            {false, 2, 1},
             {true, false, true, true, true, true, true, true, true, true}
         },
         {
             "received (2) again",
-            {2, 1},
+            {false, 2, 1},
             {true, false, true, true, true, true, true, true, true, true}
         },
         {
             "received (2, 3)",
-            {2, 2},
+            {false, 2, 2},
             {true, false, false, true, true, true, true, true, true, true}
         },
         {
             "received (1)",
-            {1, 1},
+            {false, 1, 1},
             {false, false, false, true, true, true, true, true, true, true}
         },
         {
             "received (1) again",
-            {1, 1},
+            {false, 1, 1},
             {false, false, false, true, true, true, true, true, true, true}
         },
         {
             "received (9)",
-            {9, 1},
+            {false, 9, 1},
             {false, false, false, true, true, true, true, true, false, true}
         },
         {
             "received (8, 9, 10, 11)",
-            {8, 4},
+            {false, 8, 4},
+            {false, false, false, true, true, true, true, true, false, true}
+        },
+        {
+            "received key-only (7)",
+            {true, 7, 1},
             {false, false, false, true, true, true, true, true, false, true}
         },
         {
             "received (7)",
-            {7, 1},
+            {false, 7, 1},
             {false, false, false, true, true, true, false, true, false, true}
         },
         {
             "received (4, 5, 6)",
-            {4, 3},
+            {false, 4, 3},
             {false, false, false, false, false, false, false, true, false, true}
         }
     };

--- a/versions.md
+++ b/versions.md
@@ -19,6 +19,8 @@ Forthcoming
   * New `DataWriter::set_related_datareader` method.
   * New `DataReader::set_related_datawriter` method.
   * Implemented Requester and Replier matching algorithm.
+* Process key-only payloads:
+  * New `is_serialized_key` attribute in `SerializedPayload_t`.
 
 Version v3.2.2
 --------------


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds a new field to `SerializedPayload_t` to identify payloads that only have the serialization of the key of the data type.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **NO**: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
