### PR TITLE
[23365] Add `has_more_replies` to `WriteParams` and `SampleInfo`

### DIFF
--- a/include/fastdds/dds/core/policy/ParameterTypes.hpp
+++ b/include/fastdds/dds/core/policy/ParameterTypes.hpp
@@ -184,7 +184,9 @@ enum ParameterId_t : uint16_t
     PID_RTPS_RELIABLE_READER                = 0x8201,
     PID_READER_RESOURCE_LIMITS              = 0x8202,
     /* Participant specific */
-    PID_WIREPROTOCOL_CONFIG                 = 0x8300
+    PID_WIREPROTOCOL_CONFIG                 = 0x8300,
+    /* RPC specific */
+    PID_RPC_MORE_REPLIES                    = 0x8400
 };
 
 /*!

--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -87,6 +87,9 @@ struct SampleInfo
     //!Related Sample Identity (Extension for RPC)
     rtps::SampleIdentity related_sample_identity;
 
+    //!Flag to indicate if there are more replies (Extension for RPC)
+    bool has_more_replies = false;
+
 };
 
 }  // namespace dds

--- a/include/fastdds/rtps/common/SampleIdentity.hpp
+++ b/include/fastdds/rtps/common/SampleIdentity.hpp
@@ -35,57 +35,6 @@ class FASTDDS_EXPORTED_API SampleIdentity
 public:
 
     /*!
-     * @brief Default constructor. Constructs an unknown SampleIdentity.
-     */
-    SampleIdentity()
-        : writer_guid_(GUID_t::unknown())
-        , sequence_number_(SequenceNumber_t::unknown())
-    {
-    }
-
-    /*!
-     * @brief Copy constructor.
-     */
-    SampleIdentity(
-            const SampleIdentity& sample_id)
-        : writer_guid_(sample_id.writer_guid_)
-        , sequence_number_(sample_id.sequence_number_)
-    {
-    }
-
-    /*!
-     * @brief Move constructor.
-     */
-    SampleIdentity(
-            SampleIdentity&& sample_id)
-        : writer_guid_(std::move(sample_id.writer_guid_))
-        , sequence_number_(std::move(sample_id.sequence_number_))
-    {
-    }
-
-    /*!
-     * @brief Assignment operator.
-     */
-    SampleIdentity& operator =(
-            const SampleIdentity& sample_id)
-    {
-        writer_guid_ = sample_id.writer_guid_;
-        sequence_number_ = sample_id.sequence_number_;
-        return *this;
-    }
-
-    /*!
-     * @brief Move constructor.
-     */
-    SampleIdentity& operator =(
-            SampleIdentity&& sample_id)
-    {
-        writer_guid_ = std::move(sample_id.writer_guid_);
-        sequence_number_ = std::move(sample_id.sequence_number_);
-        return *this;
-    }
-
-    /*!
      * @brief
      */
     bool operator ==(
@@ -171,9 +120,9 @@ public:
 
 private:
 
-    GUID_t writer_guid_;
+    GUID_t writer_guid_ = GUID_t::unknown();
 
-    SequenceNumber_t sequence_number_;
+    SequenceNumber_t sequence_number_ = SequenceNumber_t::unknown();
 
     friend std::istream& operator >>(
             std::istream& input,

--- a/include/fastdds/rtps/common/SampleIdentity.hpp
+++ b/include/fastdds/rtps/common/SampleIdentity.hpp
@@ -113,6 +113,18 @@ public:
         return sequence_number_;
     }
 
+    bool has_more_replies() const
+    {
+        return has_more_replies_;
+    }
+
+    SampleIdentity& has_more_replies(
+            bool more_replies)
+    {
+        has_more_replies_ = more_replies;
+        return *this;
+    }
+
     static SampleIdentity unknown()
     {
         return SampleIdentity();
@@ -123,6 +135,8 @@ private:
     GUID_t writer_guid_ = GUID_t::unknown();
 
     SequenceNumber_t sequence_number_ = SequenceNumber_t::unknown();
+
+    bool has_more_replies_ = false;
 
     friend std::istream& operator >>(
             std::istream& input,

--- a/include/fastdds/rtps/common/SampleIdentity.hpp
+++ b/include/fastdds/rtps/common/SampleIdentity.hpp
@@ -113,18 +113,6 @@ public:
         return sequence_number_;
     }
 
-    bool has_more_replies() const
-    {
-        return has_more_replies_;
-    }
-
-    SampleIdentity& has_more_replies(
-            bool more_replies)
-    {
-        has_more_replies_ = more_replies;
-        return *this;
-    }
-
     static SampleIdentity unknown()
     {
         return SampleIdentity();
@@ -135,8 +123,6 @@ private:
     GUID_t writer_guid_ = GUID_t::unknown();
 
     SequenceNumber_t sequence_number_ = SequenceNumber_t::unknown();
-
-    bool has_more_replies_ = false;
 
     friend std::istream& operator >>(
             std::istream& input,

--- a/include/fastdds/rtps/common/WriteParams.hpp
+++ b/include/fastdds/rtps/common/WriteParams.hpp
@@ -219,6 +219,18 @@ public:
         return *this;
     }
 
+    bool has_more_replies() const
+    {
+        return has_more_replies_;
+    }
+
+    WriteParams& has_more_replies(
+            bool more_replies)
+    {
+        has_more_replies_ = more_replies;
+        return *this;
+    }
+
     static WriteParams WRITE_PARAM_DEFAULT;
 
     /**
@@ -259,6 +271,8 @@ private:
     Time_t source_timestamp_{ -1, TIME_T_INFINITE_NANOSECONDS };
     /// User write data
     UserWriteDataPtr user_write_data_{nullptr};
+    /// Flag to indicate if there are more replies
+    bool has_more_replies_ = false;
 };
 
 }  // namespace rtps

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -99,6 +99,20 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                         break;
                     }
 
+                    case PID_RPC_MORE_REPLIES:
+                    {
+                        // Ignore custom PID when coming from other vendors
+                        if (rtps::c_VendorId_eProsima != change.vendor_id)
+                        {
+                            return true;
+                        }
+
+                        change.write_params.related_sample_identity().has_more_replies(true);
+                        change.write_params.sample_identity().has_more_replies(true);
+
+                        break;
+                    }
+
                     case PID_STATUS_INFO:
                     {
                         ParameterStatusInfo_t p(pid, plength);

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -107,8 +107,7 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                             return true;
                         }
 
-                        change.write_params.related_sample_identity().has_more_replies(true);
-                        change.write_params.sample_identity().has_more_replies(true);
+                        change.write_params.has_more_replies(true);
 
                         break;
                     }

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -156,10 +156,6 @@ public:
             const rtps::SampleIdentity& sample_id)
     {
         uint32_t required_size = 24 + 4; // 24 for the sample identity and 4 for the PID and length
-        if (sample_id.has_more_replies())
-        {
-            required_size += 4; // Additional parameter for has_more_replies
-        }
 
         if (cdr_message->pos + required_size > cdr_message->max_size)
         {
@@ -174,13 +170,6 @@ public:
                 sample_id.writer_guid().entityId.value, rtps::EntityId_t::size);
         rtps::CDRMessage::addInt32(cdr_message, sample_id.sequence_number().high);
         rtps::CDRMessage::addUInt32(cdr_message, sample_id.sequence_number().low);
-
-        if (sample_id.has_more_replies())
-        {
-            // Add has_more_replies parameter
-            rtps::CDRMessage::addUInt16(cdr_message, dds::PID_RPC_MORE_REPLIES);
-            rtps::CDRMessage::addUInt16(cdr_message, 0);
-        }
 
         return true;
     }
@@ -209,6 +198,19 @@ public:
                 sample_id.writer_guid().entityId.value, rtps::EntityId_t::size);
         rtps::CDRMessage::addInt32(cdr_message, sample_id.sequence_number().high);
         rtps::CDRMessage::addUInt32(cdr_message, sample_id.sequence_number().low);
+        return true;
+    }
+
+    static inline bool add_parameter_more_replies(
+            rtps::CDRMessage_t* cdr_message)
+    {
+        if (cdr_message->pos + 4 > cdr_message->max_size)
+        {
+            return false;
+        }
+
+        rtps::CDRMessage::addUInt16(cdr_message, dds::PID_RPC_MORE_REPLIES);
+        rtps::CDRMessage::addUInt16(cdr_message, 0);
         return true;
     }
 
@@ -840,11 +842,6 @@ inline bool ParameterSerializer<ParameterSampleIdentity_t>::add_content_to_cdr_m
                     parameter.sample_id.writer_guid().entityId.value, rtps::EntityId_t::size);
     valid &= rtps::CDRMessage::addInt32(cdr_message, parameter.sample_id.sequence_number().high);
     valid &= rtps::CDRMessage::addUInt32(cdr_message, parameter.sample_id.sequence_number().low);
-    if (parameter.sample_id.has_more_replies())
-    {
-        valid &= rtps::CDRMessage::addUInt16(cdr_message, dds::PID_RPC_MORE_REPLIES);
-        valid &= rtps::CDRMessage::addUInt16(cdr_message, 0); // Length of the additional parameter
-    }
     return valid;
 }
 

--- a/src/cpp/fastdds/rpc/ReplierImpl.cpp
+++ b/src/cpp/fastdds/rpc/ReplierImpl.cpp
@@ -119,6 +119,7 @@ ReturnCode_t ReplierImpl::send_reply(
 
     rtps::WriteParams wparams;
     wparams.related_sample_identity(info.related_sample_identity);
+    wparams.has_more_replies(info.has_more_replies);
 
     return replier_writer_->write(data, wparams);
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -247,6 +247,7 @@ struct ReadTakeCommand
         info.sample_identity.writer_guid(item->writerGUID);
         info.sample_identity.sequence_number(item->sequenceNumber);
         info.related_sample_identity = item->write_params.sample_identity();
+        info.has_more_replies = item->write_params.has_more_replies();
 
         info.valid_data = true;
 

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -474,6 +474,10 @@ void WriterHistory::set_fragments(
     if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
     {
         inline_qos_size += (2 * fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
+        if (change->write_params.related_sample_identity().has_more_replies())
+        {
+            inline_qos_size += 4u;
+        }
     }
     if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind)
     {

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -474,7 +474,7 @@ void WriterHistory::set_fragments(
     if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
     {
         inline_qos_size += (2 * fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
-        if (change->write_params.related_sample_identity().has_more_replies())
+        if (change->write_params.has_more_replies())
         {
             inline_qos_size += 4u;
         }

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -132,6 +132,11 @@ struct DataMsgUtils
             fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_custom_related_sample_identity(
                 msg,
                 change->write_params.related_sample_identity());
+
+            if (change->write_params.has_more_replies())
+            {
+                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_more_replies(msg);
+            }
         }
 
         if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR allows indicating in `@feed` annotated operations that a reply is not the last one in the feed.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- **NO**: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
