### PR TITLE
Add "persistence-sample-identity" to SampleInfo

### DIFF
--- a/include/fastdds/dds/subscriber/SampleInfo.hpp
+++ b/include/fastdds/dds/subscriber/SampleInfo.hpp
@@ -87,6 +87,9 @@ struct SampleInfo
     //!Related Sample Identity (Extension for RPC)
     rtps::SampleIdentity related_sample_identity;
 
+    //!Persistence Sample Identity (Extension for RPC)
+    rtps::SampleIdentity persistence_sample_identity;
+
 };
 
 }  // namespace dds

--- a/include/fastdds/rtps/common/CacheChange.hpp
+++ b/include/fastdds/rtps/common/CacheChange.hpp
@@ -68,6 +68,8 @@ struct CacheChangeReaderInfo_t
     int32_t no_writers_generation_count;
     //! Ownership stregth of its writer when the sample was received.
     uint32_t writer_ownership_strength;
+    //! Persistence writer guid associated with received sample.
+    GUID_t persistence_writer_guid;
 };
 
 /**

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -247,6 +247,8 @@ struct ReadTakeCommand
         info.sample_identity.writer_guid(item->writerGUID);
         info.sample_identity.sequence_number(item->sequenceNumber);
         info.related_sample_identity = item->write_params.sample_identity();
+        info.persistence_sample_identity.writer_guid(item->reader_info.persistence_writer_guid);
+        info.persistence_sample_identity.sequence_number(item->sequenceNumber);
 
         info.valid_data = true;
 

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -434,6 +434,20 @@ fastdds::rtps::SequenceNumber_t BaseReader::get_last_notified(
     return ret_val;
 }
 
+fastdds::rtps::GUID_t BaseReader::get_persistence_guid(
+        const fastdds::rtps::GUID_t& guid)
+{
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
+    GUID_t ret_val = guid;
+    auto p_guid = history_state_->persistence_guid_map.find(guid);
+    if (p_guid != history_state_->persistence_guid_map.end())
+    {
+        ret_val = p_guid->second;
+    }
+
+    return ret_val;
+}
+
 fastdds::rtps::SequenceNumber_t BaseReader::update_last_notified(
         const fastdds::rtps::GUID_t& guid,
         const fastdds::rtps::SequenceNumber_t& seq)

--- a/src/cpp/rtps/reader/BaseReader.hpp
+++ b/src/cpp/rtps/reader/BaseReader.hpp
@@ -396,6 +396,14 @@ protected:
             const fastdds::rtps::GUID_t& guid);
 
     /**
+     * @brief Retrieve the persistence guid for the provided writer guid.
+     *
+     * @param guid  The writer GUID to query.
+     */
+    GUID_t get_persistence_guid(
+            const GUID_t& guid);
+
+    /**
      * @brief Update the last notified sequence for a writer's GUID.
      *
      * @param guid  The GUID of the writer.

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -1155,6 +1155,9 @@ bool StatefulReader::change_received(
         a_change->reader_info.writer_ownership_strength = (std::numeric_limits<uint32_t>::max)();
     }
 
+    // Update persistence GUID information on the CacheChange.
+    a_change->reader_info.persistence_writer_guid = get_persistence_guid(a_change->writerGUID);
+
     // NOTE: Depending on QoS settings, one change can be removed from history
     // inside the call to history_->received_change
     fastdds::dds::SampleRejectedStatusKind rejection_reason;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -368,6 +368,9 @@ bool StatelessReader::change_received(
             change->reader_info.writer_ownership_strength = (std::numeric_limits<uint32_t>::max)();
         }
 
+        // Update persistence GUID information on the CacheChange.
+        change->reader_info.persistence_writer_guid = get_persistence_guid(change->writerGUID);
+
         if (history_->received_change(change, 0))
         {
             auto payload_length = change->serializedPayload.length;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds "persistence-sample-identity" to SampleInfo
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
