### PR TITLE
[23459] Fix/socket buffer size handling

### DIFF
--- a/src/cpp/rtps/transport/asio_helpers.hpp
+++ b/src/cpp/rtps/transport/asio_helpers.hpp
@@ -86,11 +86,9 @@ struct asio_helpers
         socket.set_option(BufferOptionType(value_to_set), ec);
         if (!ec)
         {
-            // Last attempt was successful. Get the actual value set.
-            int32_t max_value = static_cast<int32_t>(initial_buffer_value);
             BufferOptionType option;
             socket.get_option(option, ec);
-            if (!ec && (option.value() >= value_to_set) && (option.value() <= max_value))
+            if (!ec && (option.value() >= value_to_set))
             {
                 final_buffer_value = option.value();
                 return true;

--- a/src/cpp/rtps/transport/asio_helpers.hpp
+++ b/src/cpp/rtps/transport/asio_helpers.hpp
@@ -86,6 +86,7 @@ struct asio_helpers
         socket.set_option(BufferOptionType(value_to_set), ec);
         if (!ec)
         {
+            // Last attempt was successful. Get the actual value set.
             BufferOptionType option;
             socket.get_option(option, ec);
             if (!ec && (option.value() >= value_to_set))

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -59,8 +59,6 @@ test_UDPv4Transport::test_UDPv4Transport(
 
     test_transport_options->test_UDPv4Transport_DropLogLength = 0;
     test_transport_options->test_UDPv4Transport_ShutdownAllNetwork = false;
-    UDPv4Transport::mSendBufferSize = descriptor.sendBufferSize;
-    UDPv4Transport::mReceiveBufferSize = descriptor.receiveBufferSize;
     UDPv4Transport::configuration_.sendBufferSize = descriptor.sendBufferSize;
     UDPv4Transport::configuration_.receiveBufferSize = descriptor.receiveBufferSize;
     UDPv4Transport::configuration_.maxMessageSize = descriptor.maxMessageSize;

--- a/src/cpp/rtps/transport/test_UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/test_UDPv4Transport.cpp
@@ -61,6 +61,9 @@ test_UDPv4Transport::test_UDPv4Transport(
     test_transport_options->test_UDPv4Transport_ShutdownAllNetwork = false;
     UDPv4Transport::mSendBufferSize = descriptor.sendBufferSize;
     UDPv4Transport::mReceiveBufferSize = descriptor.receiveBufferSize;
+    UDPv4Transport::configuration_.sendBufferSize = descriptor.sendBufferSize;
+    UDPv4Transport::configuration_.receiveBufferSize = descriptor.receiveBufferSize;
+    UDPv4Transport::configuration_.maxMessageSize = descriptor.maxMessageSize;
     for (auto interf : descriptor.interfaceWhiteList)
     {
         UDPv4Transport::interface_whitelist_.emplace_back(asio::ip::make_address_v4(interf));

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -814,9 +814,6 @@ void sample_lost_test_init(
         PubSubWriter<T>& writer,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
-    reader.socket_buffer_size(SAMPLE_LOST_TEST_BUFFER_SIZE);
-    writer.socket_buffer_size(SAMPLE_LOST_TEST_BUFFER_SIZE);
-
     sample_lost_test_dw_init(writer);
     sample_lost_test_dr_init(reader, functor);
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -796,12 +796,8 @@ void sample_lost_test_dr_init(
         PubSubReader<T>& reader,
         std::function<void(const eprosima::fastdds::dds::SampleLostStatus& status)> functor)
 {
-    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
-    udp_transport->sendBufferSize = SAMPLE_LOST_TEST_BUFFER_SIZE;
-    udp_transport->receiveBufferSize = SAMPLE_LOST_TEST_BUFFER_SIZE;
 
-    reader.disable_builtin_transport()
-            .add_user_transport_to_pparams(udp_transport)
+    reader.socket_buffer_size(SAMPLE_LOST_TEST_BUFFER_SIZE)
             .sample_lost_status_functor(functor)
             .init();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This task aims to fix:

- `test_UDPv4Transport` does not actually set the socket buffer size

- `try_setting_buffer_size` final attempt sets an upper limit for the buffer size that is not implemented in the main loop

This PR is a frontport of the proper changes from https://github.com/eProsima/Fast-DDS/pull/5921
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
