### PR TITLE
[23569] Improve signal handling in RPC example

### DIFF
--- a/examples/cpp/rpc/Application.hpp
+++ b/examples/cpp/rpc/Application.hpp
@@ -43,6 +43,9 @@ public:
     //! Trigger the end of execution
     virtual void stop() = 0;
 
+    //! Check if the application is stopped
+    virtual bool is_stopped() const = 0;
+
     //! Factory method to create applications based on configuration
     static std::shared_ptr<Application> make_app(
             const CLIParser::config& config,

--- a/examples/cpp/rpc/ClientApp.hpp
+++ b/examples/cpp/rpc/ClientApp.hpp
@@ -221,6 +221,11 @@ public:
 
     void stop() override;
 
+    bool is_stopped() const override
+    {
+        return stop_.load();
+    }
+
 protected:
 
     //! Create a participant for internal RPCDDS entities
@@ -237,11 +242,6 @@ protected:
     //! @return true if the server is reachable, false otherwise
     bool ping_server(
             std::size_t attempts);
-
-    bool is_stopped()
-    {
-        return stop_.load();
-    }
 
     std::shared_ptr<calculator_example::Calculator> client_;
     dds::DomainParticipant* participant_;

--- a/examples/cpp/rpc/ServerApp.hpp
+++ b/examples/cpp/rpc/ServerApp.hpp
@@ -45,17 +45,17 @@ public:
 
     void stop() override;
 
+    bool is_stopped() const override
+    {
+        return stop_.load();
+    }
+
 protected:
 
     void create_participant();
 
     void create_server(
             const std::string& server_name);
-
-    bool is_stopped()
-    {
-        return stop_.load();
-    }
 
 private:
 

--- a/examples/cpp/rpc/main.cpp
+++ b/examples/cpp/rpc/main.cpp
@@ -86,13 +86,9 @@ int main(
         client_server_info("main",
                 app_name << " running. Please press Ctrl+C to stop the " << app_name << " at any time.");
 
-        while (true)
+        while (!app->is_stopped())
         {
-            if (app->is_stopped())
-            {
-                break;
-            }
-            else if (stop_requested.load())
+            if (stop_requested.load())
             {
                 client_server_info("main",
                         CLIParser::parse_signal(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Some errors have been reported when the RPC example application is stopped using multiple SIGINT signals, due to signal handler implicitly calls async-signal-unsafe functions. This PR solves the problem.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
