### PR TITLE
[23592] Add 'tcp_negotiation_timeout' to .xsd

### DIFF
--- a/resources/xsd/fastdds_profiles.xsd
+++ b/resources/xsd/fastdds_profiles.xsd
@@ -915,14 +915,14 @@
         ├ receiveBufferSize                     [uint32],
         ├ maxMessageSize                        [uint32],
         ├ maxInitialPeersRange                  [uint32],
-        ├ interfaceWhiteList                    [0~*],                            (NOT  available for   SHM type)
+        ├ interfaceWhiteList                    [0~*],                            (NOT  available for SHM   type)
         |   └ address                           [ipv4Address|ipv6Address]
         |   └ interface                         [string]
-        ├ netmask_filter                        [string] ("OFF", "AUTO", "ON"),   (NOT  available for   SHM type)
-        ├ interfaces                            [interfacesType],                 (NOT  available for   SHM type)
-        ├ TTL                                   [uint8],                          (ONLY available for  UDP  type)
-        ├ non_blocking_send                     [boolean],                        (NOT  available for   SHM type)
-        ├ output_port                           [uint16],                         (ONLY available for  UDP  type)
+        ├ netmask_filter                        [string] ("OFF", "AUTO", "ON"),   (NOT  available for SHM   type)
+        ├ interfaces                            [interfacesType],                 (NOT  available for SHM   type)
+        ├ TTL                                   [uint8],                          (ONLY available for UDP   type)
+        ├ non_blocking_send                     [boolean],                        (NOT  available for SHM   type)
+        ├ output_port                           [uint16],                         (ONLY available for UDP   type)
         ├ wan_addr                              [ipv4AddressFormat],              (ONLY available for TCPv4 type)
         ├ keep_alive_frequency_ms               [uint32],                         (ONLY available for TCP   type)
         ├ keep_alive_timeout_ms                 [uint32],                         (ONLY available for TCP   type)
@@ -935,15 +935,16 @@
         ├ calculate_crc                         [bool],                           (ONLY available for TCP   type)
         ├ check_crc                             [bool],                           (ONLY available for TCP   type)
         ├ enable_tcp_nodelay                    [bool],                           (ONLY available for TCP   type)
+        ├ tcp_negotiation_timeout               [uint32],                         (ONLY available for TCP   type)
         ├ keep_alive_thread                     [threadSettingsType],             (ONLY available for TCP   type)
         ├ accept_thread                         [threadSettingsType],             (ONLY available for TCP   type)
-        ├ segment_size                          [uint32],                         (ONLY available for   SHM type)
-        ├ port_queue_capacity                   [uint32],                         (ONLY available for   SHM type)
-        ├ healthy_check_timeout_ms              [uint32],                         (ONLY available for   SHM type)
-        ├ rtps_dump_file                        [string]                          (ONLY available for   SHM type)
+        ├ segment_size                          [uint32],                         (ONLY available for SHM   type)
+        ├ port_queue_capacity                   [uint32],                         (ONLY available for SHM   type)
+        ├ healthy_check_timeout_ms              [uint32],                         (ONLY available for SHM   type)
+        ├ rtps_dump_file                        [string]                          (ONLY available for SHM   type)
         ├ default_reception_threads             [threadSettingsType]
-        ├ reception_threads                     [receptionThreadsListType]        (ONLY available for   SHM type)
-        └ dump_thread                           [threadSettingsType]              (ONLY available for   SHM type) -->
+        ├ reception_threads                     [receptionThreadsListType]        (ONLY available for SHM   type)
+        └ dump_thread                           [threadSettingsType]              (ONLY available for SHM   type) -->
     <!-- TODO:  How to ensure all elements are declared properly (UDP only, TCP only, etc...)? -->
     <xs:complexType name="transportDescriptorType">
         <xs:all minOccurs="0">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds the field `tcp_negotiation_timeout` to `fastdds_profiles.xsd`, which was missing.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
   <!--  - Related documentation PR: https://github.com/eProsima/Fast-DDS-docs/pull/1111  -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
