### PR TITLE
[23610] Fix duplicated transport when using specific XML with CLI

### DIFF
--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -37,6 +37,7 @@ if(Python3_Interpreter_FOUND)
         test_fast_discovery_several_server_ids
         test_fast_discovery_invalid_locator
         test_fast_discovery_non_existent_profile
+        test_fast_discovery_tcp_via_XML
     )
 
     if(SECURITY)
@@ -124,6 +125,7 @@ if(Python3_Interpreter_FOUND)
 
     configure_file("test_xml_discovery_server_profile.xml" "test_xml_discovery_server_profile.xml" COPYONLY)
     configure_file("test_wrong_xml_discovery_server_profile.xml" "test_wrong_xml_discovery_server_profile.xml" COPYONLY)
+    configure_file("test_xml_discovery_server_tcp.xml" "test_xml_discovery_server_tcp.xml" COPYONLY)
     unset(TEST_ENVIRONMENT)
 
 endif()

--- a/test/system/tools/fds/test_xml_discovery_server_tcp.xml
+++ b/test/system/tools/fds/test_xml_discovery_server_tcp.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dds>
+    <profiles>
+        <transport_descriptors>
+            <transport_descriptor>
+                <transport_id>tcp_transport</transport_id>
+                <type>TCPv4</type>
+                <listening_ports>
+                    <port>12345</port>
+                </listening_ports>
+            </transport_descriptor>
+        </transport_descriptors>
+        <participant profile_name="tcp_ds" is_default_profile="true">
+            <rtps>
+                <useBuiltinTransports>false</useBuiltinTransports>
+                <userTransports>
+                    <transport_id>tcp_transport</transport_id>
+                </userTransports>
+                <builtin>
+                    <discovery_config>
+                        <discoveryProtocol>SERVER</discoveryProtocol>
+                    </discovery_config>
+                    <metatrafficUnicastLocatorList>
+                        <locator>
+                            <tcpv4>
+                                <address>127.0.0.1</address>
+                                <port>12345</port>
+                                <physical_port>12345</physical_port>
+                            </tcpv4>
+                        </locator>
+                    </metatrafficUnicastLocatorList>
+                </builtin>
+            </rtps>
+        </participant>
+    </profiles>
+</dds>

--- a/test/system/tools/fds/tests.py
+++ b/test/system/tools/fds/tests.py
@@ -41,6 +41,7 @@
         test_fast_discovery_several_server_ids,
         test_fast_discovery_invalid_locator,
         test_fast_discovery_non_existent_profile,
+        test_fast_discovery_tcp_via_XML,
 
 """
 
@@ -639,6 +640,19 @@ def test_fast_discovery_security_enabled_cli_prefix(fast_discovery_tool):
     exit_code = check_output(output, err, EXPECTED_OUTPUT, False, False)
     sys.exit(exit_code)
 
+def test_fast_discovery_tcp_via_XML(fast_discovery_tool):
+    """Test TCP transport loaded via XML configuration"""
+
+    XML_file_path = "test_xml_discovery_server_tcp.xml"
+    command = [fast_discovery_tool, str(command_to_int_test[Command_test.SERVER]), '-x', XML_file_path]
+    output, err, exit_code = send_command(command)
+    if exit_code != 0:
+        print(output)
+        sys.exit(exit_code)
+    EXPECTED_OUTPUT = "TCPv4:[127.0.0.1]:12345-12345"
+    exit_code = check_output(output, err, EXPECTED_OUTPUT, False, False)
+    sys.exit(exit_code)
+
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(
@@ -693,7 +707,9 @@ if __name__ == '__main__':
         'test_fast_discovery_security_enabled_xml_prefix': lambda:
             test_fast_discovery_security_enabled_xml_prefix(args.binary_path),
         'test_fast_discovery_security_enabled_cli_prefix': lambda:
-            test_fast_discovery_security_enabled_cli_prefix(args.binary_path)
+            test_fast_discovery_security_enabled_cli_prefix(args.binary_path),
+        'test_fast_discovery_tcp_via_XML': lambda:
+            test_fast_discovery_tcp_via_XML(args.binary_path)
     }
 
     tests[args.test_name]()

--- a/tools/fds/CliDiscoveryManager.cpp
+++ b/tools/fds/CliDiscoveryManager.cpp
@@ -566,6 +566,11 @@ bool CliDiscoveryManager::add_tcp_servers()
 
 void CliDiscoveryManager::configure_transports()
 {
+    if (serverQos.transport().user_transports.size() > 0)
+    {
+        // User transports already configured in XML file
+        return;
+    }
     if (!serverQos.wire_protocol().builtin.metatrafficUnicastLocatorList.has_kind<LOCATOR_KIND_UDPv4>())
     {
         serverQos.transport().use_builtin_transports = false;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

When an XML file with an user transport and a custom metatrafficUnicastLocatorList is passed to the Fast DDS CLI through the `-x` command, two TCP transports will be added to `user_transports` in the end. This PR fixes this behavior by skipping the transport creation if there is already an existing transport created.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
