### PR TITLE
[23571] Removing empty qos_list from original writer as indicated in RTPS standard 2.5

### DIFF
--- a/include/fastdds/rtps/common/OriginalWriterInfo.hpp
+++ b/include/fastdds/rtps/common/OriginalWriterInfo.hpp
@@ -129,11 +129,6 @@ private:
     GUID_t original_writer_guid_ = GUID_t::unknown();
 
     SequenceNumber_t sequence_number_ = SequenceNumber_t::unknown();
-
-    // NOTE: Even though the standard define the QoS of the original writer as a ParameterList
-    // in this class, they are not used in the current Fast DDS implementation. However, an empty
-    // ParameterList is serialized as a placeholder for future implementations.
-    // ParameterList original_writer_qos_;
 };
 
 } //namespace rtps

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -99,7 +99,7 @@ public:
     static constexpr uint32_t PARAMETER_KEY_SIZE = 20u;
     static constexpr uint32_t PARAMETER_SENTINEL_SIZE = 4u;
     static constexpr uint32_t PARAMETER_SAMPLE_IDENTITY_SIZE = 28u;
-    static constexpr uint32_t PARAMETER_ORIGINAL_WRITER_INFO_SIZE = 32u;
+    static constexpr uint32_t PARAMETER_ORIGINAL_WRITER_INFO_SIZE = 28u;
 
     static bool add_parameter_status(
             rtps::CDRMessage_t* cdr_message,
@@ -234,7 +234,6 @@ public:
     {
         // A GUID takes 16 bytes: 12 of prefix plus 4 of entity
         // A Sequence number takes 8 bytes: 4 for high and 4 for low
-        // An empty parameter list takes 4 bytes (the end sentinel and 0 as len)
         // The PID and the length take 4 bytes: 2 for PID and 2 for length
 
         uint32_t required_size = PARAMETER_ORIGINAL_WRITER_INFO_SIZE;
@@ -251,11 +250,6 @@ public:
                 original_writer_info.original_writer_guid().entityId.value, rtps::EntityId_t::size);
         rtps::CDRMessage::addInt32(cdr_message, original_writer_info.sequence_number().high);
         rtps::CDRMessage::addUInt32(cdr_message, original_writer_info.sequence_number().low);
-
-        // NOTE: original_writer_qos_ is not serialized because it is not currently used,
-        // but an empty ParameterList is serialized as a placeholder for future implementations.
-        // The end sentinel is added to be fully compliant
-        add_parameter_sentinel(cdr_message);
 
         return true;
     }
@@ -929,8 +923,6 @@ inline bool ParameterSerializer<ParameterOriginalWriterInfo_t>::read_content_fro
                     parameter.original_writer_info.original_writer_guid().entityId.value, rtps::EntityId_t::size);
     valid &= rtps::CDRMessage::readInt32(cdr_message, &parameter.original_writer_info.sequence_number().high);
     valid &= rtps::CDRMessage::readUInt32(cdr_message, &parameter.original_writer_info.sequence_number().low);
-
-    // If anyone has to implement original_writer_qos_ deserialization, this is the place to do it.
 
     return valid;
 }

--- a/versions.md
+++ b/versions.md
@@ -6,7 +6,7 @@ Forthcoming
   * Extend `MemberDescriptor` with `position()`, `literal_value()` and `is_default_literal()` methods
     to avoid inconsistencies annotating enumerations and bitmask members.
   * Extend `TypeDescriptor` with `literal_type()` to store the literal type in enumerations.
-* Add field `original_writer_guid` to `WriteParams` and `SampleInfo`
+* Add field `original_writer_info` to `WriteParams` and `SampleInfo`
 * Iterate over declared types processed with IDL Parser:
   * Add new `for_each_type_w_uri()` method in `DynamicTypeBuilderFactory`.
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR removes the empty ParameterList that was added to the original_writer_info serialization to be compliant with  RTPS v2.5 standard. 

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

* Empty ParameterList was removed from OriginalWriterInfo struct and serialization
* Parameter size changes from 32 to 28 as we remove the parameter list end sentinel and the lenght (2+2)
* Some comments indicating where the QoS should have been added are also removed

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [_N/A_] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [_N/A_] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [_N/A_] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [_N/A_] New feature has been added to the `versions.md` file (if applicable).
- [_N/A_] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [_N/A_] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
