### PR TITLE
[23655] Solve TCP disconnect while incomplete read deadlock

### DIFF
--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
@@ -70,6 +70,12 @@ const StatusMask& StatusConditionImpl::get_enabled_statuses() const
     return mask_;
 }
 
+const StatusMask& StatusConditionImpl::get_raw_status() const
+{
+    std::lock_guard<std::mutex> guard(mutex_);
+    return status_;
+}
+
 void StatusConditionImpl::set_status(
         const StatusMask& status,
         bool trigger_value)

--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.hpp
@@ -78,10 +78,7 @@ struct StatusConditionImpl
      * @brief Retrieves the list of communication statuses that are currently triggered.
      * @return Triggered status.
      */
-    const StatusMask& get_raw_status() const
-    {
-        return status_;
-    }
+    const StatusMask& get_raw_status() const;
 
     /**
      * @brief Set the trigger value of a specific status

--- a/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
+++ b/src/cpp/rtps/transport/TCPAcceptorSecure.cpp
@@ -55,7 +55,6 @@ void TCPAcceptorSecure::accept(
 
     try
     {
-#if ASIO_VERSION >= 101200
         acceptor_.async_accept(
             [locator, parent, &ssl_context](const std::error_code& error, tcp::socket socket)
             {
@@ -82,33 +81,6 @@ void TCPAcceptorSecure::accept(
                     parent->SecureSocketAccepted(nullptr, locator, error); // This method manages errors too.
                 }
             });
-#else
-        auto secure_socket = std::make_shared<asio::ssl::stream<asio::ip::tcp::socket>>(*io_context_, ssl_context);
-
-        acceptor_.async_accept(secure_socket->lowest_layer(),
-                [locator, parent, secure_socket](const std::error_code& error)
-                {
-                    if (!error)
-                    {
-                        ssl::stream_base::handshake_type role = ssl::stream_base::server;
-                        if (parent->configuration()->tls_config.handshake_role == TLSHSRole::CLIENT)
-                        {
-                            role = ssl::stream_base::client;
-                        }
-
-                        secure_socket->async_handshake(role,
-                        [secure_socket, locator, parent](const std::error_code& error)
-                        {
-                            //EPROSIMA_LOG_ERROR(RTCP_TLS, "Handshake: " << error.message());
-                            parent->SecureSocketAccepted(secure_socket, locator, error);
-                        });
-                    }
-                    else
-                    {
-                        parent->SecureSocketAccepted(nullptr, locator, error); // This method manages errors too.
-                    }
-                });
-#endif // if ASIO_VERSION >= 101200
     }
     catch (std::error_code& error)
     {

--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -66,7 +66,7 @@ TCPChannelResource::TCPChannelResource(
     , parent_(parent)
     , locator_()
     , waiting_for_keep_alive_(false)
-    , connection_status_(eConnectionStatus::eConnected)
+    , connection_status_(eConnectionStatus::eDisconnected)
     , tcp_connection_type_(TCPConnectionType::TCP_ACCEPT_TYPE)
 {
 }
@@ -376,6 +376,9 @@ void TCPChannelResource::set_socket_options(
         asio::basic_socket<asio::ip::tcp>& socket,
         const TCPTransportDescriptor* options)
 {
+    // Options setting should be done before connection is established
+    assert(!connected());
+
     uint32_t minimum_value = options->maxMessageSize;
 
     // Set the send buffer size

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -191,7 +191,8 @@ void TCPChannelResourceBasic::set_options(
 
 void TCPChannelResourceBasic::cancel()
 {
-    socket_->cancel(); // thread safe with respect to asio's read and write methods
+    std::error_code ec;
+    socket_->cancel(ec); // thread safe with respect to asio's read and write methods
 }
 
 void TCPChannelResourceBasic::close()
@@ -202,13 +203,15 @@ void TCPChannelResourceBasic::close()
     std::unique_lock<std::mutex> read_lk(read_mutex_, std::defer_lock);
     std::lock(send_lk, read_lk); // Pre C++17 alternative to std::scoped_lock
 
-    socket_->close();
+    std::error_code ec;
+    socket_->close(ec);
 }
 
 void TCPChannelResourceBasic::shutdown(
         asio::socket_base::shutdown_type what)
 {
-    socket_->shutdown(what); // thread safe with respect to asio's read and write methods
+    std::error_code ec;
+    socket_->shutdown(what, ec); // thread safe with respect to asio's read and write methods
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -14,8 +14,9 @@
 
 #include <rtps/transport/TCPChannelResourceBasic.h>
 
-#include <future>
 #include <array>
+#include <future>
+#include <mutex>
 
 #include <asio.hpp>
 #include <fastdds/utils/IPLocator.hpp>
@@ -101,25 +102,22 @@ void TCPChannelResourceBasic::connect(
 
 void TCPChannelResourceBasic::disconnect()
 {
-    if (eConnecting < change_status(eConnectionStatus::eDisconnected) && alive())
+    // Go to disconnecting state to protect from concurrent connects and disconnects
+    auto prev_status = change_status(eConnectionStatus::eDisconnecting);
+    if (eConnecting < prev_status && alive())
     {
-        std::lock_guard<std::mutex> read_lock(read_mutex_);
-        auto socket = socket_;
+        // Shutdown the socket to abort any ongoing read and write operations
+        shutdown(asio::ip::tcp::socket::shutdown_both);
 
-        std::error_code ec;
-        socket->shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+        cancel();
+        close(); // Blocks until all read and write operations have finished
 
-        asio::post(context_, [&, socket]()
-                {
-                    try
-                    {
-                        socket->cancel();
-                        socket->close();
-                    }
-                    catch (std::exception&)
-                    {
-                    }
-                });
+        // Change to disconnected state as the last step
+        change_status(eConnectionStatus::eDisconnected);
+    }
+    else if (eConnectionStatus::eDisconnecting != prev_status || !alive())
+    {
+        change_status(eConnectionStatus::eDisconnected);
     }
 }
 
@@ -128,10 +126,9 @@ uint32_t TCPChannelResourceBasic::read(
         std::size_t size,
         asio::error_code& ec)
 {
-    std::unique_lock<std::mutex> read_lock(read_mutex_);
-
-    if (eConnecting < connection_status_)
+    if (connected())
     {
+        std::unique_lock<std::mutex> read_lock(read_mutex_);
         return static_cast<uint32_t>(asio::read(*socket_, asio::buffer(buffer, size), transfer_exactly(size), ec));
     }
 
@@ -147,7 +144,7 @@ size_t TCPChannelResourceBasic::send(
 {
     size_t bytes_sent = 0;
 
-    if (eConnecting < connection_status_)
+    if (connected())
     {
         std::lock_guard<std::mutex> send_guard(send_mutex_);
 
@@ -195,23 +192,29 @@ asio::ip::tcp::endpoint TCPChannelResourceBasic::local_endpoint(
 void TCPChannelResourceBasic::set_options(
         const TCPTransportDescriptor* options)
 {
-    TCPChannelResource::set_socket_options(*socket_, options);
+    set_socket_options(*socket_, options);
 }
 
 void TCPChannelResourceBasic::cancel()
 {
-    socket_->cancel();
+    socket_->cancel(); // thread safe with respect to asio's read and write methods
 }
 
 void TCPChannelResourceBasic::close()
 {
+    // Wait for read and write operations to finish before closing the socket (otherwise not thread safe)
+    // NOTE: shutdown should have been called before closing to abort any ongoing operation
+    std::unique_lock<std::mutex> send_lk(send_mutex_, std::defer_lock);
+    std::unique_lock<std::mutex> read_lk(read_mutex_, std::defer_lock);
+    std::lock(send_lk, read_lk); // Pre C++17 alternative to std::scoped_lock
+
     socket_->close();
 }
 
 void TCPChannelResourceBasic::shutdown(
         asio::socket_base::shutdown_type what)
 {
-    socket_->shutdown(what);
+    socket_->shutdown(what); // thread safe with respect to asio's read and write methods
 }
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
@@ -78,13 +78,7 @@ void TCPChannelResourceBasic::connect(
             asio::async_connect(
                 *socket_,
                 endpoints,
-                [this, channel_weak_ptr](std::error_code ec
-#if ASIO_VERSION >= 101200
-                , ip::tcp::endpoint
-#else
-                , ip::tcp::resolver::iterator
-#endif // if ASIO_VERSION >= 101200
-                )
+                [this, channel_weak_ptr](std::error_code ec, ip::tcp::endpoint)
                 {
                     if (!channel_weak_ptr.expired())
                     {

--- a/src/cpp/rtps/transport/TCPChannelResourceBasic.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceBasic.h
@@ -28,6 +28,7 @@ class TCPChannelResourceBasic : public TCPChannelResource
     asio::io_context& context_;
 
     std::mutex send_mutex_;
+    std::mutex read_mutex_;
     std::shared_ptr<asio::ip::tcp::socket> socket_;
 
 public:

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -91,13 +91,7 @@ void TCPChannelResourceSecure::connect(
             const auto secure_socket = secure_socket_;
 
             asio::async_connect(secure_socket_->lowest_layer(), endpoints,
-                    [secure_socket, channel_weak_ptr, parent](const std::error_code& error
-#if ASIO_VERSION >= 101200
-                    , ip::tcp::endpoint
-#else
-                    , const tcp::resolver::iterator& /*endpoint*/
-#endif // if ASIO_VERSION >= 101200
-                    )
+                    [secure_socket, channel_weak_ptr, parent](const std::error_code& error, ip::tcp::endpoint)
                     {
                         if (!error)
                         {

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.cpp
@@ -347,7 +347,7 @@ void TCPChannelResourceSecure::close()
 void TCPChannelResourceSecure::shutdown(
         asio::socket_base::shutdown_type)
 {
-    // WARNING: This function blocks until receiving the peer’s close_notify
+    // WARNING: This function blocks until receiving the peer’s close_notify (or an error occurs).
     secure_socket_->shutdown();
 }
 

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -1622,27 +1622,14 @@ TEST_P(TransportTCP, stop_during_incomplete_read)
         std::to_string(global_port));
 
     asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_context);
-    asio::async_connect(
-        socket,
-        endpoints,
-        [](std::error_code ec
-#if ASIO_VERSION >= 101200
-        , asio::ip::tcp::endpoint
-#else
-        , asio::ip::tcp::resolver::iterator
-#endif // if ASIO_VERSION >= 101200asio
-        )
-        {
-            ASSERT_TRUE(!ec);
-        }
-        );
 
-    // Wait for connection to be established
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    // Synchronous socket connection
+    std::error_code ec;
+    asio::connect(socket, endpoints, ec);
+    ASSERT_TRUE(!ec);
 
     // Send an incomplete header
     TCPHeader h;
-    std::error_code ec;
     asio::write(socket, asio::buffer(&h, 3), ec);
     ASSERT_TRUE(!ec);
 

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -18,10 +18,12 @@
 #include <thread>
 #include <random>
 
+#include <asio.hpp>
 #include <gtest/gtest.h>
 
 #include <fastdds/rtps/transport/TCPv4TransportDescriptor.hpp>
 #include <fastdds/rtps/transport/TCPv6TransportDescriptor.hpp>
+#include <rtps/transport/tcp/RTCPHeader.h>
 
 #include "../api/dds-pim/TCPReqRepHelloWorldRequester.hpp"
 #include "../api/dds-pim/TCPReqRepHelloWorldReplier.hpp"
@@ -1589,6 +1591,71 @@ TEST_P(TransportTCP, large_data_tcp_no_frag)
     // Wait for reception acknowledgement
     reader.block_for_all();
     EXPECT_TRUE(writer.waitForAllAcked(std::chrono::seconds(3)));
+}
+
+/**
+ * This is a regression test for issue #23655, corresponding to a deadlock produced when destroying the TCP transport of
+ * a participant while a read operation is still ongoing.
+ *
+ * The test creates a replier using TCP transport (TCP server), then creates a raw TCP socket to connect to the replier.
+ * Once connection is established, a partial header is sent to the replier, after which the latter is deleted,
+ * expecting the read operation to be safely aborted and no deadlock to occur.
+ *
+ * This test also verifies thread safety in this particular scenario; the mutex causing the deadlock was introduced
+ * to correct a non-thread-safe access to the socket attribute, so this test also checks thread safety is still present
+ * after solving the deadlock issue.
+ *
+ */
+TEST_P(TransportTCP, stop_during_incomplete_read)
+{
+    // Create replier (TCP server)
+    TCPReqRepHelloWorldReplier* replier = new TCPReqRepHelloWorldReplier();
+    replier->init(0, 0, global_port);
+
+    ASSERT_TRUE(replier->isInitialized());
+
+    // Create raw TCP socket and connect to the server
+    asio::io_context io_context;
+    asio::ip::tcp::resolver resolver(io_context);
+    auto endpoints = resolver.resolve(
+        use_ipv6 ? "::1" : "127.0.0.1",
+        std::to_string(global_port));
+
+    asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_context);
+    asio::async_connect(
+        socket,
+        endpoints,
+        [](std::error_code ec
+#if ASIO_VERSION >= 101200
+        , asio::ip::tcp::endpoint
+#else
+        , asio::ip::tcp::resolver::iterator
+#endif // if ASIO_VERSION >= 101200asio
+        )
+        {
+            ASSERT_TRUE(!ec);
+        }
+        );
+
+    // Wait for connection to be established
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // Send an incomplete header
+    TCPHeader h;
+    std::error_code ec;
+    asio::write(socket, asio::buffer(&h, 3), ec);
+    ASSERT_TRUE(!ec);
+
+    // Wait for data to be received by the server
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // Destroy participant (and its TCP transport) while read is ongoing
+    delete replier;
+
+    // Close client's socket
+    socket.shutdown(asio::ip::tcp::socket::shutdown_both);
+    socket.cancel();
+    socket.close();
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -1640,9 +1640,9 @@ TEST_P(TransportTCP, stop_during_incomplete_read)
     delete replier;
 
     // Close client's socket
-    socket.shutdown(asio::ip::tcp::socket::shutdown_both);
-    socket.cancel();
-    socket.close();
+    socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+    socket.cancel(ec);
+    socket.close(ec);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2119,9 +2119,9 @@ TEST_F(TCPv4Tests, non_blocking_send)
     bytes_sent = sender_channel_resource->send(nullptr, 0, buffer_list, size, ec);
     ASSERT_EQ(bytes_sent, 0u);
 
-    socket.shutdown(asio::ip::tcp::socket::shutdown_both);
-    socket.cancel();
-    socket.close();
+    socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+    socket.cancel(ec);
+    socket.close(ec);
 }
 #endif // ifndef _WIN32
 

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -407,22 +407,13 @@ TEST_F(TCPv6Tests, non_blocking_send)
         IPLocator::ip_to_string(serverLoc),
         std::to_string(IPLocator::getPhysicalPort(serverLoc)));
 
+    // Synchronous socket connection
     asio::ip::tcp::socket socket = asio::ip::tcp::socket (io_context);
-    asio::async_connect(
-        socket,
-        endpoints,
-        [](std::error_code ec
-#if ASIO_VERSION >= 101200
-        , asio::ip::tcp::endpoint
-#else
-        , asio::ip::tcp::resolver::iterator
-#endif // if ASIO_VERSION >= 101200
-        )
-        {
-            ASSERT_TRUE(!ec);
-        }
-        );
+    std::error_code ec;
+    asio::connect(socket, endpoints, ec);
+    ASSERT_TRUE(!ec);
 
+    // Wait a bit until server accepts the connection
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     /*
@@ -437,7 +428,6 @@ TEST_F(TCPv6Tests, non_blocking_send)
             std::static_pointer_cast<TCPChannelResourceBasic>(sender_unbound_channel_resources[0]);
 
     // Prepare the message
-    asio::error_code ec;
     std::vector<octet> message(msg_size, 0);
     const octet* data = message.data();
     size_t size = message.size();

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -455,9 +455,9 @@ TEST_F(TCPv6Tests, non_blocking_send)
     bytes_sent = sender_channel_resource->send(nullptr, 0, buffer_list, size, ec);
     ASSERT_EQ(bytes_sent, 0u);
 
-    socket.shutdown(asio::ip::tcp::socket::shutdown_both);
-    socket.cancel();
-    socket.close();
+    socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+    socket.cancel(ec);
+    socket.close(ec);
 }
 #endif // ifndef _WIN32
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR attempts to solve the deadlock produced when a read operation never completes (e.g. peer blocks before ending a transmission), and the TCP channel resource is disconnected (normally on closure while cleaning the associated transport).
Summing up, the solution consists in shutting down the socket before acquiring the culprit read mutex, so that any ongoing write/read operations are aborted even if not completed.

In addition, some other changes in this PR target general thread safety and attempt to improve overall resilience:
- New "disconnecting" state to protect from concurrent connect/disconnects.
- Assert that socket options are only configured before connection is established.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/a_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/a_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/a_ New feature has been added to the `versions.md` file (if applicable).
- _N/a_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/a_ If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
