### PR TITLE
[23654] Change non_blocking_send threshold to sendBufferSize

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -363,9 +363,10 @@ bool TCPChannelResource::check_socket_send_buffer(
 
 
     size_t future_queue_size = size_t(bytesInSendQueue) + msg_size;
-    // TCP actually allocates twice the size of the buffer requested.
-    if (future_queue_size > size_t(2 * parent_->configuration()->sendBufferSize))
+    if (future_queue_size > size_t(parent_->configuration()->sendBufferSize))
     {
+        // NOTE: TCP actually allocates about twice the size of the buffer requested, still we use the user-provided
+        // value as threshold to avoid blocking if the actual allocated space falls below our estimation
         return false;
     }
     return true;

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1571,15 +1571,15 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size * 2, 0);
+    std::vector<octet> message(msg_size, 0);
     const octet* data = message.data();
     size_t size = message.size();
     NetworkBuffer buffers(data, size);
     std::vector<NetworkBuffer> buffer_list;
     buffer_list.push_back(buffers);
 
-    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // it should be able to send a message of msg_size*2.
+    // Send the message with no header. Since TCP actually allocates about twice the size of the buffer requested, and
+    // since the threshold to discard (sendBufferSize) is set to msg_size, it should be able to send a message of msg_size.
     size_t bytes_sent = sender_channel_resource->send(nullptr, 0, buffer_list, size, ec);
     ASSERT_EQ(bytes_sent, size);
 
@@ -1590,8 +1590,9 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     ASSERT_EQ(ec, asio::error_code());
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
-    message.resize(msg_size * 2 + 1);
+    // Now try to send a message whose size surpasses the threshold to discard (sendBufferSize):
+    //  (msg_size + 1) + bytes_in_send_buffer(0) > sendBufferSize
+    message.resize(msg_size + 1);
     data = message.data();
     size = message.size();
     buffer_list.clear();
@@ -2109,15 +2110,15 @@ TEST_F(TCPv4Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size * 2, 0);
+    std::vector<octet> message(msg_size, 0);
     const octet* data = message.data();
     size_t size = message.size();
     NetworkBuffer buffers(data, size);
     std::vector<NetworkBuffer> buffer_list;
     buffer_list.push_back(buffers);
 
-    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // it should be able to send a message of msg_size*2.
+    // Send the message with no header. Since TCP actually allocates about twice the size of the buffer requested, and
+    // since the threshold to discard (sendBufferSize) is set to msg_size, it should be able to send a message of msg_size.
     size_t bytes_sent = sender_channel_resource->send(nullptr, 0, buffer_list, size, ec);
     ASSERT_EQ(bytes_sent, size);
 
@@ -2126,8 +2127,9 @@ TEST_F(TCPv4Tests, non_blocking_send)
     size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
-    message.resize(msg_size * 2 + 1);
+    // Now try to send a message whose size surpasses the threshold to discard (sendBufferSize):
+    //  (msg_size + 1) + bytes_in_send_buffer(0) > sendBufferSize
+    message.resize(msg_size + 1);
     data = message.data();
     size = message.size();
     buffer_list.clear();

--- a/test/unittest/transport/TCPv6Tests.cpp
+++ b/test/unittest/transport/TCPv6Tests.cpp
@@ -438,15 +438,15 @@ TEST_F(TCPv6Tests, non_blocking_send)
 
     // Prepare the message
     asio::error_code ec;
-    std::vector<octet> message(msg_size * 2, 0);
+    std::vector<octet> message(msg_size, 0);
     const octet* data = message.data();
     size_t size = message.size();
     NetworkBuffer buffers(data, size);
     std::vector<NetworkBuffer> buffer_list;
     buffer_list.push_back(buffers);
 
-    // Send the message with no header. Since TCP actually allocates twice the size of the buffer requested
-    // it should be able to send a message of msg_size*2.
+    // Send the message with no header. Since TCP actually allocates about twice the size of the buffer requested, and
+    // since the threshold to discard (sendBufferSize) is set to msg_size, it should be able to send a message of msg_size.
     size_t bytes_sent = sender_channel_resource->send(nullptr, 0, buffer_list, size, ec);
     ASSERT_EQ(bytes_sent, size);
 
@@ -455,8 +455,9 @@ TEST_F(TCPv6Tests, non_blocking_send)
     size_t bytes_read = asio::read(socket, asio::buffer(buffer, size), asio::transfer_exactly(size), ec);
     ASSERT_EQ(bytes_read, size);
 
-    // Now try to send a message that is bigger than the buffer size: (msg_size*2 + 1) + bytes_in_send_buffer(0) > 2*sendBufferSize
-    message.resize(msg_size * 2 + 1);
+    // Now try to send a message whose size surpasses the threshold to discard (sendBufferSize):
+    //  (msg_size + 1) + bytes_in_send_buffer(0) > sendBufferSize
+    message.resize(msg_size + 1);
     data = message.data();
     size = message.size();
     buffer_list.clear();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Currently the non blocking size feature assumes that the size of TCP sockets allocated by the OS is twice the value requested (sendBufferSize). However, it has been observed that the actual reserved value may fall below that value, hence blocking when the buffer gets full and ruining the purpose of this feature.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/a_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/a_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/a_ New feature has been added to the `versions.md` file (if applicable).
- _N/a_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
