### PR TITLE
[23845] Apply uncrustify to master

### DIFF
--- a/src/cpp/fastdds/xtypes/dynamic_types/DynamicTypeBuilderImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/DynamicTypeBuilderImpl.cpp
@@ -546,7 +546,7 @@ ReturnCode_t DynamicTypeBuilderImpl::add_member(
 
         // Member type and enum's literal type must be the same, if literal type is specified
         if (type_descriptor_.literal_type() &&
-            descriptor->type()->get_kind() != type_descriptor_.literal_type()->get_kind())
+                descriptor->type()->get_kind() != type_descriptor_.literal_type()->get_kind())
         {
             EPROSIMA_LOG_ERROR(DYN_TYPES, "Descriptor type kind differs from the literal type kind.");
             return RETCODE_BAD_PARAMETER;

--- a/src/cpp/fastdds/xtypes/dynamic_types/DynamicTypeImpl.cpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/DynamicTypeImpl.cpp
@@ -222,9 +222,11 @@ traits<DynamicTypeImpl>::ref_type DynamicTypeImpl::resolve_alias_enclosed_type()
 
     if (TK_ALIAS == ret_value->get_kind())
     {
-        do {
+        do
+        {
             ret_value = traits<DynamicType>::narrow<DynamicTypeImpl>(ret_value->get_descriptor().base_type());
-        } while (TK_ALIAS == ret_value->get_kind());
+        }
+        while (TK_ALIAS == ret_value->get_kind());
     }
 
     return ret_value;

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/AppendableAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/AppendableAnnotation.hpp
@@ -73,6 +73,7 @@ protected:
         EPROSIMA_LOG_ERROR(IDL_PARSER, "Trying to apply @appendable annotation to a MemberDescriptor.");
         return false;
     }
+
 };
 
 } // namespace idlparser

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/BitBoundAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/BitBoundAnnotation.hpp
@@ -54,8 +54,8 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT16));
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT16));
         }
 
         return initialized_;
@@ -74,7 +74,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_BIT_BOUND_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -98,7 +98,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_BIT_BOUND_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 
@@ -118,7 +118,7 @@ protected:
             {
                 EPROSIMA_LOG_ERROR(IDL_PARSER,
                         "Failed to get literal kind from bound for annotation '" << IDL_BUILTIN_ANN_BIT_BOUND_TAG
-                                                                                  << "': " << e.what());
+                                                                                 << "': " << e.what());
                 return false;
             }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/DefaultAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/DefaultAnnotation.hpp
@@ -54,8 +54,8 @@ public:
             // Note: The member is processed as a string, so it can be used to set the default value of any type.
             // In the future, it should be processed as a "any" type member.
             initialized_ = add_primitive_or_string_member(IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->create_string_type(
-                                    static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+                            DynamicTypeBuilderFactory::get_instance()->create_string_type(
+                                static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
         }
 
         return initialized_;
@@ -85,7 +85,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_DEFAULT_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/DefaultLiteralAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/DefaultLiteralAnnotation.hpp
@@ -72,6 +72,7 @@ protected:
         descriptor->is_default_literal(true);
         return true;
     }
+
 };
 
 } // namespace idlparser

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ExtensibilityAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ExtensibilityAnnotation.hpp
@@ -95,7 +95,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_EXTENSIBILITY_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ExternalAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ExternalAnnotation.hpp
@@ -54,9 +54,9 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
-                                IDL_TRUE_TAG);
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
+                IDL_TRUE_TAG);
         }
 
         return initialized_;
@@ -86,7 +86,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_EXTERNAL_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -101,7 +101,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_EXTERNAL_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/FinalAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/FinalAnnotation.hpp
@@ -73,6 +73,7 @@ protected:
         EPROSIMA_LOG_ERROR(IDL_PARSER, "Trying to apply @final annotation to a MemberDescriptor.");
         return false;
     }
+
 };
 
 } // namespace idlparser

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/IdAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/IdAnnotation.hpp
@@ -54,7 +54,7 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(IDL_VALUE_TAG,
-                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT32));
+                            DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT32));
         }
 
         return initialized_;
@@ -100,7 +100,7 @@ protected:
                 "Failed to convert value '" << parameters.at(
                     IDL_VALUE_TAG)
                                             << "' for annotation '" << IDL_BUILTIN_ANN_ID_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/KeyAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/KeyAnnotation.hpp
@@ -54,9 +54,9 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
-                                IDL_TRUE_TAG);
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
+                IDL_TRUE_TAG);
         }
 
         return initialized_;
@@ -86,7 +86,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_KEY_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -101,7 +101,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_KEY_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/MutableAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/MutableAnnotation.hpp
@@ -73,6 +73,7 @@ protected:
         EPROSIMA_LOG_ERROR(IDL_PARSER, "Trying to apply @mutable annotation to a MemberDescriptor.");
         return false;
     }
+
 };
 
 } // namespace idlparser

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/NestedAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/NestedAnnotation.hpp
@@ -54,9 +54,9 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
-                                IDL_TRUE_TAG);
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
+                IDL_TRUE_TAG);
         }
 
         return initialized_;
@@ -75,7 +75,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_NESTED_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -90,7 +90,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_NESTED_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/OptionalAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/OptionalAnnotation.hpp
@@ -54,9 +54,9 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                            IDL_VALUE_TAG,
-                            DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
-                            IDL_TRUE_TAG);
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_BOOLEAN),
+                IDL_TRUE_TAG);
         }
 
         return initialized_;
@@ -86,7 +86,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_OPTIONAL_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -101,7 +101,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_OPTIONAL_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/PositionAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/PositionAnnotation.hpp
@@ -54,8 +54,8 @@ public:
         if (!initialized_)
         {
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT16));
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_UINT16));
         }
 
         return initialized_;
@@ -85,7 +85,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_POSITION_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -100,7 +100,7 @@ protected:
                     "Failed to convert value '" << parameters.at(
                         IDL_VALUE_TAG)
                                                 << "' for annotation '" << IDL_BUILTIN_ANN_POSITION_TAG << "': " <<
-                            e.what());
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/TryConstructAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/TryConstructAnnotation.hpp
@@ -56,7 +56,8 @@ public:
             TypeDescriptor::_ref_type enum_type_descriptor = traits<TypeDescriptor>::make_shared();
             enum_type_descriptor->kind(TK_ENUM);
             enum_type_descriptor->name(IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_TAG);
-            DynamicTypeBuilder::_ref_type enum_builder = DynamicTypeBuilderFactory::get_instance()->create_type(enum_type_descriptor);
+            DynamicTypeBuilder::_ref_type enum_builder = DynamicTypeBuilderFactory::get_instance()->create_type(
+                enum_type_descriptor);
             MemberDescriptor::_ref_type enum_member_descriptor = traits<MemberDescriptor>::make_shared();
             enum_member_descriptor->type(DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_INT32));
             enum_member_descriptor->name(IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_DISCARD_TAG);
@@ -72,9 +73,9 @@ public:
 
             success &= add_declared_type(IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_TAG, enum_builder->build());
             success &= add_declared_type_member(
-                            IDL_VALUE_TAG,
-                            IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_TAG,
-                            IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_USE_DEFAULT_TAG);
+                IDL_VALUE_TAG,
+                IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_TAG,
+                IDL_BUILTIN_ANN_TRY_CONSTRUCT_FAIL_ACTION_USE_DEFAULT_TAG);
 
             initialized_ = success;
         }
@@ -106,7 +107,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_TRY_CONSTRUCT_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ValueAnnotation.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/Annotations/ValueAnnotation.hpp
@@ -56,9 +56,9 @@ public:
             // Note: The member is processed as a string, so it can be used to set the default value of any type.
             // In the future, it should be processed as a "any" type member.
             initialized_ = add_primitive_or_string_member(
-                                IDL_VALUE_TAG,
-                                DynamicTypeBuilderFactory::get_instance()->create_string_type(
-                                    static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
+                IDL_VALUE_TAG,
+                DynamicTypeBuilderFactory::get_instance()->create_string_type(
+                    static_cast<uint32_t>(LENGTH_UNLIMITED))->build());
         }
 
         return initialized_;
@@ -88,7 +88,7 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Missing required parameter '" << IDL_VALUE_TAG
                                                    << "' for annotation '" << IDL_BUILTIN_ANN_VALUE_TAG <<
-                            "'.");
+                    "'.");
             return false;
         }
 
@@ -102,8 +102,8 @@ protected:
             EPROSIMA_LOG_ERROR(IDL_PARSER,
                     "Invalid value '" << parameters.at(
                         IDL_VALUE_TAG)
-                                                << "' for annotation '" << IDL_BUILTIN_ANN_VALUE_TAG << "': " <<
-                            e.what());
+                                      << "' for annotation '" << IDL_BUILTIN_ANN_VALUE_TAG << "': " <<
+                    e.what());
             return false;
         }
 

--- a/src/cpp/fastdds/xtypes/serializers/json/dynamic_data_json.cpp
+++ b/src/cpp/fastdds/xtypes/serializers/json/dynamic_data_json.cpp
@@ -1077,7 +1077,7 @@ ReturnCode_t json_serialize_bitmask_member(
         for (const auto& it : bitmask_members)
         {
             MemberDescriptorImpl& member_desc =
-                            traits<DynamicTypeMember>::narrow<DynamicTypeMemberImpl>(it.second)->get_descriptor();
+                    traits<DynamicTypeMember>::narrow<DynamicTypeMemberImpl>(it.second)->get_descriptor();
 
             if (u64_value & (0x01ull << member_desc.position()))
             {

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -84,7 +84,8 @@ void DataSharingListener::run()
 
             // If some writer added new data, there may be something to read.
             // If there were matching/unmatching, we may not have finished our last loop
-        } while (is_running_.load() &&
+        }
+        while (is_running_.load() &&
         (notification_->notification_->new_data.load() || writer_pools_changed_.load(std::memory_order_relaxed)));
     }
 }

--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -613,7 +613,8 @@ public:
 
                         status.counter = status.last_verified_counter + 1;
                     }
-                } while (1);
+                }
+                while (1);
 
                 node_->waiting_count--;
                 status.is_waiting = 0;

--- a/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemManager.hpp
@@ -549,7 +549,8 @@ public:
                 {
                     collisions_count--;
                 }
-            } while (collisions_count > 0 && nullptr == segment_name_lock_);
+            }
+            while (collisions_count > 0 && nullptr == segment_name_lock_);
 
             if (nullptr == segment_name_lock_)
             {

--- a/src/cpp/security/artifact_providers/FileProvider.cpp
+++ b/src/cpp/security/artifact_providers/FileProvider.cpp
@@ -128,8 +128,8 @@ X509_STORE* FileProvider::load_ca(
                             const char* error_msg = X509_verify_cert_error_string(error_code);
 
                             exception = _SecurityException_(
-                                    "Error '" + std::to_string(error_code) + "' verifying CA certificate for " +
-                                    ca_sn + ": " + error_msg);
+                                "Error '" + std::to_string(error_code) + "' verifying CA certificate for " +
+                                ca_sn + ": " + error_msg);
                             X509_STORE_CTX_free(ctx);
                         }
                         else

--- a/src/cpp/utils/collections/impl/node-sizes/foonathan/map_node_size_impl.hpp
+++ b/src/cpp/utils/collections/impl/node-sizes/foonathan/map_node_size_impl.hpp
@@ -33,7 +33,7 @@
  */
 
 template <typename K, typename V>
-struct map_node_size : foonathan::memory::map_node_size<std::pair<size_t, typename std::map<K, V>::value_type> >
+struct map_node_size : foonathan::memory::map_node_size<std::pair<size_t, typename std::map<K, V>::value_type>>
 {
 };
 

--- a/src/cpp/utils/collections/impl/node-sizes/foonathan/set_node_size_impl.hpp
+++ b/src/cpp/utils/collections/impl/node-sizes/foonathan/set_node_size_impl.hpp
@@ -33,7 +33,7 @@
  */
 
 template <typename K>
-struct set_node_size : foonathan::memory::set_node_size<std::pair<size_t, typename std::set<K>::value_type> >
+struct set_node_size : foonathan::memory::set_node_size<std::pair<size_t, typename std::set<K>::value_type>>
 {
 };
 

--- a/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustExclusiveLock.hpp
@@ -247,7 +247,8 @@ private:
                 close(fd);
                 fd = -1;
             }
-        } while (fd == -1);
+        }
+        while (fd == -1);
         return fd;
     }
 

--- a/src/cpp/utils/shared_memory/RobustSharedLock.hpp
+++ b/src/cpp/utils/shared_memory/RobustSharedLock.hpp
@@ -398,7 +398,8 @@ private:
                 close(fd);
                 throw std::runtime_error(("failed to lock " + file_path).c_str());
             }
-        } while (fd == -1);
+        }
+        while (fd == -1);
 
         return fd;
     }

--- a/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsStatistics.cpp
@@ -123,7 +123,8 @@ static void wait_statistics(
             total_samples += info_seq.length();
             reader->return_loan(data_seq, info_seq);
         }
-    } while (total_samples < num_samples);
+    }
+    while (total_samples < num_samples);
 
     std::cout << "Received " << total_samples << " samples on " << topic_name << std::endl;
 }

--- a/test/performance/throughput/ThroughputSubscriber.cpp
+++ b/test/performance/throughput/ThroughputSubscriber.cpp
@@ -804,7 +804,8 @@ void ThroughputSubscriber::run()
             std::cout << "-----------------------------------------------------------------------" << std::endl;
         }
 
-    } while (stop_count != 2);
+    }
+    while (stop_count != 2);
 
     return;
 }

--- a/test/unittest/security/logging/BuiltinLogTopicTests.cpp
+++ b/test/unittest/security/logging/BuiltinLogTopicTests.cpp
@@ -14,7 +14,9 @@
 
 #include "LoggingPluginTests.hpp"
 
-int main(int argc, char** argv)
+int main(
+        int argc,
+        char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR applies Uncrustify to the whole repo to accelerate backports.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
