### PR TITLE
[23986] Fix handling of InstanceHandle use cases

### DIFF
--- a/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
+++ b/include/fastdds/dds/core/status/SampleRejectedStatus.hpp
@@ -37,7 +37,9 @@ enum SampleRejectedStatusKind
     //! Exceeds the max_samples limit
     REJECTED_BY_SAMPLES_LIMIT,
     //! Exceeds the max_samples_per_instance limit
-    REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT
+    REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT,
+    //! Instance could not be determined
+    REJECTED_BY_UNKNOWN_INSTANCE
 };
 
 //! @brief A struct storing the sample rejected status

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -122,6 +122,7 @@ public:
             rtps::CDRMessage_t* cdr_message,
             const rtps::InstanceHandle_t& iHandle)
     {
+        // Size of parameter key is 20 bytes: 4 for PID (2) and length (2), 16 for the key hash
         if (cdr_message->pos + 20 >= cdr_message->max_size)
         {
             return false;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -768,7 +768,11 @@ ReturnCode_t DataWriterImpl::check_instance_preconditions(
 #if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
 #endif // if HAVE_SECURITY
-        type_->compute_key(data, instance_handle, is_key_protected);
+        if(!type_->compute_key(data, instance_handle, is_key_protected) || !instance_handle.isDefined())
+        {
+            EPROSIMA_LOG_ERROR(DATA_WRITER, "Could not compute key for data");
+            return RETCODE_PRECONDITION_NOT_MET;
+        }
     }
 
 #if !defined(NDEBUG)
@@ -1122,7 +1126,11 @@ ReturnCode_t DataWriterImpl::create_new_change_with_params(
 #if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
 #endif // if HAVE_SECURITY
-        type_->compute_key(data, handle, is_key_protected);
+        if(!type_->compute_key(data, handle, is_key_protected) || !handle.isDefined())
+        {
+            EPROSIMA_LOG_ERROR(DATA_WRITER, "Could not compute key for data");
+            return RETCODE_PRECONDITION_NOT_MET;
+        }
     }
 
     return perform_create_new_change(changeKind, data, wparams, handle);

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -778,7 +778,7 @@ ReturnCode_t DataWriterImpl::check_instance_preconditions(
 #if !defined(NDEBUG)
     if (handle.isDefined() && instance_handle != handle)
     {
-        EPROSIMA_LOG_ERROR(DATA_WRITER, "handle differs from data's key.");
+        EPROSIMA_LOG_ERROR(DATA_WRITER, "Handle differs from data's key.");
         return RETCODE_PRECONDITION_NOT_MET;
     }
 #endif // if !defined(NDEBUG)

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -676,9 +676,9 @@ ReturnCode_t DataWriterImpl::check_write_preconditions(
     if (type_.get()->is_compute_key_provided)
     {
         bool is_key_protected = false;
-    #if HAVE_SECURITY
+#if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
-    #endif // if HAVE_SECURITY
+#endif // if HAVE_SECURITY
         if (!type_->compute_key(data, instance_handle, is_key_protected) || !instance_handle.isDefined())
         {
             EPROSIMA_LOG_ERROR(DATA_WRITER, "Could not compute key for data");

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -768,7 +768,7 @@ ReturnCode_t DataWriterImpl::check_instance_preconditions(
 #if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
 #endif // if HAVE_SECURITY
-        if(!type_->compute_key(data, instance_handle, is_key_protected) || !instance_handle.isDefined())
+        if (!type_->compute_key(data, instance_handle, is_key_protected) || !instance_handle.isDefined())
         {
             EPROSIMA_LOG_ERROR(DATA_WRITER, "Could not compute key for data");
             return RETCODE_PRECONDITION_NOT_MET;
@@ -1126,7 +1126,7 @@ ReturnCode_t DataWriterImpl::create_new_change_with_params(
 #if HAVE_SECURITY
         is_key_protected = writer_->getAttributes().security_attributes().is_key_protected;
 #endif // if HAVE_SECURITY
-        if(!type_->compute_key(data, handle, is_key_protected) || !handle.isDefined())
+        if (!type_->compute_key(data, handle, is_key_protected) || !handle.isDefined())
         {
             EPROSIMA_LOG_ERROR(DATA_WRITER, "Could not compute key for data");
             return RETCODE_PRECONDITION_NOT_MET;

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -676,7 +676,7 @@ ReturnCode_t DataWriterImpl::check_write_preconditions(
     if (type_.get()->is_compute_key_provided)
     {
         #if defined(NDEBUG) // In Release build, compute key only if necessary
-        if (!instance_handle.isDefined())
+        if (!handle.isDefined())
         #endif // if !defined(NDEBUG)
         {
             bool is_key_protected = false;
@@ -697,13 +697,6 @@ ReturnCode_t DataWriterImpl::check_write_preconditions(
             return RETCODE_PRECONDITION_NOT_MET;
         }
         #endif // if !defined(NDEBUG)
-    }
-
-    // Check if the Handle is different from the special value HANDLE_NIL and
-    // does not correspond with the instance referred by the data
-    if (handle.isDefined() && handle != instance_handle)
-    {
-        return RETCODE_PRECONDITION_NOT_MET;
     }
 
     return RETCODE_OK;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -2040,12 +2040,11 @@ InstanceHandle_t DataReaderImpl::lookup_instance(
         const void* instance) const
 {
     InstanceHandle_t handle = HANDLE_NIL;
-
     if (instance && type_->is_compute_key_provided)
     {
         if (type_->compute_key(const_cast<void*>(instance), handle, false))
         {
-            if (!history_.is_instance_present(handle))
+            if (!history_.is_instance_present(handle) || !handle.isDefined())
             {
                 handle = HANDLE_NIL;
             }

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -221,8 +221,7 @@ bool DataReaderHistory::received_change_keep_all(
             return add_to_reader_history_if_not_full(a_change, rejection_reason);
         }
 
-        // TODO (ecuesta): Add a new rejection reason for the DDS case, SAMPLE_REJECTED_UNKNOWN_KEY
-        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
+        rejection_reason = REJECTED_BY_UNKNOWN_INSTANCE;
         return false;
     }
 
@@ -264,7 +263,7 @@ bool DataReaderHistory::received_change_keep_last(
             return add_to_reader_history_if_not_full(a_change, rejection_reason);
         }
 
-        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
+        rejection_reason = REJECTED_BY_UNKNOWN_INSTANCE;
         return false;
     }
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -221,6 +221,7 @@ bool DataReaderHistory::received_change_keep_all(
             return add_to_reader_history_if_not_full(a_change, rejection_reason);
         }
 
+        // TODO (ecuesta): Add a new rejection reason for the DDS case, SAMPLE_REJECTED_UNKNOWN_KEY
         rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
         return false;
     }

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -221,7 +221,8 @@ bool DataReaderHistory::received_change_keep_all(
             return add_to_reader_history_if_not_full(a_change, rejection_reason);
         }
 
-        rejection_reason = REJECTED_BY_UNKNOWN_INSTANCE;
+        FASTDDS_TODO_BEFORE(3, 5, "Change REJECTED_BY_INSTANCES_LIMIT for REJECTED_BY_UNKNOWN_INSTANCE");
+        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
         return false;
     }
 
@@ -263,7 +264,8 @@ bool DataReaderHistory::received_change_keep_last(
             return add_to_reader_history_if_not_full(a_change, rejection_reason);
         }
 
-        rejection_reason = REJECTED_BY_UNKNOWN_INSTANCE;
+        FASTDDS_TODO_BEFORE(3, 5, "Change REJECTED_BY_INSTANCES_LIMIT for REJECTED_BY_UNKNOWN_INSTANCE");
+        rejection_reason = REJECTED_BY_INSTANCES_LIMIT;
         return false;
     }
 

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -240,6 +240,7 @@ uint32_t ReaderProxyData::get_serialized_size(
     ret_val += dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(type_name);
 
     // PID_KEY_HASH
+    // WriterProxyData always contains the writers GUID as a key hash
     ret_val += 4 + 16;
 
     // PID_PROTOCOL_VERSION

--- a/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ReaderProxyData.cpp
@@ -240,7 +240,7 @@ uint32_t ReaderProxyData::get_serialized_size(
     ret_val += dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(type_name);
 
     // PID_KEY_HASH
-    // WriterProxyData always contains the writers GUID as a key hash
+    // ReaderProxyData always contains the reader's GUID as a key hash
     ret_val += 4 + 16;
 
     // PID_PROTOCOL_VERSION

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -229,7 +229,7 @@ uint32_t WriterProxyData::get_serialized_size(
     ret_val += dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(type_name);
 
     // PID_KEY_HASH
-    // WriterProxyData always contains the writers GUID as a key hash
+    // WriterProxyData always contains the writer's GUID as a key hash
     ret_val += 4 + 16;
 
     // PID_TYPE_MAX_SIZE_SERIALIZED

--- a/src/cpp/rtps/builtin/data/WriterProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/WriterProxyData.cpp
@@ -229,6 +229,7 @@ uint32_t WriterProxyData::get_serialized_size(
     ret_val += dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(type_name);
 
     // PID_KEY_HASH
+    // WriterProxyData always contains the writers GUID as a key hash
     ret_val += 4 + 16;
 
     // PID_TYPE_MAX_SIZE_SERIALIZED

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -63,7 +63,7 @@ static CacheChange_t* initialize_change(
     reserved_change->kind = change_kind;
     if ((WITH_KEY == writer->getAttributes().topicKind) && !handle.isDefined())
     {
-        EPROSIMA_LOG_WARNING(RTPS_WRITER, "Changes in KEYED Writers need a valid instanceHandle");
+        EPROSIMA_LOG_WARNING(RTPS_WRITER, "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
     }
     reserved_change->instanceHandle = handle;
     reserved_change->writerGUID = writer->getGuid();
@@ -485,6 +485,7 @@ void WriterHistory::set_fragments(
     }
     if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind)
     {
+        // TODO(ecuesta): Review
         inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_KEY_SIZE;
         inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_STATUS_SIZE;
     }

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -61,11 +61,6 @@ static CacheChange_t* initialize_change(
         RTPSWriter* writer)
 {
     reserved_change->kind = change_kind;
-    if ((WITH_KEY == writer->getAttributes().topicKind) && !handle.isDefined())
-    {
-        EPROSIMA_LOG_WARNING(RTPS_WRITER,
-                "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
-    }
     reserved_change->instanceHandle = handle;
     reserved_change->writerGUID = writer->getGuid();
     reserved_change->writer_info.previous = nullptr;

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -486,12 +486,17 @@ void WriterHistory::set_fragments(
     {
         inline_qos_size += 4u;
     }
-    if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind)
+    if (change->instanceHandle.isDefined() && TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind)
     {
-        // TODO (Review): KEY_HASH inlineQoS could be added even if the change is ALIVE. It could always be sent.
-        // The only restriction is that it MUST be present if the change is not ALIVE (DIPOSE or UNREGISTER).
+        // KEY_HASH inlineQoS could be added even if the change is ALIVE. It could always be sent.
+        // The only restriction is that it MUST be present if the change is not ALIVE (DISPOSE or UNREGISTER).
+        // It is sent it always as long as the instanceHandle is defined.
         inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_KEY_SIZE;
-        inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_STATUS_SIZE;
+        if (change->kind != ALIVE)
+        {
+            // If the change is not ALIVE, STATUS inlineQoS will also be added.
+            inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_STATUS_SIZE;
+        }
     }
 
     // If inlineqos for related_sample_identity is required, then remove its size from the final fragment size.

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -152,10 +152,10 @@ bool WriterHistory::prepare_and_add_change(
         return false;
     }
     if (TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind && !a_change->instanceHandle.isDefined() &&
-            a_change->kind != ALIVE)
+            a_change->kind != ALIVE && a_change->serializedPayload.length == 0)
     {
         EPROSIMA_LOG_ERROR(RTPS_WRITER_HISTORY,
-                "Changes of type not equal to ALIVE in KEYED Writers need a valid instanceHandle.");
+                "Changes of type not equal to ALIVE in KEYED Writers need a valid instanceHandle or the payload to be transmitted");
         return false;
     }
 

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -63,7 +63,8 @@ static CacheChange_t* initialize_change(
     reserved_change->kind = change_kind;
     if ((WITH_KEY == writer->getAttributes().topicKind) && !handle.isDefined())
     {
-        EPROSIMA_LOG_WARNING(RTPS_WRITER, "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
+        EPROSIMA_LOG_WARNING(RTPS_WRITER,
+                "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
     }
     reserved_change->instanceHandle = handle;
     reserved_change->writerGUID = writer->getGuid();

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -486,7 +486,8 @@ void WriterHistory::set_fragments(
     }
     if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind)
     {
-        // TODO(ecuesta): Review
+        // TODO (Review): KEY_HASH inlineQoS could be added even if the change is ALIVE. It could always be sent.
+        // The only restriction is that it MUST be present if the change is not ALIVE (DIPOSE or UNREGISTER).
         inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_KEY_SIZE;
         inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_STATUS_SIZE;
     }

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -151,6 +151,13 @@ bool WriterHistory::prepare_and_add_change(
                 "' bytes and cannot be resized.");
         return false;
     }
+    if (TopicKind_t::WITH_KEY == mp_writer->getAttributes().topicKind && !a_change->instanceHandle.isDefined() &&
+            a_change->kind != ALIVE)
+    {
+        EPROSIMA_LOG_ERROR(RTPS_WRITER_HISTORY,
+                "Changes of type not equal to ALIVE in KEYED Writers need a valid instanceHandle.");
+        return false;
+    }
 
     if (m_isHistoryFull)
     {

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -631,7 +631,8 @@ bool RTPSMessageGroup::add_data(
     if (!RTPSMessageCreator::addSubmessageData(submessage_msg_, &change_to_add, endpoint_->getAttributes().topicKind,
             readerId, expectsInlineQos, inline_qos, is_big_submessage, copy_data, pending_buffer_, pending_padding_))
     {
-        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
+        EPROSIMA_LOG_ERROR(RTPS_WRITER,
+                "Cannot add DATA submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
         change_to_add.serializedPayload.data = nullptr;
         return false;
     }
@@ -750,7 +751,8 @@ bool RTPSMessageGroup::add_data_frag(
             change_to_add.serializedPayload, endpoint_->getAttributes().topicKind, readerId,
             expectsInlineQos, inline_qos, copy_data, pending_buffer_, pending_padding_))
     {
-        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA_FRAG submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
+        EPROSIMA_LOG_ERROR(RTPS_WRITER,
+                "Cannot add DATA_FRAG submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
         change_to_add.serializedPayload.data = nullptr;
         return false;
     }

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -631,7 +631,7 @@ bool RTPSMessageGroup::add_data(
     if (!RTPSMessageCreator::addSubmessageData(submessage_msg_, &change_to_add, endpoint_->getAttributes().topicKind,
             readerId, expectsInlineQos, inline_qos, is_big_submessage, copy_data, pending_buffer_, pending_padding_))
     {
-        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA submsg to the CDRMessage. Buffer too small");
+        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
         change_to_add.serializedPayload.data = nullptr;
         return false;
     }
@@ -750,7 +750,7 @@ bool RTPSMessageGroup::add_data_frag(
             change_to_add.serializedPayload, endpoint_->getAttributes().topicKind, readerId,
             expectsInlineQos, inline_qos, copy_data, pending_buffer_, pending_padding_))
     {
-        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA_FRAG submsg to the CDRMessage. Buffer too small");
+        EPROSIMA_LOG_ERROR(RTPS_WRITER, "Cannot add DATA_FRAG submsg to the CDRMessage. Either buffer is too small or handle was required and not set");
         change_to_add.serializedPayload.data = nullptr;
         return false;
     }

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -149,15 +149,15 @@ struct DataMsgUtils
 
         if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))
         {
-            if(change->instanceHandle.isDefined())
+            if (change->instanceHandle.isDefined())
             {
                 /**
                  * If instanceHandle is not defined, this means the key hash is not populated. It makes no sense
                  * to serialize a parameter with an undefined or empty value because it could be interpreted as
                  * a 'valid' key hash on the reader side
-                **/
+                 **/
                 fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
-                    change->instanceHandle);
+                        change->instanceHandle);
 
                 /** Changes like UNREGISTER or DISPOSE must include the key, they can't be sent without key */
                 if (ALIVE != change->kind)
@@ -302,12 +302,12 @@ bool RTPSMessageCreator::addSubmessageData(
 
         added_no_error &= CDRMessage::addUInt16(msg, 0); //ENCAPSULATION OPTIONS
 
-        if(change->instanceHandle.isDefined())
+        if (change->instanceHandle.isDefined())
         {
             // Even if requested in the serializedPayload, it makes no sense an undefined key hash
             added_no_error &=
-                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
-                        change->instanceHandle);
+                    fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
+                            change->instanceHandle);
         }
 
         added_no_error &= fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg,

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -167,16 +167,8 @@ struct DataMsgUtils
             }
             else
             {
-                if (ALIVE != change->kind || expectsInlineQos)
-                {
-                    EPROSIMA_LOG_ERROR(RTPS_WRITER,
-                            "Changes in KEYED Writers need a valid instanceHandle. The behavior is undefined");
-                }
-                else
-                {
-                    EPROSIMA_LOG_WARNING(RTPS_WRITER,
-                            "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
-                }
+                EPROSIMA_LOG_WARNING(RTPS_WRITER,
+                        "Change does not have a valid instanceHandle. KEY_HASH will not be serialized.");
             }
         }
 
@@ -279,6 +271,15 @@ bool RTPSMessageCreator::addSubmessageData(
     //Add INLINE QOS AND SERIALIZED PAYLOAD DEPENDING ON FLAGS:
     if (inlineQosFlag) //inlineQoS
     {
+        if(WITH_KEY == topicKind &&
+           change->instanceHandle.isDefined() == false &&
+           (expectsInlineQos || change->kind != ALIVE))
+        {
+            // Instance handle is required but not defined
+            EPROSIMA_LOG_ERROR(RTPS_WRITER,
+                    "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
+            return false;
+        }
         DataMsgUtils::serialize_inline_qos(msg, change, topicKind, expectsInlineQos, inlineQos, status);
     }
 
@@ -469,6 +470,15 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     //Add INLINE QOS AND SERIALIZED PAYLOAD DEPENDING ON FLAGS:
     if (inlineQosFlag) //inlineQoS
     {
+        if(WITH_KEY == topicKind &&
+           change->instanceHandle.isDefined() == false &&
+           (expectsInlineQos || change->kind != ALIVE))
+        {
+            // Instance handle is required but not defined
+            EPROSIMA_LOG_ERROR(RTPS_WRITER,
+                    "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
+            return false;
+        }
         DataMsgUtils::serialize_inline_qos(msg, change, topicKind, expectsInlineQos, inlineQos, status);
     }
 

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -271,9 +271,9 @@ bool RTPSMessageCreator::addSubmessageData(
     //Add INLINE QOS AND SERIALIZED PAYLOAD DEPENDING ON FLAGS:
     if (inlineQosFlag) //inlineQoS
     {
-        if(WITH_KEY == topicKind &&
-           change->instanceHandle.isDefined() == false &&
-           (expectsInlineQos || change->kind != ALIVE))
+        if (WITH_KEY == topicKind &&
+                change->instanceHandle.isDefined() == false &&
+                (expectsInlineQos || change->kind != ALIVE))
         {
             // Instance handle is required but not defined
             EPROSIMA_LOG_ERROR(RTPS_WRITER,
@@ -470,9 +470,9 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     //Add INLINE QOS AND SERIALIZED PAYLOAD DEPENDING ON FLAGS:
     if (inlineQosFlag) //inlineQoS
     {
-        if(WITH_KEY == topicKind &&
-           change->instanceHandle.isDefined() == false &&
-           (expectsInlineQos || change->kind != ALIVE))
+        if (WITH_KEY == topicKind &&
+                change->instanceHandle.isDefined() == false &&
+                (expectsInlineQos || change->kind != ALIVE))
         {
             // Instance handle is required but not defined
             EPROSIMA_LOG_ERROR(RTPS_WRITER,

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -149,13 +149,13 @@ struct DataMsgUtils
 
         if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))
         {
+            if(change->instanceHandle.isDefined())
+            {
             fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
                     change->instanceHandle);
-
-            if (ALIVE != change->kind)
-            {
-                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
             }
+            fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
+
         }
 
         if (inlineQos != nullptr)
@@ -292,11 +292,14 @@ bool RTPSMessageCreator::addSubmessageData(
         }
 
         added_no_error &= CDRMessage::addUInt16(msg, 0); //ENCAPSULATION OPTIONS
+        if(change->instanceHandle.isDefined())
+        {
         added_no_error &=
                 fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
                         change->instanceHandle);
-        added_no_error &=
-                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg,
+        }
+
+        added_no_error &= fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg,
                         status);
         added_no_error &= fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_sentinel(msg);
     }

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -154,7 +154,11 @@ struct DataMsgUtils
             fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
                     change->instanceHandle);
             }
+
+            if (ALIVE != change->kind)
+            {
             fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
+            }
 
         }
 

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -165,6 +165,19 @@ struct DataMsgUtils
                     fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
                 }
             }
+            else
+            {
+                if (ALIVE != change->kind || expectsInlineQos)
+                {
+                    EPROSIMA_LOG_ERROR(RTPS_WRITER,
+                    "Changes in KEYED Writers need a valid instanceHandle. The behavior is undefined");
+                }
+                else
+                {
+                    EPROSIMA_LOG_WARNING(RTPS_WRITER,
+                    "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
+                }
+            }
         }
 
         if (inlineQos != nullptr)
@@ -174,7 +187,6 @@ struct DataMsgUtils
 
         fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_sentinel(msg);
     }
-
 };
 
 }  // empty namespace

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -170,12 +170,12 @@ struct DataMsgUtils
                 if (ALIVE != change->kind || expectsInlineQos)
                 {
                     EPROSIMA_LOG_ERROR(RTPS_WRITER,
-                    "Changes in KEYED Writers need a valid instanceHandle. The behavior is undefined");
+                            "Changes in KEYED Writers need a valid instanceHandle. The behavior is undefined");
                 }
                 else
                 {
                     EPROSIMA_LOG_WARNING(RTPS_WRITER,
-                    "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
+                            "Changes in KEYED Writers need a valid instanceHandle. The data will be handled as if it came from an unkeyed topic.");
                 }
             }
         }
@@ -187,6 +187,7 @@ struct DataMsgUtils
 
         fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_sentinel(msg);
     }
+
 };
 
 }  // empty namespace

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -164,6 +164,12 @@ struct DataMsgUtils
                 fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
             }
         }
+        else if (ALIVE != change->kind && change->serializedPayload.length > 0)
+        {
+            // This case is added in order to support DISPOSE or UNREGISTER changes when the data
+            // is passed in the payload. Thus the KEY_HASH inline QoS is not compulsory for us
+            fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
+        }
 
         if (inlineQos != nullptr)
         {
@@ -266,11 +272,11 @@ bool RTPSMessageCreator::addSubmessageData(
     {
         if (WITH_KEY == topicKind &&
                 change->instanceHandle.isDefined() == false &&
-                (expectsInlineQos || change->kind != ALIVE))
+                change->kind != ALIVE && change->serializedPayload.length == 0)
         {
             // Instance handle is required but not defined
             EPROSIMA_LOG_ERROR(RTPS_WRITER,
-                    "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
+                    "DISPOSE or UNREGISTER Changes in KEYED Writers need a valid instanceHandle or the payload to be transmitted. Message won't be serialized");
             return false;
         }
         if (WITH_KEY == topicKind &&
@@ -472,11 +478,11 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
     {
         if (WITH_KEY == topicKind &&
                 change->instanceHandle.isDefined() == false &&
-                (expectsInlineQos || change->kind != ALIVE))
+                change->kind != ALIVE && change->serializedPayload.length == 0)
         {
             // Instance handle is required but not defined
             EPROSIMA_LOG_ERROR(RTPS_WRITER,
-                    "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
+                    "DISPOSE or UNREGISTER Changes in KEYED Writers need a valid instanceHandle or the payload to be transmitted. Message won't be serialized");
             return false;
         }
         if (WITH_KEY == topicKind &&

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -147,28 +147,21 @@ struct DataMsgUtils
                 msg, change->write_params.original_writer_info());
         }
 
-        if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))
+        if (WITH_KEY == topicKind && change->instanceHandle.isDefined() &&
+                (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))
         {
-            if (change->instanceHandle.isDefined())
-            {
-                /**
-                 * If instanceHandle is not defined, this means the key hash is not populated. It makes no sense
-                 * to serialize a parameter with an undefined or empty value because it could be interpreted as
-                 * a 'valid' key hash on the reader side
-                 **/
-                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
-                        change->instanceHandle);
+            /**
+             * If instanceHandle is not defined, this means the key hash is not populated. It makes no sense
+             * to serialize a parameter with an undefined or empty value because it could be interpreted as
+             * a 'valid' key hash on the reader side
+             **/
+            fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_key(msg,
+                    change->instanceHandle);
 
-                /** Changes like UNREGISTER or DISPOSE must include the key, they can't be sent without key */
-                if (ALIVE != change->kind)
-                {
-                    fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
-                }
-            }
-            else
+            /** Changes like UNREGISTER or DISPOSE must include the key, they can't be sent without key */
+            if (ALIVE != change->kind)
             {
-                EPROSIMA_LOG_WARNING(RTPS_WRITER,
-                        "Change does not have a valid instanceHandle. KEY_HASH will not be serialized.");
+                fastdds::dds::ParameterSerializer<fastdds::dds::Parameter_t>::add_parameter_status(msg, status);
             }
         }
 
@@ -279,6 +272,13 @@ bool RTPSMessageCreator::addSubmessageData(
             EPROSIMA_LOG_ERROR(RTPS_WRITER,
                     "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
             return false;
+        }
+        if (WITH_KEY == topicKind &&
+                change->instanceHandle.isDefined() == false)
+        {
+            // Instance handle should be defined but is not compulsory, this is just a warning
+            EPROSIMA_LOG_WARNING(RTPS_WRITER,
+                    "Change does not have a valid instanceHandle. KEY_HASH will not be serialized.");
         }
         DataMsgUtils::serialize_inline_qos(msg, change, topicKind, expectsInlineQos, inlineQos, status);
     }
@@ -478,6 +478,13 @@ bool RTPSMessageCreator::addSubmessageDataFrag(
             EPROSIMA_LOG_ERROR(RTPS_WRITER,
                     "Changes in KEYED Writers need a valid instanceHandle. Message won't be serialized");
             return false;
+        }
+        if (WITH_KEY == topicKind &&
+                change->instanceHandle.isDefined() == false)
+        {
+            // Instance handle should be defined but is not compulsory, this is just a warning
+            EPROSIMA_LOG_WARNING(RTPS_WRITER,
+                    "Change does not have a valid instanceHandle. KEY_HASH will not be serialized.");
         }
         DataMsgUtils::serialize_inline_qos(msg, change, topicKind, expectsInlineQos, inlineQos, status);
     }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -825,6 +825,9 @@ bool StatefulReader::process_data_frag_msg(
                          */
                         if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
                         {
+                            EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << work_change->writerGUID << " with sequence number: "
+                                            << work_change->sequenceNumber <<
+                                            " ignored. Could not compute key in keyed topic.");
                             pWP->irrelevant_change_set(work_change->sequenceNumber);
                             has_to_notify = true;
                         }
@@ -1199,6 +1202,9 @@ bool StatefulReader::change_received(
              */
             if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
             {
+                EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << a_change->writerGUID << " with sequence number: "
+                                                                       << a_change->sequenceNumber <<
+                        " ignored. Could not compute key in keyed topic.");
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 NotifyChanges(prox);
             }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -825,9 +825,8 @@ bool StatefulReader::process_data_frag_msg(
                          */
                         if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
                         {
-                            EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << work_change->writerGUID << " with sequence number: "
-                                                                                    << work_change->sequenceNumber <<
-                                    " ignored. Could not compute key in keyed topic.");
+                            EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << work_change->writerGUID << " with sequence number: " <<
+                                    work_change->sequenceNumber << " ignored. Could not compute key in keyed topic.");
                             pWP->irrelevant_change_set(work_change->sequenceNumber);
                             has_to_notify = true;
                         }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -819,6 +819,15 @@ bool StatefulReader::process_data_frag_msg(
                             pWP->irrelevant_change_set(work_change->sequenceNumber);
                             has_to_notify = true;
                         }
+
+                        /* Special case: rejected by REJECTED_BY_UNKNOWN_INSTANCE should never be received again.
+                         * Because the instance will still be unknown
+                         */
+                        if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
+                        {
+                            pWP->irrelevant_change_set(work_change->sequenceNumber);
+                            has_to_notify = true;
+                        }
                     }
 
                     History::const_iterator chit = history_->find_change_nts(work_change);
@@ -1180,6 +1189,15 @@ bool StatefulReader::change_received(
             /* Special case: rejected by REJECTED_BY_INSTANCES_LIMIT should never be received again.
              */
             if (fastdds::dds::REJECTED_BY_INSTANCES_LIMIT == rejection_reason)
+            {
+                prox->irrelevant_change_set(a_change->sequenceNumber);
+                NotifyChanges(prox);
+            }
+
+            /* Special case: rejected by REJECTED_BY_UNKNOWN_INSTANCE should never be received again.
+             * Because the instance will still be unknown
+             */
+            if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
             {
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 NotifyChanges(prox);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -826,8 +826,8 @@ bool StatefulReader::process_data_frag_msg(
                         if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
                         {
                             EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << work_change->writerGUID << " with sequence number: "
-                                            << work_change->sequenceNumber <<
-                                            " ignored. Could not compute key in keyed topic.");
+                                                                                    << work_change->sequenceNumber <<
+                                    " ignored. Could not compute key in keyed topic.");
                             pWP->irrelevant_change_set(work_change->sequenceNumber);
                             has_to_notify = true;
                         }
@@ -1203,7 +1203,7 @@ bool StatefulReader::change_received(
             if (fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE == rejection_reason)
             {
                 EPROSIMA_LOG_ERROR(RTPS_READER, "Change received from " << a_change->writerGUID << " with sequence number: "
-                                                                       << a_change->sequenceNumber <<
+                                                                        << a_change->sequenceNumber <<
                         " ignored. Could not compute key in keyed topic.");
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 NotifyChanges(prox);

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -373,16 +373,16 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenComputeKeyFails)
         typedef KeyedHelloWorldPubSubType::type type;
 
         bool compute_key(
-                eprosima::fastdds::rtps::SerializedPayload_t& ,
-                eprosima::fastdds::rtps::InstanceHandle_t& ,
+                eprosima::fastdds::rtps::SerializedPayload_t&,
+                eprosima::fastdds::rtps::InstanceHandle_t&,
                 bool ) override
         {
            return false;
         }
 
         bool compute_key(
-                const void* const ,
-                eprosima::fastdds::rtps::InstanceHandle_t& ,
+                const void* const,
+                eprosima::fastdds::rtps::InstanceHandle_t&,
                 bool ) override
         {
             // Returning false to simulate failure to compute key
@@ -501,7 +501,7 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
         typedef KeyedHelloWorldPubSubType::type type;
 
         bool compute_key(
-                eprosima::fastdds::rtps::SerializedPayload_t& ,
+                eprosima::fastdds::rtps::SerializedPayload_t&,
                 eprosima::fastdds::rtps::InstanceHandle_t& handle,
                 bool ) override
         {
@@ -510,7 +510,7 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
         }
 
         bool compute_key(
-                const void* const ,
+                const void* const,
                 eprosima::fastdds::rtps::InstanceHandle_t& handle,
                 bool ) override
         {

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -29,8 +29,6 @@
 #include "../utils/filter_helpers.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
-#include "RTPSWithRegistrationReader.hpp"
-#include "RTPSWithRegistrationWriter.hpp"
 #include "UDPMessageSender.hpp"
 
 TEST(KeyedTopic, RegistrationNonKeyedFail)
@@ -297,112 +295,6 @@ TEST(KeyedTopic, DataWriterAlwaysSendTheSerializedKeyViaInlineQoS)
 
     EXPECT_TRUE(writer_sends_inline_qos);
     EXPECT_TRUE(writer_sends_pid_key_hash);
-}
-
-/**
- * Checks that an RTPS Writer does not serialize the KEY_HASH inline QoS parameter
- * when the instance handle provided at write time is undefined.
- */
-TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
-{
-    using namespace eprosima::fastdds::dds;
-    using namespace eprosima::fastdds::rtps;
-
-    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
-
-    bool writer_sends_inline_qos = true;
-    bool writer_sends_pid_key_hash = true;
-
-    // Custom transport layer to inspect outgoing messages
-    test_transport->drop_data_messages_filter_ = [&writer_sends_inline_qos,
-                    &writer_sends_pid_key_hash](eprosima::fastdds::rtps::CDRMessage_t& msg) -> bool
-            {
-                // Check for inline_qos
-                uint8_t flags = msg.buffer[msg.pos - 3];
-                auto old_pos = msg.pos;
-
-                // Skip extraFlags, read octetsToInlineQos, and calculate inline qos position.
-                msg.pos += 2;
-                uint16_t to_inline_qos = eprosima::fastdds::helpers::cdr_parse_u16(
-                    (char*)&msg.buffer[msg.pos]);
-                msg.pos += 2;
-
-                uint32_t inline_qos_pos = msg.pos + to_inline_qos;
-
-                // Filters are only applied to user data
-                // no need to check if the packets comer from a builtin
-
-                writer_sends_inline_qos &= static_cast<bool>((flags & (1 << 1)));
-
-                // Stop seeking if inline qos are not present
-                // Fail the test afterwards
-                if (!writer_sends_inline_qos)
-                {
-                    return false;
-                }
-                else
-                {
-                    // Process inline qos
-                    msg.pos = inline_qos_pos;
-                    bool key_hash_was_found = false;
-                    while (msg.pos < msg.length)
-                    {
-                        uint16_t pid = eprosima::fastdds::helpers::cdr_parse_u16(
-                            (char*)&msg.buffer[msg.pos]);
-                        msg.pos += 2;
-                        uint16_t plen = eprosima::fastdds::helpers::cdr_parse_u16(
-                            (char*)&msg.buffer[msg.pos]);
-                        msg.pos += 2;
-                        uint32_t next_pos = msg.pos + plen;
-
-                        if (pid == eprosima::fastdds::dds::PID_KEY_HASH)
-                        {
-                            key_hash_was_found = true;
-                        }
-                        else if (pid == eprosima::fastdds::dds::PID_SENTINEL)
-                        {
-                            break;
-                        }
-
-                        msg.pos = next_pos;
-                    }
-
-                    writer_sends_pid_key_hash &= key_hash_was_found;
-                    msg.pos = old_pos;
-                }
-
-                // Do not drop the packet in any case
-                return false;
-            };
-
-    RTPSWithRegistrationWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-    RTPSWithRegistrationReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-
-    writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport).init();
-    ASSERT_TRUE(writer.isInitialized());
-    reader.init();
-    ASSERT_TRUE(reader.isInitialized());
-
-    // Wait for discovery.
-    writer.wait_discovery();
-    reader.wait_discovery();
-
-    // Generate a sample
-    auto data = default_keyedhelloworld_data_generator(1);
-    // Sending a defined handle in KEY_HASH inline qos
-    InstanceHandle_t handle;
-    handle.value[0] = 1;
-    writer.send_sample(data.front(), handle);
-    // Message must contain pid KEY_HASH
-    EXPECT_TRUE(writer_sends_inline_qos);
-    EXPECT_TRUE(writer_sends_pid_key_hash);
-    // Now sending an undefined handle
-    handle.clear();
-    writer.send_sample(data.front(), handle);
-    // The writer should not send pid KEY_HASH as it was not defined
-    // NOTE: InlineQoS could still contain other parameters it is enough
-    // that either inline qos is not sent or pid key hash is not sent
-    EXPECT_TRUE(!writer_sends_inline_qos || !writer_sends_pid_key_hash);
 }
 
 // Check that compute_key is called with a key-only payload when KEY_HASH is not present

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -29,6 +29,8 @@
 #include "../utils/filter_helpers.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
 #include "UDPMessageSender.hpp"
 
 TEST(KeyedTopic, RegistrationNonKeyedFail)
@@ -297,134 +299,10 @@ TEST(KeyedTopic, DataWriterAlwaysSendTheSerializedKeyViaInlineQoS)
     EXPECT_TRUE(writer_sends_pid_key_hash);
 }
 
-TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenComputeKeyFails)
-{
-    using namespace eprosima::fastdds::dds;
-    using namespace eprosima::fastdds::rtps;
-
-    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
-
-    bool writer_sends_inline_qos = true;
-    bool writer_sends_pid_key_hash = true;
-
-    test_transport->drop_data_messages_filter_ = [&writer_sends_inline_qos,
-                    &writer_sends_pid_key_hash](eprosima::fastdds::rtps::CDRMessage_t& msg) -> bool
-            {
-                // Check for inline_qos
-                uint8_t flags = msg.buffer[msg.pos - 3];
-                auto old_pos = msg.pos;
-
-                // Skip extraFlags, read octetsToInlineQos, and calculate inline qos position.
-                msg.pos += 2;
-                uint16_t to_inline_qos = eprosima::fastdds::helpers::cdr_parse_u16(
-                    (char*)&msg.buffer[msg.pos]);
-                msg.pos += 2;
-
-                uint32_t inline_qos_pos = msg.pos + to_inline_qos;
-
-                // Filters are only applied to user data
-                // no need to check if the packets comer from a builtin
-
-                writer_sends_inline_qos &= static_cast<bool>((flags & (1 << 1)));
-
-                // Stop seeking if inline qos are not present
-                // Fail the test afterwards
-                if (!writer_sends_inline_qos)
-                {
-                    return false;
-                }
-                else
-                {
-                    // Process inline qos
-                    msg.pos = inline_qos_pos;
-                    bool key_hash_was_found = false;
-                    while (msg.pos < msg.length)
-                    {
-                        uint16_t pid = eprosima::fastdds::helpers::cdr_parse_u16(
-                            (char*)&msg.buffer[msg.pos]);
-                        msg.pos += 2;
-                        uint16_t plen = eprosima::fastdds::helpers::cdr_parse_u16(
-                            (char*)&msg.buffer[msg.pos]);
-                        msg.pos += 2;
-                        uint32_t next_pos = msg.pos + plen;
-
-                        if (pid == eprosima::fastdds::dds::PID_KEY_HASH)
-                        {
-                            key_hash_was_found = true;
-                        }
-                        else if (pid == eprosima::fastdds::dds::PID_SENTINEL)
-                        {
-                            break;
-                        }
-
-                        msg.pos = next_pos;
-                    }
-
-                    writer_sends_pid_key_hash &= key_hash_was_found;
-                    msg.pos = old_pos;
-                }
-
-                // Do not drop the packet in any case
-                return false;
-    };
-
-    struct TestTypeSupport : public KeyedHelloWorldPubSubType
-    {
-        typedef KeyedHelloWorldPubSubType::type type;
-
-        bool compute_key(
-                eprosima::fastdds::rtps::SerializedPayload_t&,
-                eprosima::fastdds::rtps::InstanceHandle_t&,
-                bool ) override
-        {
-           return false;
-        }
-
-        bool compute_key(
-                const void* const,
-                eprosima::fastdds::rtps::InstanceHandle_t&,
-                bool ) override
-        {
-            // Returning false to simulate failure to compute key
-            return false;
-        }
-
-    private:
-
-        mutable std::mutex mtx_;
-        std::condition_variable cv_;
-        std::uint32_t key_only_payload_count_ = 0;
-    };
-
-
-    PubSubWriter<TestTypeSupport> writer(TEST_TOPIC_NAME);
-    PubSubReader<TestTypeSupport> reader(TEST_TOPIC_NAME);
-    auto type_support_ptr = std::dynamic_pointer_cast<TestTypeSupport>(reader.get_type_support());
-
-    writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport).init();
-    ASSERT_TRUE(writer.isInitialized());
-
-    reader.expect_inline_qos(false).init();
-    ASSERT_TRUE(reader.isInitialized());
-
-    // Wait for discovery.
-    writer.wait_discovery();
-    reader.wait_discovery();
-
-
-    // Start of proper test
-
-    // Generate a sample
-    auto data = default_keyedhelloworld_data_generator(1);
-    InstanceHandle_t undefined_handle;
-    // Send the sample with an undefined key
-    writer.send_sample(data.front(), undefined_handle);
-    // Reception
-    reader.startReception(data);
-    // The writer should not send pid KEY_HASH as it was not defined
-    EXPECT_FALSE(writer_sends_pid_key_hash);
-}
-
+/**
+ * Checks that an RTPS Writer does not serialize the KEY_HASH inline QoS parameter
+ * when the instance handle provided at write time is undefined.
+ */
 TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
 {
     using namespace eprosima::fastdds::dds;
@@ -435,6 +313,7 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
     bool writer_sends_inline_qos = true;
     bool writer_sends_pid_key_hash = true;
 
+    // Custom transport layer to inspect outgoing messages
     test_transport->drop_data_messages_filter_ = [&writer_sends_inline_qos,
                     &writer_sends_pid_key_hash](eprosima::fastdds::rtps::CDRMessage_t& msg) -> bool
             {
@@ -496,43 +375,12 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
                 return false;
     };
 
-    struct TestTypeSupport : public KeyedHelloWorldPubSubType
-    {
-        typedef KeyedHelloWorldPubSubType::type type;
-
-        bool compute_key(
-                eprosima::fastdds::rtps::SerializedPayload_t&,
-                eprosima::fastdds::rtps::InstanceHandle_t& handle,
-                bool ) override
-        {
-            handle = eprosima::fastdds::rtps::InstanceHandle_t();
-            return true;
-        }
-
-        bool compute_key(
-                const void* const,
-                eprosima::fastdds::rtps::InstanceHandle_t& handle,
-                bool ) override
-        {
-            handle = eprosima::fastdds::rtps::InstanceHandle_t();
-            return true;
-        }
-
-    private:
-
-        mutable std::mutex mtx_;
-        std::condition_variable cv_;
-        std::uint32_t key_only_payload_count_ = 0;
-    };
-
-    PubSubWriter<TestTypeSupport> writer(TEST_TOPIC_NAME);
-    PubSubReader<TestTypeSupport> reader(TEST_TOPIC_NAME);
-    auto type_support_ptr = std::dynamic_pointer_cast<TestTypeSupport>(reader.get_type_support());
+    RTPSWithRegistrationWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    RTPSWithRegistrationReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
 
     writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport).init();
     ASSERT_TRUE(writer.isInitialized());
-
-    reader.expect_inline_qos(false).init();
+    reader.init();
     ASSERT_TRUE(reader.isInitialized());
 
     // Wait for discovery.
@@ -541,14 +389,20 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
 
     // Generate a sample
     auto data = default_keyedhelloworld_data_generator(1);
-    // Set undefined handle, howeveer, compute_key will overwrite it as it is undefined
-    InstanceHandle_t undefined_handle;
-    // Send the sample with an undefined key
-    writer.send_sample(data.front(), undefined_handle);
-    // Reception
-    reader.startReception(data);
+    // Sending a defined handle in KEY_HASH inline qos
+    InstanceHandle_t handle;
+    handle.value[0] = 1;
+    writer.send_sample(data.front(), handle);
+    // Message must contain pid KEY_HASH
+    EXPECT_TRUE(writer_sends_inline_qos);
+    EXPECT_TRUE(writer_sends_pid_key_hash);
+    // Now sending an undefined handle
+    handle.clear();
+    writer.send_sample(data.front(), handle);
     // The writer should not send pid KEY_HASH as it was not defined
-    EXPECT_FALSE(writer_sends_pid_key_hash);
+    // NOTE: InlineQoS could still contain other parameters it is enough
+    // that either inline qos is not sent or pid key hash is not sent
+    EXPECT_TRUE(!writer_sends_inline_qos || !writer_sends_pid_key_hash);
 }
 
 // Check that compute_key is called with a key-only payload when KEY_HASH is not present

--- a/test/blackbox/common/BlackboxTestsKeys.cpp
+++ b/test/blackbox/common/BlackboxTestsKeys.cpp
@@ -373,7 +373,7 @@ TEST(KeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
 
                 // Do not drop the packet in any case
                 return false;
-    };
+            };
 
     RTPSWithRegistrationWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
     RTPSWithRegistrationReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3680,10 +3680,6 @@ TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
             return false;
         }
 
-    private:
-
-        mutable std::mutex mtx_;
-        std::condition_variable cv_;
     };
 
     // Force using UDP transport

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3653,6 +3653,9 @@ TEST(DDSStatus, several_writers_on_unack_sample_removed)
 /**
  *   Checks that a sample is rejected with reason REJECTED_BY_UNKNOWN_INSTANCE when the KEY_HASH
  *   parameter is not present in the CDR message and cannot be computed on the reader side
+ *
+ *   NOTE: At the moment this checks REJECTED_BY_INSTANCES_LIMIT instead of REJECTED_BY_UNKNOWN_INSTANCE
+ *   until FAST DDS 3.5 is released, to avoid an ABI break.
  **/
 TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
 {
@@ -3707,7 +3710,8 @@ TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
                 std::lock_guard<std::mutex> lock(test_mtx);
                 test_status.total_count = status.total_count;
                 test_status.total_count_change += status.total_count_change;
-                ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE, status.last_reason);
+                FASTDDS_TODO_BEFORE(3, 5, "Change REJECTED_BY_INSTANCES_LIMIT for REJECTED_BY_UNKNOWN_INSTANCE");
+                ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_INSTANCES_LIMIT, status.last_reason);
                 test_status.last_reason = status.last_reason;
                 test_status.last_instance_handle = status.last_instance_handle;
                 test_cv.notify_one();
@@ -3796,7 +3800,8 @@ TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
     ASSERT_EQ(1u, test_status.total_count);
     ASSERT_EQ(1u, test_status.total_count_change);
     // The rejection reason and instance handle are as expected
-    ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE, test_status.last_reason);
+    FASTDDS_TODO_BEFORE(3, 5, "Change REJECTED_BY_INSTANCES_LIMIT for REJECTED_BY_UNKNOWN_INSTANCE");
+    ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_INSTANCES_LIMIT, test_status.last_reason);
     ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3708,7 +3708,7 @@ TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
     sample_rejected_test_init(reader, writer, [&test_mtx, &test_cv, &test_status](
                 const eprosima::fastdds::dds::SampleRejectedStatus& status)
             {
-                std::unique_lock<std::mutex> lock(test_mtx);
+                std::lock_guard<std::mutex> lock(test_mtx);
                 test_status.total_count = status.total_count;
                 test_status.total_count_change += status.total_count_change;
                 ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE, status.last_reason);

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -29,6 +29,7 @@
 #include "BlackboxTests.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
+#include "UDPMessageSender.hpp"
 
 using namespace eprosima::fastdds::rtps;
 
@@ -1785,6 +1786,20 @@ template<typename T>
 void sample_rejected_test_init(
         PubSubReader<T>& reader,
         PubSubWriter<T>& writer,
+        std::function<void(const eprosima::fastdds::dds::SampleRejectedStatus& status)> functor)
+{
+    sample_rejected_test_dw_init(writer);
+    sample_rejected_test_dr_init(reader, functor);
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+}
+
+template<typename T, typename U>
+void sample_rejected_test_init(
+        PubSubReader<T>& reader,
+        PubSubWriter<U>& writer,
         std::function<void(const eprosima::fastdds::dds::SampleRejectedStatus& status)> functor)
 {
     sample_rejected_test_dw_init(writer);
@@ -3633,6 +3648,161 @@ TEST(DDSStatus, several_writers_on_unack_sample_removed)
     reliable_writer.send_sample(reliable_data.front());
     reliable_writer.waitForAllAcked(std::chrono::milliseconds(150));
     EXPECT_EQ(listener.notified_writer(), &(reliable_writer.get_native_writer()));
+}
+
+/**
+ *   Checks that a sample is rejected with reason REJECTED_BY_UNKNOWN_INSTANCE when the KEY_HASH
+ *   parameter is not present in the CDR message and cannot be computed on the reader side
+ **/
+TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
+{
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastdds::rtps;
+
+    struct TestTypeSupport : public KeyedHelloWorldPubSubType
+    {
+        typedef KeyedHelloWorldPubSubType::type type;
+
+
+        bool compute_key(
+                eprosima::fastdds::rtps::SerializedPayload_t&,
+                eprosima::fastdds::rtps::InstanceHandle_t&,
+                bool ) override
+        {
+            return false;
+        }
+
+        bool compute_key(
+                const void* const,
+                eprosima::fastdds::rtps::InstanceHandle_t&,
+                bool ) override
+        {
+            return false;
+        }
+
+    private:
+
+        mutable std::mutex mtx_;
+        std::condition_variable cv_;
+        std::uint32_t key_only_payload_count_ = 0;
+    };
+
+    // Force using UDP transport
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    // Writer can compute key normally
+    PubSubWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    writer.disable_builtin_transport().add_user_transport_to_pparams(udp_transport);
+
+    // Reader use custom TypeSupport that cannot compute key
+    PubSubReader<TestTypeSupport> reader(TEST_TOPIC_NAME);
+    // Set custom reader locator so we can send hand-crafted data to a known location
+    Locator_t reader_locator;
+    ASSERT_TRUE(IPLocator::setIPv4(reader_locator, "127.0.0.1"));
+    reader_locator.port = 7000;
+    reader.add_to_unicast_locator_list("127.0.0.1", 7000);
+    reader.disable_builtin_transport().add_user_transport_to_pparams(udp_transport);
+
+    std::mutex test_mtx;
+    std::condition_variable test_cv;
+    eprosima::fastdds::dds::SampleRejectedStatus test_status;
+    sample_rejected_test_init(reader, writer, [&test_mtx, &test_cv, &test_status](
+                const eprosima::fastdds::dds::SampleRejectedStatus& status)
+            {
+                std::unique_lock<std::mutex> lock(test_mtx);
+                test_status.total_count = status.total_count;
+                test_status.total_count_change += status.total_count_change;
+                ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE, status.last_reason);
+                test_status.last_reason = status.last_reason;
+                test_status.last_instance_handle = status.last_instance_handle;
+                test_cv.notify_one();
+            });
+
+    ASSERT_TRUE(reader.isInitialized());
+    ASSERT_TRUE(writer.isInitialized());
+
+    // Starting normal reception of some data just to ensure everything is working properly
+    auto data = default_keyedhelloworld_data_generator(2);
+    reader.startReception(data);
+    // Send data
+    writer.send(data);
+    EXPECT_TRUE(data.empty());
+    reader.block_for_all();
+
+    // Sending fake message, remember DataReader cannot recompute key as compute_key is
+    // overridden to always return false
+    UDPMessageSender fake_msg_sender;
+
+    // Send hand-crafted data that does not contain KEY_HASH PID
+    {
+        auto writer_guid = writer.datawriter_guid();
+
+        struct KeyOnlyPayloadPacket
+        {
+            std::array<char, 4> rtps_id{ {'R', 'T', 'P', 'S'} };
+            std::array<uint8_t, 2> protocol_version{ {2, 3} };
+            std::array<uint8_t, 2> vendor_id{ {0x01, 0x0F} };
+            GuidPrefix_t sender_prefix{};
+
+            struct DataSubMsg
+            {
+                struct Header
+                {
+                    uint8_t submessage_id = 0x15;
+    #if FASTDDS_IS_BIG_ENDIAN_TARGET
+                    uint8_t flags = 0x08;
+    #else
+                    uint8_t flags = 0x09;
+    #endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
+                    uint16_t octets_to_next_header = 28;
+                    uint16_t extra_flags = 0;
+                    uint16_t octets_to_inline_qos = 16;
+                    EntityId_t reader_id{};
+                    EntityId_t writer_id{};
+                    SequenceNumber_t sn{ 3 };
+                };
+
+                struct SerializedData
+                {
+                    uint8_t encapsulation[2] = {0x00, CDR_LE};
+                    uint8_t encapsulation_opts[2] = {0x00, 0x00};
+                    uint8_t data[4] = {0x0A, 0x00, 0x00, 0x00};
+                };
+
+                Header header;
+                SerializedData payload;
+            }
+            data;
+        };
+
+        KeyOnlyPayloadPacket key_only_packet{};
+        key_only_packet.sender_prefix = writer_guid.guidPrefix;
+        key_only_packet.data.header.writer_id = writer_guid.entityId;
+        key_only_packet.data.header.reader_id = reader.datareader_guid().entityId;
+
+        CDRMessage_t msg(0);
+        uint32_t msg_len = static_cast<uint32_t>(sizeof(key_only_packet));
+        msg.init(reinterpret_cast<octet*>(&key_only_packet), msg_len);
+        msg.length = msg_len;
+        msg.pos = msg_len;
+        fake_msg_sender.send(msg, reader_locator);
+    }
+
+    // Wait in the cv for the listener to be called
+    std::unique_lock<std::mutex> lock(test_mtx);
+    test_cv.wait_for(lock,
+            std::chrono::milliseconds(500),
+            [&test_status]() -> bool
+            {
+                return test_status.total_count >= 1;
+            });
+
+    // Only one sample was rejected
+    ASSERT_EQ(1u, test_status.total_count);
+    ASSERT_EQ(1u, test_status.total_count_change);
+    // The rejection reason and instance handle are as expected
+    ASSERT_EQ(eprosima::fastdds::dds::REJECTED_BY_UNKNOWN_INSTANCE, test_status.last_reason);
+    ASSERT_EQ(c_InstanceHandle_Unknown, test_status.last_instance_handle);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -3684,7 +3684,6 @@ TEST(DDSStatus, keyed_sample_discard_by_unknown_instance)
 
         mutable std::mutex mtx_;
         std::condition_variable cv_;
-        std::uint32_t key_only_payload_count_ = 0;
     };
 
     // Force using UDP transport

--- a/test/blackbox/common/RTPSBlackboxTestsKeys.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsKeys.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/blackbox/common/RTPSBlackboxTestsKeys.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsKeys.cpp
@@ -1,0 +1,138 @@
+// Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "BlackboxTests.hpp"
+
+#include <memory>
+#include <mutex>
+
+#include <fastdds/dds/core/policy/ParameterTypes.hpp>
+#include <fastdds/dds/topic/TypeSupport.hpp>
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <fastdds/rtps/common/InstanceHandle.hpp>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/rtps/transport/test_UDPv4TransportDescriptor.hpp>
+
+#include "../types/HelloWorldPubSubTypes.hpp"
+#include "../types/KeyedHelloWorldPubSubTypes.hpp"
+#include "../utils/filter_helpers.hpp"
+#include "RTPSWithRegistrationReader.hpp"
+#include "RTPSWithRegistrationWriter.hpp"
+#include "UDPMessageSender.hpp"
+
+/**
+ * Checks that an RTPS Writer does not serialize the KEY_HASH inline QoS parameter
+ * when the instance handle provided at write time is undefined.
+ */
+TEST(RTPSKeyedTopic, DataWriterDoesNotSendTheSerializedKeyWhenInstanceUndefined)
+{
+    using namespace eprosima::fastdds::dds;
+    using namespace eprosima::fastdds::rtps;
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+
+    bool writer_sends_inline_qos = true;
+    bool writer_sends_pid_key_hash = true;
+
+    // Custom transport layer to inspect outgoing messages
+    test_transport->drop_data_messages_filter_ = [&writer_sends_inline_qos,
+                    &writer_sends_pid_key_hash](eprosima::fastdds::rtps::CDRMessage_t& msg) -> bool
+            {
+                // Check for inline_qos
+                uint8_t flags = msg.buffer[msg.pos - 3];
+                auto old_pos = msg.pos;
+
+                // Skip extraFlags, read octetsToInlineQos, and calculate inline qos position.
+                msg.pos += 2;
+                uint16_t to_inline_qos = eprosima::fastdds::helpers::cdr_parse_u16(
+                    (char*)&msg.buffer[msg.pos]);
+                msg.pos += 2;
+
+                uint32_t inline_qos_pos = msg.pos + to_inline_qos;
+
+                // Filters are only applied to user data
+                // no need to check if the packets comer from a builtin
+
+                writer_sends_inline_qos &= static_cast<bool>((flags & (1 << 1)));
+
+                // Stop seeking if inline qos are not present
+                // Fail the test afterwards
+                if (!writer_sends_inline_qos)
+                {
+                    return false;
+                }
+                else
+                {
+                    // Process inline qos
+                    msg.pos = inline_qos_pos;
+                    bool key_hash_was_found = false;
+                    while (msg.pos < msg.length)
+                    {
+                        uint16_t pid = eprosima::fastdds::helpers::cdr_parse_u16(
+                            (char*)&msg.buffer[msg.pos]);
+                        msg.pos += 2;
+                        uint16_t plen = eprosima::fastdds::helpers::cdr_parse_u16(
+                            (char*)&msg.buffer[msg.pos]);
+                        msg.pos += 2;
+                        uint32_t next_pos = msg.pos + plen;
+
+                        if (pid == eprosima::fastdds::dds::PID_KEY_HASH)
+                        {
+                            key_hash_was_found = true;
+                        }
+                        else if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+                        {
+                            break;
+                        }
+
+                        msg.pos = next_pos;
+                    }
+
+                    writer_sends_pid_key_hash &= key_hash_was_found;
+                    msg.pos = old_pos;
+                }
+
+                // Do not drop the packet in any case
+                return false;
+            };
+
+    RTPSWithRegistrationWriter<KeyedHelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    RTPSWithRegistrationReader<KeyedHelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    writer.disable_builtin_transport().add_user_transport_to_pparams(test_transport).init();
+    ASSERT_TRUE(writer.isInitialized());
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    // Wait for discovery.
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Generate a sample
+    auto data = default_keyedhelloworld_data_generator(1);
+    // Sending a defined handle in KEY_HASH inline qos
+    InstanceHandle_t handle;
+    handle.value[0] = 1;
+    writer.send_sample(data.front(), handle);
+    // Message must contain pid KEY_HASH
+    EXPECT_TRUE(writer_sends_inline_qos);
+    EXPECT_TRUE(writer_sends_pid_key_hash);
+    // Now sending an undefined handle
+    handle.clear();
+    writer.send_sample(data.front(), handle);
+    // The writer should not send pid KEY_HASH as it was not defined
+    // NOTE: InlineQoS could still contain other parameters it is enough
+    // that either inline qos is not sent or pid key hash is not sent
+    EXPECT_TRUE(!writer_sends_inline_qos || !writer_sends_pid_key_hash);
+}

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -298,7 +298,7 @@ public:
         return ch;
     }
 
-     eprosima::fastdds::rtps::CacheChange_t* send_sample(
+    eprosima::fastdds::rtps::CacheChange_t* send_sample(
             type& msg,
             const eprosima::fastdds::rtps::InstanceHandle_t& handle)
     {

--- a/test/blackbox/common/RTPSWithRegistrationWriter.hpp
+++ b/test/blackbox/common/RTPSWithRegistrationWriter.hpp
@@ -298,6 +298,33 @@ public:
         return ch;
     }
 
+     eprosima::fastdds::rtps::CacheChange_t* send_sample(
+            type& msg,
+            const eprosima::fastdds::rtps::InstanceHandle_t& handle)
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(eprosima::fastdds::rtps::DEFAULT_XCDR_VERSION);
+        size_t current_alignment{ 0 };
+        uint32_t cdr_size = static_cast<uint32_t>(calculator.calculate_serialized_size(msg, current_alignment));
+        eprosima::fastdds::rtps::CacheChange_t* ch = history_->create_change(
+            cdr_size, eprosima::fastdds::rtps::ALIVE, handle);
+
+        eprosima::fastcdr::FastBuffer buffer((char*)ch->serializedPayload.data, ch->serializedPayload.max_size);
+        eprosima::fastcdr::Cdr cdr(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                eprosima::fastdds::rtps::DEFAULT_XCDR_VERSION);
+
+        cdr.serialize_encapsulation();
+        cdr << msg;
+
+        ch->serializedPayload.length = static_cast<uint32_t>(cdr.get_serialized_data_length());
+        if (ch->serializedPayload.length > 65000u)
+        {
+            ch->setFragmentSize(65000u);
+        }
+
+        history_->add_change(ch);
+        return ch;
+    }
+
     bool remove_change (
             const eprosima::fastdds::rtps::SequenceNumber_t& sequence_number)
     {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -335,7 +335,7 @@ public:
             fastdds::rtps::InstanceHandle_t& ihandle,
             bool /*force_md5*/) override
     {
-        // Setting instance as valid
+        // Setting instance as invalid
         ihandle.clear();
         return false;
     }
@@ -345,7 +345,7 @@ public:
             fastdds::rtps::InstanceHandle_t& ihandle,
             bool /*force_md5*/) override
     {
-        // Setting instance as valid
+        // Setting instance as invalid
         ihandle.clear();
         return false;
     }
@@ -372,7 +372,7 @@ public:
             fastdds::rtps::InstanceHandle_t& ihandle,
             bool /*force_md5*/) override
     {
-        // Setting instance as valid
+        // Setting instance as invalid
         ihandle.clear();
         return true;
     }
@@ -382,7 +382,7 @@ public:
             fastdds::rtps::InstanceHandle_t& ihandle,
             bool /*force_md5*/) override
     {
-        // Setting instance as valid
+        // Setting instance as invalid
         ihandle.clear();
         return true;
     }

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -275,6 +275,7 @@ public:
         ihandle.value[0] = 1;
         return false;
     }
+
 };
 
 
@@ -311,6 +312,7 @@ public:
         ihandle.value[0] = 1;
         return true;
     }
+
 };
 
 
@@ -347,6 +349,7 @@ public:
         ihandle.clear();
         return false;
     }
+
 };
 
 
@@ -383,6 +386,7 @@ public:
         ihandle.clear();
         return true;
     }
+
 };
 
 class BoundedTopicDataTypeMock : public TopicDataType
@@ -973,11 +977,11 @@ TEST(DataWriterTests, write_with_compute_key_true_defined_instance)
     #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
-    #endif
+    #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     instance_type->compute_key(&data, valid_handle);
@@ -986,7 +990,7 @@ TEST(DataWriterTests, write_with_compute_key_true_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    #endif
+    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1031,11 +1035,11 @@ TEST(DataWriterTests, write_with_compute_key_true_undefined_instance)
     #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
-    #endif
+    #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
@@ -1045,7 +1049,7 @@ TEST(DataWriterTests, write_with_compute_key_true_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1091,11 +1095,11 @@ TEST(DataWriterTests, write_with_compute_key_false_defined_instance)
     #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
-    #endif
+    #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
@@ -1105,7 +1109,7 @@ TEST(DataWriterTests, write_with_compute_key_false_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1151,11 +1155,11 @@ TEST(DataWriterTests, write_with_compute_key_false_undefined_instance)
     #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
-    #endif
+    #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
@@ -1165,7 +1169,7 @@ TEST(DataWriterTests, write_with_compute_key_false_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif
+    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -974,9 +974,9 @@ TEST(DataWriterTests, write_with_compute_key_true_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_OK);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
+    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
@@ -1032,9 +1032,9 @@ TEST(DataWriterTests, write_with_compute_key_true_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
+    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
@@ -1046,7 +1046,7 @@ TEST(DataWriterTests, write_with_compute_key_true_undefined_instance)
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns invalid instance
     #if defined(NDEBUG)
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
@@ -1092,9 +1092,9 @@ TEST(DataWriterTests, write_with_compute_key_false_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
+    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
@@ -1106,7 +1106,7 @@ TEST(DataWriterTests, write_with_compute_key_false_defined_instance)
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns false
     #if defined(NDEBUG)
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
@@ -1152,9 +1152,9 @@ TEST(DataWriterTests, write_with_compute_key_false_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is valid because instance is not recomputed
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_OK);
+    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
+    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)
     #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
@@ -1166,7 +1166,7 @@ TEST(DataWriterTests, write_with_compute_key_false_undefined_instance)
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns false
     #if defined(NDEBUG)
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
+    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #else
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     #endif // if defined(NDEBUG)

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -974,23 +974,12 @@ TEST(DataWriterTests, write_with_compute_key_true_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_OK);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_OK);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
-    #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     instance_type->compute_key(&data, valid_handle);
-    // Both debug and release work fine because the key is the same as computed
-    #if defined(NDEBUG)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    #else
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_OK);
-    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1032,24 +1021,14 @@ TEST(DataWriterTests, write_with_compute_key_true_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
-    #if !defined(NDEBUG) // In Debug build, instance is recomputed and detected as different
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns invalid instance
-    #if defined(NDEBUG)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #else
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1092,24 +1071,14 @@ TEST(DataWriterTests, write_with_compute_key_false_defined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
-    #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns false
-    #if defined(NDEBUG)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #else
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
@@ -1152,24 +1121,14 @@ TEST(DataWriterTests, write_with_compute_key_false_undefined_instance)
     ASSERT_TRUE(datawriter->write(&data, wp) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write(&data, HANDLE_NIL) == RETCODE_PRECONDITION_NOT_MET);
     // Fails with valid handle
-    #if defined(NDEBUG) // In Release build, this is not valid because instance is recomputed and differs
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
     ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
-    #if !defined(NDEBUG) // In Debug build, instance is recomputed and compute_key fails
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    ASSERT_TRUE(datawriter->write_w_timestamp(&data, valid_handle, ts) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if !defined(NDEBUG)
 
     valid_handle.clear();
     valid_handle.value[0] = 1; // Same as computed instance
     ASSERT_TRUE(valid_handle.isDefined());
     // Attempt to recompute key to check equality, but compute_key returns false
-    #if defined(NDEBUG)
     ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #else
-    ASSERT_TRUE(datawriter->write(&data, valid_handle) == RETCODE_PRECONDITION_NOT_MET);
-    #endif // if defined(NDEBUG)
 
     // Cleanup
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);

--- a/test/unittest/rtps/history/WriterHistoryTests.cpp
+++ b/test/unittest/rtps/history/WriterHistoryTests.cpp
@@ -106,7 +106,7 @@ TEST(WriterHistoryTests, final_high_mark_for_frag_overflow)
     }
 }
 
-TEST(WriterHistoryTests, add_change_with_undefined_instance_handle)
+TEST(WriterHistoryTests, add_change_with_undefined_instance_handle_and_no_payload)
 {
     uint32_t domain_id = 0;
 
@@ -139,7 +139,7 @@ TEST(WriterHistoryTests, add_change_with_undefined_instance_handle)
     ASSERT_FALSE(history->add_change(change));
 }
 
-TEST(WriterHistoryTests, add_change_with_defined_instance_handle)
+TEST(WriterHistoryTests, add_change_with_defined_instance_handle_and_no_payload)
 {
     uint32_t domain_id = 0;
 
@@ -172,6 +172,41 @@ TEST(WriterHistoryTests, add_change_with_defined_instance_handle)
     ASSERT_TRUE(history->add_change(change));
     change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
     change->instanceHandle.value[0] = 1;
+    ASSERT_TRUE(history->add_change(change));
+}
+
+TEST(WriterHistoryTests, add_change_with_payload_but_undefined_handle)
+{
+    uint32_t domain_id = 0;
+
+    RTPSParticipantAttributes p_attr;
+    RTPSParticipant* participant = RTPSDomain::createParticipant(
+        domain_id, true, p_attr);
+
+    ASSERT_NE(participant, nullptr);
+
+    HistoryAttributes h_attr;
+    WriterHistory* history = new WriterHistory(h_attr);
+
+    WriterAttributes w_attr;
+    // The topic must be keyed to use instance handles
+    w_attr.endpoint.topicKind = WITH_KEY;
+    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, w_attr, history);
+
+    ASSERT_NE(writer, nullptr);
+
+    CacheChange_t* change = history->create_change(ALIVE);
+    // This len simulates a payload
+    change->serializedPayload.length = 10;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_DISPOSED);
+    change->serializedPayload.length = 10;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_UNREGISTERED);
+    change->serializedPayload.length = 10;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
+    change->serializedPayload.length = 10;
     ASSERT_TRUE(history->add_change(change));
 }
 

--- a/test/unittest/rtps/history/WriterHistoryTests.cpp
+++ b/test/unittest/rtps/history/WriterHistoryTests.cpp
@@ -106,6 +106,75 @@ TEST(WriterHistoryTests, final_high_mark_for_frag_overflow)
     }
 }
 
+TEST(WriterHistoryTests, add_change_with_undefined_instance_handle)
+{
+    uint32_t domain_id = 0;
+
+    RTPSParticipantAttributes p_attr;
+    RTPSParticipant* participant = RTPSDomain::createParticipant(
+        domain_id, true, p_attr);
+
+    ASSERT_NE(participant, nullptr);
+
+    HistoryAttributes h_attr;
+    WriterHistory* history = new WriterHistory(h_attr);
+
+    WriterAttributes w_attr;
+    // The topic must be keyed to use instance handles
+    w_attr.endpoint.topicKind = WITH_KEY;
+    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, w_attr, history);
+
+    ASSERT_NE(writer, nullptr);
+
+    // Any of these changes have a well defined instance handle
+    CacheChange_t* change = history->create_change(ALIVE);
+    // Valid because ALIVE changes don't enforce defined instance handles
+    ASSERT_TRUE(history->add_change(change));
+    // Rest are invalid because instance handle is enforced to be defined
+    change = history->create_change(NOT_ALIVE_DISPOSED);
+    ASSERT_FALSE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_UNREGISTERED);
+    ASSERT_FALSE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
+    ASSERT_FALSE(history->add_change(change));
+}
+
+TEST(WriterHistoryTests, add_change_with_defined_instance_handle)
+{
+    uint32_t domain_id = 0;
+
+    RTPSParticipantAttributes p_attr;
+    RTPSParticipant* participant = RTPSDomain::createParticipant(
+        domain_id, true, p_attr);
+
+    ASSERT_NE(participant, nullptr);
+
+    HistoryAttributes h_attr;
+    WriterHistory* history = new WriterHistory(h_attr);
+
+    WriterAttributes w_attr;
+    // The topic must be keyed to use instance handles
+    w_attr.endpoint.topicKind = WITH_KEY;
+    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, w_attr, history);
+
+    ASSERT_NE(writer, nullptr);
+
+    // All these changes have a well defined instance handle and they must be added successfully
+    CacheChange_t* change = history->create_change(ALIVE);
+    // Setting any value makes the handle defined because of its = operator
+    change->instanceHandle.value[0] = 1;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_DISPOSED);
+    change->instanceHandle.value[0] = 1;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_UNREGISTERED);
+    change->instanceHandle.value[0] = 1;
+    ASSERT_TRUE(history->add_change(change));
+    change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
+    change->instanceHandle.value[0] = 1;
+    ASSERT_TRUE(history->add_change(change));
+}
+
 } // namespace rtps
 } // namespace fastdds
 } // namespace eprosima


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

The issue that started this investigation was the case where a Safe DDS Writer and a Safe DDS Reader in different domains talked to one another through a DDS Router in a KEYED topic.

- If the router had RTPS participants, samples were all written in the same instance (the default) in the Safe DDS Reader, because they were sent as being valid
- If the router had DDS participants, the issue was in the DDS Router participants. The Writer placed all changes in the same instance (default), the Reader rejected because the instance had never been initialised, but the rejection reason was misleading

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
  | instanceHandle (in change/write) | compute_key | current behavior | expected result | notes (on the expected result)
-- | -- | -- | -- | -- | --
| RTPSWriter | NULL or UNDEF | X | provided KEY_HASH sent (it was read as valid*) | no KEY_HASH sent but message is sent anyway | Case required to allow forwarding in router with RTPS participants
| | OK | X | inlineQoS KEY_HASH sent in message | inlineQoS KEY_HASH sent in message |  
DDSWriter | NULL or UNDEF | TRUE | computed KEY_HASH sent in message | computed KEY_HASH sent in message |  
| | OK | TRUE | In Release: The key is not recomputedIn Debug: The key is recomputed, if they differ, PRECONDITION_NOT_MET | In Release: The key is not recomputedIn Debug: The key is recomputed, if they differ, PRECONDITION_NOT_MET |  
| | NULL or UNDEF | FALSE (or returned undef handle) | provided KEY_HASH sent (it was read as valid*) | PRECONDITION NOT MET | If we don't throw error, we don't know in which history each sample should be stored and samples are at risk of being overwritten
| | OK | FALSE (or returned undef handle) | In Release: The key is not recomputedIn Debug: The key is recomputed, if they differ, PRECONDITION_NOT_MET | In Release: The key is not recomputedIn Debug: The key is recomputed, if they differ, PRECONDITION_NOT_MET |  

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
  | instanceHandle (from msg) | compute_key | current behavior | expected result | notes (on the expected result)
-- | -- | -- | -- | -- | --
| RTPSReader | NULL or UNDEF | X | ok | ok | Case required to allow forwarding in router with RTPS participants
| | OK | X | ok | ok |  
| DDSReader | NULL or UNDEF | TRUE | uses computed key | uses computed key |  
| | OK | TRUE | uses provided key | uses provided key | Could recompute and check for an error?
| | NULL or UNDEF | FALSE (or returned undef handle) | REJECTED_BY_INSTANCES_LIMIT | REJECTED_BY_UNKNOWN_INSTANCE | Added category to be more explicit
| | OK | FALSE (or returned undef handle) | uses provided key | uses provided key |  

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
