### PR TITLE
Fix entity and user and IDs in profiles to match the int16_t specification

### DIFF
--- a/src/cpp/xmlparser/XMLElementParser.cpp
+++ b/src/cpp/xmlparser/XMLElementParser.cpp
@@ -4282,21 +4282,21 @@ XMLP_ret XMLParser::getXMLPublisherAttributes(
         {
             // userDefinedID - int16type
             int i = 0;
-            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 32767 || i < 0)
             {
                 return XMLP_ret::XML_ERROR;
             }
-            publisher.setUserDefinedID(static_cast<uint8_t>(i));
+            publisher.setUserDefinedID(static_cast<int16_t>(i));
         }
         else if (strcmp(name, ENTITY_ID) == 0)
         {
             // entityID - int16Type
             int i = 0;
-            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 32767 || i < 0)
             {
                 return XMLP_ret::XML_ERROR;
             }
-            publisher.setEntityID(static_cast<uint8_t>(i));
+            publisher.setEntityID(static_cast<int16_t>(i));
         }
         else if (strcmp(name, MATCHED_SUBSCRIBERS_ALLOCATION) == 0)
         {
@@ -4451,21 +4451,21 @@ XMLP_ret XMLParser::getXMLSubscriberAttributes(
         {
             // userDefinedID - int16Type
             int i = 0;
-            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 32767 || i < 0)
             {
                 return XMLP_ret::XML_ERROR;
             }
-            subscriber.setUserDefinedID(static_cast<uint8_t>(i));
+            subscriber.setUserDefinedID(static_cast<int16_t>(i));
         }
         else if (strcmp(name, ENTITY_ID) == 0)
         {
             // entityID - int16Type
             int i = 0;
-            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 255)
+            if (XMLP_ret::XML_OK != getXMLInt(p_aux0, &i, ident) || i > 32767 || i < 0)
             {
                 return XMLP_ret::XML_ERROR;
             }
-            subscriber.setEntityID(static_cast<uint8_t>(i));
+            subscriber.setEntityID(static_cast<int16_t>(i));
         }
         else if (strcmp(name, MATCHED_PUBLISHERS_ALLOCATION) == 0)
         {

--- a/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/PublisherAttributes.hpp
@@ -121,7 +121,7 @@ public:
      * @param id User defined ID to be set
      */
     inline void setUserDefinedID(
-            uint8_t id)
+            int16_t id)
     {
         m_userDefinedID = id;
     }
@@ -131,7 +131,7 @@ public:
      * @param id Entity ID to be set
      */
     inline void setEntityID(
-            uint8_t id)
+            int16_t id)
     {
         m_entityID = id;
     }

--- a/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
+++ b/src/cpp/xmlparser/attributes/SubscriberAttributes.hpp
@@ -124,7 +124,7 @@ public:
      * @param id User defined ID to be set
      */
     inline void setUserDefinedID(
-            uint8_t id)
+            int16_t id)
     {
         m_userDefinedID = id;
     }
@@ -134,7 +134,7 @@ public:
      * @param id Entity ID to be set
      */
     inline void setEntityID(
-            uint8_t id)
+            int16_t id)
     {
         m_entityID = id;
     }

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1459,8 +1459,8 @@ public:
     }
 
     PubSubReader& setSubscriberIDs(
-            uint8_t UserID,
-            uint8_t EntityID)
+            int16_t UserID,
+            int16_t EntityID)
     {
         datareader_qos_.endpoint().user_defined_id = UserID;
         datareader_qos_.endpoint().entity_id = EntityID;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1483,8 +1483,8 @@ public:
     }
 
     PubSubWriter& setPublisherIDs(
-            uint8_t UserID,
-            uint8_t EntityID)
+            int16_t UserID,
+            int16_t EntityID)
     {
         datawriter_qos_.endpoint().user_defined_id = UserID;
         datawriter_qos_.endpoint().entity_id = EntityID;

--- a/test/unittest/xmlparser/XMLProfileParserTests.cpp
+++ b/test/unittest/xmlparser/XMLProfileParserTests.cpp
@@ -4144,6 +4144,304 @@ TEST_F(XMLProfileParserBasicTests, datareader_thread_settings)
     }
 }
 
+/*
+ * Tests the validation of entityID and userDefinedID in data_writer profile
+ * Values should be in range [0, 32767]
+ */
+TEST_F(XMLProfileParserBasicTests, XMLParserDataWriterEntityIDValidation)
+{
+    // Test valid values at boundaries
+    {
+        const char* xml_valid_min =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_valid_min">
+                            <entityID>0</entityID>
+                            <userDefinedID>0</userDefinedID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        ASSERT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::loadXMLString(xml_valid_min, strlen(xml_valid_min)));
+
+        xmlparser::PublisherAttributes pub_atts;
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::fillPublisherAttributes("test_writer_valid_min", pub_atts));
+        EXPECT_EQ(pub_atts.getEntityID(), 0);
+        EXPECT_EQ(pub_atts.getUserDefinedID(), 0);
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_valid_max =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_valid_max">
+                            <entityID>32767</entityID>
+                            <userDefinedID>32767</userDefinedID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        ASSERT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::loadXMLString(xml_valid_max, strlen(xml_valid_max)));
+
+        xmlparser::PublisherAttributes pub_atts;
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::fillPublisherAttributes("test_writer_valid_max", pub_atts));
+        EXPECT_EQ(pub_atts.getEntityID(), 32767);
+        EXPECT_EQ(pub_atts.getUserDefinedID(), 32767);
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // Test invalid values - negative
+    {
+        const char* xml_invalid_negative_entity =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_invalid_neg">
+                            <entityID>-1</entityID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_negative_entity,
+                strlen(xml_invalid_negative_entity)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_negative_user =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_invalid_neg">
+                            <userDefinedID>-1</userDefinedID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_negative_user,
+                strlen(xml_invalid_negative_user)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // Test invalid values - too large
+    {
+        const char* xml_invalid_large_entity =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_invalid_large">
+                            <entityID>32768</entityID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_large_entity,
+                strlen(xml_invalid_large_entity)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_large_user =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_invalid_large">
+                            <userDefinedID>32768</userDefinedID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_large_user,
+                strlen(xml_invalid_large_user)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_very_large =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_writer profile_name="test_writer_invalid_very_large">
+                            <entityID>65536</entityID>
+                            <userDefinedID>100000</userDefinedID>
+                        </data_writer>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_very_large,
+                strlen(xml_invalid_very_large)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+}
+
+/*
+ * Tests the validation of entityID and userDefinedID in data_reader profile
+ * Values should be in range [0, 32767]
+ */
+TEST_F(XMLProfileParserBasicTests, XMLParserDataReaderEntityIDValidation)
+{
+    // Test valid values at boundaries
+    {
+        const char* xml_valid_min =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_valid_min">
+                            <entityID>0</entityID>
+                            <userDefinedID>0</userDefinedID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        ASSERT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::loadXMLString(xml_valid_min, strlen(xml_valid_min)));
+
+        xmlparser::SubscriberAttributes sub_atts;
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::fillSubscriberAttributes("test_reader_valid_min", sub_atts));
+        EXPECT_EQ(sub_atts.getEntityID(), 0);
+        EXPECT_EQ(sub_atts.getUserDefinedID(), 0);
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_valid_max =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_valid_max">
+                            <entityID>32767</entityID>
+                            <userDefinedID>32767</userDefinedID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        ASSERT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::loadXMLString(xml_valid_max, strlen(xml_valid_max)));
+
+        xmlparser::SubscriberAttributes sub_atts;
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_OK,
+                xmlparser::XMLProfileManager::fillSubscriberAttributes("test_reader_valid_max", sub_atts));
+        EXPECT_EQ(sub_atts.getEntityID(), 32767);
+        EXPECT_EQ(sub_atts.getUserDefinedID(), 32767);
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // Test invalid values - negative
+    {
+        const char* xml_invalid_negative_entity =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_invalid_neg">
+                            <entityID>-1</entityID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_negative_entity,
+                strlen(xml_invalid_negative_entity)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_negative_user =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_invalid_neg">
+                            <userDefinedID>-1</userDefinedID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_negative_user,
+                strlen(xml_invalid_negative_user)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    // Test invalid values - too large
+    {
+        const char* xml_invalid_large_entity =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_invalid_large">
+                            <entityID>32768</entityID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_large_entity,
+                strlen(xml_invalid_large_entity)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_large_user =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_invalid_large">
+                            <userDefinedID>32768</userDefinedID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_large_user,
+                strlen(xml_invalid_large_user)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+
+    {
+        const char* xml_invalid_very_large =
+                R"(<?xml version="1.0" encoding="UTF-8" ?>
+                <dds xmlns="http://www.eprosima.com">
+                    <profiles>
+                        <data_reader profile_name="test_reader_invalid_very_large">
+                            <entityID>65536</entityID>
+                            <userDefinedID>100000</userDefinedID>
+                        </data_reader>
+                    </profiles>
+                </dds>)";
+
+        EXPECT_EQ(xmlparser::XMLP_ret::XML_ERROR,
+                xmlparser::XMLProfileManager::loadXMLString(xml_invalid_very_large,
+                strlen(xml_invalid_very_large)));
+
+        xmlparser::XMLProfileManager::DeleteInstance();
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(XMLProfileParserTests, XMLProfileParserTests, testing::Values(false));
 INSTANTIATE_TEST_SUITE_P(XMLProfileParserEnvVarTests, XMLProfileParserTests, testing::Values(true));
 


### PR DESCRIPTION
## Description

As pointed out in https://github.com/eProsima/Fast-DDS/issues/2686, the `entityID` and `userDefinedID` fields don't meet the specification of `int16_t` for data reader and data writer XML configuration:

* https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/datawriter.html#datawriter-configuration
* https://fast-dds.docs.eprosima.com/en/latest/fastdds/xml_configuration/datareader.html#datareader-configuration

This significantly limits the usability of static EDP in larger deployments.

While these changes are to non-public APIs as of version 3.0 according to the [versions.md](https://github.com/eProsima/Fast-DDS/blob/master/versions.md?plain=1#L121) file, it would still be useful to back-port these to at least 2.14.x, which is the current version in use by ROS2's Jazzy LTS release. As these interfaces were considered part of the public API prior to version 3.0, how should this be handled? One option is to keep the previously-defined functions which accept `uint8_t` for the user and entity IDs and mark them as deprecated. 

@Mergifyio backport 3.3.x 3.2.x 2.14.x 2.10.x

Fixes https://github.com/eProsima/Fast-DDS/issues/2686

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [X] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [X] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [X] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [X] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
