### PR TITLE
[24056] Improve Open SSL includes

### DIFF
--- a/src/cpp/security/OpenSSLInit.hpp
+++ b/src/cpp/security/OpenSSLInit.hpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <memory>
 
-#include <openssl/evp.h>
-#include <openssl/engine.h>
-#include <openssl/rand.h>
-#include <openssl/err.h>
+#include <openssl/crypto.h>
 
 namespace eprosima {
 namespace fastdds {

--- a/src/cpp/security/artifact_providers/FileProvider.cpp
+++ b/src/cpp/security/artifact_providers/FileProvider.cpp
@@ -18,6 +18,9 @@
 
 #include <security/artifact_providers/FileProvider.hpp>
 
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
 #include <cassert>
 #include <cstring>
 #include <iostream>

--- a/src/cpp/security/artifact_providers/FileProvider.hpp
+++ b/src/cpp/security/artifact_providers/FileProvider.hpp
@@ -20,13 +20,11 @@
 #define _SECURITY_ARTIFACTPROVIDERS_FILEPROVIDER_HPP_
 
 #include <functional>
+#include <string>
 
-#include <openssl/engine.h>
-#include <openssl/err.h>
-#include <openssl/ssl.h>
+#include <openssl/types.h>
 
 #include <rtps/security/exceptions/SecurityException.h>
-
 
 namespace eprosima {
 namespace fastdds {
@@ -63,10 +61,10 @@ public:
 
 };
 
-} // namespace detail
-} //namespace security
-} //namespace rtps
-} //namespace fastdds
-} //namespace eprosima
+}  // namespace detail
+}  // namespace security
+}  // namespace rtps
+}  // namespace fastdds
+}  // namespace eprosima
 
 #endif  // _SECURITY_ARTIFACTPROVIDERS_FILEPROVIDER_HPP_

--- a/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
+++ b/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
@@ -26,6 +26,17 @@
 #include <security/artifact_providers/Pkcs11Provider.hpp>
 
 #include <iostream>
+#include <string>
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/types.h>
+
+#if !defined(OPENSSL_NO_ENGINE)
+#include <openssl/engine.h>
+#include <openssl/ui.h>
+#endif // !defined(OPENSSL_NO_ENGINE)
 
 #include <fastdds/dds/log/Log.hpp>
 #include <utils/SystemInfo.hpp>
@@ -41,6 +52,8 @@ namespace fastdds {
 namespace rtps {
 namespace security {
 namespace detail {
+
+#if !defined(OPENSSL_NO_ENGINE)
 
 constexpr const char* FASTDDS_PKCS11_PIN = "FASTDDS_PKCS11_PIN";
 constexpr const char* PKCS11_ENGINE_ID = "pkcs11";
@@ -79,8 +92,15 @@ static int ui_close(
     return UI_method_get_closer(UI_OpenSSL())(ui);
 }
 
+#endif  // !defined(OPENSSL_NO_ENGINE)
+
 Pkcs11Provider::Pkcs11Provider()
 {
+#if defined(OPENSSL_NO_ENGINE)
+    has_initialization_error_ = true;
+    initialization_exception_ =
+            _SecurityException_(std::string("Cannot retrieve 'pkcs11' engine because 'OPENSSL_NO_ENGINE' is defined"));
+#else
     SSL_load_error_strings();                /* readable error messages */
     SSL_library_init();                      /* initialize library */
 
@@ -123,10 +143,12 @@ Pkcs11Provider::Pkcs11Provider()
         ENGINE_free(pkcs11_);
         return;
     }
+#endif // defined(OPENSSL_NO_ENGINE)
 }
 
 Pkcs11Provider::~Pkcs11Provider()
 {
+#if !defined(OPENSSL_NO_ENGINE)
     ENGINE_finish(pkcs11_);
     ENGINE_free(pkcs11_);
 
@@ -134,6 +156,7 @@ Pkcs11Provider::~Pkcs11Provider()
     {
         UI_destroy_method(ui_method_);
     }
+#endif  // !defined(OPENSSL_NO_ENGINE)
 }
 
 EVP_PKEY* Pkcs11Provider::load_private_key(
@@ -142,6 +165,10 @@ EVP_PKEY* Pkcs11Provider::load_private_key(
         const std::string& /*password*/,
         SecurityException& exception)
 {
+#if defined(OPENSSL_NO_ENGINE)
+    exception = initialization_exception_;
+    return nullptr;
+#else
     if (has_initialization_error_)
     {
         exception = initialization_exception_;
@@ -165,6 +192,7 @@ EVP_PKEY* Pkcs11Provider::load_private_key(
     }
 
     return returnedValue;
+#endif  // defined(OPENSSL_NO_ENGINE)
 }
 
 } // namespace detail

--- a/src/cpp/security/artifact_providers/Pkcs11Provider.hpp
+++ b/src/cpp/security/artifact_providers/Pkcs11Provider.hpp
@@ -19,9 +19,9 @@
 #ifndef _SECURITY_ARTIFACTPROVIDERS_PKCS11PROVIDER_HPP_
 #define _SECURITY_ARTIFACTPROVIDERS_PKCS11PROVIDER_HPP_
 
-#include <openssl/engine.h>
-#include <openssl/err.h>
-#include <openssl/ssl.h>
+#include <string>
+
+#include <openssl/types.h>
 
 #include <rtps/security/exceptions/SecurityException.h>
 
@@ -48,16 +48,13 @@ public:
 
 private:
 
-    EVP_PKEY* load_private_key_impl(
-            X509* certificate,
-            const std::string& file,
-            const std::string& password,
-            SecurityException& exception);
-
     SecurityException initialization_exception_;
     bool has_initialization_error_ = false;
+
+#if !defined(OPENSSL_NO_ENGINE)
     ENGINE* pkcs11_ = nullptr;
     UI_METHOD* ui_method_ = nullptr;
+#endif // !defined(OPENSSL_NO_ENGINE)
 };
 
 } // namespace detail


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

It has been reported that Fast DDS fails to build with security in RHEL 10, since it is not shipping `openssl/engine.h`.

This PR performs some cleanup in the OpenSSL included files to avoid including the missing header unless it is available, taking into account `OPENSSL_NO_ENGINE`.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.3.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
