### PR TITLE
[23951] Run xtypes test cases in parallel

### DIFF
--- a/test/dds/xtypes/test_build.py
+++ b/test/dds/xtypes/test_build.py
@@ -172,6 +172,14 @@ async def run_command(test_case, process_args, timeout):
 
 
 async def execute_commands(test_case, commands):
+    """
+    Execute a list of commands asynchronously.
+
+    :param[in]  test_case  Name of the test case.
+    :param[in]  commands   List of commands to be executed.
+
+    :return Sum of the return codes of each command.
+    """
     tasks = []
     async with asyncio.TaskGroup() as tg:
         for command in commands:
@@ -181,10 +189,24 @@ async def execute_commands(test_case, commands):
     return sum([proc.result() for proc in tasks])
 
 async def execute_commands_with_sem(test_case, commands, sem):
+    """
+    Execute commands using a semaphore to limit parallel executions.
+
+   :param[in]  test_case  Name of the test case.
+   :param[in]  commands   List of commands to be executed.
+   :param[in]  sem        Semaphore to limit parallel executions.
+    """
     async with sem:
         return await execute_commands(test_case, commands)
 
 async def execute_test_cases(test_cases):
+    """
+    Execute all test cases, retrying failed ones up to 3 times.
+
+    :param[in]  test_cases  List of test cases to be executed.
+
+    :return Tuple (total test value, list of successful cases, list of failling cases)
+    """
     total_test_value = 0
     successful_cases = []
     failling_cases = []
@@ -229,6 +251,7 @@ async def execute_test_cases(test_cases):
             await asyncio.sleep(2)
             total_test_value = 0
 
+    # If there are still pending cases, they are considered failling
     for test_case in pending_cases:
         failling_cases.append(f"Test {test_case.get('TestCase')}")
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This refactors the `test_build.py` used for Type Discovery communication tests so the cases in the json file are tested in parallel.
It should fix the timeouts we are seeing in MacOS

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
