### PR TITLE
[24165] Fix compilation warnings and errors in Ubuntu Focal

### DIFF
--- a/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
+++ b/src/cpp/rtps/attributes/RTPSParticipantAttributes.cpp
@@ -191,6 +191,7 @@ static void setup_transports_shm(
 {
 #ifdef FASTDDS_SHM_TRANSPORT_DISABLED
     static_cast<void>(att);
+    static_cast<void>(options);
     EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Trying to configure SHM transport only, "
             << "but Fast DDS was built without SHM transport support.");
 #else
@@ -223,6 +224,7 @@ static void setup_large_data_shm_transport(
 {
 #ifdef FASTDDS_SHM_TRANSPORT_DISABLED
     static_cast<void>(att);
+    static_cast<void>(options);
     EPROSIMA_LOG_ERROR(RTPS_PARTICIPANT, "Trying to configure Large Data transport, "
             << "but Fast DDS was built without SHM transport support. Will use "
             << "TCP for communications on the same host.");

--- a/src/cpp/security/artifact_providers/FileProvider.hpp
+++ b/src/cpp/security/artifact_providers/FileProvider.hpp
@@ -22,7 +22,14 @@
 #include <functional>
 #include <string>
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#else
 #include <openssl/types.h>
+#endif // if OPENSSL_VERSION_NUMBER < 0x30000000L
+
 
 #include <rtps/security/exceptions/SecurityException.h>
 

--- a/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
+++ b/src/cpp/security/artifact_providers/Pkcs11Provider.cpp
@@ -31,7 +31,6 @@
 #include <openssl/conf.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
-#include <openssl/types.h>
 
 #if !defined(OPENSSL_NO_ENGINE)
 #include <openssl/engine.h>

--- a/src/cpp/security/artifact_providers/Pkcs11Provider.hpp
+++ b/src/cpp/security/artifact_providers/Pkcs11Provider.hpp
@@ -21,7 +21,13 @@
 
 #include <string>
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#else
 #include <openssl/types.h>
+#endif // if OPENSSL_VERSION_NUMBER < 0x30000000L
 
 #include <rtps/security/exceptions/SecurityException.h>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes warnings due to some variables not used in some cases. Also fixes compilation against openssl 1.1.1 introduced in #6240 .
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.5.x
<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
