### PR TITLE
[24015] Remove unused keep_alive logic

### DIFF
--- a/src/cpp/rtps/transport/TCPChannelResource.cpp
+++ b/src/cpp/rtps/transport/TCPChannelResource.cpp
@@ -53,7 +53,6 @@ TCPChannelResource::TCPChannelResource(
     : ChannelResource(maxMsgSize)
     , parent_ (parent)
     , locator_(locator)
-    , waiting_for_keep_alive_(false)
     , connection_status_(eConnectionStatus::eDisconnected)
     , tcp_connection_type_(TCPConnectionType::TCP_CONNECT_TYPE)
 {
@@ -65,7 +64,6 @@ TCPChannelResource::TCPChannelResource(
     : ChannelResource(maxMsgSize)
     , parent_(parent)
     , locator_()
-    , waiting_for_keep_alive_(false)
     , connection_status_(eConnectionStatus::eDisconnected)
     , tcp_connection_type_(TCPConnectionType::TCP_ACCEPT_TYPE)
 {
@@ -196,7 +194,6 @@ void TCPChannelResource::add_logical_port(
             }
         }
     }
-
 }
 
 void TCPChannelResource::send_pending_open_logical_ports(

--- a/src/cpp/rtps/transport/TCPChannelResource.h
+++ b/src/cpp/rtps/transport/TCPChannelResource.h
@@ -65,7 +65,6 @@ protected:
 
     TCPTransportInterface* parent_;
     Locator locator_;
-    bool waiting_for_keep_alive_;
     // Must be accessed after lock pending_logical_mutex_
     std::map<TCPTransactionId, uint16_t> negotiating_logical_ports_;
     std::map<TCPTransactionId, uint16_t> last_checked_logical_port_;

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -77,14 +77,10 @@ namespace rtps {
 
 using Log = fastdds::dds::Log;
 
-static const int s_default_keep_alive_frequency = 5000; // 5 SECONDS
-static const int s_default_keep_alive_timeout = 15000; // 15 SECONDS
-//static const int s_clean_deleted_sockets_pool_timeout = 100; // 100 MILLISECONDS
-
 TCPTransportDescriptor::TCPTransportDescriptor()
     : SocketTransportDescriptor(s_maximumMessageSize, s_maximumInitialPeersRange)
-    , keep_alive_frequency_ms(s_default_keep_alive_frequency)
-    , keep_alive_timeout_ms(s_default_keep_alive_timeout)
+    , keep_alive_frequency_ms(0)
+    , keep_alive_timeout_ms(0)
     , max_logical_port(100)
     , logical_port_range(20)
     , logical_port_increment(2)
@@ -168,7 +164,6 @@ TCPTransportInterface::TCPTransportInterface(
 #if TLS_FOUND
     , ssl_context_(asio::ssl::context::sslv23)
 #endif // if TLS_FOUND
-    , keep_alive_event_(io_context_timers_)
 {
 }
 
@@ -180,13 +175,6 @@ void TCPTransportInterface::clean()
 {
     assert(receiver_resources_.size() == 0);
     alive_.store(false);
-
-    keep_alive_event_.cancel();
-    if (io_context_timers_thread_.joinable())
-    {
-        io_context_timers_.stop();
-        io_context_timers_thread_.join();
-    }
 
     {
         std::vector<std::shared_ptr<TCPChannelResource>> channels;
@@ -583,15 +571,7 @@ bool TCPTransportInterface::init(
 
     if (0 < configuration()->keep_alive_frequency_ms)
     {
-        auto ioContextTimersFunction = [&]()
-                {
-                    asio::executor_work_guard<asio::io_context::executor_type> work =
-                            make_work_guard(io_context_timers_.
-                                            get_executor());
-                    io_context_timers_.run();
-                };
-        io_context_timers_thread_ = create_thread(ioContextTimersFunction,
-                        configuration()->keep_alive_thread, "dds.tcp_keep");
+        EPROSIMA_LOG_WARNING(RTCP, "Keep alive feature only available in Fast DDS Pro.");
     }
 
     return true;
@@ -1074,64 +1054,6 @@ bool TCPTransportInterface::OpenInputChannel(
         }
     }
     return success;
-}
-
-void TCPTransportInterface::keep_alive()
-{
-    std::map<Locator, std::shared_ptr<TCPChannelResource>> tmp_vec;
-
-    {
-        std::unique_lock<std::mutex> scopedLock(sockets_map_mutex_); // Why mutex here?
-        tmp_vec = channel_resources_;
-    }
-
-
-    for (auto& channel_resource : tmp_vec)
-    {
-        if (TCPChannelResource::TCPConnectionType::TCP_CONNECT_TYPE == channel_resource.second->tcp_connection_type())
-        {
-            rtcp_message_manager_->sendKeepAliveRequest(channel_resource.second);
-        }
-    }
-    //TODO Check timeout.
-
-    /*
-       const TCPTransportDescriptor* config = configuration(); // Keep a copy for us.
-
-       std::chrono::time_point<std::chrono::system_clock> time_now = std::chrono::system_clock::now();
-       std::chrono::time_point<std::chrono::system_clock> next_time = time_now +
-        std::chrono::milliseconds(config->keep_alive_frequency_ms);
-       std::chrono::time_point<std::chrono::system_clock> timeout_time =
-        time_now + std::chrono::milliseconds(config->keep_alive_timeout_ms);
-
-       while (channel && TCPChannelResource::TCPConnectionStatus::TCP_CONNECTED == channel->tcp_connection_status())
-       {
-        if (channel->connection_established())
-        {
-            // KeepAlive
-            if (config->keep_alive_frequency_ms > 0 && config->keep_alive_timeout_ms > 0)
-            {
-                time_now = std::chrono::system_clock::now();
-
-                // Keep Alive Management
-                if (!channel->waiting_for_keep_alive_ && time_now > next_time)
-                {
-                    std::unique_lock<std::mutex> scopedLock(sockets_map_mutex_); // Why mutex here?
-                    rtcp_message_manager_->sendKeepAliveRequest(channel);
-                    channel->waiting_for_keep_alive_ = true;
-                    next_time = time_now + std::chrono::milliseconds(config->keep_alive_frequency_ms);
-                    timeout_time = time_now + std::chrono::milliseconds(config->keep_alive_timeout_ms);
-                }
-                else if (channel->waiting_for_keep_alive_ && time_now >= timeout_time)
-                {
-                    // Disable the socket to erase it after the reception.
-                    close_tcp_socket(channel);
-                }
-            }
-        }
-       }
-       EPROSIMA_LOG_INFO(RTCP, "End perform_rtcp_management_thread " << channel->locator());
-     */
 }
 
 void TCPTransportInterface::create_listening_thread(

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -96,7 +96,6 @@ protected:
     asio::ssl::context ssl_context_;
 #endif // if TLS_FOUND
     eprosima::thread io_context_thread_;
-    eprosima::thread io_context_timers_thread_;
     std::shared_ptr<RTCPMessageManager> rtcp_message_manager_;
     std::mutex rtcp_message_manager_mutex_;
     std::condition_variable rtcp_message_manager_cv_;
@@ -111,8 +110,6 @@ protected:
     std::map<uint16_t, std::pair<TransportReceiverInterface*, ReceiverInUseCV*>> receiver_resources_;
 
     std::vector<std::pair<TCPChannelResource*, uint64_t>> sockets_timestamp_;
-
-    asio::steady_timer keep_alive_event_;
 
     std::map<Locator, std::shared_ptr<TCPAcceptor>> acceptors_;
 
@@ -496,8 +493,6 @@ public:
     virtual const TCPTransportDescriptor* configuration() const = 0;
 
     virtual TCPTransportDescriptor* configuration() = 0;
-
-    void keep_alive();
 
     void update_network_interfaces() override;
 

--- a/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
+++ b/src/cpp/rtps/transport/tcp/RTCPMessageManager.cpp
@@ -645,7 +645,7 @@ ResponseCode RTCPMessageManager::processOpenLogicalPortResponse(
 }
 
 ResponseCode RTCPMessageManager::processKeepAliveResponse(
-        std::shared_ptr<TCPChannelResource>& channel,
+        std::shared_ptr<TCPChannelResource>& /*channel*/,
         ResponseCode respCode,
         const TCPTransactionId& transaction_id)
 {
@@ -654,7 +654,6 @@ ResponseCode RTCPMessageManager::processKeepAliveResponse(
         switch (respCode)
         {
             case RETCODE_OK:
-                channel->waiting_for_keep_alive_ = false;
                 break;
             case RETCODE_UNKNOWN_LOCATOR:
                 return RETCODE_UNKNOWN_LOCATOR;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR removes unused code regarding an unimplemented keep alive feature.
<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
