### PR TITLE
Backport #5796: Add missing #include <cstdint> in DDSSQLFilter headers to 2.6.x

### DIFF
--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp
@@ -19,6 +19,7 @@
 #ifndef _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERCOMPOUNDCONDITION_HPP_
 #define _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERCOMPOUNDCONDITION_HPP_
 
+#include <cstdint>
 #include <memory>
 
 #include "DDSFilterCondition.hpp"

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterPredicate.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterPredicate.hpp
@@ -19,6 +19,7 @@
 #ifndef _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERPREDICATE_HPP_
 #define _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERPREDICATE_HPP_
 
+#include <cstdint>
 #include <memory>
 
 #include "DDSFilterCondition.hpp"

--- a/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp
+++ b/src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp
@@ -19,6 +19,7 @@
 #ifndef _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERVALUE_HPP_
 #define _FASTDDS_TOPIC_DDSSQLFILTER_DDSFILTERVALUE_HPP_
 
+#include <cstdint>
 #include <memory>
 #include <regex>
 


### PR DESCRIPTION
## Summary

Backport of PR #5796 to the `2.6.x` branch.

GCC 13+ and GCC 15+ no longer provide transitive includes for fixed-width integer types (`uint8_t`, `uint32_t`, etc.). The following DDSSQLFilter headers use these types without explicitly including `<cstdint>`, causing compilation failures:

- `DDSFilterCompoundCondition.hpp` — uses `uint8_t` in `OperationKind` enum and member variable
- `DDSFilterPredicate.hpp` — uses `uint8_t` in `OperationKind` enum
- `DDSFilterValue.hpp` — uses `uint64_t`, `int64_t` in union members

This fix was already applied to `master`, `3.1.x`, `2.14.x`, and `2.10.x` but the `2.6.x` backport was skipped. Since ROS 2 Humble depends on Fast-DDS 2.6.x and is supported until 2027, this backport is important for users building with modern compilers.

## Changes

Added `#include <cstdint>` to:
- `src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterCompoundCondition.hpp`
- `src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterPredicate.hpp`
- `src/cpp/fastdds/topic/DDSSQLFilter/DDSFilterValue.hpp`

## References

- Issue: #5790
- Original fix: #5796
- Backport to 3.1.x: #5804
- Backport to 2.14.x: #5802
- Backport to 2.10.x: #5803