### PR TITLE
Fix XML parser null-dereference bugs on 2.6.x

### DIFF
--- a/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLDynamicParser.cpp
@@ -868,17 +868,24 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(
     if (p_element != nullptr)
     {
         const char* disc = p_element->Attribute(TYPE);
-        p_dynamictypebuilder_t discriminator = getDiscriminatorTypeBuilder(disc);
-        if (discriminator == nullptr)
+        if (disc == nullptr)
         {
-            logError(XMLPARSER,
-                    "Error parsing union discriminator: Only primitive types allowed (found type " << disc << ").");
+            logError(XMLPARSER, "Error parsing union discriminator: 'type' attribute not found.");
             ret = XMLP_ret::XML_ERROR;
         }
         else
         {
-            p_dynamictypebuilder_t typeBuilder = types::DynamicTypeBuilderFactory::get_instance()->create_union_builder(
-                discriminator);
+            p_dynamictypebuilder_t discriminator = getDiscriminatorTypeBuilder(disc);
+            if (discriminator == nullptr)
+            {
+                logError(XMLPARSER,
+                        "Error parsing union discriminator: Only primitive types allowed (found type " << disc << ").");
+                ret = XMLP_ret::XML_ERROR;
+            }
+            else
+            {
+                p_dynamictypebuilder_t typeBuilder = types::DynamicTypeBuilderFactory::get_instance()->create_union_builder(
+                    discriminator);
             typeBuilder->set_name(name);
 
             uint32_t mId = 0;
@@ -931,6 +938,7 @@ XMLP_ret XMLParser::parseXMLUnionDynamicType(
             {
                 types::DynamicTypeBuilderFactory::get_instance()->delete_builder(typeBuilder);
                 ret = XMLP_ret::XML_ERROR;
+            }
             }
         }
     }

--- a/src/cpp/rtps/xmlparser/XMLParser.cpp
+++ b/src/cpp/rtps/xmlparser/XMLParser.cpp
@@ -1511,7 +1511,13 @@ XMLP_ret XMLParser::parseXMLConsumer(
 
     if (p_element != nullptr)
     {
-        std::string classStr = p_element->GetText();
+        const char* classText = p_element->GetText();
+        if (classText == nullptr)
+        {
+            logError(XMLPARSER, "Error parsing log consumer: <class> element has no text content");
+            return XMLP_ret::XML_ERROR;
+        }
+        std::string classStr = classText;
 
         if (std::strcmp(classStr.c_str(), "StdoutConsumer") == 0)
         {
@@ -1545,7 +1551,15 @@ XMLP_ret XMLParser::parseXMLConsumer(
                     if (nullptr != (p_auxName = property->FirstChildElement(NAME)))
                     {
                         // Get property name
-                        std::string s = p_auxName->GetText();
+                        const char* nameText = p_auxName->GetText();
+                        if (nameText == nullptr)
+                        {
+                            logError(XMLPARSER, "Error parsing StdoutErrConsumer property: <name> has no text content");
+                            ret = XMLP_ret::XML_NOK;
+                            property = property->NextSiblingElement(PROPERTY);
+                            continue;
+                        }
+                        std::string s = nameText;
 
                         if (std::strcmp(s.c_str(), "stderr_threshold") == 0)
                         {
@@ -1568,7 +1582,16 @@ XMLP_ret XMLParser::parseXMLConsumer(
                             if (nullptr != (p_auxValue = property->FirstChildElement(VALUE)))
                             {
                                 // Get property value and use it to set the threshold.
-                                std::string threshold_str = p_auxValue->GetText();
+                                const char* valueText = p_auxValue->GetText();
+                                if (valueText == nullptr)
+                                {
+                                    logError(XMLPARSER,
+                                            "Error parsing StdoutErrConsumer property: <value> has no text content");
+                                    ret = XMLP_ret::XML_NOK;
+                                    property = property->NextSiblingElement(PROPERTY);
+                                    continue;
+                                }
+                                std::string threshold_str = valueText;
                                 if (std::strcmp(threshold_str.c_str(), "Log::Kind::Error") == 0)
                                 {
                                     threshold = Log::Kind::Error;
@@ -1625,7 +1648,15 @@ XMLP_ret XMLParser::parseXMLConsumer(
                     // name - stringType
                     if (nullptr != (p_auxName = property->FirstChildElement(NAME)))
                     {
-                        std::string s = p_auxName->GetText();
+                        const char* propNameText = p_auxName->GetText();
+                        if (propNameText == nullptr)
+                        {
+                            logError(XMLPARSER, "Error parsing FileConsumer property: <name> has no text content");
+                            ret = XMLP_ret::XML_NOK;
+                            property = property->NextSiblingElement(PROPERTY);
+                            continue;
+                        }
+                        std::string s = propNameText;
 
                         if (std::strcmp(s.c_str(), "filename") == 0)
                         {

--- a/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
+++ b/src/cpp/rtps/xmlparser/XMLProfileManager.cpp
@@ -521,6 +521,11 @@ XMLP_ret XMLProfileManager::extractParticipantProfile(
     std::string profile_name = "";
 
     p_node_participant_t node_part = dynamic_cast<p_node_participant_t>(profile.get());
+    if (node_part == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_part->getAttributes().find(PROFILE_NAME);
     if (it == node_part->getAttributes().end() || it->second.empty())
     {
@@ -554,6 +559,11 @@ XMLP_ret XMLProfileManager::extractPublisherProfile(
     std::string profile_name = "";
 
     p_node_publisher_t node_part = dynamic_cast<p_node_publisher_t>(profile.get());
+    if (node_part == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_part->getAttributes().find(PROFILE_NAME);
     if (it == node_part->getAttributes().end() || it->second.empty())
     {
@@ -587,6 +597,11 @@ XMLP_ret XMLProfileManager::extractSubscriberProfile(
     std::string profile_name = "";
 
     p_node_subscriber_t node_part = dynamic_cast<p_node_subscriber_t>(profile.get());
+    if (node_part == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_part->getAttributes().find(PROFILE_NAME);
     if (it == node_part->getAttributes().end() || it->second.empty())
     {
@@ -677,6 +692,11 @@ XMLP_ret XMLProfileManager::extractTopicProfile(
     std::string profile_name = "";
 
     p_node_topic_t node_topic = dynamic_cast<p_node_topic_t>(profile.get());
+    if (node_topic == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_topic->getAttributes().find(PROFILE_NAME);
     if (it == node_topic->getAttributes().end() || it->second.empty())
     {
@@ -710,6 +730,11 @@ XMLP_ret XMLProfileManager::extractRequesterProfile(
     std::string profile_name = "";
 
     p_node_requester_t node_requester = dynamic_cast<p_node_requester_t>(profile.get());
+    if (node_requester == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_requester->getAttributes().find(PROFILE_NAME);
     if (it == node_requester->getAttributes().end() || it->second.empty())
     {
@@ -738,6 +763,11 @@ XMLP_ret XMLProfileManager::extractReplierProfile(
     std::string profile_name = "";
 
     p_node_replier_t node_replier = dynamic_cast<p_node_replier_t>(profile.get());
+    if (node_replier == nullptr)
+    {
+        logError(XMLPARSER, "Error adding profile from file '" << filename << "': unexpected node type");
+        return XMLP_ret::XML_ERROR;
+    }
     node_att_map_cit_t it = node_replier->getAttributes().find(PROFILE_NAME);
     if (it == node_replier->getAttributes().end() || it->second.empty())
     {


### PR DESCRIPTION
## Summary

Fixes multiple null-dereference bugs in the XML parser on the 2.6.x branch that can cause crashes when loading XML configuration files, including the default XML file at startup via `loadDefaultXMLFile()`.

These are the 2.6.x equivalents of issues found by oss-fuzz on master (PRs #4961, #5007, #5080, #5565, #5668). The master fixes cannot be cherry-picked because the Dynamic Types API was completely rewritten between 2.6.x and 2.10.x, so these are manually written fixes for the same class of bugs.

## Bugs Fixed

### 1. `parseXMLConsumer()` in `XMLParser.cpp` (4 locations)

`TinyXML2::GetText()` can return `nullptr` when XML elements have no text content (e.g., `<class/>`, `<name></name>`). The return value was passed directly to `std::string` constructors, which is undefined behavior (typically segfault). Added null checks with error logging before each `std::string` construction.

- Line 1514: `<class>` element text
- Line 1548: StdoutErrConsumer `<name>` element text
- Line 1571: StdoutErrConsumer `<value>` element text
- Line 1651: FileConsumer `<name>` element text

### 2. `parseXMLUnionDynamicType()` in `XMLDynamicParser.cpp`

`Attribute(TYPE)` can return `nullptr` when the `<discriminator>` element lacks a `type` attribute. The null `const char*` was passed to `getDiscriminatorTypeBuilder()` whose parameter is `const std::string&`, causing undefined behavior. Added null check before use.

### 3. `extractXxxProfile()` methods in `XMLProfileManager.cpp` (6 locations)

`dynamic_cast` results were dereferenced without null checks. If the cast fails, the resulting `nullptr` is immediately used to call `getAttributes()`. Added null checks after each `dynamic_cast`.

- `extractParticipantProfile()` (line 523)
- `extractPublisherProfile()` (line 556)
- `extractSubscriberProfile()` (line 589)
- `extractTopicProfile()` (line 679)
- `extractRequesterProfile()` (line 712)
- `extractReplierProfile()` (line 740)

## Files Changed

- `src/cpp/rtps/xmlparser/XMLParser.cpp`
- `src/cpp/rtps/xmlparser/XMLDynamicParser.cpp`
- `src/cpp/rtps/xmlparser/XMLProfileManager.cpp`

## References

- Issue: #6331
- Related oss-fuzz fixes on master: #4961, #5007, #5080, #5565, #5668