### PR TITLE
feat: RTI Connext Micro 2.4.9 interop patches

### DIFF
--- a/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
+++ b/src/cpp/rtps/builtin/data/ParticipantProxyData.cpp
@@ -73,7 +73,7 @@ ParticipantProxyData::ParticipantProxyData(
         fastdds::dds::DOMAIN_ID_UNKNOWN,
         allocation
         )
-    , m_protocol_version(c_ProtocolVersion)
+    , m_protocol_version(c_ProtocolVersion_2_1)  // RTI Micro interop: advertise RTPS 2.1
     , m_expects_inline_qos(false)
     , m_available_builtin_endpoints(0)
     , m_network_configuration(0)
@@ -166,11 +166,8 @@ uint32_t ParticipantProxyData::get_serialized_size(
     // PID_VENDORID
     ret_val += 4 + PARAMETER_VENDOR_LENGTH;
 
-    // PID_PRODUCT_VERSION
-    ret_val += 4 + PARAMETER_PRODUCT_VERSION_LENGTH;
-
-    // PID_DOMAIN_ID
-    ret_val += 4 + PARAMETER_DOMAINID_LENGTH;
+    // RTI Micro interop: PID_PRODUCT_VERSION (0x8000) removed — vendor PID causes crash
+    // RTI Micro interop: PID_DOMAIN_ID (0x000F) removed — RTPS 2.3+ PID causes crash
 
     if (m_expects_inline_qos)
     {
@@ -181,15 +178,8 @@ uint32_t ParticipantProxyData::get_serialized_size(
     // PID_PARTICIPANT_GUID
     ret_val += 4 + PARAMETER_GUID_LENGTH;
 
-    // PID_NETWORK_CONFIGURATION_SET
-    ret_val += 4 + PARAMETER_NETWORKCONFIGSET_LENGTH;
-
-    if (machine_id.size() > 0)
-    {
-        // PID_MACHINE_ID
-        ret_val +=
-                fastdds::dds::ParameterSerializer<Parameter_t>::cdr_serialized_size(machine_id);
-    }
+    // RTI Micro interop: PID_NETWORK_CONFIGURATION_SET (0x8007) removed — vendor PID causes crash
+    // RTI Micro interop: PID_MACHINE_ID (0x8003) removed — vendor PID causes crash
 
     // PID_METATRAFFIC_MULTICAST_LOCATOR
     ret_val +=
@@ -257,15 +247,9 @@ uint32_t ParticipantProxyData::get_serialized_size(
     }
 #endif // if HAVE_SECURITY
 
-    if (force_including_optional_qos || should_send_optional_qos())
-    {
-        // No need for QosPoliciesSerializer::should_be_sent since it is always different from the default.
-        // For instance, the locator lists.
+    // RTI Micro interop: PID_WIREPROTOCOL_CONFIG (0x8300) removed — vendor PID causes crash
+    (void)force_including_optional_qos;
 
-        // PID_WIREPROTOCOL_CONFIG
-        ret_val += fastdds::dds::QosPoliciesSerializer<dds::WireProtocolConfigQos>::cdr_serialized_size(
-            wire_protocol.value());
-    }
     // PID_SENTINEL
     return ret_val + 4;
 }
@@ -302,26 +286,8 @@ bool ParticipantProxyData::write_to_cdr_message(
             return false;
         }
     }
-    {
-        ParameterProductVersion_t p(fastdds::dds::PID_PRODUCT_VERSION,
-                PARAMETER_PRODUCT_VERSION_LENGTH);
-        p.version.major = this->product_version.major;
-        p.version.minor = this->product_version.minor;
-        p.version.patch = this->product_version.patch;
-        p.version.tweak = this->product_version.tweak;
-        if (!fastdds::dds::ParameterSerializer<ParameterProductVersion_t>::add_to_cdr_message(p, msg))
-        {
-            return false;
-        }
-    }
-    {
-        ParameterDomainId_t p(fastdds::dds::PID_DOMAIN_ID, 4);
-        p.domain_id = this->domain_id;
-        if (!fastdds::dds::ParameterSerializer<ParameterDomainId_t>::add_to_cdr_message(p, msg))
-        {
-            return false;
-        }
-    }
+    // RTI Micro interop: PID_PRODUCT_VERSION (0x8000) removed
+    // RTI Micro interop: PID_DOMAIN_ID (0x000F) removed
     if (this->m_expects_inline_qos)
     {
         ParameterBool_t p(fastdds::dds::PID_EXPECTS_INLINE_QOS, PARAMETER_BOOL_LENGTH,
@@ -338,25 +304,8 @@ bool ParticipantProxyData::write_to_cdr_message(
             return false;
         }
     }
-    {
-        ParameterNetworkConfigSet_t p(fastdds::dds::PID_NETWORK_CONFIGURATION_SET,
-                PARAMETER_NETWORKCONFIGSET_LENGTH);
-        p.netconfigSet = m_network_configuration;
-        if (!fastdds::dds::ParameterSerializer<ParameterNetworkConfigSet_t>::add_to_cdr_message(
-                    p,
-                    msg))
-        {
-            return false;
-        }
-    }
-    if (machine_id.size() > 0)
-    {
-        ParameterString_t p(fastdds::dds::PID_MACHINE_ID, 0, machine_id);
-        if (!fastdds::dds::ParameterSerializer<ParameterString_t>::add_to_cdr_message(p, msg))
-        {
-            return false;
-        }
-    }
+    // RTI Micro interop: PID_NETWORK_CONFIGURATION_SET (0x8007) removed
+    // RTI Micro interop: PID_MACHINE_ID (0x8003) removed
     for (const Locator_t& it : metatraffic_locators.multicast)
     {
         ParameterLocator_t p(fastdds::dds::PID_METATRAFFIC_MULTICAST_LOCATOR, PARAMETER_LOCATOR_LENGTH,
@@ -475,18 +424,8 @@ bool ParticipantProxyData::write_to_cdr_message(
     }
 #endif // if HAVE_SECURITY
 
-    // serialize optional QoS if present
-    if (force_write_optional_qos || should_send_optional_qos())
-    {
-        // No need for QosPoliciesSerializer::should_be_sent since it is always different from the default.
-        // For instance, the discovery protocol is always different from NONE.
-        if (!fastdds::dds::QosPoliciesSerializer<dds::WireProtocolConfigQos>::add_to_cdr_message(
-                    wire_protocol.value(),
-                    msg))
-        {
-            return false;
-        }
-    }
+    // RTI Micro interop: PID_WIREPROTOCOL_CONFIG (0x8300) removed
+    (void)force_write_optional_qos;
 
     return fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sentinel(msg);
 }

--- a/src/cpp/rtps/messages/RTPSMessageCreator.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageCreator.cpp
@@ -56,7 +56,8 @@ bool RTPSMessageCreator::addHeader(
         CDRMessage_t* msg,
         const GuidPrefix_t& guidPrefix)
 {
-    return RTPSMessageCreator::addHeader(msg, guidPrefix, c_ProtocolVersion, c_VendorId_eProsima);
+    // RTI Micro interop: send RTPS 2.1 (RTI Micro 2.4.9 drops messages with version > 2.1)
+    return RTPSMessageCreator::addHeader(msg, guidPrefix, c_ProtocolVersion_2_1, c_VendorId_eProsima);
 }
 
 bool RTPSMessageCreator::addCustomContent(

--- a/src/cpp/rtps/messages/RTPSMessageGroup.cpp
+++ b/src/cpp/rtps/messages/RTPSMessageGroup.cpp
@@ -499,7 +499,8 @@ bool RTPSMessageGroup::add_info_dst_in_buffer(
     if ((header_msg_->length == RTPSMESSAGE_HEADER_SIZE) &&
             participant_->security_attributes().is_rtps_protected && endpoint_->supports_rtps_protection())
     {
-        RTPSMessageCreator::addSubmessageInfoSRC(buffer, c_ProtocolVersion, c_VendorId_eProsima,
+        // RTI Micro interop: send RTPS 2.1
+        RTPSMessageCreator::addSubmessageInfoSRC(buffer, c_ProtocolVersion_2_1, c_VendorId_eProsima,
                 participant_->getGuid().guidPrefix);
     }
 #endif // if HAVE_SECURITY


### PR DESCRIPTION
RTPS version downgrade:
- Send RTPS 2.1 instead of 2.2+ in header, INFO_SRC, and SPDP
- RTI Micro 2.4.9 drops all messages with protocol version > 2.1

Remove 5 SPDP PIDs that crash RTI Micro's parser:
- PID_DOMAIN_ID (0x000F) - RTPS 2.3+ PID, not recognized by Micro
- PID_PRODUCT_VERSION (0x8000) - eProsima vendor PID
- PID_MACHINE_ID (0x8003) - eProsima vendor PID
- PID_NETWORK_CONFIGURATION_SET (0x8007) - eProsima vendor PID
- PID_WIREPROTOCOL_CONFIG (0x8300) - eProsima vendor PID

Verified working: FastDDS 3.4.1 (Windows) <-> RTI Micro 2.4.9 (Linux/aarch64)
- SPDP discovery: bidirectional
- SEDP endpoint discovery: automatic (Simple EDP / DPDE)
- Data delivery: BEST_EFFORT, topic HEARTBEAT, confirmed

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.5.x 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
