### PR TITLE
[2.6.x] Fix related_sample_identity interoperability with the standard RPC-over-DDS PID

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
+#include <fastdds/rtps/common/VendorId_t.hpp>
 #include "ParameterList.hpp"
 #include "ParameterSerializer.hpp"
 
@@ -26,6 +27,13 @@
 namespace eprosima {
 namespace fastdds {
 namespace dds {
+
+namespace {
+
+constexpr ParameterId_t pid_standard_rpc_related_sample_identity =
+        static_cast<ParameterId_t>(0x0083);
+
+} // namespace
 
 
 bool ParameterList::writeEncapsulationToCDRMsg(
@@ -40,14 +48,17 @@ bool ParameterList::writeEncapsulationToCDRMsg(
 bool ParameterList::updateCacheChangeFromInlineQos(
         fastrtps::rtps::CacheChange_t& change,
         fastrtps::rtps::CDRMessage_t* msg,
+        const fastrtps::rtps::VendorId_t& source_vendor_id,
         uint32_t& qos_size)
 {
+    static const fastrtps::rtps::VendorId_t c_VendorId_rti_connext = {0x01, 0x01};
+
     auto parameter_process = [&](
         fastrtps::rtps::CDRMessage_t* msg,
         const ParameterId_t pid,
         uint16_t plength)
             {
-                switch (pid)
+                switch (static_cast<uint16_t>(pid))
                 {
                     case PID_KEY_HASH:
                     {
@@ -61,8 +72,18 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                         break;
                     }
 
-                    case PID_RELATED_SAMPLE_IDENTITY:
+                    case static_cast<uint16_t>(pid_standard_rpc_related_sample_identity):
+                    case static_cast<uint16_t>(PID_RELATED_SAMPLE_IDENTITY):
                     {
+                        if (pid == PID_RELATED_SAMPLE_IDENTITY)
+                        {
+                            if ((fastrtps::rtps::c_VendorId_eProsima != source_vendor_id) &&
+                                    (c_VendorId_rti_connext != source_vendor_id))
+                            {
+                                return true;
+                            }
+                        }
+
                         if (plength >= 24)
                         {
                             ParameterSampleIdentity_t p(pid, plength);

--- a/src/cpp/fastdds/core/policy/ParameterList.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.hpp
@@ -53,12 +53,14 @@ public:
      * Update the information of a cache change parsing the inline qos from a CDRMessage
      * @param[inout] change Reference to the cache change to be updated.
      * @param[in] msg Pointer to the message (the pos should be correct, otherwise the behaviour is undefined).
+     * @param[in] source_vendor_id Vendor identifier of the participant that sent the inline QoS.
      * @param[out] qos_size Number of bytes processed.
      * @return true if parsing was correct, false otherwise.
      */
     static bool updateCacheChangeFromInlineQos(
             fastrtps::rtps::CacheChange_t& change,
             fastrtps::rtps::CDRMessage_t* msg,
+            const fastrtps::rtps::VendorId_t& source_vendor_id,
             uint32_t& qos_size);
 
     /**

--- a/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
+++ b/src/cpp/fastdds/core/policy/ParameterSerializer.hpp
@@ -30,6 +30,13 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
+namespace detail {
+
+constexpr ParameterId_t pid_standard_rpc_related_sample_identity =
+        static_cast<ParameterId_t>(0x0083);
+
+} // namespace detail
+
 template <typename Parameter>
 class ParameterSerializer
 {
@@ -145,6 +152,29 @@ public:
     }
 
     static bool add_parameter_sample_identity(
+            fastrtps::rtps::CDRMessage_t* cdr_message,
+            const fastrtps::rtps::SampleIdentity& sample_id)
+    {
+        if (cdr_message->pos + 28 > cdr_message->max_size)
+        {
+            return false;
+        }
+
+        fastrtps::rtps::CDRMessage::addUInt16(cdr_message, detail::pid_standard_rpc_related_sample_identity);
+        fastrtps::rtps::CDRMessage::addUInt16(cdr_message, 24);
+        fastrtps::rtps::CDRMessage::addData(cdr_message,
+                sample_id.writer_guid().guidPrefix.value, fastrtps::rtps::GuidPrefix_t::size);
+        fastrtps::rtps::CDRMessage::addData(cdr_message,
+                sample_id.writer_guid().entityId.value, fastrtps::rtps::EntityId_t::size);
+        fastrtps::rtps::CDRMessage::addInt32(cdr_message, sample_id.sequence_number().high);
+        fastrtps::rtps::CDRMessage::addUInt32(cdr_message, sample_id.sequence_number().low);
+        return true;
+    }
+
+    /**
+     * Add the legacy/custom related_sample_identity parameter to an inline QoS parameter list.
+     */
+    static bool add_parameter_custom_related_sample_identity(
             fastrtps::rtps::CDRMessage_t* cdr_message,
             const fastrtps::rtps::SampleIdentity& sample_id)
     {

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -296,7 +296,7 @@ void WriterHistory::set_fragments(
     uint32_t inline_qos_size = change->inline_qos.length;
     if (change->write_params.related_sample_identity() != SampleIdentity::unknown())
     {
-        inline_qos_size += fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE;
+        inline_qos_size += (2 * fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
     }
     if (ChangeKind_t::ALIVE != change->kind && TopicKind_t::WITH_KEY == mp_writer->m_att.topicKind)
     {

--- a/src/cpp/rtps/messages/MessageReceiver.cpp
+++ b/src/cpp/rtps/messages/MessageReceiver.cpp
@@ -790,7 +790,7 @@ bool MessageReceiver::proc_Submsg_Data(
 
     if (inlineQosFlag)
     {
-        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, inlineQosSize))
+        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, source_vendor_id_, inlineQosSize))
         {
             logInfo(RTPS_MSG_IN, IDSTRING "SubMessage Data ERROR, Inline Qos ParameterList error");
             return false;
@@ -980,7 +980,7 @@ bool MessageReceiver::proc_Submsg_DataFrag(
 
     if (inlineQosFlag)
     {
-        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, inlineQosSize))
+        if (!ParameterList::updateCacheChangeFromInlineQos(ch, msg, source_vendor_id_, inlineQosSize))
         {
             logInfo(RTPS_MSG_IN, IDSTRING "SubMessage Data ERROR, Inline Qos ParameterList error");
             return false;

--- a/src/cpp/rtps/messages/submessages/DataMsg.hpp
+++ b/src/cpp/rtps/messages/submessages/DataMsg.hpp
@@ -126,6 +126,9 @@ struct DataMsgUtils
         {
             fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_sample_identity(msg,
                     change->write_params.related_sample_identity());
+            fastdds::dds::ParameterSerializer<Parameter_t>::add_parameter_custom_related_sample_identity(
+                msg,
+                change->write_params.related_sample_identity());
         }
 
         if (WITH_KEY == topicKind && (!change->writerGUID.is_builtin() || expectsInlineQos || ALIVE != change->kind))

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantFactoryQos.hpp>
@@ -38,6 +39,7 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <rtps/transport/test_UDPv4Transport.h>
+#include <fastdds/rtps/messages/CDRMessage.h>
 
 #include "BlackboxTests.hpp"
 #include "mock/BlackboxMockConsumer.h"
@@ -50,6 +52,136 @@ namespace fastdds {
 namespace dds {
 
 using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+
+namespace
+{
+
+constexpr eprosima::fastdds::dds::ParameterId_t pid_standard_rpc_related_sample_identity =
+        static_cast<eprosima::fastdds::dds::ParameterId_t>(0x0083);
+
+constexpr eprosima::fastdds::dds::ParameterId_t pid_legacy_fastdds_related_sample_identity =
+        eprosima::fastdds::dds::PID_RELATED_SAMPLE_IDENTITY;
+
+bool check_related_sample_identity_field(
+        eprosima::fastrtps::rtps::CDRMessage_t& msg,
+        bool& exists_standard_related_sample_identity,
+        bool& exists_custom_related_sample_identity,
+        bool drop_standard_related_sample_identity = false,
+        bool drop_custom_related_sample_identity = true)
+{
+    auto old_pos = msg.pos;
+    uint8_t flags = msg.buffer[msg.pos - 3];
+
+    msg.pos += 2;
+    uint16_t to_inline_qos = 0;
+    eprosima::fastrtps::rtps::CDRMessage::readUInt16(&msg, &to_inline_qos);
+
+    if ((flags & (1 << 1)) == 0)
+    {
+        msg.pos = old_pos;
+        return false;
+    }
+
+    uint32_t original_pos = msg.pos + to_inline_qos;
+    uint32_t qos_size = 0;
+
+    auto parameter_process = [&](
+        eprosima::fastrtps::rtps::CDRMessage_t* msg,
+        eprosima::fastdds::dds::ParameterId_t& pid,
+        uint16_t plength,
+        uint32_t& pid_pos)
+            {
+                switch (static_cast<uint16_t>(pid))
+                {
+                    case static_cast<uint16_t>(pid_legacy_fastdds_related_sample_identity):
+                    {
+                        if (plength >= 24)
+                        {
+                            eprosima::fastdds::dds::ParameterSampleIdentity_t p(pid, plength);
+                            if (!eprosima::fastdds::dds::ParameterSerializer<
+                                        eprosima::fastdds::dds::ParameterSampleIdentity_t>::read_from_cdr_message(
+                                        p, msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_custom_related_sample_identity = true;
+                            if (drop_custom_related_sample_identity)
+                            {
+                                msg->buffer[pid_pos] = 0xff;
+                                msg->buffer[pid_pos + 1] = 0xff;
+                            }
+                        }
+                        break;
+                    }
+                    case static_cast<uint16_t>(pid_standard_rpc_related_sample_identity):
+                    {
+                        if (plength >= 24)
+                        {
+                            eprosima::fastdds::dds::ParameterSampleIdentity_t p(pid, plength);
+                            if (!eprosima::fastdds::dds::ParameterSerializer<
+                                        eprosima::fastdds::dds::ParameterSampleIdentity_t>::read_from_cdr_message(
+                                        p, msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_standard_related_sample_identity = true;
+                            if (drop_standard_related_sample_identity)
+                            {
+                                msg->buffer[pid_pos] = 0xff;
+                                msg->buffer[pid_pos + 1] = 0xff;
+                            }
+                        }
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+                return true;
+            };
+
+    bool is_sentinel = false;
+    while (!is_sentinel)
+    {
+        msg.pos = original_pos + qos_size;
+
+        eprosima::fastdds::dds::ParameterId_t pid{eprosima::fastdds::dds::PID_SENTINEL};
+        bool valid = true;
+        auto msg_pid_pos = msg.pos;
+        pid = static_cast<eprosima::fastdds::dds::ParameterId_t>(
+            static_cast<uint16_t>(msg.buffer[msg.pos]) |
+            (static_cast<uint16_t>(msg.buffer[msg.pos + 1]) << 8));
+        msg.pos += 2;
+        uint16_t plength = static_cast<uint16_t>(msg.buffer[msg.pos]) |
+                (static_cast<uint16_t>(msg.buffer[msg.pos + 1]) << 8);
+        msg.pos += 2;
+
+        if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+        {
+            plength = 0;
+            is_sentinel = true;
+        }
+
+        qos_size += (4 + plength);
+        qos_size = (qos_size + 3) & ~3;
+
+        if (!valid || ((msg.pos + plength) > msg.length))
+        {
+            return false;
+        }
+        else if (!is_sentinel)
+        {
+            if (!parameter_process(&msg, pid, plength, msg_pid_pos))
+            {
+                return false;
+            }
+        }
+    }
+    msg.pos = old_pos;
+    return true;
+}
+
+}  // namespace
 
 /**
  * This is a regression test for redmine issue #21060.
@@ -409,6 +541,149 @@ TEST(DDSBasic, max_output_message_size_writer)
     reader.block_for_all(std::chrono::seconds(1));
     EXPECT_EQ(reader.getReceivedCount(), 1u);
 
+}
+
+/**
+ * This test checks that both the standard RPC-over-DDS related_sample_identity PID
+ * and the legacy/custom Fast DDS PID are sent, and that the standard PID is
+ * properly interpreted when the custom one is removed in transit.
+ */
+TEST(DDSBasic, PidRelatedSampleIdentity)
+{
+    PubSubWriter<HelloWorldPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_standard_related_sample_identity = false;
+    bool exists_custom_related_sample_identity = false;
+
+    test_transport->drop_data_messages_filter_ =
+            [&exists_standard_related_sample_identity, &exists_custom_related_sample_identity]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                bool ret = check_related_sample_identity_field(
+                    msg, exists_standard_related_sample_identity, exists_custom_related_sample_identity);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    exists_standard_related_sample_identity = false;
+    exists_custom_related_sample_identity = false;
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    HelloWorld data;
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity;
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(51, 24);
+    related_sample_identity.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity;
+
+    ASSERT_TRUE(native_writer.write((void *)&data, write_params));
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    HelloWorld read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 2;
+    ASSERT_TRUE(native_reader.wait_for_unread_message(timeout));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void *)&read_data, &info));
+
+    ASSERT_TRUE(exists_standard_related_sample_identity);
+    ASSERT_TRUE(exists_custom_related_sample_identity);
+    ASSERT_EQ(related_sample_identity, info.related_sample_identity);
+}
+
+/**
+ * This test checks that the legacy/custom Fast DDS related_sample_identity PID
+ * is still properly interpreted when the standard PID is removed in transit.
+ */
+TEST(DDSBasic, PidCustomRelatedSampleIdentity)
+{
+    PubSubWriter<HelloWorldPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_standard_related_sample_identity = false;
+    bool exists_custom_related_sample_identity = false;
+
+    test_transport->drop_data_messages_filter_ =
+            [&exists_standard_related_sample_identity, &exists_custom_related_sample_identity]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                bool ret = check_related_sample_identity_field(
+                    msg,
+                    exists_standard_related_sample_identity,
+                    exists_custom_related_sample_identity,
+                    true,
+                    false);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    exists_standard_related_sample_identity = false;
+    exists_custom_related_sample_identity = false;
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    HelloWorld data;
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity;
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(77, 33);
+    related_sample_identity.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity;
+
+    ASSERT_TRUE(native_writer.write((void *)&data, write_params));
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    HelloWorld read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 2;
+    ASSERT_TRUE(native_reader.wait_for_unread_message(timeout));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void *)&read_data, &info));
+
+    ASSERT_TRUE(exists_standard_related_sample_identity);
+    ASSERT_TRUE(exists_custom_related_sample_identity);
+    ASSERT_EQ(related_sample_identity, info.related_sample_identity);
 }
 
 } // namespace dds

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,7 @@
 Forthcoming
 -----------
 
+* Fixed `related_sample_identity` wire compatibility with peers that use the standard RPC-over-DDS PID while preserving legacy Fast DDS custom-PID interoperability.
 
 
 Version 2.6.9


### PR DESCRIPTION
## Description

This PR fixes a `related_sample_identity` interoperability issue in `2.6.x`.

The current `2.6.x` line preserves the legacy/custom Fast DDS encoding for `related_sample_identity`, but it does not fully interoperate with peers that emit only the standard RPC-over-DDS PID (`0x0083`). This can break request/reply correlation across DDS implementations in Humble-era deployments that still use Fast DDS `2.6.x`.

This change keeps the public `2.6.x` PID definitions unchanged and limits the fix to the existing inline QoS send/receive path.

Specifically:
- the receive path now accepts the standard RPC-over-DDS `related_sample_identity` PID (`0x0083`)
- the legacy/custom Fast DDS PID remains supported with a vendor guard
- the send path emits both encodings when `related_sample_identity` is set
- writer-side inline QoS sizing is updated so both parameters fit in outgoing DATA / DATA_FRAG messages
- blackbox regression tests were added for:
  - standard-only receive behavior
  - custom-only receive behavior

This PR does not modify `rmw_fastrtps`, ROS 2 request/reply logic, or unrelated RPC / transport behavior.

## Applicable backports

None. This PR directly targets the `2.6.x` branch.

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [x] Any new/modified methods have been properly documented using Doxygen.
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension)
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior.
- [x] Changes are API compatible.
- [x] New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. 
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.