### PR TITLE
[2.6.x] Fix non-builtin related_sample_identity interoperability with the standard RPC-over-DDS PID

### DIFF
--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -94,6 +94,10 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                                 return false;
                             }
 
+                            // Only the new standard 0x0083 path is gated for
+                            // non-builtin traffic; the existing legacy/custom
+                            // 0x800f handling above remains unchanged to avoid
+                            // discovery and builtin regressions.
                             if (!change.writerGUID.is_builtin())
                             {
                                 change.write_params.sample_identity(p.sample_id);

--- a/src/cpp/fastdds/core/policy/ParameterList.cpp
+++ b/src/cpp/fastdds/core/policy/ParameterList.cpp
@@ -27,6 +27,12 @@ namespace eprosima {
 namespace fastdds {
 namespace dds {
 
+namespace {
+
+constexpr ParameterId_t pid_standard_rpc_related_sample_identity =
+        static_cast<ParameterId_t>(0x0083);
+
+} // namespace
 
 bool ParameterList::writeEncapsulationToCDRMsg(
         fastrtps::rtps::CDRMessage_t* msg)
@@ -73,6 +79,25 @@ bool ParameterList::updateCacheChangeFromInlineQos(
                             }
 
                             change.write_params.sample_identity(p.sample_id);
+                        }
+                        break;
+                    }
+
+                    case pid_standard_rpc_related_sample_identity:
+                    {
+                        if (plength >= 24)
+                        {
+                            ParameterSampleIdentity_t p(pid, plength);
+                            if (!fastdds::dds::ParameterSerializer<ParameterSampleIdentity_t>::read_from_cdr_message(p,
+                                    msg, plength))
+                            {
+                                return false;
+                            }
+
+                            if (!change.writerGUID.is_builtin())
+                            {
+                                change.write_params.sample_identity(p.sample_id);
+                            }
                         }
                         break;
                     }

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -22,7 +22,7 @@
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/rtps/common/WriteParams.h>
 #include <fastdds/rtps/messages/CDRMessage.h>
-#include <fastdds/core/policy//ParameterSerializer.hpp>
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 
 #include <mutex>
 
@@ -34,6 +34,13 @@ namespace {
 
 constexpr uint16_t pid_standard_rpc_related_sample_identity = 0x0083;
 
+/*!
+ * @brief Append the standard RPC-over-DDS related_sample_identity PID to inline QoS.
+ *
+ * The extra PID is emitted only for non-builtin writers and only when a
+ * related sample identity is present, preserving the existing builtin and
+ * legacy/custom behavior.
+ */
 bool append_standard_related_sample_identity_inline_qos(
         CacheChange_t& change)
 {

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -21,6 +21,7 @@
 #include <fastdds/dds/log/Log.hpp>
 #include <fastdds/rtps/writer/RTPSWriter.h>
 #include <fastdds/rtps/common/WriteParams.h>
+#include <fastdds/rtps/messages/CDRMessage.h>
 #include <fastdds/core/policy//ParameterSerializer.hpp>
 
 #include <mutex>
@@ -28,6 +29,51 @@
 namespace eprosima {
 namespace fastrtps {
 namespace rtps {
+
+namespace {
+
+constexpr uint16_t pid_standard_rpc_related_sample_identity = 0x0083;
+
+bool append_standard_related_sample_identity_inline_qos(
+        CacheChange_t& change)
+{
+    if (change.writerGUID.is_builtin() ||
+            change.write_params.related_sample_identity() == SampleIdentity::unknown())
+    {
+        return true;
+    }
+
+    change.inline_qos.reserve(
+        change.inline_qos.length +
+        fastdds::dds::ParameterSerializer<Parameter_t>::PARAMETER_SAMPLE_IDENTITY_SIZE);
+
+    CDRMessage_t msg(change.inline_qos);
+    const SampleIdentity& sample_id = change.write_params.related_sample_identity();
+
+    bool valid = true;
+    valid &= CDRMessage::addUInt16(&msg, pid_standard_rpc_related_sample_identity);
+    valid &= CDRMessage::addUInt16(&msg, 24);
+    valid &= CDRMessage::addData(
+        &msg,
+        sample_id.writer_guid().guidPrefix.value,
+        GuidPrefix_t::size);
+    valid &= CDRMessage::addData(
+        &msg,
+        sample_id.writer_guid().entityId.value,
+        EntityId_t::size);
+    valid &= CDRMessage::addInt32(&msg, sample_id.sequence_number().high);
+    valid &= CDRMessage::addUInt32(&msg, sample_id.sequence_number().low);
+
+    if (valid)
+    {
+        change.inline_qos.length = msg.length;
+        change.inline_qos.pos = msg.pos;
+    }
+
+    return valid;
+}
+
+} // namespace
 
 WriteParams WriteParams::WRITE_PARAM_DEFAULT;
 
@@ -94,6 +140,11 @@ bool WriterHistory::prepare_and_add_change(
     wparams.sample_identity().writer_guid(a_change->writerGUID);
     wparams.sample_identity().sequence_number(a_change->sequenceNumber);
     wparams.related_sample_identity(wparams.sample_identity());
+    if (!append_standard_related_sample_identity_inline_qos(*a_change))
+    {
+        logError(RTPS_WRITER_HISTORY, "Failed to append standard related_sample_identity inline QoS");
+        return false;
+    }
     set_fragments(a_change);
 
     m_changes.push_back(a_change);

--- a/src/cpp/rtps/history/WriterHistory.cpp
+++ b/src/cpp/rtps/history/WriterHistory.cpp
@@ -40,6 +40,11 @@ constexpr uint16_t pid_standard_rpc_related_sample_identity = 0x0083;
  * The extra PID is emitted only for non-builtin writers and only when a
  * related sample identity is present, preserving the existing builtin and
  * legacy/custom behavior.
+ *
+ * @param change Cache change whose inline QoS may be extended with the
+ *               standard related_sample_identity PID.
+ * @return true if the PID was appended successfully, or if no append was
+ *         needed for the current change.
  */
 bool append_standard_related_sample_identity_inline_qos(
         CacheChange_t& change)

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fastdds/core/policy/ParameterSerializer.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantFactoryQos.hpp>
@@ -38,6 +39,7 @@
 #include <fastrtps/xmlparser/XMLProfileManager.h>
 
 #include <rtps/transport/test_UDPv4Transport.h>
+#include <fastdds/rtps/messages/CDRMessage.h>
 
 #include "BlackboxTests.hpp"
 #include "mock/BlackboxMockConsumer.h"
@@ -50,6 +52,136 @@ namespace fastdds {
 namespace dds {
 
 using ReturnCode_t = eprosima::fastrtps::types::ReturnCode_t;
+
+namespace
+{
+
+constexpr eprosima::fastdds::dds::ParameterId_t pid_standard_rpc_related_sample_identity =
+        static_cast<eprosima::fastdds::dds::ParameterId_t>(0x0083);
+
+constexpr eprosima::fastdds::dds::ParameterId_t pid_legacy_fastdds_related_sample_identity =
+        eprosima::fastdds::dds::PID_RELATED_SAMPLE_IDENTITY;
+
+bool check_related_sample_identity_field(
+        eprosima::fastrtps::rtps::CDRMessage_t& msg,
+        bool& exists_standard_related_sample_identity,
+        bool& exists_custom_related_sample_identity,
+        bool drop_standard_related_sample_identity = false,
+        bool drop_custom_related_sample_identity = true)
+{
+    auto old_pos = msg.pos;
+    uint8_t flags = msg.buffer[msg.pos - 3];
+
+    msg.pos += 2;
+    uint16_t to_inline_qos = 0;
+    eprosima::fastrtps::rtps::CDRMessage::readUInt16(&msg, &to_inline_qos);
+
+    if ((flags & (1 << 1)) == 0)
+    {
+        msg.pos = old_pos;
+        return false;
+    }
+
+    uint32_t original_pos = msg.pos + to_inline_qos;
+    uint32_t qos_size = 0;
+
+    auto parameter_process = [&](
+        eprosima::fastrtps::rtps::CDRMessage_t* msg,
+        eprosima::fastdds::dds::ParameterId_t& pid,
+        uint16_t plength,
+        uint32_t& pid_pos)
+            {
+                switch (static_cast<uint16_t>(pid))
+                {
+                    case static_cast<uint16_t>(pid_legacy_fastdds_related_sample_identity):
+                    {
+                        if (plength >= 24)
+                        {
+                            eprosima::fastdds::dds::ParameterSampleIdentity_t p(pid, plength);
+                            if (!eprosima::fastdds::dds::ParameterSerializer<
+                                        eprosima::fastdds::dds::ParameterSampleIdentity_t>::read_from_cdr_message(
+                                        p, msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_custom_related_sample_identity = true;
+                            if (drop_custom_related_sample_identity)
+                            {
+                                msg->buffer[pid_pos] = 0xff;
+                                msg->buffer[pid_pos + 1] = 0xff;
+                            }
+                        }
+                        break;
+                    }
+                    case static_cast<uint16_t>(pid_standard_rpc_related_sample_identity):
+                    {
+                        if (plength >= 24)
+                        {
+                            eprosima::fastdds::dds::ParameterSampleIdentity_t p(pid, plength);
+                            if (!eprosima::fastdds::dds::ParameterSerializer<
+                                        eprosima::fastdds::dds::ParameterSampleIdentity_t>::read_from_cdr_message(
+                                        p, msg, plength))
+                            {
+                                return false;
+                            }
+                            exists_standard_related_sample_identity = true;
+                            if (drop_standard_related_sample_identity)
+                            {
+                                msg->buffer[pid_pos] = 0xff;
+                                msg->buffer[pid_pos + 1] = 0xff;
+                            }
+                        }
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+                return true;
+            };
+
+    bool is_sentinel = false;
+    while (!is_sentinel)
+    {
+        msg.pos = original_pos + qos_size;
+
+        eprosima::fastdds::dds::ParameterId_t pid{eprosima::fastdds::dds::PID_SENTINEL};
+        bool valid = true;
+        auto msg_pid_pos = msg.pos;
+        pid = static_cast<eprosima::fastdds::dds::ParameterId_t>(
+            static_cast<uint16_t>(msg.buffer[msg.pos]) |
+            (static_cast<uint16_t>(msg.buffer[msg.pos + 1]) << 8));
+        msg.pos += 2;
+        uint16_t plength = static_cast<uint16_t>(msg.buffer[msg.pos]) |
+                (static_cast<uint16_t>(msg.buffer[msg.pos + 1]) << 8);
+        msg.pos += 2;
+
+        if (pid == eprosima::fastdds::dds::PID_SENTINEL)
+        {
+            plength = 0;
+            is_sentinel = true;
+        }
+
+        qos_size += (4 + plength);
+        qos_size = (qos_size + 3) & ~3;
+
+        if (!valid || ((msg.pos + plength) > msg.length))
+        {
+            return false;
+        }
+        else if (!is_sentinel)
+        {
+            if (!parameter_process(&msg, pid, plength, msg_pid_pos))
+            {
+                return false;
+            }
+        }
+    }
+    msg.pos = old_pos;
+    return true;
+}
+
+} // namespace
 
 /**
  * This is a regression test for redmine issue #21060.
@@ -409,6 +541,149 @@ TEST(DDSBasic, max_output_message_size_writer)
     reader.block_for_all(std::chrono::seconds(1));
     EXPECT_EQ(reader.getReceivedCount(), 1u);
 
+}
+
+/**
+ * This test checks that both the standard RPC-over-DDS related_sample_identity PID
+ * and the legacy/custom Fast DDS PID are sent, and that the standard PID is
+ * properly interpreted when the custom one is removed in transit.
+ */
+TEST(DDSBasic, PidRelatedSampleIdentity)
+{
+    PubSubWriter<HelloWorldPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_standard_related_sample_identity = false;
+    bool exists_custom_related_sample_identity = false;
+
+    test_transport->drop_data_messages_filter_ =
+            [&exists_standard_related_sample_identity, &exists_custom_related_sample_identity]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                bool ret = check_related_sample_identity_field(
+                    msg, exists_standard_related_sample_identity, exists_custom_related_sample_identity);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    exists_standard_related_sample_identity = false;
+    exists_custom_related_sample_identity = false;
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    HelloWorld data;
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity;
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(51, 24);
+    related_sample_identity.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity;
+
+    ASSERT_TRUE(native_writer.write((void *)&data, write_params));
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    HelloWorld read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 2;
+    ASSERT_TRUE(native_reader.wait_for_unread_message(timeout));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void *)&read_data, &info));
+
+    ASSERT_TRUE(exists_standard_related_sample_identity);
+    ASSERT_TRUE(exists_custom_related_sample_identity);
+    ASSERT_EQ(related_sample_identity, info.related_sample_identity);
+}
+
+/**
+ * This test checks that the legacy/custom Fast DDS related_sample_identity PID
+ * is still properly interpreted when the standard PID is removed in transit.
+ */
+TEST(DDSBasic, PidCustomRelatedSampleIdentity)
+{
+    PubSubWriter<HelloWorldPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_standard_related_sample_identity = false;
+    bool exists_custom_related_sample_identity = false;
+
+    test_transport->drop_data_messages_filter_ =
+            [&exists_standard_related_sample_identity, &exists_custom_related_sample_identity]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                bool ret = check_related_sample_identity_field(
+                    msg,
+                    exists_standard_related_sample_identity,
+                    exists_custom_related_sample_identity,
+                    true,
+                    false);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    exists_standard_related_sample_identity = false;
+    exists_custom_related_sample_identity = false;
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    HelloWorld data;
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity;
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(77, 33);
+    related_sample_identity.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity;
+
+    ASSERT_TRUE(native_writer.write((void *)&data, write_params));
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    HelloWorld read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 2;
+    ASSERT_TRUE(native_reader.wait_for_unread_message(timeout));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void *)&read_data, &info));
+
+    ASSERT_TRUE(exists_standard_related_sample_identity);
+    ASSERT_TRUE(exists_custom_related_sample_identity);
+    ASSERT_EQ(related_sample_identity, info.related_sample_identity);
 }
 
 } // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsBasic.cpp
@@ -686,6 +686,105 @@ TEST(DDSBasic, PidCustomRelatedSampleIdentity)
     ASSERT_EQ(related_sample_identity, info.related_sample_identity);
 }
 
+/**
+ * This test checks that the standard RPC-over-DDS related_sample_identity PID
+ * is also preserved on fragmented DATA_FRAG traffic when the custom PID is
+ * removed in transit.
+ */
+TEST(DDSBasic, PidRelatedSampleIdentityFragmented)
+{
+    PubSubWriter<Data1mbPubSubType> reliable_writer(TEST_TOPIC_NAME);
+    PubSubReader<Data1mbPubSubType> reliable_reader(TEST_TOPIC_NAME);
+
+    auto test_transport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    bool exists_standard_related_sample_identity = false;
+    bool exists_custom_related_sample_identity = false;
+
+    test_transport->sendBufferSize = 65536;
+    test_transport->receiveBufferSize = 65536;
+    test_transport->maxMessageSize = 1024;
+    test_transport->drop_data_frag_messages_filter_ =
+            [&exists_standard_related_sample_identity, &exists_custom_related_sample_identity]
+            (eprosima::fastrtps::rtps::CDRMessage_t& msg)-> bool
+            {
+                auto old_pos = msg.pos;
+
+                eprosima::fastrtps::rtps::EntityId_t reader_id;
+                eprosima::fastrtps::rtps::EntityId_t writer_id;
+                eprosima::fastrtps::rtps::SequenceNumber_t seq_num;
+                uint32_t first_fragment = 0;
+
+                msg.pos += 2; // flags
+                msg.pos += 2; // octets to inline qos
+                eprosima::fastrtps::rtps::CDRMessage::readEntityId(&msg, &reader_id);
+                eprosima::fastrtps::rtps::CDRMessage::readEntityId(&msg, &writer_id);
+                eprosima::fastrtps::rtps::CDRMessage::readSequenceNumber(&msg, &seq_num);
+                eprosima::fastrtps::rtps::CDRMessage::readUInt32(&msg, &first_fragment);
+                msg.pos = old_pos;
+
+                static_cast<void>(reader_id);
+                static_cast<void>(writer_id);
+                static_cast<void>(seq_num);
+
+                if (first_fragment != 1)
+                {
+                    return false;
+                }
+
+                bool ret = check_related_sample_identity_field(
+                    msg, exists_standard_related_sample_identity, exists_custom_related_sample_identity);
+                EXPECT_TRUE(ret);
+                return false;
+            };
+
+    reliable_writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_writer.isInitialized());
+
+    reliable_reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(test_transport)
+            .init();
+    ASSERT_TRUE(reliable_reader.isInitialized());
+
+    reliable_writer.wait_discovery();
+    reliable_reader.wait_discovery();
+
+    exists_standard_related_sample_identity = false;
+    exists_custom_related_sample_identity = false;
+
+    DataWriter& native_writer = reliable_writer.get_native_writer();
+
+    auto samples = default_data16kb_data_generator(1);
+    ASSERT_FALSE(samples.empty());
+    Data1mb data = samples.front();
+    eprosima::fastrtps::rtps::WriteParams write_params;
+    eprosima::fastrtps::rtps::SampleIdentity related_sample_identity;
+    eprosima::fastrtps::rtps::GUID_t unknown_guid;
+    related_sample_identity.writer_guid(unknown_guid);
+    eprosima::fastrtps::rtps::SequenceNumber_t seq(91, 17);
+    related_sample_identity.sequence_number(seq);
+    write_params.related_sample_identity() = related_sample_identity;
+
+    ASSERT_TRUE(native_writer.write((void *)&data, write_params));
+
+    DataReader& native_reader = reliable_reader.get_native_reader();
+
+    Data1mb read_data;
+    eprosima::fastdds::dds::SampleInfo info;
+    eprosima::fastrtps::Duration_t timeout;
+    timeout.seconds = 5;
+    ASSERT_TRUE(native_reader.wait_for_unread_message(timeout));
+
+    ASSERT_EQ(ReturnCode_t::RETCODE_OK, native_reader.take_next_sample((void *)&read_data, &info));
+
+    ASSERT_TRUE(exists_standard_related_sample_identity);
+    ASSERT_TRUE(exists_custom_related_sample_identity);
+    ASSERT_EQ(related_sample_identity, info.related_sample_identity);
+}
+
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima


### PR DESCRIPTION
## Description

This PR fixes a `related_sample_identity` interoperability issue in `2.6.x` for non-builtin traffic.

Fast DDS `2.6.x` preserves the legacy/custom `related_sample_identity` encoding (`0x800f`), but it does not fully interoperate with peers that emit only the standard RPC-over-DDS PID (`0x0083`). This is a general interoperability issue in the `related_sample_identity` path; ROS 2 service request/reply correlation is one observable symptom of it.

This revision keeps the patch surface minimal and conservative for `2.6.x`:

- it does not modify public PID definitions
- it does not change public API or ABI
- it does not alter builtin discovery traffic
- it preserves the existing legacy/custom Fast DDS PID path (`0x800f`)

The compatibility change is limited to non-builtin traffic:

- on send, non-builtin writers append the standard `0x0083` encoding to `change.inline_qos`
- on receive, standard `0x0083` is recognized only for non-builtin cache changes
- the legacy/custom `0x800f` receive behavior remains unchanged

This supersedes the earlier closed draft in #6353 with a smaller implementation that avoids changing pre-existing discovery behavior for the legacy/custom PID.

## Files changed

- `src/cpp/rtps/history/WriterHistory.cpp`
- `src/cpp/fastdds/core/policy/ParameterList.cpp`
- `test/blackbox/common/DDSBlackboxTestsBasic.cpp`

## Validation

Fast DDS in-tree validation:
- `DDSBasic.PidRelatedSampleIdentity`: pass
- `DDSBasic.PidCustomRelatedSampleIdentity`: pass
- `DDSBasic.PidRelatedSampleIdentityFragmented`: pass

Local targeted coverage assessment:
- performed with the modified runtime files under a local coverage build
- local targeted coverage shows the touched runtime paths are exercised; I could not compare against the latest nightly coverage baseline from the local environment
- the local targeted assessment does not show a coverage decrease for the modified runtime paths
- note: the official nightly Jenkins coverage baseline could not be queried from the local environment, so this is a local targeted assessment rather than a nightly-equivalent full-project comparison

Documentation build validation:
- local documentation validation was run with `CHECK_DOCUMENTATION=ON`
- `fastdds_doxygen` completed successfully in a fresh local container build

Additional ROS 2 Humble shipped-stack integration validation:
- validated with a Debian-package-shaped `ros-humble-fastrtps` build, not a raw local source build
- cross-RMW end-to-end validation was performed together with the corresponding patched CycloneDDS + patched `rmw_cyclonedds` standard-service-wire stack
- `Cyclone client -> Fast DDS service`: pass
- `Fast DDS client -> Cyclone service`: pass

Additional local full-suite validation:
- the shared "normal" test group was rebuilt and rerun in a fresh container
- isolated reruns were also performed for stateful / hang-prone cases
- persistent isolated failures were compared against clean upstream `2.6.x`
- the remaining isolated `FAIL` set also reproduces on upstream under the same local container/build conditions, so there is currently no stable in-tree regression attributable to this patch
- preserving the existing `0x800f` receive path unchanged avoids altering pre-existing builtin/discovery behavior

## Applicable backports

None. This PR directly targets the `2.6.x` branch.

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added. <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] Documentation builds and tests pass locally. <!-- Change to [x] only if you actually ran the docs build/test locally. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
